### PR TITLE
Include PTR types in SPF Builder

### DIFF
--- a/pkg/spflib/parse.go
+++ b/pkg/spflib/parse.go
@@ -84,6 +84,9 @@ func Parse(text string, dnsres Resolver) (*SPFRecord, error) {
 			}
 		} else if strings.HasPrefix(part, "exists:") {
 			p.IsLookup = true
+		} else if strings.HasPrefix(part, "ptr:") {
+			p.IsLookup = true
+		}
 		} else {
 			return nil, errors.Errorf("Unsupported spf part %s", part)
 		}

--- a/pkg/spflib/parse.go
+++ b/pkg/spflib/parse.go
@@ -84,7 +84,6 @@ func Parse(text string, dnsres Resolver) (*SPFRecord, error) {
 			}
 		} else if strings.HasPrefix(part, "exists:") || strings.HasPrefix(part, "ptr:") {
 			p.IsLookup = true
-		}
 		} else {
 			return nil, errors.Errorf("Unsupported spf part %s", part)
 		}

--- a/pkg/spflib/parse.go
+++ b/pkg/spflib/parse.go
@@ -82,9 +82,7 @@ func Parse(text string, dnsres Resolver) (*SPFRecord, error) {
 					return nil, errors.Errorf("In included spf: %s", err)
 				}
 			}
-		} else if strings.HasPrefix(part, "exists:") {
-			p.IsLookup = true
-		} else if strings.HasPrefix(part, "ptr:") {
+		} else if strings.HasPrefix(part, "exists:") || strings.HasPrefix(part, "ptr:") {
 			p.IsLookup = true
 		}
 		} else {

--- a/pkg/spflib/parse_test.go
+++ b/pkg/spflib/parse_test.go
@@ -21,6 +21,7 @@ func TestParse(t *testing.T) {
 		"include:sendgrid.net",
 		"include:spf.mtasv.net",
 		"exists:%{i}._spf.sparkpostmail.com",
+		"ptr:sparkpostmail.com",
 		"~all"}, " "), dnsres)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
SPF builder doesn't support PTR types.

I think PTR counts as a DNS lookup, but happy for more opinions on the matter.