### PR TITLE
Route53 provider: Pass the right correction message based on action

### DIFF
--- a/providers/route53/route53Provider.go
+++ b/providers/route53/route53Provider.go
@@ -224,14 +224,15 @@ func (r *route53Provider) GetDomainCorrections(dc *models.DomainConfig) ([]*mode
 	changeReq := &r53.ChangeResourceRecordSetsInput{
 		ChangeBatch: &r53.ChangeBatch{Changes: changes},
 	}
+
 	delReq := &r53.ChangeResourceRecordSetsInput{
 		ChangeBatch: &r53.ChangeBatch{Changes: dels},
 	}
 
-	addCorrection := func(req *r53.ChangeResourceRecordSetsInput) {
+	addCorrection := func(msg string, req *r53.ChangeResourceRecordSetsInput) {
 		corrections = append(corrections,
 			&models.Correction{
-				Msg: changeDesc,
+				Msg: msg,
 				F: func() error {
 					req.HostedZoneId = zone.Id
 					_, err := r.client.ChangeResourceRecordSets(req)
@@ -239,11 +240,13 @@ func (r *route53Provider) GetDomainCorrections(dc *models.DomainConfig) ([]*mode
 				},
 			})
 	}
+
 	if len(dels) > 0 {
-		addCorrection(delReq)
+		addCorrection(delDesc, delReq)
 	}
+
 	if len(changes) > 0 {
-		addCorrection(changeReq)
+		addCorrection(changeDesc, changeReq)
 	}
 
 	return corrections, nil


### PR DESCRIPTION
Fixes #150.

Correction messages are tracked in different variables between UPSERTs and DELETEs. Formerly, this lead to the wrong correction message (or a blank correction message) being printed when performing DELETEs.

I don't know if this is the correct idiomatic solution, but it does print the right messages now.