### PR TITLE
Fix Linode provider

### DIFF
--- a/integrationTest/providers.json
+++ b/integrationTest/providers.json
@@ -46,7 +46,7 @@
     "COMMENT": "25: Linode's hostname validation does not allow the target domain TLD",
     "token": "$LINODE_TOKEN",
     "domain": "$LINODE_DOMAIN",
-    "knownFailures": "25"
+    "knownFailures": "27"
   },
   "NS1": {
     "domain": "$NS1_DOMAIN",


### PR DESCRIPTION
In response to #323.

I've tested it with the Linode provider, and due to commit https://github.com/StackExchange/dnscontrol/commit/19ca7600726ba8251e4038bc6c94e004e55697de, the order of the integration tests have changed. So, the failing test's number has changed from 25 to 27 in `providers.json`.

Moreover, the integration test for TXT records does not pass anymore because fixTxt has been removed (https://github.com/StackExchange/dnscontrol/commit/de4455942bf38dc6b49e03b56748b00be5c062cf#diff-cbc2e007a10f561a01f36d383d88aa80R259), which the provider relied on.

All other integration tests pass.

This fixes all those problems, but I haven't been able to test whether `fixTxt` breaks other providers.