### PR TITLE
Fix #479: Filter SOA records from Digitalocean

### DIFF
--- a/providers/digitalocean/digitaloceanProvider.go
+++ b/providers/digitalocean/digitaloceanProvider.go
@@ -102,9 +102,13 @@ func (api *DoApi) GetDomainCorrections(dc *models.DomainConfig) ([]*models.Corre
 		return nil, err
 	}
 
-	existingRecords := make([]*models.RecordConfig, len(records))
+	var existingRecords []*models.RecordConfig
 	for i := range records {
-		existingRecords[i] = toRc(dc, &records[i])
+		r := toRc(dc, &records[i])
+		if r.Type == "SOA" {
+			continue
+		}
+		existingRecords = append(existingRecords, r)
 	}
 
 	// Normalize


### PR DESCRIPTION
My understanding is that SOA record is managed by Digitalocean automatically, so there is no reason to handle it here? And currently this is broken because code in `toRR` can't parse the target field.