### PR TITLE
encode and decode name.com txt records

### DIFF
--- a/providers/namedotcom/records_test.go
+++ b/providers/namedotcom/records_test.go
@@ -9,16 +9,16 @@ var txtData = []struct {
 	decoded []string
 	encoded string
 }{
-	{[]string{`simple`}, `"simple"`},
-	{[]string{`changed`}, `"changed"`},
-	{[]string{`with spaces`}, `"with spaces"`},
-	{[]string{`with whitespace`}, `"with whitespace"`},
-	{[]string{"one", "two"}, `"\"one\"\"two\""`},
-	{[]string{"eh", "bee", "cee"}, `"\"eh\"\"bee\"\"cee\""`},
-	{[]string{"o\"ne", "tw\"o"}, `"\"o\\\"ne\"\"tw\\\"o\""`},
-	{[]string{"dimple"}, `"dimple"`},
-	{[]string{"fun", "two"}, `"\"fun\"\"two\""`},
-	{[]string{"eh", "bzz", "cee"}, `"\"eh\"\"bzz\"\"cee\""`},
+	{[]string{`simple`}, `simple`},
+	{[]string{`changed`}, `changed`},
+	{[]string{`with spaces`}, `with spaces`},
+	{[]string{`with whitespace`}, `with whitespace`},
+	{[]string{"one", "two"}, `"one""two"`},
+	{[]string{"eh", "bee", "cee"}, `"eh""bee""cee"`},
+	{[]string{"o\"ne", "tw\"o"}, `"o\"ne""tw\"o"`},
+	{[]string{"dimple"}, `dimple`},
+	{[]string{"fun", "two"}, `"fun""two"`},
+	{[]string{"eh", "bzz", "cee"}, `"eh""bzz""cee"`},
 }
 
 func TestEncodeTxt(t *testing.T) {


### PR DESCRIPTION
This fixes the tests. The integration tests work now too.

There were some small omissions and a double encoding at one point.
I also always forget about raw string literals, so I changed the strings to be more readable as well.

Also, I'll add this to our documentation on Monday, but for single TXT records, we don't require the double quotes at the beginning and end, and in that case it is a raw string so double quotes can exist anywhere inside the string on their own. For multiTXTs we surround them by double quotes and escape any double quotes inside with a backslash.