### PR TITLE
Update docs to properly use ROUTE53 in examples

### DIFF
--- a/docs/_providers/name.com.md
+++ b/docs/_providers/name.com.md
@@ -40,7 +40,7 @@ Example javascript (Registrar only. DNS hosted elsewhere):
 
 {% highlight js %}
 var REG_NAMECOM = NewRegistrar("name.com","NAMEDOTCOM");
-var R53 = NewDnsProvider("r53", ROUTE53);
+var R53 = NewDnsProvider("r53", "ROUTE53");
 
 D("example.tld", REG_NAMECOM, DnsProvider(R53),
     A("test","1.2.3.4")

--- a/docs/_providers/namecheap.md
+++ b/docs/_providers/namecheap.md
@@ -49,7 +49,7 @@ Example javascript:
 
 {% highlight js %}
 var namecheap = NewRegistrar("namecheap.com","NAMECHEAP");
-var R53 = NewDnsProvider("r53", ROUTE53);
+var R53 = NewDnsProvider("r53", "ROUTE53");
 
 D("example.tld", namecheap, DnsProvider(R53),
     A("test","1.2.3.4")

--- a/docs/_providers/route53.md
+++ b/docs/_providers/route53.md
@@ -7,7 +7,7 @@ jsId: ROUTE53
 
 ## Configuration
 
-By default, you can configure aws setting like the [go sdk configuration](https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html). For example you can use environment variables: 
+By default, you can configure aws setting like the [go sdk configuration](https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html). For example you can use environment variables:
 ```
 $ export AWS_ACCESS_KEY_ID=XXXXXXXXX
 $ export AWS_SECRET_ACCESS_KEY=YYYYYYYYY
@@ -34,7 +34,7 @@ Example javascript:
 
 {% highlight js %}
 var REG_NAMECOM = NewRegistrar("name.com","NAMEDOTCOM");
-var R53 = NewDnsProvider("r53", ROUTE53);
+var R53 = NewDnsProvider("r53", "ROUTE53");
 
 D("example.tld", REG_NAMECOM, DnsProvider(R53),
     A("test","1.2.3.4")
@@ -47,7 +47,7 @@ DNSControl depends on a standard [aws access key](https://aws.amazon.com/develop
 
 ## New domains
 
-If a domain does not exist in your Route53 account, DNSControl 
+If a domain does not exist in your Route53 account, DNSControl
 will *not* automatically add it. You can do that either manually
 via the control panel, or via the command `dnscontrol create-domains`
 command.


### PR DESCRIPTION
There were several doc files that were using ROUTE53 as a raw token instead of string.  This commit is just adding double quotes to make the documentation consistent.