### PR TITLE
Fix #339 prevent the ovh provider to panic on SPF and DKIM record types

### DIFF
--- a/providers/ovh/ovhProvider.go
+++ b/providers/ovh/ovhProvider.go
@@ -154,15 +154,17 @@ func nativeToRecord(r *Record, origin string) *models.RecordConfig {
 		TTL:      uint32(r.TTL),
 		Original: r,
 	}
+
 	rtype := r.FieldType
-	rec.SetLabel(r.SubDomain, origin)
-	if err := rec.PopulateFromString(rtype, r.Target, origin); err != nil {
-		panic(errors.Wrap(err, "unparsable record received from ovh"))
-	}
 
 	// ovh uses a custom type for SPF and DKIM
 	if rtype == "SPF" || rtype == "DKIM" {
-		rec.Type = "TXT"
+		rtype = "TXT"
+	}
+
+	rec.SetLabel(r.SubDomain, origin)
+	if err := rec.PopulateFromString(rtype, r.Target, origin); err != nil {
+		panic(errors.Wrap(err, "unparsable record received from ovh"))
 	}
 
 	// ovh default is 3600


### PR DESCRIPTION
OVH uses special SPF and DKIM invalid types for records added with the web ui (or default zone records).

The ovh provider didn't correctly handle those invalid record types and was panic'ing.
This change prevents the panic by converting such records to TXT (which is what they are in fact), but also auto-corrects any SPF or DKIM records to TXT ones so that next `push` will see no modifications.