### PR TITLE
Improve Route53 documentation (#221)

### DIFF
--- a/docs/_providers/route53.md
+++ b/docs/_providers/route53.md
@@ -17,12 +17,14 @@ You can specify the API credentials in the credentials json file:
 }
 {% endhighlight %}
 
-You can also use environment variables, but this is discouraged.
+You can also use environment variables, but this is discouraged, unless your environment provides them already.
 
 ```
 $ export AWS_ACCESS_KEY_ID=XXXXXXXXX
 $ export AWS_SECRET_ACCESS_KEY=YYYYYYYYY
 ```
+
+You can find some other ways to authenticate to Route53 in the [go sdk configuration](https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html).
 
 ## Metadata
 This provider does not recognize any special metadata fields unique to route 53.

--- a/docs/_providers/route53.md
+++ b/docs/_providers/route53.md
@@ -6,14 +6,7 @@ jsId: ROUTE53
 # Amazon Route 53 Provider
 
 ## Configuration
-
-By default, you can configure aws setting like the [go sdk configuration](https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html). For example you can use environment variables:
-```
-$ export AWS_ACCESS_KEY_ID=XXXXXXXXX
-$ export AWS_SECRET_ACCESS_KEY=YYYYYYYYY
-```
-
-It is also possible to specify an aws access key in the providers config json file:
+You can specify the API credentials in the credentials json file:
 
 {% highlight json %}
 {
@@ -24,13 +17,18 @@ It is also possible to specify an aws access key in the providers config json fi
 }
 {% endhighlight %}
 
-## Metadata
+You can also use environment variables, but this is discouraged.
 
+```
+$ export AWS_ACCESS_KEY_ID=XXXXXXXXX
+$ export AWS_SECRET_ACCESS_KEY=YYYYYYYYY
+```
+
+## Metadata
 This provider does not recognize any special metadata fields unique to route 53.
 
 ## Usage
-
-Example javascript:
+Example Javascript:
 
 {% highlight js %}
 var REG_NONE = NewRegistrar("none","NONE");
@@ -42,18 +40,12 @@ D("example.tld", REG_NONE, DnsProvider(R53),
 {%endhighlight%}
 
 ## Activation
-
-DNSControl depends on a standard [aws access key](https://aws.amazon.com/developers/access-keys/) with permission to list, create and update hosted zones.
+DNSControl depends on a standard [AWS access key](https://aws.amazon.com/developers/access-keys/) with permission to list, create and update hosted zones.
 
 ## New domains
-
-If a domain does not exist in your Route53 account, DNSControl
-will *not* automatically add it. You can do that either manually
-via the control panel, or via the command `dnscontrol create-domains`
-command.
+If a domain does not exist in your Route53 account, DNSControl will *not* automatically add it with the `create-domains` command. You can do that either manually via the control panel, or via the command `dnscontrol create-domains` command.
 
 ## Caveats
-
 This code may not function properly if a domain has R53 as a Registrar
 but not as a DnsProvider.  The situation is described in
 [PR#155](https://github.com/StackExchange/dnscontrol/pull/155).
@@ -67,7 +59,4 @@ Error getting corrections: AccessDeniedException: User: arn:aws:iam::86839973084
 Done. 1 corrections.
 ```
 
-If this happens to you, we'd appreciate it if you could helps us
-fix the code.  In the meanwhile, you can give the account additional
-IAM permissions so that it can do DNS-related actions, or simply
-use `NewRegistrar(..., 'NONE')` for now.
+If this happens to you, we'd appreciate it if you could help us fix the code.  In the meanwhile, you can give the account additional IAM permissions so that it can do DNS-related actions, or simply use `NewRegistrar(..., 'NONE')` for now.


### PR DESCRIPTION
- Grammar fixes
- Formatting improvements
- Don't encourage using environment vars instead of the credentials file

See #221 