### PR TITLE
OVH DNS Provider (#143)

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -11,3 +11,4 @@ providers/ns1 @captncraig
 # providers/route53
 # providers/softlayer
 providers/vultr  @geek1011
+providers/ovh @masterzen

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Currently supported DNS providers:
  - Route 53
  - SoftLayer
  - Vultr
+ - OVH
 
 At Stack Overflow, we use this system to manage hundreds of domains
 and subdomains across multiple registrars and DNS providers.

--- a/docs/_includes/matrix.html
+++ b/docs/_includes/matrix.html
@@ -100,8 +100,8 @@
 		<td class="danger">
 			<i class="fa fa-times text-danger" aria-hidden="true"></i>
 		</td>
-		<td class="danger">
-			<i class="fa fa-times text-danger" aria-hidden="true"></i>
+		<td class="success">
+			<i class="fa fa-check text-success" aria-hidden="true"></i>
 		</td>
 		<td class="success">
 			<i class="fa fa-check text-success" aria-hidden="true"></i>

--- a/docs/_includes/matrix.html
+++ b/docs/_includes/matrix.html
@@ -359,8 +359,8 @@
 		<td class="success">
 			<i class="fa fa-check text-success" aria-hidden="true"></i>
 		</td>
-		<td class="danger">
-			<i class="fa fa-times text-danger" aria-hidden="true"></i>
+		<td class="success">
+			<i class="fa fa-check text-success" aria-hidden="true"></i>
 		</td>
 		<td class="success">
 			<i class="fa fa-check text-success" aria-hidden="true"></i>

--- a/docs/_includes/matrix.html
+++ b/docs/_includes/matrix.html
@@ -16,6 +16,7 @@
 	<th class="rotate"><div><span>NAMECHEAP</span></div></th>
 	<th class="rotate"><div><span>NAMEDOTCOM</span></div></th>
 	<th class="rotate"><div><span>NS1</span></div></th>
+	<th class="rotate"><div><span>OVH</span></div></th>
 	<th class="rotate"><div><span>ROUTE53</span></div></th>
 	<th class="rotate"><div><span>SOFTLAYER</span></div></th>
 	<th class="rotate"><div><span>VULTR</span></div></th>
@@ -50,6 +51,9 @@
 		</td>
 		<td class="success">
 			<i class="fa fa-check text-success" aria-hidden="true"></i>
+		</td>
+		<td class="danger">
+			<i class="fa fa-times text-danger" aria-hidden="true"></i>
 		</td>
 		<td class="danger">
 			<i class="fa fa-times text-danger" aria-hidden="true"></i>
@@ -96,6 +100,9 @@
 		<td class="danger">
 			<i class="fa fa-times text-danger" aria-hidden="true"></i>
 		</td>
+		<td class="danger">
+			<i class="fa fa-times text-danger" aria-hidden="true"></i>
+		</td>
 		<td class="success">
 			<i class="fa fa-check text-success" aria-hidden="true"></i>
 		</td>
@@ -108,6 +115,9 @@
 		</tr>
 	<tr>
 		<th class="row-header" style="text-decoration: underline;" data-toggle="tooltip" data-container="body" data-placement="top" title="Can manage and serve DNS zones">DNS Provider</th>
+		<td class="success">
+			<i class="fa fa-check text-success" aria-hidden="true"></i>
+		</td>
 		<td class="success">
 			<i class="fa fa-check text-success" aria-hidden="true"></i>
 		</td>
@@ -170,6 +180,9 @@
 			<i class="fa fa-check text-success" aria-hidden="true"></i>
 		</td>
 		<td><i class="fa fa-minus dim"></i></td>
+		<td class="danger">
+			<i class="fa fa-times text-danger" aria-hidden="true"></i>
+		</td>
 		<td class="danger" data-toggle="tooltip" data-container="body" data-placement="top" title="R53 does not provide a generic ALIAS functionality. They do have &#39;ALIAS&#39; CNAME types to point at various AWS infrastructure, but dnscontrol has not implemented those.">
 			<i class="fa has-tooltip fa-times text-danger" aria-hidden="true"></i>
 		</td>
@@ -217,6 +230,9 @@
 		<td class="success">
 			<i class="fa fa-check text-success" aria-hidden="true"></i>
 		</td>
+		<td class="success">
+			<i class="fa fa-check text-success" aria-hidden="true"></i>
+		</td>
 		</tr>
 	<tr>
 		<th class="row-header" style="text-decoration: underline;" data-toggle="tooltip" data-container="body" data-placement="top" title="Provider supports adding PTR records for reverse lookup zones">PTR</th>
@@ -244,6 +260,9 @@
 			<a href="https://www.name.com/support/articles/205188508-Reverse-DNS-records"><i class="fa has-tooltip fa-times text-danger" aria-hidden="true"></i></a>
 		</td>
 		<td><i class="fa fa-minus dim"></i></td>
+		<td class="danger">
+			<i class="fa fa-times text-danger" aria-hidden="true"></i>
+		</td>
 		<td class="success">
 			<i class="fa fa-check text-success" aria-hidden="true"></i>
 		</td>
@@ -274,6 +293,9 @@
 		</td>
 		<td><i class="fa fa-minus dim"></i></td>
 		<td><i class="fa fa-minus dim"></i></td>
+		<td class="danger">
+			<i class="fa fa-times text-danger" aria-hidden="true"></i>
+		</td>
 		<td class="success">
 			<i class="fa fa-check text-success" aria-hidden="true"></i>
 		</td>
@@ -300,6 +322,9 @@
 		</td>
 		<td><i class="fa fa-minus dim"></i></td>
 		<td><i class="fa fa-minus dim"></i></td>
+		<td class="success">
+			<i class="fa fa-check text-success" aria-hidden="true"></i>
+		</td>
 		<td><i class="fa fa-minus dim"></i></td>
 		<td><i class="fa fa-minus dim"></i></td>
 		<td class="danger">
@@ -333,6 +358,9 @@
 		</td>
 		<td class="success">
 			<i class="fa fa-check text-success" aria-hidden="true"></i>
+		</td>
+		<td class="danger">
+			<i class="fa fa-times text-danger" aria-hidden="true"></i>
 		</td>
 		<td class="success">
 			<i class="fa fa-check text-success" aria-hidden="true"></i>
@@ -372,6 +400,9 @@
 		<td class="danger">
 			<i class="fa fa-times text-danger" aria-hidden="true"></i>
 		</td>
+		<td class="danger" data-toggle="tooltip" data-container="body" data-placement="top" title="New domains require registration">
+			<i class="fa has-tooltip fa-times text-danger" aria-hidden="true"></i>
+		</td>
 		<td class="success">
 			<i class="fa fa-check text-success" aria-hidden="true"></i>
 		</td>
@@ -407,6 +438,9 @@
 		</td>
 		<td class="danger">
 			<i class="fa fa-times text-danger" aria-hidden="true"></i>
+		</td>
+		<td class="success">
+			<i class="fa fa-check text-success" aria-hidden="true"></i>
 		</td>
 		<td class="success">
 			<i class="fa fa-check text-success" aria-hidden="true"></i>

--- a/docs/_providers/ovh.md
+++ b/docs/_providers/ovh.md
@@ -39,6 +39,18 @@ D("example.tld", REG_OVH, DnsProvider(OVH),
 );
 {% endhighlight %}
 
+Example javascript (Registrar only. DNS hosted elsewhere):
+
+{% highlight js %}
+var REG_OVH = NewRegistrar("ovh", "OVH");
+var R53 = NewDnsProvider("r53", "ROUTE53");
+
+D("example.tld", REG_OVH, DnsProvider(R53),
+    A("test","1.2.3.4")
+);
+{%endhighlight%}
+
+
 ## Activation
 
 To obtain the OVH keys, one need to register an app at OVH by following the
@@ -62,16 +74,24 @@ curl -XPOST -H"X-Ovh-Application: <you-app-key>" -H "Content-type: application/j
       "path": "/domain/zone/*"
     },
     {
-      "method": "GET",
-      "path": "/domain/*"
-    },
-    {
       "method": "POST",
       "path": "/domain/zone/*"
     },
     {
       "method": "PUT",
       "path": "/domain/zone/*"
+    },
+    {
+      "method": "GET",
+      "path": "/domain/*"
+    },
+    {
+      "method": "PUT",
+      "path": "/domain/*"
+    },
+    {
+      "method": "POST",
+      "path": "/domain/*/nameServers/update"
     }
   ]
 }'
@@ -97,3 +117,19 @@ If a domain does not exist in your OVH account, DNSControl
 will *not* automatically add it. You'll need to do that via the
 control panel manually.
 
+## Dual providers scenario
+
+Since OVH doesn't allow to host DNS for a domain that is not registered in their registrar, some dual providers
+scenario might not be possible:
+
+| registrar | zone        | working? |
+|:---------:|:-----------:|:--------:|
+|  OVH      | other       |    √     |
+|  OVH      | OVH + other |    √     |
+|  other    | OVH         |    X     |
+
+## Caveat
+
+OVH doesn't allow resetting the zone to the OVH DNS through the API. If for any reasons OVH NS entries were
+removed the only way to add them back is by using the OVH Control Panel (in the DNS Servers tab, click on the "Reset the
+DNS servers" button.

--- a/docs/_providers/ovh.md
+++ b/docs/_providers/ovh.md
@@ -120,7 +120,7 @@ control panel manually.
 ## Dual providers scenario
 
 Since OVH doesn't allow to host DNS for a domain that is not registered in their registrar, some dual providers
-scenario might not be possible:
+scenario are not possible:
 
 | registrar | zone        | working? |
 |:---------:|:-----------:|:--------:|

--- a/docs/_providers/ovh.md
+++ b/docs/_providers/ovh.md
@@ -1,0 +1,99 @@
+---
+name: Ovh
+layout: default
+jsId: OVH
+---
+# OVH Provider
+
+## Configuration
+
+In your providers config json file you must provide a OVH app-key, app-secret-key and consumer-key:
+
+{% highlight json %}
+{
+  "ovh":{
+    "app-key": "your app key",
+    "app-secret-key": "your app secret key",
+    "consumer-key": "your consumer key"
+  }
+}
+{% endhighlight %}
+
+See [the Activation section](#activation) for details on obtaining these credentials.
+
+## Metadata
+
+This provider does not recognize any special metadata fields unique to OVH.
+
+## Usage
+
+Example javascript:
+
+Example javascript (DNS hosted with OVH):
+{% highlight js %}
+var REG_OVH = NewRegistrar("ovh", "OVH");
+var OVH = NewDnsProvider("ovh", "OVH");
+
+D("example.tld", REG_OVH, DnsProvider(OVH),
+    A("test","1.2.3.4")
+);
+{% endhighlight %}
+
+## Activation
+
+To obtain the OVH keys, one need to register an app at OVH by following the
+[OVH API Getting Started](https://api.ovh.com/g934.first_step_with_api)
+
+It consist in declaring the app at https://eu.api.ovh.com/createApp/
+which gives the `app-key` and `app-secret-key`.
+
+Once done, to obtain the `consumer-key` it is necessary to authorize the just created app
+to access the data in a specific account:
+
+{% highlight bash %}
+curl -XPOST -H"X-Ovh-Application: <you-app-key>" -H "Content-type: application/json" https://eu.api.ovh.com/1.0/auth/credential -d'{
+  "accessRules": [
+    {
+      "method": "DELETE",
+      "path": "/domain/zone/*"
+    },
+    {
+      "method": "GET",
+      "path": "/domain/zone/*"
+    },
+    {
+      "method": "GET",
+      "path": "/domain/*"
+    },
+    {
+      "method": "POST",
+      "path": "/domain/zone/*"
+    },
+    {
+      "method": "PUT",
+      "path": "/domain/zone/*"
+    }
+  ]
+}'
+{% endhighlight %}
+
+It should return something akin to:
+{% highlight json %}
+{
+  "validationUrl": "https://eu.api.ovh.com/auth/?credentialToken=<long-token>",
+  "consumerKey": "<your-consumer-key>",
+  "state": "pendingValidation"
+}
+{% endhighlight %}
+
+Open the "validationUrl" in a brower and log in with your OVH account. This will link the app with your account,
+authorizing it to access your zones and domains.
+
+Do not forget to fill the `consumer-key` of your `creds.json`.
+
+## New domains
+
+If a domain does not exist in your OVH account, DNSControl
+will *not* automatically add it. You'll need to do that via the
+control panel manually.
+

--- a/docs/provider-list.md
+++ b/docs/provider-list.md
@@ -65,7 +65,7 @@ Maintainers of contributed providers:
 * gandi @TomOnTime
 * namecheap @captncraig
 * ns1 @captncraig
-* OVH @Oprax
+* OVH @masterzen
 * Vultr @geek1011
 
 ### Requested providers
@@ -83,5 +83,4 @@ code to support this provider, please re-open the issue. We'd be glad to help in
   <li>Hurricane Electric (dns.he.net) (<a href="https://github.com/StackExchange/dnscontrol/issues/118">#118</a>)</li>
   <li>INWX (<a href="https://github.com/StackExchange/dnscontrol/issues/254">#254</a>)</li>
   <li>Linode (<a href="https://github.com/StackExchange/dnscontrol/issues/121">#121</a>)</li>
-  <li>OVH (<a href="https://github.com/StackExchange/dnscontrol/issues/143">#143</a>)</li>
 </ul>

--- a/integrationTest/integration_test.go
+++ b/integrationTest/integration_test.go
@@ -384,12 +384,15 @@ func makeTests(t *testing.T) []*TestCase {
 	if !providers.ProviderHasCabability(*providerToRun, providers.CanUseTLSA) {
 		t.Log("Skipping TLSA Tests because provider does not support them")
 	} else {
+		sha256hash := strings.Repeat("0123456789abcdef", 4)
+		sha512hash := strings.Repeat("0123456789abcdef", 8)
+		reversedSha512 := strings.Repeat("fedcba9876543210", 8)
 		tests = append(tests, tc("Empty"),
-			tc("TLSA record", tlsa("_443._tcp", 3, 1, 1, "abcdef0123456789==")),
-			tc("TLSA change usage", tlsa("_443._tcp", 2, 1, 1, "abcdef0123456789==")),
-			tc("TLSA change selector", tlsa("_443._tcp", 2, 0, 1, "abcdef0123456789==")),
-			tc("TLSA change matchingtype", tlsa("_443._tcp", 2, 0, 0, "abcdef0123456789==")),
-			tc("TLSA change certificate", tlsa("_443._tcp", 2, 0, 0, "0123456789abcdef==")),
+			tc("TLSA record", tlsa("_443._tcp", 3, 1, 1, sha256hash)),
+			tc("TLSA change usage", tlsa("_443._tcp", 2, 1, 1, sha256hash)),
+			tc("TLSA change selector", tlsa("_443._tcp", 2, 0, 1, sha256hash)),
+			tc("TLSA change matchingtype", tlsa("_443._tcp", 2, 0, 2, sha512hash)),
+			tc("TLSA change certificate", tlsa("_443._tcp", 2, 0, 2, reversedSha512)),
 		)
 	}
 

--- a/integrationTest/providers.json
+++ b/integrationTest/providers.json
@@ -66,5 +66,11 @@
   "VULTR": {
     "token": "$VULTR_TOKEN",
     "domain": "$VULTR_DOMAIN"
+  },
+  "OVH": {
+    "app-key": "$OVH_APP_KEY",
+    "app-secret-key": "$OVH_APP_SECRET_KEY",
+    "consumer-key": "$OVH_CONSUMER_KEY",
+    "domain": "$OVH_DOMAIN"
   }
 }

--- a/providers/_all/all.go
+++ b/providers/_all/all.go
@@ -13,6 +13,7 @@ import (
 	_ "github.com/StackExchange/dnscontrol/providers/namecheap"
 	_ "github.com/StackExchange/dnscontrol/providers/namedotcom"
 	_ "github.com/StackExchange/dnscontrol/providers/ns1"
+	_ "github.com/StackExchange/dnscontrol/providers/ovh"
 	_ "github.com/StackExchange/dnscontrol/providers/route53"
 	_ "github.com/StackExchange/dnscontrol/providers/softlayer"
 	_ "github.com/StackExchange/dnscontrol/providers/vultr"

--- a/providers/ovh/ovhProvider.go
+++ b/providers/ovh/ovhProvider.go
@@ -1,0 +1,177 @@
+package ovh
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/StackExchange/dnscontrol/models"
+	"github.com/StackExchange/dnscontrol/providers"
+	"github.com/StackExchange/dnscontrol/providers/diff"
+	"github.com/miekg/dns/dnsutil"
+	"github.com/xlucas/go-ovh/ovh"
+)
+
+type ovhProvider struct {
+	client *ovh.Client
+	zones  map[string]bool
+}
+
+var docNotes = providers.DocumentationNotes{
+	providers.DocDualHost:            providers.Cannot(),
+	providers.DocCreateDomains:       providers.Cannot("New domains require registration"),
+	providers.DocOfficiallySupported: providers.Cannot(),
+	providers.CanUseAlias:            providers.Cannot(),
+	providers.CanUseTLSA:             providers.Can(),
+	providers.CanUseCAA:              providers.Cannot(),
+	providers.CanUsePTR:              providers.Cannot(),
+}
+
+func newOVH(m map[string]string, metadata json.RawMessage) (*ovhProvider, error) {
+	appKey, appSecretKey, consumerKey := m["app-key"], m["app-secret-key"], m["consumer-key"]
+
+	c := ovh.NewClient(ovh.ENDPOINT_EU_OVHCOM, appKey, appSecretKey, consumerKey, false)
+
+	// Check for time lag
+	if err := c.PollTimeshift(); err != nil {
+		return nil, err
+	}
+
+	return &ovhProvider{client: c}, nil
+}
+
+func newDsp(conf map[string]string, metadata json.RawMessage) (providers.DNSServiceProvider, error) {
+	return newOVH(conf, metadata)
+}
+
+func init() {
+	providers.RegisterDomainServiceProviderType("OVH", newDsp, providers.CanUseSRV, providers.CanUseTLSA, docNotes)
+}
+
+func (c *ovhProvider) GetNameservers(domain string) ([]*models.Nameserver, error) {
+	if err := c.fetchZones(); err != nil {
+		return nil, err
+	}
+	_, ok := c.zones[domain]
+	if !ok {
+		return nil, fmt.Errorf("%s not listed in zones for ovh account", domain)
+	}
+
+	ns, err := c.fetchNS(domain)
+	if err != nil {
+		return nil, err
+	}
+
+	return models.StringsToNameservers(ns), nil
+}
+
+type errNoExist struct {
+	domain string
+}
+
+func (e errNoExist) Error() string {
+	return fmt.Sprintf("Domain %s not found in your ovh account", e.domain)
+}
+
+func (c *ovhProvider) GetDomainCorrections(dc *models.DomainConfig) ([]*models.Correction, error) {
+	dc.Punycode()
+	dc.CombineMXs()
+
+	if !c.zones[dc.Name] {
+		return nil, errNoExist{dc.Name}
+	}
+
+	records, err := c.fetchRecords(dc.Name)
+	if err != nil {
+		return nil, err
+	}
+
+	var actual []*models.RecordConfig
+	for _, r := range records {
+		if r.FieldType == "SOA" {
+			continue
+		}
+
+		// skip ovh managed apex NS
+		if r.FieldType == "NS" && r.SubDomain == "" {
+			continue
+		}
+
+		if r.SubDomain == "" {
+			r.SubDomain = "@"
+		}
+
+		// ovh uses a custom type for SPF and DKIM
+		if r.FieldType == "SPF" || r.FieldType == "DKIM" {
+			r.FieldType = "TXT"
+		}
+
+		// ovh default is 3600
+		if r.TTL == 0 {
+			r.TTL = 3600
+		}
+
+		rec := &models.RecordConfig{
+			NameFQDN:       dnsutil.AddOrigin(r.SubDomain, dc.Name),
+			Name:           r.SubDomain,
+			Type:           r.FieldType,
+			Target:         r.Target,
+			TTL:            uint32(r.TTL),
+			CombinedTarget: true,
+			Original:       r,
+		}
+		actual = append(actual, rec)
+	}
+
+	// Normalize
+	models.Downcase(actual)
+
+	newList := make([]*models.RecordConfig, 0, len(dc.Records))
+	for _, rec := range dc.Records {
+		// apex NS can't be managed directly
+		if rec.Type == "NS" && rec.NameFQDN == dc.Name {
+			continue
+		}
+		newList = append(newList, rec)
+	}
+	dc.Records = newList
+
+	differ := diff.New(dc)
+	_, create, delete, modify := differ.IncrementalDiff(actual)
+
+	corrections := []*models.Correction{}
+
+	for _, del := range delete {
+		rec := del.Existing.Original.(*Record)
+		corrections = append(corrections, &models.Correction{
+			Msg: del.String(),
+			F:   c.deleteRecordFunc(rec.Id, dc.Name),
+		})
+	}
+
+	for _, cre := range create {
+		rec := cre.Desired
+		corrections = append(corrections, &models.Correction{
+			Msg: cre.String(),
+			F:   c.createRecordFunc(rec, dc.Name),
+		})
+	}
+
+	for _, mod := range modify {
+		oldR := mod.Existing.Original.(*Record)
+		newR := mod.Desired
+		corrections = append(corrections, &models.Correction{
+			Msg: mod.String(),
+			F:   c.updateRecordFunc(oldR, newR, dc.Name),
+		})
+	}
+
+	if len(corrections) > 0 {
+		corrections = append(corrections, &models.Correction{
+			Msg: "REFRESH zone " + dc.Name,
+			F: func() error {
+				return c.refreshZone(dc.Name)
+			},
+		})
+	}
+
+	return corrections, nil
+}

--- a/providers/ovh/ovhProvider.go
+++ b/providers/ovh/ovhProvider.go
@@ -18,7 +18,7 @@ type ovhProvider struct {
 }
 
 var docNotes = providers.DocumentationNotes{
-	providers.DocDualHost:            providers.Cannot(),
+	providers.DocDualHost:            providers.Can(),
 	providers.DocCreateDomains:       providers.Cannot("New domains require registration"),
 	providers.DocOfficiallySupported: providers.Cannot(),
 	providers.CanUseAlias:            providers.Cannot(),
@@ -97,11 +97,6 @@ func (c *ovhProvider) GetDomainCorrections(dc *models.DomainConfig) ([]*models.C
 			continue
 		}
 
-		// skip ovh managed apex NS
-		if r.FieldType == "NS" && r.SubDomain == "" {
-			continue
-		}
-
 		if r.SubDomain == "" {
 			r.SubDomain = "@"
 		}
@@ -130,16 +125,6 @@ func (c *ovhProvider) GetDomainCorrections(dc *models.DomainConfig) ([]*models.C
 
 	// Normalize
 	models.Downcase(actual)
-
-	newList := make([]*models.RecordConfig, 0, len(dc.Records))
-	for _, rec := range dc.Records {
-		// apex NS can't be managed directly
-		if rec.Type == "NS" && rec.NameFQDN == dc.Name {
-			continue
-		}
-		newList = append(newList, rec)
-	}
-	dc.Records = newList
 
 	differ := diff.New(dc)
 	_, create, delete, modify := differ.IncrementalDiff(actual)

--- a/providers/ovh/protocol.go
+++ b/providers/ovh/protocol.go
@@ -1,0 +1,156 @@
+package ovh
+
+import (
+	"fmt"
+	"github.com/StackExchange/dnscontrol/models"
+	"github.com/miekg/dns/dnsutil"
+)
+
+type Void struct {
+}
+
+// fetchDomainList gets list of zones for account
+func (c *ovhProvider) fetchZones() error {
+	if c.zones != nil {
+		return nil
+	}
+	c.zones = map[string]bool{}
+
+	var response []string
+
+	err := c.client.Call("GET", "/domain/zone", nil, &response)
+
+	if err != nil {
+		return err
+	}
+
+	for _, d := range response {
+		c.zones[d] = true
+	}
+	return nil
+}
+
+type Zone struct {
+	LastUpdate      string   `json:"lastUpdate,omitempty"`
+	HasDNSAnycast   bool     `json:"hasDNSAnycast,omitempty"`
+	NameServers     []string `json:"nameServers"`
+	DNSSecSupported bool     `json:"dnssecSupported"`
+}
+
+// get info about a zone.
+func (c *ovhProvider) fetchZone(fqdn string) (*Zone, error) {
+	var response Zone
+
+	err := c.client.Call("GET", "/domain/zone/"+fqdn, nil, &response)
+	if err != nil {
+		return nil, err
+	}
+
+	return &response, nil
+}
+
+type Record struct {
+	Target    string `json:"target,omitempty"`
+	Zone      string `json:"zone,omitempty"`
+	TTL       uint32 `json:"ttl,omitempty"`
+	FieldType string `json:"fieldType,omitempty"`
+	Id        int64  `json:"id,omitempty"`
+	SubDomain string `json:"subDomain,omitempty"`
+}
+
+type records struct {
+	recordsId []int
+}
+
+func (c *ovhProvider) fetchRecords(fqdn string) ([]*Record, error) {
+	var recordIds []int
+
+	err := c.client.Call("GET", "/domain/zone/"+fqdn+"/record", nil, &recordIds)
+	if err != nil {
+		return nil, err
+	}
+
+	records := make([]*Record, len(recordIds))
+	for i, id := range recordIds {
+		r, err := c.fecthRecord(fqdn, id)
+		if err != nil {
+			return nil, err
+		}
+		records[i] = r
+	}
+
+	return records, nil
+}
+
+func (c *ovhProvider) fecthRecord(fqdn string, id int) (*Record, error) {
+	var response Record
+
+	err := c.client.Call("GET", fmt.Sprintf("/domain/zone/%s/record/%d", fqdn, id), nil, &response)
+	if err != nil {
+		return nil, err
+	}
+	return &response, nil
+}
+
+// Returns a function that can be invoked to delete a record in a zone.
+func (c *ovhProvider) deleteRecordFunc(id int64, fqdn string) func() error {
+	return func() error {
+		err := c.client.Call("DELETE", fmt.Sprintf("/domain/zone/%s/record/%d", fqdn, id), nil, nil)
+		if err != nil {
+			return err
+		}
+		return nil
+	}
+}
+
+// Returns a function that can be invoked to create a record in a zone.
+func (c *ovhProvider) createRecordFunc(rc *models.RecordConfig, fqdn string) func() error {
+	return func() error {
+		record := Record{
+			SubDomain: dnsutil.TrimDomainName(rc.NameFQDN, fqdn),
+			FieldType: rc.Type,
+			Target:    rc.Content(),
+			TTL:       rc.TTL,
+		}
+		if record.SubDomain == "@" {
+			record.SubDomain = ""
+		}
+		var response Record
+		err := c.client.Call("POST", fmt.Sprintf("/domain/zone/%s/record", fqdn), &record, &response)
+		return err
+	}
+}
+
+// Returns a function that can be invoked to update a record in a zone.
+func (c *ovhProvider) updateRecordFunc(old *Record, rc *models.RecordConfig, fqdn string) func() error {
+	return func() error {
+		record := Record{
+			SubDomain: dnsutil.TrimDomainName(rc.NameFQDN, fqdn),
+			FieldType: rc.Type,
+			Target:    rc.Content(),
+			TTL:       rc.TTL,
+			Zone:      fqdn,
+			Id:        old.Id,
+		}
+		if record.SubDomain == "@" {
+			record.SubDomain = ""
+		}
+
+		return c.client.Call("PUT", fmt.Sprintf("/domain/zone/%s/record/%d", fqdn, old.Id), &record, &Void{})
+	}
+}
+
+func (c *ovhProvider) refreshZone(fqdn string) error {
+	return c.client.Call("POST", fmt.Sprintf("/domain/zone/%s/refresh", fqdn), nil, &Void{})
+}
+
+// fetch the NS OVH attributed to this zone (which is distinct from fetchRealNS which
+// get the exact NS stored at the registrar
+func (c *ovhProvider) fetchNS(fqdn string) ([]string, error) {
+	zone, err := c.fetchZone(fqdn)
+	if err != nil {
+		return nil, err
+	}
+
+	return zone.NameServers, nil
+}

--- a/vendor/github.com/xlucas/go-ovh/LICENSE
+++ b/vendor/github.com/xlucas/go-ovh/LICENSE
@@ -1,0 +1,340 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 2, June 1991
+
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc., <http://fsf.org/>
+ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+License is intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users.  This
+General Public License applies to most of the Free Software
+Foundation's software and to any other program whose authors commit to
+using it.  (Some other Free Software Foundation software is covered by
+the GNU Lesser General Public License instead.)  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if you
+distribute copies of the software, or if you modify it.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must give the recipients all the rights that
+you have.  You must make sure that they, too, receive or can get the
+source code.  And you must show them these terms so they know their
+rights.
+
+  We protect your rights with two steps: (1) copyright the software, and
+(2) offer you this license which gives you legal permission to copy,
+distribute and/or modify the software.
+
+  Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software.  If the software is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original, so
+that any problems introduced by others will not reflect on the original
+authors' reputations.
+
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that redistributors of a free
+program will individually obtain patent licenses, in effect making the
+program proprietary.  To prevent this, we have made it clear that any
+patent must be licensed for everyone's free use or not licensed at all.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                    GNU GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License applies to any program or other work which contains
+a notice placed by the copyright holder saying it may be distributed
+under the terms of this General Public License.  The "Program", below,
+refers to any such program or work, and a "work based on the Program"
+means either the Program or any derivative work under copyright law:
+that is to say, a work containing the Program or a portion of it,
+either verbatim or with modifications and/or translated into another
+language.  (Hereinafter, translation is included without limitation in
+the term "modification".)  Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running the Program is not restricted, and the output from the Program
+is covered only if its contents constitute a work based on the
+Program (independent of having been made by running the Program).
+Whether that is true depends on what the Program does.
+
+  1. You may copy and distribute verbatim copies of the Program's
+source code as you receive it, in any medium, provided that you
+conspicuously and appropriately publish on each copy an appropriate
+copyright notice and disclaimer of warranty; keep intact all the
+notices that refer to this License and to the absence of any warranty;
+and give any other recipients of the Program a copy of this License
+along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
+
+  2. You may modify your copy or copies of the Program or any portion
+of it, thus forming a work based on the Program, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) You must cause the modified files to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    b) You must cause any work that you distribute or publish, that in
+    whole or in part contains or is derived from the Program or any
+    part thereof, to be licensed as a whole at no charge to all third
+    parties under the terms of this License.
+
+    c) If the modified program normally reads commands interactively
+    when run, you must cause it, when started running for such
+    interactive use in the most ordinary way, to print or display an
+    announcement including an appropriate copyright notice and a
+    notice that there is no warranty (or else, saying that you provide
+    a warranty) and that users may redistribute the program under
+    these conditions, and telling the user how to view a copy of this
+    License.  (Exception: if the Program itself is interactive but
+    does not normally print such an announcement, your work based on
+    the Program is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Program,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
+
+    a) Accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of Sections
+    1 and 2 above on a medium customarily used for software interchange; or,
+
+    b) Accompany it with a written offer, valid for at least three
+    years, to give any third party, for a charge no more than your
+    cost of physically performing source distribution, a complete
+    machine-readable copy of the corresponding source code, to be
+    distributed under the terms of Sections 1 and 2 above on a medium
+    customarily used for software interchange; or,
+
+    c) Accompany it with the information you received as to the offer
+    to distribute corresponding source code.  (This alternative is
+    allowed only for noncommercial distribution and only if you
+    received the program in object code or executable form with such
+    an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for
+making modifications to it.  For an executable work, complete source
+code means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to
+control compilation and installation of the executable.  However, as a
+special exception, the source code distributed need not include
+anything that is normally distributed (in either source or binary
+form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component
+itself accompanies the executable.
+
+If distribution of executable or object code is made by offering
+access to copy from a designated place, then offering equivalent
+access to copy the source code from the same place counts as
+distribution of the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  4. You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License.  Any attempt
+otherwise to copy, modify, sublicense or distribute the Program is
+void, and will automatically terminate your rights under this License.
+However, parties who have received copies, or rights, from you under
+this License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+  5. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Program or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+  6. Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+  7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Program at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Program by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  8. If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded.  In such case, this License incorporates
+the limitation as if written in the body of this License.
+
+  9. The Free Software Foundation may publish revised and/or new versions
+of the General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and "any
+later version", you have the option of following the terms and conditions
+either of that version or of any later version published by the Free
+Software Foundation.  If the Program does not specify a version number of
+this License, you may choose any version ever published by the Free Software
+Foundation.
+
+  10. If you wish to incorporate parts of the Program into other free
+programs whose distribution conditions are different, write to the author
+to ask for permission.  For software which is copyrighted by the Free
+Software Foundation, write to the Free Software Foundation; we sometimes
+make exceptions for this.  Our decision will be guided by the two goals
+of preserving the free status of all derivatives of our free software and
+of promoting the sharing and reuse of software generally.
+
+                            NO WARRANTY
+
+  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+REPAIR OR CORRECTION.
+
+  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    {description}
+    Copyright (C) {year}  {fullname}
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this
+when it starts in an interactive mode:
+
+    Gnomovision version 69, Copyright (C) year name of author
+    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, the commands you use may
+be called something other than `show w' and `show c'; they could even be
+mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the program, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+  `Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+  {signature of Ty Coon}, 1 April 1989
+  Ty Coon, President of Vice
+
+This General Public License does not permit incorporating your program into
+proprietary programs.  If your program is a subroutine library, you may
+consider it more useful to permit linking proprietary applications with the
+library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.
+

--- a/vendor/github.com/xlucas/go-ovh/ovh/client.go
+++ b/vendor/github.com/xlucas/go-ovh/ovh/client.go
@@ -1,0 +1,157 @@
+package ovh
+
+import (
+	"bytes"
+	"crypto/sha1"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"strconv"
+	"time"
+)
+
+// OVH endpoints list
+const (
+	ENDPOINT_CA_OVHCOM     = "https://ca.api.ovh.com/1.0"
+	ENDPOINT_CA_KIMSUFI    = "https://ca.api.kimsufi.com/1.0"
+	ENDPOINT_CA_RUNABOVE   = "https://api.runabove.com/1.0"
+	ENDPOINT_CA_SOYOUSTART = "https://ca.api.soyoustart.com/1.0"
+	ENDPOINT_EU_OVHCOM     = "https://eu.api.ovh.com/1.0"
+	ENDPOINT_EU_KIMSUFI    = "https://eu.api.kimsufi.com/1.0"
+	ENDPOINT_EU_RUNABOVE   = "https://api.runabove.com/1.0"
+	ENDPOINT_EU_SOYOUSTART = "https://eu.api.soyoustart.com/1.0"
+)
+
+// Client helps interacting with OVH API endpoints.
+type Client struct {
+	AppKey      string
+	AppSecret   string
+	ConsumerKey string
+	Endpoint    string
+	TimeShift   time.Duration
+	Debug       bool
+}
+
+// NewClient builds up a new client link to the specified endpoint
+// with given authentication information and no timeshift.
+func NewClient(endpoint, ak, as, ck string, debug bool) *Client {
+	return &Client{
+		AppKey:      ak,
+		AppSecret:   as,
+		ConsumerKey: ck,
+		Endpoint:    endpoint,
+		TimeShift:   0,
+		Debug:       debug,
+	}
+}
+
+func computeSignature(appSecret, consumerKey, method, url string, body []byte, timestamp int64) string {
+	hasher := sha1.New()
+	pattern := fmt.Sprintf("%s+%s+%s+%s+%s+%d",
+		appSecret,
+		consumerKey,
+		method,
+		url,
+		body,
+		timestamp)
+	hasher.Write([]byte(pattern))
+	return fmt.Sprintf("$1$%x", hasher.Sum(nil))
+}
+
+func sendRequest(appKey, consumerKey, signature string, timestamp int64, method, url string, body []byte) ([]byte, error) {
+	req, err := http.NewRequest(method, url, bytes.NewBuffer(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Add("X-Ovh-Application", appKey)
+	req.Header.Add("X-Ovh-Consumer", consumerKey)
+	req.Header.Add("X-Ovh-Signature", signature)
+	req.Header.Add("X-Ovh-Timestamp", fmt.Sprintf("%d", timestamp))
+
+	httpClient := &http.Client{}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	outBytes, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("Unexpected HTTP return code (%s : %s).", resp.Status, outBytes)
+	}
+
+	return outBytes, err
+}
+
+// PollTimeshift calculates the difference between
+// local and remote system time through a call to
+// the API. It may be useful to call this function
+// to avoid signatures to be rejected due to
+// timeshift or network delay.
+func (c *Client) PollTimeshift() error {
+	sysTime := time.Now()
+	resp, err := http.Get(c.Endpoint + "/auth/time")
+	if err != nil {
+		return err
+	}
+	outPayload, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+	apiTime, err := strconv.ParseInt(string(outPayload), 10, 64)
+	if err != nil {
+		return err
+	}
+	c.TimeShift = time.Unix(apiTime, 0).Sub(sysTime)
+	return err
+}
+
+// Call sends a request to the OVH API and returns response content.
+// Input and output json processing will leverage json
+// marshalling/unmarshalling of the specified interfaces.
+func (c *Client) Call(method, path string, in interface{}, out interface{}) error {
+	var (
+		inBytes, outBytes []byte
+		err               error
+	)
+	if in != nil {
+		inBytes, err = json.Marshal(in)
+	}
+	if err != nil {
+		return err
+	}
+
+	url := c.Endpoint + path
+	timestamp := time.Now().Add(c.TimeShift).Unix()
+	signature := computeSignature(c.AppSecret, c.ConsumerKey, method, url, inBytes, timestamp)
+
+	if c.Debug {
+		log.Printf("Method = %s", method)
+		log.Printf("URL = %s", url)
+		log.Printf("Timestamp = %d", timestamp)
+		log.Printf("Signature = %s", signature)
+		log.Printf("Body = %s", inBytes)
+	}
+
+	outBytes, err = sendRequest(c.AppKey, c.ConsumerKey, signature, timestamp, method, url, inBytes)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(outBytes, &out)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *Client) SetDebug(debug bool) {
+	c.Debug = debug
+}

--- a/vendor/github.com/xlucas/go-ovh/ovh/doc.go
+++ b/vendor/github.com/xlucas/go-ovh/ovh/doc.go
@@ -1,0 +1,5 @@
+/*
+A simple helper library around the OVH API.
+
+*/
+package ovh

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -495,6 +495,12 @@
 			"revisionTime": "2017-09-11T04:08:19Z"
 		},
 		{
+			"checksumSHA1": "MLGPYuRc7BtUuKmIV8f/jXpYWvg=",
+			"path": "github.com/xlucas/go-ovh/ovh",
+			"revision": "ef0d1f19f39c291ed08d5d5258175d8a2134ab1c",
+			"revisionTime": "2015-12-21T16:03:54Z"
+		},
+		{
 			"checksumSHA1": "9jjO5GjLa0XF/nfWihF02RoH4qc=",
 			"path": "golang.org/x/net/context",
 			"revision": "4971afdc2f162e82d185353533d3cf16188a9f4e",


### PR DESCRIPTION
This adds the OVH provider along with its documentation:

- [x] DNS Provider
- [x] Registrar Provider
- [x] documentation

A few comments:
* the provider unfortunately can't use `CanUsePTR` because OVH supports only setting PTR with a target in the arpa zone. This makes the integration tests 31 and 32 fail horribly (can we make those use the arpa zone?)
* OVH now supports setting apex NS records, so dual providers scenario can be accomplished 
* OVH doesn't support CAA (I'm going to ask them when they plan to support those).