### PR TITLE
Added _amazonses to list of allowed name with underscore

### DIFF
--- a/pkg/normalize/validate.go
+++ b/pkg/normalize/validate.go
@@ -77,7 +77,7 @@ func validateRecordTypes(rec *models.RecordConfig, domain string, pTypes []strin
 
 // underscores in names are often used erroneously. They are valid for dns records, but invalid for urls.
 // here we list common records expected to have underscores. Anything else containing an underscore will print a warning.
-var expectedUnderscores = []string{"_domainkey", "_dmarc"}
+var expectedUnderscores = []string{"_domainkey", "_dmarc", "_amazonses"}
 
 func checkLabel(label string, rType string, domain string) error {
 	if label == "@" {


### PR DESCRIPTION
_amazonses record is used by [Amazon SES to verify domain](https://docs.aws.amazon.com/ses/latest/DeveloperGuide/dns-txt-records.html).

This currently generate a warning "`WARNING: label _amazonses.example.com contains an underscore`"