### PR TITLE
add ALIAS support for Name.com provider

### DIFF
--- a/providers/namedotcom/namedotcomProvider.go
+++ b/providers/namedotcom/namedotcomProvider.go
@@ -41,7 +41,7 @@ func newProvider(conf map[string]string) (*nameDotCom, error) {
 
 func init() {
 	providers.RegisterRegistrarType("NAMEDOTCOM", newReg)
-	providers.RegisterDomainServiceProviderType("NAMEDOTCOM", newDsp)
+	providers.RegisterDomainServiceProviderType("NAMEDOTCOM", newDsp, providers.CanUseAlias)
 }
 
 ///

--- a/providers/namedotcom/records.go
+++ b/providers/namedotcom/records.go
@@ -27,6 +27,12 @@ func (n *nameDotCom) GetDomainCorrections(dc *models.DomainConfig) ([]*models.Co
 		actual[i] = r.toRecord()
 	}
 
+	for _, rec := range dc.Records {
+		if rec.Type == "ALIAS" {
+			rec.Type = "ANAME"
+		}
+	}
+
 	checkNSModifications(dc)
 
 	differ := diff.New(dc)


### PR DESCRIPTION
Name.com just implemented ALIAS records, which we are calling ANAME records to match with the current draft https://tools.ietf.org/html/draft-ietf-dnsop-aname-00.