### PR TITLE
Fix apex CNAME validation

### DIFF
--- a/normalize/validate.go
+++ b/normalize/validate.go
@@ -277,7 +277,7 @@ func checkCNAMEs(dc *models.DomainConfig) (errs []error) {
 		}
 	}
 	for _, r := range dc.Records {
-		if cnames[r.Name] && r.Type != "CNAME" {
+		if cnames[r.Name] && r.Name != "@" && r.Type != "CNAME" {
 			errs = append(errs, fmt.Errorf("Cannot have CNAME and %s record with same name: %s", r.Type, r.NameFQDN))
 		}
 	}


### PR DESCRIPTION
Cloudflare supports apex CNAMEs, but the validation was throwing errors like this because there were also MX records there:

    ERROR: Cannot have CNAME and MX record with same name: example.com

A better solution would only allow apex CNAMEs on providers that actually support it, but since that wasn't checked before, I figure this is a good interim solution.