### PR TITLE
Added PTR record support for prettyzone

### DIFF
--- a/providers/bind/prettyzone.go
+++ b/providers/bind/prettyzone.go
@@ -67,6 +67,12 @@ func (z *zoneGenData) Less(i, j int) bool {
 		if pa != pb {
 			return pa < pb
 		}
+	case dns.TypePTR:
+		ta2, tb2 := a.(*dns.PTR), b.(*dns.PTR)
+		pa, pb := ta2.Ptr, tb2.Ptr
+		if pa != pb {
+			return pa < pb
+		}
 	case dns.TypeCAA:
 		ta2, tb2 := a.(*dns.CAA), b.(*dns.CAA)
 		// sort by tag

--- a/providers/bind/prettyzone_test.go
+++ b/providers/bind/prettyzone_test.go
@@ -181,6 +181,27 @@ var testdataZFSRV = `$TTL 300
                  IN SRV   10 10 9999 foo.com.
 `
 
+func TestWriteZoneFilePtr(t *testing.T) {
+	//exhibits explicit ttls and long name
+	r1, _ := dns.NewRR(`bosun.org. 300 IN PTR chell.bosun.org`)
+	r2, _ := dns.NewRR(`bosun.org. 300 IN PTR barney.bosun.org.`)
+	r3, _ := dns.NewRR(`bosun.org. 300 IN PTR alex.bosun.org.`)
+	buf := &bytes.Buffer{}
+	WriteZoneFile(buf, []dns.RR{r1, r2, r3}, "bosun.org")
+	if buf.String() != testdataZFPTR {
+		t.Log(buf.String())
+		t.Log(testdataZFPTR)
+		t.Fatalf("Zone file does not match.")
+	}
+	parseAndRegen(t, buf, testdataZFPTR)
+}
+
+var testdataZFPTR = `$TTL 300
+@                IN PTR   alex.bosun.org.
+                 IN PTR   barney.bosun.org.
+                 IN PTR   chell.bosun.org.
+`
+
 func TestWriteZoneFileCaa(t *testing.T) {
 	//exhibits explicit ttls and long name
 	r1, _ := dns.NewRR(`bosun.org. 300 IN CAA 0 issuewild ";"`)


### PR DESCRIPTION
When one DNS name map to several PTR records, dnscontrol will crash with

```
CREATING ZONEFILE: zones/128_27.18.20.172.in-addr.arpa.zone
panic: zoneGenData Less: unimplemented rtype PTR

goroutine 1 [running]:
github.com/StackExchange/dnscontrol/providers/bind.(*zoneGenData).Less(0xc420598c90, 0x1, 0x0, 0x11)
	/home/whs/build/go/src/github.com/StackExchange/dnscontrol/providers/bind/prettyzone.go:84 +0x921
sort.doPivot(0xf3ac20, 0xc420598c90, 0x0, 0x22, 0x30, 0xffffffffffffffff)
	/usr/lib/go/src/sort/sort.go:119 +0xe9
sort.quickSort(0xf3ac20, 0xc420598c90, 0x0, 0x22, 0xc)
	/usr/lib/go/src/sort/sort.go:192 +0x80
sort.Sort(0xf3ac20, 0xc420598c90)
	/usr/lib/go/src/sort/sort.go:220 +0x79
github.com/StackExchange/dnscontrol/providers/bind.(*zoneGenData).generateZoneFileHelper(0xc420598c90, 0xf35c60, 0xc42000f0f0, 0x20, 0x21)
	/home/whs/build/go/src/github.com/StackExchange/dnscontrol/providers/bind/prettyzone.go:152 +0x4f
github.com/StackExchange/dnscontrol/providers/bind.WriteZoneFile(0xf35c60, 0xc42000f0f0, 0xc4205b2b40, 0x22, 0x22, 0xc4204cae40, 0x1d, 0x0, 0x4c65b5)
	/home/whs/build/go/src/github.com/StackExchange/dnscontrol/providers/bind/prettyzone.go:144 +0x23e
github.com/StackExchange/dnscontrol/providers/bind.(*Bind).GetDomainCorrections.func1(0xb6b8a4, 0x8)
	/home/whs/build/go/src/github.com/StackExchange/dnscontrol/providers/bind/bindProvider.go:270 +0x35a
main.printOrRunCorrections(0xc42000f0e8, 0x1, 0x1, 0x7ffd98fde20b, 0x4, 0xd)
	/home/whs/build/go/src/github.com/StackExchange/dnscontrol/main.go:297 +0x1fd
main.main()
	/home/whs/build/go/src/github.com/StackExchange/dnscontrol/main.go:230 +0xeb0
```

This patch fixed the above crash by adding support for PTR records sorting.