### PR TITLE
OVH: Fixed registrar ns correction

### DIFF
--- a/providers/ovh/ovhProvider.go
+++ b/providers/ovh/ovhProvider.go
@@ -65,7 +65,7 @@ func (c *ovhProvider) GetNameservers(domain string) ([]*models.Nameserver, error
 		return nil, errors.Errorf("%s not listed in zones for ovh account", domain)
 	}
 
-	ns, err := c.fetchNS(domain)
+	ns, err := c.fetchRegistrarNS(domain)
 	if err != nil {
 		return nil, err
 	}
@@ -178,27 +178,31 @@ func nativeToRecord(r *Record, origin string) *models.RecordConfig {
 
 func (c *ovhProvider) GetRegistrarCorrections(dc *models.DomainConfig) ([]*models.Correction, error) {
 
-	ns, err := c.fetchRegistrarNS(dc.Name)
+	// get the actual in-use nameservers
+	actualNs, err := c.fetchRegistrarNS(dc.Name)
 	if err != nil {
 		return nil, err
 	}
 
-	sort.Strings(ns)
-	found := strings.Join(ns, ",")
-
-	desiredNs := []string{}
+	// get the actual used ones + the configured one through dnscontrol
+	expectedNs := []string{}
 	for _, d := range dc.Nameservers {
-		desiredNs = append(desiredNs, d.Name)
+		expectedNs = append(expectedNs, d.Name)
 	}
-	sort.Strings(desiredNs)
-	desired := strings.Join(desiredNs, ",")
 
-	if found != desired {
+	sort.Strings(actualNs)
+	actual := strings.Join(actualNs, ",")
+
+	sort.Strings(expectedNs)
+	expected := strings.Join(expectedNs, ",")
+
+	// check if we need to change something
+	if actual != expected {
 		return []*models.Correction{
 			{
-				Msg: fmt.Sprintf("Change Nameservers from '%s' to '%s'", found, desired),
+				Msg: fmt.Sprintf("Change Nameservers from '%s' to '%s'", actual, expected),
 				F: func() error {
-					err := c.updateNS(dc.Name, desiredNs)
+					err := c.updateNS(dc.Name, expectedNs)
 					if err != nil {
 						return err
 					}
@@ -206,5 +210,6 @@ func (c *ovhProvider) GetRegistrarCorrections(dc *models.DomainConfig) ([]*model
 				}},
 		}, nil
 	}
+
 	return nil, nil
 }

--- a/providers/ovh/protocol.go
+++ b/providers/ovh/protocol.go
@@ -35,10 +35,10 @@ func (c *ovhProvider) fetchZones() error {
 
 // Zone describes the attributes of a DNS zone.
 type Zone struct {
-	LastUpdate      string   `json:"lastUpdate,omitempty"`
+	DNSSecSupported bool     `json:"dnssecSupported"`
 	HasDNSAnycast   bool     `json:"hasDNSAnycast,omitempty"`
 	NameServers     []string `json:"nameServers"`
-	DNSSecSupported bool     `json:"dnssecSupported"`
+	LastUpdate      string   `json:"lastUpdate,omitempty"`
 }
 
 // get info about a zone.


### PR DESCRIPTION
This PR addresses a wrong behavior when the domain takes use of the additional OVH anycast service (Anycast can be ordered separately for a yearly fee). If used, `fetchNS()` will return back *all* nameservers referenced with a domain, whenever in use or not - so in case of anycast-enabled domains: 2x normal dns server, 2x anycast dns servers. This causes non-anycast nameservers being always added.

If anycast is enabled, IMHO it does not really make sense to add non-anycast nameservers. This PR uses `fetchRegistrarNS()` to get the **currently in-use** registrar nameserver. This way it works as intended.

(Regarding changes in file `protocol.go`: This is simply a line-switch-change to be consistent with the order as OVH returns back the data from their API.)