### PR TITLE
Add ca-certificates to Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN cp dnscontrol-Linux /go/bin/dnscontrol
 RUN dnscontrol version
 
 FROM alpine
+RUN apk add --no-cache ca-certificates
 COPY --from=build-env /go/bin/dnscontrol /usr/local/bin
 WORKDIR /dns
 RUN dnscontrol version


### PR DESCRIPTION
It was causing errors like this:

```
Error fetching domain list from cloudflare: Get https://api.cloudflare.com/client/v4/zones/?page=1&per_page=50: x509: failed to load system roots and no roots provided
```