### PR TITLE
Fix #312 - rewrite IGNORE to use GetLabel

### DIFF
--- a/providers/diff/diff.go
+++ b/providers/diff/diff.go
@@ -6,7 +6,6 @@ import (
 	"sort"
 
 	"github.com/StackExchange/dnscontrol/models"
-	"github.com/miekg/dns/dnsutil"
 )
 
 // Correlation stores a difference between two domains.
@@ -75,16 +74,16 @@ func (d *differ) IncrementalDiff(existing []*models.RecordConfig) (unchanged, cr
 	existingByNameAndType := map[key][]*models.RecordConfig{}
 	desiredByNameAndType := map[key][]*models.RecordConfig{}
 	for _, e := range existing {
-		if d.matchIgnored(e.NameFQDN, d.dc.Name) {
-			log.Printf("Ignoring record %s %s due to IGNORE", e.NameFQDN, e.Type)
+		if d.matchIgnored(e.GetLabel()) {
+			log.Printf("Ignoring record %s %s due to IGNORE", e.GetLabel(), e.Type)
 		} else {
 			k := key{e.NameFQDN, e.Type}
 			existingByNameAndType[k] = append(existingByNameAndType[k], e)
 		}
 	}
 	for _, dr := range desired {
-		if d.matchIgnored(dr.NameFQDN, d.dc.Name) {
-			panic(fmt.Sprintf("Trying to update/add IGNOREd record: %s %s", dr.NameFQDN, dr.Type))
+		if d.matchIgnored(dr.GetLabel()) {
+			panic(fmt.Sprintf("Trying to update/add IGNOREd record: %s %s", dr.GetLabel(), dr.Type))
 		} else {
 			k := key{dr.NameFQDN, dr.Type}
 			desiredByNameAndType[k] = append(desiredByNameAndType[k], dr)
@@ -215,11 +214,9 @@ func sortedKeys(m map[string]*models.RecordConfig) []string {
 	return s
 }
 
-func (d *differ) matchIgnored(nameFQDN, domain string) bool {
-	// ignored labels are not fqdn
-	name := dnsutil.TrimDomainName(nameFQDN, domain)
+func (d *differ) matchIgnored(name string) bool {
 	for _, tst := range d.dc.IgnoredLabels {
-		if name == tst || nameFQDN == tst {
+		if name == tst {
 			return true
 		}
 	}


### PR DESCRIPTION
As discussed in #312, after the refactor to generalize the use of `GetLabel`, this change makes IGNORE also use `GetLabel`.

Tested on provider OVH and Route 53.