### PR TITLE
OVH url fix + green build

### DIFF
--- a/docs/_providers/ovh.md
+++ b/docs/_providers/ovh.md
@@ -54,7 +54,7 @@ D("example.tld", REG_OVH, DnsProvider(R53),
 ## Activation
 
 To obtain the OVH keys, one need to register an app at OVH by following the
-[OVH API Getting Started](https://api.ovh.com/g934.first_step_with_api)
+[OVH API Getting Started](https://docs.ovh.com/gb/en/customer/first-steps-with-ovh-api/)
 
 It consist in declaring the app at https://eu.api.ovh.com/createApp/
 which gives the `app-key` and `app-secret-key`.


### PR DESCRIPTION
This fixes the URL to OVH's First Step Using The API guide, ~as well as a fix for the failing build on master~.