### PR TITLE
fix names for internal transformed records

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ certs/
 spfcache*
 adzonedump.*
 zones/
+stack.sh

--- a/pkg/normalize/validate.go
+++ b/pkg/normalize/validate.go
@@ -195,7 +195,7 @@ func importTransform(srcDomain, dstDomain *models.DomainConfig, transforms []tra
 		newRec := func() *models.RecordConfig {
 			rec2, _ := rec.Copy()
 			newlabel := rec2.GetLabelFQDN()
-			rec2.SetLabelFromFQDN(newlabel, dstDomain.Name)
+			rec2.SetLabel(newlabel, dstDomain.Name)
 			if ttl != 0 {
 				rec2.TTL = ttl
 			}


### PR DESCRIPTION
Transformed records were not given the correct fqdn.

For our transform to `.internal`, and src record `foo.stackexchange.com`, the transformed record is not getting the `.internal` added onto the end, so the fqdn is not inside the same zone.

This PR:

1. Fixes the bug in inport transform that creates the wrong fqdn.
2. Makes the AD provider use the standard diff messages that include fqdn.
3. Add a validation pass to make sure EVERY record has an fqdn that ends i the correct domain name.