### PR TITLE
Fix #310 R53_ALIAS not being registered as custom type

### DIFF
--- a/providers/route53/route53Provider.go
+++ b/providers/route53/route53Provider.go
@@ -70,6 +70,7 @@ var features = providers.DocumentationNotes{
 func init() {
 	providers.RegisterDomainServiceProviderType("ROUTE53", newRoute53Dsp, features)
 	providers.RegisterRegistrarType("ROUTE53", newRoute53Reg)
+	providers.RegisterCustomRecordType("R53_ALIAS", "ROUTE53", "")
 }
 
 func sPtr(s string) *string {


### PR DESCRIPTION
Apparently I've forgot to register the R53_ALIAS custom record
type, thus preventing to use R53_ALIAS in a js file.
The integration still worked fine because they probably don't run
the validation.

I'm very sorry for the trouble.