### PR TITLE
Populate ovh zones cache as early as possible (#412)

### DIFF
--- a/docs/_includes/matrix.html
+++ b/docs/_includes/matrix.html
@@ -443,7 +443,9 @@
 		<td><i class="fa fa-minus dim"></i></td>
 		<td><i class="fa fa-minus dim"></i></td>
 		<td><i class="fa fa-minus dim"></i></td>
-		<td><i class="fa fa-minus dim"></i></td>
+		<td class="success">
+			<i class="fa fa-check text-success" aria-hidden="true"></i>
+		</td>
 		<td class="success">
 			<i class="fa fa-check text-success" aria-hidden="true"></i>
 		</td>

--- a/providers/ovh/ovhProvider.go
+++ b/providers/ovh/ovhProvider.go
@@ -39,7 +39,11 @@ func newOVH(m map[string]string, metadata json.RawMessage) (*ovhProvider, error)
 		return nil, err
 	}
 
-	return &ovhProvider{client: c}, nil
+	ovh := &ovhProvider{client: c}
+	if err := ovh.fetchZones(); err != nil {
+		return nil, err
+	}
+	return ovh, nil
 }
 
 func newDsp(conf map[string]string, metadata json.RawMessage) (providers.DNSServiceProvider, error) {
@@ -56,9 +60,6 @@ func init() {
 }
 
 func (c *ovhProvider) GetNameservers(domain string) ([]*models.Nameserver, error) {
-	if err := c.fetchZones(); err != nil {
-		return nil, err
-	}
 	_, ok := c.zones[domain]
 	if !ok {
 		return nil, errors.Errorf("%s not listed in zones for ovh account", domain)


### PR DESCRIPTION
We were caching the zones in GetNameservers which wasn’t a good idea, because this one might not be called if not name servers are selected for this ovh domain. 
In this case, GetDomainCorrections would fail with an unknown domain.
Instead the idea is to populate the zones cache as soon as the provider is initialized.