### PR TITLE
Correctly group R53_ALIAS records during IncrementalDiff.

### DIFF
--- a/models/record.go
+++ b/models/record.go
@@ -246,7 +246,15 @@ type RecordKey struct {
 
 // Key converts a RecordConfig into a RecordKey.
 func (rc *RecordConfig) Key() RecordKey {
-	return RecordKey{rc.Name, rc.Type}
+	t := rc.Type
+	if rc.R53Alias != nil {
+		if v, ok := rc.R53Alias["type"]; ok {
+			// Route53 aliases append their alias type, so that records for the same
+			// label with different alias types are considered separate.
+			t = fmt.Sprintf("%s_%s", t, v)
+		}
+	}
+	return RecordKey{rc.Name, t}
 }
 
 // Records is a list of *RecordConfig.

--- a/models/record_test.go
+++ b/models/record_test.go
@@ -1,0 +1,33 @@
+package models
+
+import "testing"
+
+func TestKey(t *testing.T) {
+	var tests = []struct {
+		rc       RecordConfig
+		expected RecordKey
+	}{
+		{
+			RecordConfig{Type: "A", Name: "@"},
+			RecordKey{Type: "A", Name: "@"},
+		},
+		{
+			RecordConfig{Type: "R53_ALIAS", Name: "@"},
+			RecordKey{Type: "R53_ALIAS", Name: "@"},
+		},
+		{
+			RecordConfig{Type: "R53_ALIAS", Name: "@", R53Alias: map[string]string{"foo": "bar"}},
+			RecordKey{Type: "R53_ALIAS", Name: "@"},
+		},
+		{
+			RecordConfig{Type: "R53_ALIAS", Name: "@", R53Alias: map[string]string{"type": "AAAA"}},
+			RecordKey{Type: "R53_ALIAS_AAAA", Name: "@"},
+		},
+	}
+	for i, test := range tests {
+		actual := test.rc.Key()
+		if test.expected != actual {
+			t.Errorf("%d: Expected %s, got %s", i, test.expected, actual)
+		}
+	}
+}

--- a/providers/diff/diff.go
+++ b/providers/diff/diff.go
@@ -68,16 +68,14 @@ func (d *differ) IncrementalDiff(existing []*models.RecordConfig) (unchanged, cr
 	desired := d.dc.Records
 
 	// sort existing and desired by name
-	type key struct {
-		name, rType string
-	}
-	existingByNameAndType := map[key][]*models.RecordConfig{}
-	desiredByNameAndType := map[key][]*models.RecordConfig{}
+
+	existingByNameAndType := map[models.RecordKey][]*models.RecordConfig{}
+	desiredByNameAndType := map[models.RecordKey][]*models.RecordConfig{}
 	for _, e := range existing {
 		if d.matchIgnored(e.GetLabel()) {
 			log.Printf("Ignoring record %s %s due to IGNORE", e.GetLabel(), e.Type)
 		} else {
-			k := key{e.GetLabelFQDN(), e.Type}
+			k := e.Key()
 			existingByNameAndType[k] = append(existingByNameAndType[k], e)
 		}
 	}
@@ -85,7 +83,7 @@ func (d *differ) IncrementalDiff(existing []*models.RecordConfig) (unchanged, cr
 		if d.matchIgnored(dr.GetLabel()) {
 			panic(fmt.Sprintf("Trying to update/add IGNOREd record: %s %s", dr.GetLabel(), dr.Type))
 		} else {
-			k := key{dr.GetLabelFQDN(), dr.Type}
+			k := dr.Key()
 			desiredByNameAndType[k] = append(desiredByNameAndType[k], dr)
 		}
 	}
@@ -93,7 +91,7 @@ func (d *differ) IncrementalDiff(existing []*models.RecordConfig) (unchanged, cr
 	if d.dc.KeepUnknown {
 		for k := range existingByNameAndType {
 			if _, ok := desiredByNameAndType[k]; !ok {
-				log.Printf("Ignoring record set %s %s due to NO_PURGE", k.rType, k.name)
+				log.Printf("Ignoring record set %s %s due to NO_PURGE", k.Type, k.Name)
 				delete(existingByNameAndType, k)
 			}
 		}


### PR DESCRIPTION
This mirrors logic in the R53 provider, and deals with spurious corrections in
the case that aliases exist for both A and AAAA records, which is common.

This also centralizes logic around keys to the models package and adds tests.