### PR TITLE
gcloud provider doc update

### DIFF
--- a/docs/_providers/gcloud.md
+++ b/docs/_providers/gcloud.md
@@ -54,7 +54,7 @@ D("example.tld", REG_NAMECOM, DnsProvider(GCLOUD),
 
     <img src="{{ site.github.url }}/assets/gcloud-json-screen.png" alt="New Service Account" style="width: 900px;"/>
 
-3. Choose an existing user, or create a new one. The user requires "App Engine Admin" rights.
+3. Choose an existing user, or create a new one. The user requires the "DNS Administrator" role.
 4. Download the JSON key and copy it into your `creds.json` under the name of your gcloud provider.
 
 ## New domains


### PR DESCRIPTION
Google now calls the required role "DNS Administrator" rather than "App Engine Admin"