### PR TITLE
update go version to 1.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.9-alpine AS build-env
+FROM golang:1.10-alpine AS build-env
 WORKDIR /go/src/github.com/StackExchange/dnscontrol
 ADD . .
 RUN apk update && apk add git

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Writing new plugins is very easy.
 
 ## From source
 
-DNSControl can be built with Go version 1.7 or higher. To install, simply run 
+DNSControl can be built with Go version 1.10 or higher. To install, simply run
 
 `go get github.com/StackExchange/dnscontrol`
 


### PR DESCRIPTION
Can not build by go version under 1.9.
because using the strings.Builder by library.
https://github.com/StackExchange/dnscontrol/blob/36228949e9b6192f517708ea99d06481e7b18513/vendor/github.com/hexonet/go-sdk/client/socketcfg/socketcfg.go#L62

So update to 1.10 of docker image and README.md.