### PR TITLE
Create directories with execute permissions so they can be opened

### DIFF
--- a/pkg/acme/acme.go
+++ b/pkg/acme/acme.go
@@ -77,7 +77,7 @@ func (c *certManager) IssueOrRenewCert(cfg *CertConfig, renewUnder int, verbose 
 	}
 
 	log.Printf("Checking certificate [%s]", cfg.CertName)
-	if err := os.MkdirAll(filepath.Dir(c.certFile(cfg.CertName, "json")), perms); err != nil {
+	if err := os.MkdirAll(filepath.Dir(c.certFile(cfg.CertName, "json")), dirPerms); err != nil {
 		return false, err
 	}
 	existing, err := c.readCertificate(cfg.CertName)

--- a/pkg/acme/registration.go
+++ b/pkg/acme/registration.go
@@ -61,10 +61,12 @@ func (c *certManager) accountKeyFile() string {
 	return filepath.Join(c.accountDirectory(), "account.key")
 }
 
-const perms os.FileMode = 0644 // TODO: probably lock this down more
+// TODO: probably lock these down more
+const perms os.FileMode = 0644
+const dirPerms os.FileMode = 0755
 
 func (c *certManager) createAccount() error {
-	if err := os.MkdirAll(c.accountDirectory(), perms); err != nil {
+	if err := os.MkdirAll(c.accountDirectory(), dirPerms); err != nil {
 		return err
 	}
 	privateKey, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)

--- a/pkg/acme/registration.go
+++ b/pkg/acme/registration.go
@@ -63,7 +63,7 @@ func (c *certManager) accountKeyFile() string {
 
 // TODO: probably lock these down more
 const perms os.FileMode = 0644
-const dirPerms os.FileMode = 0755
+const dirPerms os.FileMode = 0700
 
 func (c *certManager) createAccount() error {
 	if err := os.MkdirAll(c.accountDirectory(), dirPerms); err != nil {


### PR DESCRIPTION
`get-certs` currently fails with a permission denied after it creates new directories because MkdirAll is using 0644 instead of 0755. This PR resolves that.