### PR TITLE
Improve softlayer documentation (#221)

### DIFF
--- a/docs/_providers/softlayer.md
+++ b/docs/_providers/softlayer.md
@@ -8,10 +8,9 @@ jsId: SOFTLAYER
 # SoftLayer DNS Provider
 
 ## Configuration
+To authenticate with SoftLayer requires at least a `username` and `api_key` for authentication. It can also optionally take a `timeout` and `endpoint_url` parameter however these are optional and will use standard defaults if not provided.
 
-To authenticate with SoftLayer requires at least a `username` and `api_key` for authentication.
-It can also optionally take a `timeout` and `endpoint_url` parameter however these are optional and will use standard defaults if not provided.
-These can be supplied via the standard 'creds.json' like so:
+These can be supplied in the `creds.json` file:
 {% highlight json %}
 {
   "softlayer": {
@@ -21,11 +20,9 @@ These can be supplied via the standard 'creds.json' like so:
 }
 {% endhighlight %}
 
-To maintain compatibility with existing softlayer CLI services these can also be provided by the `SL_USERNAME` and `SL_API_KEY` environment variables or specified in the ~/.softlayer.
-More information about these methods can be found at [the softlayer-go library documentation](https://github.com/softlayer/softlayer-go#sessions).
+To maintain compatibility with existing softlayer CLI services these can also be provided by the `SL_USERNAME` and `SL_API_KEY` environment variables or specified in the `~/.softlayer`, but this is discouraged. More information about these methods can be found at [the softlayer-go library documentation](https://github.com/softlayer/softlayer-go#sessions).
 
 ## Usage
-
 Use this provider like any other DNS Provider:
 
 {% highlight js %}
@@ -38,7 +35,6 @@ D("example.tld", registrary, DnsProvider(SOFTLAYER),
 {%endhighlight%}
 
 ## Metadata
-
 This provider does not recognize any special metadata fields unique to SoftLayer dns.
 For compatibility with the pre-generated NAMESERVER fields it's recommended to set the NS TTL to 86400 such as:
 


### PR DESCRIPTION
- Add note that using the creds.json file is the preferred method of authentication
- Improve formatting

See #221