### PR TITLE
Fix small typo in Javascript DSL document

### DIFF
--- a/docs/js.md
+++ b/docs/js.md
@@ -4,7 +4,7 @@ layout: default
 
 # Javascript DSL
 
-DNSControl uses javascript as its primary input language to provide power and flexibility to configure your domains. The ultimate purpose of the javascript is to consturct a
+DNSControl uses javascript as its primary input language to provide power and flexibility to configure your domains. The ultimate purpose of the javascript is to construct a
 [DNSConfig](https://godoc.org/github.com/StackExchange/dnscontrol/models#DNSConfig) object that will be passed to the go backend and operated on. 
 
 {% include funcList.md title="Top Level Functions" dir="global" %}


### PR DESCRIPTION
Typo: 'consturct' --> 'construct'.