### PR TITLE
Add _acme-challenge as an allowed record name

### DIFF
--- a/pkg/normalize/validate.go
+++ b/pkg/normalize/validate.go
@@ -85,7 +85,7 @@ func validateRecordTypes(rec *models.RecordConfig, domain string, pTypes []strin
 
 // underscores in names are often used erroneously. They are valid for dns records, but invalid for urls.
 // here we list common records expected to have underscores. Anything else containing an underscore will print a warning.
-var labelUnderscores = []string{"_domainkey", "_dmarc", "_amazonses"}
+var labelUnderscores = []string{"_domainkey", "_dmarc", "_amazonses", "_acme-challenge"}
 
 //these record types may contain underscores
 var rTypeUnderscores = []string{"SRV", "TLSA", "TXT"}


### PR DESCRIPTION
I am using [acme-dns](https://github.com/joohoi/acme-dns) which requires me to add a CNAME record on `_acme-challenge` to another domain name. This pull request removes the warning created when doing that.