### PR TITLE
Update digitalocean.md

### DIFF
--- a/docs/_providers/digitalocean.md
+++ b/docs/_providers/digitalocean.md
@@ -26,7 +26,7 @@ Example Javascript:
 
 {% highlight js %}
 var REG_NONE = NewRegistrar('none', 'NONE')
-var DIGITALOCEAN = NewDnsProvider("do", "DIGITALOCEAN");
+var DIGITALOCEAN = NewDnsProvider("digitalocean", "DIGITALOCEAN");
 
 D("example.tld", REG_NONE, DnsProvider(DIGITALOCEAN),
     A("test","1.2.3.4")


### PR DESCRIPTION
Documentation fix to resolve, "Creating do dns provider: Digitalocean Token must be provided." error.