### PR TITLE
Include support for exists element in SPF.

### DIFF
--- a/pkg/spflib/parse.go
+++ b/pkg/spflib/parse.go
@@ -79,6 +79,8 @@ func Parse(text string, dnsres Resolver) (*SPFRecord, error) {
 					return nil, errors.Errorf("In included spf: %s", err)
 				}
 			}
+		} else if strings.HasPrefix(part, "exists:") {
+			p.IsLookup = true
 		} else {
 			return nil, errors.Errorf("Unsupported spf part %s", part)
 		}

--- a/pkg/spflib/parse_test.go
+++ b/pkg/spflib/parse_test.go
@@ -20,6 +20,7 @@ func TestParse(t *testing.T) {
 		"include:servers.mcsv.net",
 		"include:sendgrid.net",
 		"include:spf.mtasv.net",
+		"exists:%{i}._spf.sparkpostmail.com",
 		"~all"}, " "), dnsres)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Hi,

Related to issues #355, I suspect it would only take a simple change of the handling for the ```exists:``` element to work, however I could be very wrong (and totally happy for you to tell me so).