### PR TITLE
Delegation Sets and retries

### DIFF
--- a/docs/_providers/gcloud.md
+++ b/docs/_providers/gcloud.md
@@ -23,12 +23,13 @@ For Google cloud authentication, DNSControl requires a JSON 'Service Account Key
         "auth_uri": "https://accounts.google.com/o/oauth2/auth",
         "token_uri": "https://accounts.google.com/o/oauth2/token",
         "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
-        "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/dnscontrolsdfsdfsdf%40craigdnstest.iam.gserviceaccount.com"
+        "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/dnscontrolsdfsdfsdf%40craigdnstest.iam.gserviceaccount.com",
+        "name_server_set" : "optional_name_server_set_name (contact your TAM)"
     }
 }
 {% endhighlight %}
 
-**Note**: The `project_id`, `private_key`, and `client_email`, are the only fields that are strictly required, but it is sometimes easier to just paste the entire json object in. Either way is fine.
+**Note**: The `project_id`, `private_key`, and `client_email`, are the only fields that are strictly required, but it is sometimes easier to just paste the entire json object in. Either way is fine.  `name_server_set` is optional and requires special permission from your TAM at Google in order to setup (See [Name server sets](#name_server_sets) below)
 
 See [the Activation section](#activation) for some tips on obtaining these credentials.
 
@@ -58,5 +59,13 @@ D("example.tld", REG_NAMECOM, DnsProvider(GCLOUD),
 
 ## New domains
 If a domain does not exist in your Google Cloud DNS account, DNSControl
-will *not* automatically add it with the `create-domains` account. You'll need to do that via the
-control panel manually.
+will *not* automatically add it with the `push` command. You'll need to do that via the
+control panel manually or via the `create-domains` command.
+
+## Name server sets
+
+This optional feature lets you pin domains to a set of GCLOUD name servers.  The `nameServerSet` field is exposed in their API but there is
+currently no facility for creating a name server set.  You need special permission from your technical account manager at Google and they 
+will enable it on your account, responding with a list of names to use in the `name_server_set` field above.
+
+> `name_server_set` only applies on `create-domains` at the moment. Additional work needs to be done to support it during `push`

--- a/docs/_providers/route53.md
+++ b/docs/_providers/route53.md
@@ -13,7 +13,8 @@ You can specify the API credentials in the credentials json file:
  "r53_main":{
       "KeyId": "your-aws-key",
       "SecretKey": "your-aws-secret-key",
-      "Token": "optional-sts-token"
+      "Token": "optional-sts-token",
+      "DelegationSet" : "optional-delegation-set-id"
  }
 }
 {% endhighlight %}
@@ -56,7 +57,32 @@ D('example.tld', REG_NONE, DnsProvider(R53),
 DNSControl depends on a standard [AWS access key](https://aws.amazon.com/developers/access-keys/) with permission to list, create and update hosted zones.
 
 ## New domains
-If a domain does not exist in your Route53 account, DNSControl will *not* automatically add it with the `create-domains` command. You can do that either manually via the control panel, or via the command `dnscontrol create-domains` command.
+If a domain does not exist in your Route53 account, DNSControl will *not* automatically add it with the `push` command. You can do that either manually via the control panel, or via the command `dnscontrol create-domains` command.
+
+## Delegation Sets
+Creation of new delegation sets are not supported by this code.  However, if you have a delegation set already created, ala:
+
+```
+$ aws route53 create-reusable-delegation-set --caller-reference "foo"
+{
+    "Location": "https://route53.amazonaws.com/2013-04-01/delegationset/12312312123",
+    "DelegationSet": {
+        "Id": "/delegationset/12312312123",
+        "CallerReference": "foo",
+        "NameServers": [
+            "ns-1056.awsdns-04.org",
+            "ns-215.awsdns-26.com",
+            "ns-1686.awsdns-18.co.uk",
+            "ns-970.awsdns-57.net"
+        ]
+    }
+}
+```
+
+You can then reference the DelegationSet.Id in your `r53_main` block (with your other credentials) to have all created domains placed in that
+delegation set.  Note that you you only want the portion of the `Id` after the `/delegationset/` (the `12312312123` in the example above).
+
+> Delegation sets only apply during `create-domains` at the moment.  Further work needs to be done to have them apply during `push`.
 
 ## Caveats
 This code may not function properly if a domain has R53 as a Registrar


### PR DESCRIPTION
- Support DelegationSet for Route53 (create-domains only)
- Retry Route53 operations which fail for rate limits under large numbers of domains
- Support for name_server_set for GCloud (create-domains only)
- Docs for both