### PR TITLE
doc: update documentation for Gandi to mention the LiveDNS provider

### DIFF
--- a/docs/_providers/gandi.md
+++ b/docs/_providers/gandi.md
@@ -6,6 +6,19 @@ jsId: GANDI
 ---
 # Gandi Provider
 
+There are two providers for Gandi:
+
+ 1. `GANDI` uses the v3 API and is able to act as a registrar provider
+    and a DNS provider. It is not able to handle domains that have
+    migrated to the new LiveDNS API. You need to get the API key from
+    the [v4 interface][].
+
+ 2. `GANDI-LIVEDNS` uses the LiveDNS API and is only able to act as a
+    DNS provider. You need to get the API key from the [v5 interface][].
+
+[v4 interface]: https://v4.gandi.net
+[v5 interface]: https://v5.gandi.net
+
 ## Configuration
 In your credentials file you must provide your Gandi.net API key:
 


### PR DESCRIPTION
The `GANDI` provider also seems to be unable to see new domains (the
ones bought through the new interface), but I didn't mention that as
it may be a bug that could be solves at some point.