### PR TITLE
Opt-in Amazon Route 53 to CAA

### DIFF
--- a/providers/route53/route53Provider.go
+++ b/providers/route53/route53Provider.go
@@ -57,7 +57,7 @@ func newRoute53(m map[string]string, metadata json.RawMessage) (*route53Provider
 }
 
 func init() {
-	providers.RegisterDomainServiceProviderType("ROUTE53", newRoute53Dsp, providers.CanUsePTR, providers.CanUseSRV)
+	providers.RegisterDomainServiceProviderType("ROUTE53", newRoute53Dsp, providers.CanUsePTR, providers.CanUseSRV, providers.CanUseCAA)
 	providers.RegisterRegistrarType("ROUTE53", newRoute53Reg)
 }
 


### PR DESCRIPTION
Two weeks ago, Amazon [announced](https://aws.amazon.com/about-aws/whats-new/2017/08/amazon-route-53-now-supports-caa-records/) support for the CAA record type to Route 53.

Fortunately, support for CAA was already addd to `dnscontrol` in https://github.com/StackExchange/dnscontrol/pull/161, which means it's just a matter of opting-in Route 53 to CAA using the CanUseCAA` flag.

I tested both adding, modifying, and removing records ( including record with the different types, e.g. `issue`, `issuewild`, `iodef`), and it all seems to work fine.