### PR TITLE
OVH does support CAA (and already works)

### DIFF
--- a/providers/ovh/ovhProvider.go
+++ b/providers/ovh/ovhProvider.go
@@ -20,7 +20,7 @@ type ovhProvider struct {
 
 var features = providers.DocumentationNotes{
 	providers.CanUseAlias:            providers.Cannot(),
-	providers.CanUseCAA:              providers.Cannot(),
+	providers.CanUseCAA:              providers.Can(),
 	providers.CanUsePTR:              providers.Cannot(),
 	providers.CanUseSRV:              providers.Can(),
 	providers.CanUseTLSA:             providers.Can(),


### PR DESCRIPTION
Using CAA seems to work properly with the current implementation. Tested it using the CAA examples from the documentation just without any further issues:
```
	CAA("@", "iodef", "mailto:test@example.com", CAA_CRITICAL),
	CAA("@", "issue", "letsencrypt.org"),
	CAA("@", "issuewild", ";"),
```