### PR TITLE
Document require() and make it support relative paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ spfcache*
 adzonedump.*
 zones/
 stack.sh
+.idea/

--- a/commands/printIR.go
+++ b/commands/printIR.go
@@ -3,7 +3,6 @@ package commands
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"github.com/StackExchange/dnscontrol/models"
@@ -101,11 +100,8 @@ func ExecuteDSL(args ExecuteDSLArgs) (*models.DNSConfig, error) {
 	if args.JSFile == "" {
 		return nil, errors.Errorf("No config specified")
 	}
-	text, err := ioutil.ReadFile(args.JSFile)
-	if err != nil {
-		return nil, errors.Errorf("Reading js file %s: %s", args.JSFile, err)
-	}
-	dnsConfig, err := js.ExecuteJavascript(string(text), args.DevMode)
+
+	dnsConfig, err := js.ExecuteJavascript(args.JSFile, args.DevMode)
 	if err != nil {
 		return nil, errors.Errorf("Executing javascript in %s: %s", args.JSFile, err)
 	}

--- a/docs/_functions/global/require.md
+++ b/docs/_functions/global/require.md
@@ -1,0 +1,52 @@
+---
+name: require
+parameters:
+  - path
+---
+
+`require(...)` behaves similarly to its equivalent in node.js. You can use it
+to split your configuration across multiple files. If the path starts with a
+`.`, it is calculated relative to the current file. For example:
+
+{% include startExample.html %}
+{% highlight js %}
+
+// dnsconfig.js
+require('kubernetes/clusters.js');
+
+D("mydomain.net", REG, PROVIDER, 
+    IncludeKubernetes()
+);
+
+{%endhighlight%}
+
+{% highlight js %}
+
+// kubernetes/clusters.js
+require('./clusters/prod.js');
+require('./clusters/dev.js');
+
+function IncludeKubernetes() {
+    return [includeK8Sprod(), includeK8Sdev()];
+}
+
+{%endhighlight%}
+
+{% highlight js %}
+
+// kubernetes/clusters/prod.js
+function includeK8Sprod() {
+    return [ /* ... */ ];
+}
+
+{%endhighlight%}
+
+{% highlight js %}
+
+// kubernetes/clusters/dev.js
+function includeK8Sdev() {
+    return [ /* ... */ ];
+}
+
+{%endhighlight%}
+{% include endExample.html %}

--- a/pkg/js/js.go
+++ b/pkg/js/js.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"path/filepath"
+	"strings"
 
 	"github.com/StackExchange/dnscontrol/models"
 	"github.com/StackExchange/dnscontrol/pkg/printer"
@@ -84,8 +85,13 @@ func require(call otto.FunctionCall) otto.Value {
 		throw(call.Otto, err.Error())
 	}
 
+	if strings.HasPrefix(file, ".") {
+		file = absFile
+	}
+
 	printer.Debugf("requiring: %s\n", absFile)
-	data, err := ioutil.ReadFile(absFile)
+	data, err := ioutil.ReadFile(file)
+
 	if err != nil {
 		throw(call.Otto, err.Error())
 	}

--- a/pkg/js/js_test.go
+++ b/pkg/js/js_test.go
@@ -34,11 +34,7 @@ func TestParsedFiles(t *testing.T) {
 		m := minify.New()
 		m.AddFunc("json", minjson.Minify)
 		t.Run(f.Name(), func(t *testing.T) {
-			content, err := ioutil.ReadFile(filepath.Join(testDir, f.Name()))
-			if err != nil {
-				t.Fatal(err)
-			}
-			conf, err := ExecuteJavascript(string(content), true)
+			conf, err := ExecuteJavascript(string(filepath.Join(testDir, f.Name())), true)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/js/parse_tests/008-import.js
+++ b/pkg/js/parse_tests/008-import.js
@@ -1,2 +1,2 @@
 
-require("pkg/js/parse_tests/import.js")
+require("./import.js")

--- a/pkg/js/parse_tests/020-complexRequire.js
+++ b/pkg/js/parse_tests/020-complexRequire.js
@@ -1,0 +1,1 @@
+require('./complexImports/base.js');

--- a/pkg/js/parse_tests/020-complexRequire.json
+++ b/pkg/js/parse_tests/020-complexRequire.json
@@ -1,0 +1,33 @@
+{
+  "registrars": [],
+  "dns_providers": [],
+  "domains": [
+    {
+      "name": "foo.com",
+      "registrar": "none",
+      "dnsProviders": {},
+      "records": [
+        {
+          "type": "A",
+          "name": "@",
+          "target": "1.2.3.4"
+        },
+        {
+          "type": "CNAME",
+          "name": "A",
+          "target": "foo.com."
+        },
+        {
+          "type": "CNAME",
+          "name": "C",
+          "target": "foo.com."
+        },
+        {
+          "type": "CNAME",
+          "name": "B",
+          "target": "foo.com."
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/js/parse_tests/020-complexRequire.json
+++ b/pkg/js/parse_tests/020-complexRequire.json
@@ -24,6 +24,11 @@
         },
         {
           "type": "CNAME",
+          "name": "D",
+          "target": "foo.com."
+        },
+        {
+          "type": "CNAME",
           "name": "B",
           "target": "foo.com."
         }

--- a/pkg/js/parse_tests/complexImports/a/a.js
+++ b/pkg/js/parse_tests/complexImports/a/a.js
@@ -1,0 +1,3 @@
+function a() {
+    return CNAME("A", "foo.com.")
+}

--- a/pkg/js/parse_tests/complexImports/a/c/c.js
+++ b/pkg/js/parse_tests/complexImports/a/c/c.js
@@ -1,0 +1,8 @@
+require('../a.js');
+
+function c() {
+    return [
+        a(),
+        CNAME("C", "foo.com.")
+    ]
+}

--- a/pkg/js/parse_tests/complexImports/b/b.js
+++ b/pkg/js/parse_tests/complexImports/b/b.js
@@ -1,0 +1,3 @@
+function b() {
+    return CNAME("B", "foo.com.")
+}

--- a/pkg/js/parse_tests/complexImports/b/b.js
+++ b/pkg/js/parse_tests/complexImports/b/b.js
@@ -1,3 +1,8 @@
+require('pkg/js/parse_tests/complexImports/b/d/d.js');
+
 function b() {
-    return CNAME("B", "foo.com.")
+    return [
+        d(),
+        CNAME("B", "foo.com.")
+    ];
 }

--- a/pkg/js/parse_tests/complexImports/b/d/d.js
+++ b/pkg/js/parse_tests/complexImports/b/d/d.js
@@ -1,0 +1,3 @@
+function d() {
+    return CNAME("D", "foo.com.")
+}

--- a/pkg/js/parse_tests/complexImports/base.js
+++ b/pkg/js/parse_tests/complexImports/base.js
@@ -1,0 +1,8 @@
+require('./a/c/c.js');
+require('./b/b.js');
+
+D("foo.com","none",
+    A("@","1.2.3.4"),
+    c(),
+    b()
+);


### PR DESCRIPTION
This brings `require(...)` more in-line with its equivalent in node.js by allowing imports relative to the file currently being parsed. I've made some assumptions in how the parsing works in that only one block is being parsed at a time. If there's a better way to do this with the javascript engine you're using I'm all ears.

I've also added some documentation for `require(...)`. Please let me know if it belongs in a different place.

Fixes #440 