### PR TITLE
Return error for pending corrections in preview

### DIFF
--- a/commands/previewPush.go
+++ b/commands/previewPush.go
@@ -165,6 +165,9 @@ DomainLoop:
 	if anyErrors {
 		return errors.Errorf("Completed with errors")
 	}
+	if totalCorrections != 0 {
+		return errors.Errorf("Corrections pending")
+	}
 	return nil
 }
 


### PR DESCRIPTION
Return a non-zero error code if there are corrections for preview
step. This is especially useful for automated alerting and scripting
around changes to the zone not reflected in the configuration.

Fixes #437 