### PR TITLE
CLOUDFLARE: Support CAA rtype

### DIFF
--- a/docs/_includes/matrix.html
+++ b/docs/_includes/matrix.html
@@ -294,7 +294,9 @@
 		<td class="success">
 			<i class="fa fa-check text-success" aria-hidden="true"></i>
 		</td>
-		<td><i class="fa fa-minus dim"></i></td>
+		<td class="success">
+			<i class="fa fa-check text-success" aria-hidden="true"></i>
+		</td>
 		<td><i class="fa fa-minus dim"></i></td>
 		<td class="success">
 			<i class="fa fa-check text-success" aria-hidden="true"></i>

--- a/providers/cloudflare/cloudflareProvider.go
+++ b/providers/cloudflare/cloudflareProvider.go
@@ -41,7 +41,7 @@ var docNotes = providers.DocumentationNotes{
 }
 
 func init() {
-	providers.RegisterDomainServiceProviderType("CLOUDFLAREAPI", newCloudflare, providers.CanUseSRV, providers.CanUseAlias, docNotes)
+	providers.RegisterDomainServiceProviderType("CLOUDFLAREAPI", newCloudflare, providers.CanUseSRV, providers.CanUseAlias, providers.CanUseCAA, docNotes)
 	providers.RegisterCustomRecordType("CF_REDIRECT", "CLOUDFLAREAPI", "")
 	providers.RegisterCustomRecordType("CF_TEMP_REDIRECT", "CLOUDFLAREAPI", "")
 }
@@ -365,20 +365,35 @@ func (c *cfRecord) toRecord(domain string) *models.RecordConfig {
 		c.Content = dnsutil.AddOrigin(c.Content+".", domain)
 	}
 	rc := &models.RecordConfig{
-		NameFQDN:     c.Name,
-		Type:         c.Type,
-		Target:       c.Content,
-		MxPreference: c.Priority,
-		TTL:          c.TTL,
-		Original:     c,
+		NameFQDN: c.Name,
+		Type:     c.Type,
+		Target:   c.Content,
+		TTL:      c.TTL,
+		Original: c,
 	}
-	if c.Type == "SRV" {
+	switch c.Type { // #rtype_variations
+	case "A", "AAAA", "ANAME", "CNAME", "NS", "TXT":
+		// nothing additional needed.
+	case "CAA":
+		var err error
+		rc.CaaTag, rc.CaaFlag, rc.Target, err = models.SplitCombinedCaaValue(c.Content)
+		if err != nil {
+			panic(err)
+		}
+	case "MX":
+		rc.MxPreference = c.Priority
+	case "SRV":
 		data := *c.Data
 		rc.SrvPriority = data.Priority
 		rc.SrvWeight = data.Weight
 		rc.SrvPort = data.Port
 		rc.Target = dnsutil.AddOrigin(data.Target+".", domain)
+	default:
+		panic(fmt.Sprintf("toRecord unimplemented rtype %v", c.Type))
+		// We panic so that we quickly find any switch statements
+		// that have not been updated for a new RR type.
 	}
+
 	return rc
 }
 

--- a/providers/cloudflare/cloudflareProvider.go
+++ b/providers/cloudflare/cloudflareProvider.go
@@ -333,13 +333,16 @@ func newCloudflare(m map[string]string, metadata json.RawMessage) (providers.DNS
 
 // Used on the "existing" records.
 type cfRecData struct {
-	Service  string `json:"service"`
-	Proto    string `json:"proto"`
 	Name     string `json:"name"`
-	Priority uint16 `json:"priority"`
-	Weight   uint16 `json:"weight"`
-	Port     uint16 `json:"port"`
 	Target   string `json:"target"`
+	Service  string `json:"service"`  // SRV
+	Proto    string `json:"proto"`    // SRV
+	Priority uint16 `json:"priority"` // SRV
+	Weight   uint16 `json:"weight"`   // SRV
+	Port     uint16 `json:"port"`     // SRV
+	Tag      string `json:"tag"`      // CAA
+	Flags    uint8  `json:"flags"`    // CAA
+	Value    string `json:"value"`    // CAA
 }
 
 type cfRecord struct {

--- a/providers/cloudflare/rest.go
+++ b/providers/cloudflare/rest.go
@@ -67,6 +67,7 @@ func (c *CloudflareApi) getRecordsForDomain(id string, domain string) ([]*models
 			return nil, fmt.Errorf("Error fetching record list cloudflare: %s", stringifyErrors(data.Errors))
 		}
 		for _, rec := range data.Result {
+			//fmt.Printf("REC: %+v\n", rec)
 			records = append(records, rec.toRecord(domain))
 		}
 		ri := data.ResultInfo
@@ -75,6 +76,7 @@ func (c *CloudflareApi) getRecordsForDomain(id string, domain string) ([]*models
 		}
 		page++
 	}
+	//fmt.Printf("DEBUG REORDS=%v\n", records)
 	return records, nil
 }
 
@@ -146,6 +148,8 @@ func (c *CloudflareApi) createRec(rec *models.RecordConfig, domainID string) []*
 	prio := ""
 	if rec.Type == "MX" {
 		prio = fmt.Sprintf(" %d ", rec.MxPreference)
+	} else if rec.Type == "CAA" {
+		content = rec.Content()
 	}
 	arr := []*models.Correction{{
 		Msg: fmt.Sprintf("CREATE record: %s %s %d%s %s", rec.Name, rec.Type, rec.TTL, prio, content),

--- a/providers/vultr/vultrProvider.go
+++ b/providers/vultr/vultrProvider.go
@@ -255,6 +255,11 @@ func toRecordConfig(dc *models.DomainConfig, r *vultr.DNSRecord) (*models.Record
 
 	if r.Type == "CAA" {
 		// Vultr returns in the format "[flag] [tag] [value]"
+		// TODO(tal): I copied this code into models/dns.go.  At this point
+		// we can probably replace the code below with:
+		// rc.CaaFlag, rc.CaaTag, rc.Target, err := models.SplitCombinedCaaValue(rc.Target)
+		// return rc, err
+
 		splitData := strings.SplitN(rc.Target, " ", 3)
 		if len(splitData) != 3 {
 			return nil, fmt.Errorf("Unexpected data for CAA record returned by Vultr")


### PR DESCRIPTION
* If you add an CAA record in the web UI, then add the right CAA() statement in dnsconfig.js, things will work.
* dnscontrol push can not create new (or fix existing) CAA records.