### PR TITLE
Add support for MX priorities of "" (0)

### DIFF
--- a/providers/cloudflare/cloudflareProvider.go
+++ b/providers/cloudflare/cloudflareProvider.go
@@ -385,10 +385,14 @@ func (c *cfRecord) nativeToRecord(domain string) *models.RecordConfig {
 	switch rType := c.Type; rType { // #rtype_variations
 	case "MX":
 		var priority uint16
-		if p, err := c.Priority.Int64(); err != nil {
-			panic(errors.Wrap(err, "error decoding priority from cloudflare record"))
+		if c.Priority = "" {
+			priority = 0
 		} else {
-			priority = uint16(p)
+			if p, err := c.Priority.Int64(); err != nil {
+				panic(errors.Wrap(err, "error decoding priority from cloudflare record"))
+			} else {
+				priority = uint16(p)
+			}
 		}
 		if err := rc.SetTargetMX(priority, c.Content); err != nil {
 			panic(errors.Wrap(err, "unparsable MX record received from cloudflare"))

--- a/providers/cloudflare/cloudflareProvider.go
+++ b/providers/cloudflare/cloudflareProvider.go
@@ -385,7 +385,7 @@ func (c *cfRecord) nativeToRecord(domain string) *models.RecordConfig {
 	switch rType := c.Type; rType { // #rtype_variations
 	case "MX":
 		var priority uint16
-		if c.Priority = "" {
+		if c.Priority == "" {
 			priority = 0
 		} else {
 			if p, err := c.Priority.Int64(); err != nil {


### PR DESCRIPTION
This fixes #371 and builds upon #368 and removes the casting error when the MX priority specified from CloudFlare is an empty string (```""```).

We might need to consider similar logic for SRV record priorities too.