### PR TITLE
NO_PURGE honored globally

### DIFF
--- a/providers/activedir/domains.go
+++ b/providers/activedir/domains.go
@@ -55,9 +55,6 @@ func (c *adProvider) GetDomainCorrections(dc *models.DomainConfig) ([]*models.Co
 	// Generate changes.
 	corrections := []*models.Correction{}
 	for _, del := range dels {
-		if dc.KeepUnknown {
-			break
-		}
 		corrections = append(corrections, c.deleteRec(dc.Name, del.Existing))
 	}
 	for _, cre := range creates {

--- a/providers/cloudflare/cloudflareProvider.go
+++ b/providers/cloudflare/cloudflareProvider.go
@@ -103,9 +103,6 @@ func (c *CloudflareApi) GetDomainCorrections(dc *models.DomainConfig) ([]*models
 	corrections := []*models.Correction{}
 
 	for _, d := range del {
-		if dc.KeepUnknown {
-			continue
-		}
 		corrections = append(corrections, c.deleteRec(d.Existing.Original.(*cfRecord), id))
 	}
 	for _, d := range create {

--- a/providers/diff/diff.go
+++ b/providers/diff/diff.go
@@ -2,6 +2,7 @@ package diff
 
 import (
 	"fmt"
+	"log"
 	"sort"
 
 	"github.com/StackExchange/dnscontrol/models"
@@ -65,6 +66,15 @@ func (d *differ) IncrementalDiff(existing []*models.RecordConfig) (unchanged, cr
 	for _, d := range desired {
 		k := key{d.NameFQDN, d.Type}
 		desiredByNameAndType[k] = append(desiredByNameAndType[k], d)
+	}
+	//if NO_PURGE is set, just remove anything that is only in existing.
+	if d.dc.KeepUnknown {
+		for k := range existingByNameAndType {
+			if _, ok := desiredByNameAndType[k]; !ok {
+				log.Printf("Ignoring record set %s %s due to NO_PURGE", k.rType, k.name)
+				delete(existingByNameAndType, k)
+			}
+		}
 	}
 	// Look through existing records. This will give us changes and deletions and some additions.
 	// Each iteration is only for a single type/name record set

--- a/providers/diff/diff_test.go
+++ b/providers/diff/diff_test.go
@@ -128,9 +128,14 @@ func TestMetaChange(t *testing.T) {
 }
 
 func checkLengths(t *testing.T, existing, desired []*models.RecordConfig, unCount, createCount, delCount, modCount int, valFuncs ...func(*models.RecordConfig) map[string]string) (un, cre, del, mod Changeset) {
+	return checkLengthsFull(t, existing, desired, unCount, createCount, delCount, modCount, false, valFuncs...)
+}
+
+func checkLengthsFull(t *testing.T, existing, desired []*models.RecordConfig, unCount, createCount, delCount, modCount int, keepUnknown bool, valFuncs ...func(*models.RecordConfig) map[string]string) (un, cre, del, mod Changeset) {
 	dc := &models.DomainConfig{
-		Name:    "example.com",
-		Records: desired,
+		Name:        "example.com",
+		Records:     desired,
+		KeepUnknown: keepUnknown,
 	}
 	d := New(dc, valFuncs...)
 	un, cre, del, mod = d.IncrementalDiff(existing)
@@ -150,4 +155,16 @@ func checkLengths(t *testing.T, existing, desired []*models.RecordConfig, unCoun
 		t.FailNow()
 	}
 	return
+}
+
+func TestNoPurge(t *testing.T) {
+	existing := []*models.RecordConfig{
+		myRecord("www MX 1 1.1.1.1"),
+		myRecord("www MX 1 2.2.2.2"),
+		myRecord("www2 MX 1 1.1.1.1"),
+	}
+	desired := []*models.RecordConfig{
+		myRecord("www MX 1 1.1.1.1"),
+	}
+	checkLengthsFull(t, existing, desired, 1, 0, 1, 0, true)
 }


### PR DESCRIPTION
Turns out this was a little tricky. We want to ignore record sets that exist in the provider but not in our config. At the same time, if we go from 2 A records to 1, we want to be able to do that. Tests should cover it.