### PR TITLE
Fix DNSimple SRV and MX records

### DIFF
--- a/integrationTest/providers.json
+++ b/integrationTest/providers.json
@@ -17,10 +17,10 @@
     "domain": "$DO_DOMAIN"
   },
   "DNSIMPLE": {
-    "COMMENT": "16/17: no ns records managable. Not even for subdomains.",
+    "COMMENT": "20-22: no ns records managable. Not even for subdomains.",
     "baseurl": "https://api.sandbox.dnsimple.com",
     "domain": "$DNSIMPLE_DOMAIN",
-    "knownFailures": "18,19,20",
+    "knownFailures": "20,21,22",
     "token": "$DNSIMPLE_TOKEN"
   },
   "GANDI": {

--- a/providers/dnsimple/dnsimpleProvider.go
+++ b/providers/dnsimple/dnsimpleProvider.go
@@ -384,7 +384,7 @@ func removeOtherNS(dc *models.DomainConfig) {
 }
 
 // Return the correct combined content for all special record types, Target for everything else
-// We used to use RecordConfig.MergeToContent() but that's not provided anymore
+// Using RecordConfig.GetTargetCombined returns priority in the string, which we do not allow
 func getTargetRecordContent(rc *models.RecordConfig) string {
 	switch rtype := rc.Type; rtype {
 	case "CAA":


### PR DESCRIPTION
This was broken when commenting out the MergeToTarget.

This gets us back to tests passing.

Fixes: #408