### PR TITLE
Update documentation to reflect that Route 53 supports the CAA record type

### DIFF
--- a/docs/_functions/domain/CAA.md
+++ b/docs/_functions/domain/CAA.md
@@ -17,7 +17,7 @@ Flags are controlled by modifier.:
 
 - CAA_CRITICAL: Issuer critical flag. CA that does not understand this tag will refuse to issue certificate for this domain.
 
-CAA record is supported only by BIND and Google Cloud DNS. Some certificate authorities may not support this record until the mandatory date of September 2017.
+CAA record is supported only by BIND, Google Cloud DNS, and Amazon Route 53. Some certificate authorities may not support this record until the mandatory date of September 2017.
 
 {% include startExample.html %}
 {% highlight js %}


### PR DESCRIPTION
I failed to update the docs in #193.