### PR TITLE
Added Cloudflare options for target account

### DIFF
--- a/docs/_providers/cloudflare.md
+++ b/docs/_providers/cloudflare.md
@@ -18,6 +18,19 @@ In the credentials file you must provide your Cloudflare API username and access
 }
 {% endhighlight %}
 
+If your Cloudflare account has access to multiple Cloudflare accounts, you can specify which Cloudflare account should be used when adding new domains:
+
+{% highlight json %}
+{
+  "cloudflare": {
+    "apikey": "...",
+    "apiuser": "...",
+    "accountid": "your-cloudflare-account-id",
+    "accountname": "your-cloudflare-account-name"
+  }
+}
+{% endhighlight %}
+
 ## Metadata
 Record level metadata availible:
    * `cloudflare_proxy` ("on", "off", or "full")

--- a/providers/cloudflare/cloudflareProvider.go
+++ b/providers/cloudflare/cloudflareProvider.go
@@ -24,6 +24,8 @@ Cloudflare API DNS provider:
 Info required in `creds.json`:
    - apikey
    - apiuser
+   - accountid (optional)
+   - accountname (optional)
 
 Record level metadata available:
    - cloudflare_proxy ("on", "off", or "full")
@@ -54,6 +56,8 @@ func init() {
 type CloudflareApi struct {
 	ApiKey          string `json:"apikey"`
 	ApiUser         string `json:"apiuser"`
+	AccountID       string `json:"accountid"`
+	AccountName     string `json:"accountname"`
 	domainIndex     map[string]string
 	nameservers     map[string][]string
 	ipConversions   []transform.IpConversion
@@ -305,6 +309,12 @@ func newCloudflare(m map[string]string, metadata json.RawMessage) (providers.DNS
 	// check api keys from creds json file
 	if api.ApiKey == "" || api.ApiUser == "" {
 		return nil, errors.Errorf("cloudflare apikey and apiuser must be provided")
+	}
+
+	// Check account data if set
+	api.AccountID, api.AccountName = m["accountid"], m["accountname"]
+	if (api.AccountID != "" && api.AccountName == "") || (api.AccountID == "" && api.AccountName != "") {
+		return nil, errors.Errorf("either both cloudflare accountid and accountname must be provided or neither")
 	}
 
 	err := api.fetchDomainList()

--- a/providers/cloudflare/rest.go
+++ b/providers/cloudflare/rest.go
@@ -99,10 +99,21 @@ func (c *CloudflareApi) deleteRec(rec *cfRecord, domainID string) *models.Correc
 func (c *CloudflareApi) createZone(domainName string) (string, error) {
 	type createZone struct {
 		Name string `json:"name"`
+
+		Account struct {
+			ID   string `json:"id"`
+			Name string `json:"name"`
+		} `json:"account"`
 	}
 	var id string
 	cz := &createZone{
 		Name: domainName}
+
+	if c.AccountID != "" || c.AccountName != "" {
+		cz.Account.ID = c.AccountID
+		cz.Account.Name = c.AccountName
+	}
+
 	buf := &bytes.Buffer{}
 	encoder := json.NewEncoder(buf)
 	if err := encoder.Encode(cz); err != nil {


### PR DESCRIPTION
This pull request adds two settings that can be set in the creds.json that allow you to specify the account where new domains should be added to. If the fields are left empty (the current situation) new domains end up in the account of the user the credentials belong to.

We bumped into this because the user that dnscontrol uses to push changes has access to multiple Cloudflare accounts and new domains we pushed ended up in the wrong account.
