### PR TITLE
sort returned nameservers

### DIFF
--- a/providers/dnsimple/dnsimpleProvider.go
+++ b/providers/dnsimple/dnsimpleProvider.go
@@ -147,6 +147,7 @@ func (c *DnsimpleApi) GetRegistrarCorrections(dc *models.DomainConfig) ([]*model
 	if err != nil {
 		return nil, err
 	}
+  sort.Strings(nameServers)
 
 	actual := strings.Join(nameServers, ",")
 


### PR DESCRIPTION
The API isn't sorting the name servers so even when they match they would report being different. 
This will prevent it trying to update them every time

I tested this locally on my configuations