### PR TITLE
Fix bug in Route 53 ALIAS record

### DIFF
--- a/providers/route53/route53Provider.go
+++ b/providers/route53/route53Provider.go
@@ -108,7 +108,13 @@ type key struct {
 }
 
 func getKey(r *models.RecordConfig) key {
-	return key{r.GetLabelFQDN(), r.Type}
+	var recordType = r.Type
+
+	if r.R53Alias != nil {
+		recordType = fmt.Sprintf("%s_%s", recordType, r.R53Alias["type"])
+	}
+
+	return key{r.GetLabelFQDN(), recordType}
 }
 
 type errNoExist struct {


### PR DESCRIPTION
While test-driving the Route 53 ALIAS record type, I noticed a little bug that prevents one from using multiple ALIAS records for the same record set name. For example, two ALIAS records for the record set name `www` with record set types `A` and `AAAA`, respectively.

```javascript
D("foo.bar", REGISTRAR, DnsProvider("ROUTE53"),
  R53_ALIAS("www", "AAAA", "foo.cloudfront.net.", R53_ZONE("BAZ")),
  R53_ALIAS("www", "A", "foo.cloudfront.net.", R53_ZONE("BAZ"))
);
```

If one would deploy this configuration, then only an ALIAS record set for `www` with record set type `A` would have been created. The first one (`www` with record set type `AAAA`) would have been skipped.

This is caused by the way the `updates` map in the example below is populated. The key (a struct) contains both a 'Name' (e.g. `www.foo.bar`) and a `Type` (e.g. `R53_ALIAS`). Which means that two ALIAS records, with different record set types, end up with the same key (`www.foo.bar`, `R53_ALIAS`), which means that only either of the ALIAS records (the latter) is actually deployed.

https://github.com/StackExchange/dnscontrol/blob/cd58d26545dd3f13b21a254be7dcd67b792728b1/providers/route53/route53Provider.go#L191-L198

I have added a quick fix that appends the resource record type to the actual record type so that different ALIAS records will actually be considered as such. I'm curious to know what you think, and/or whether this should be addresses in a different way.