### PR TITLE
Add redirect support to SPF

### DIFF
--- a/docs/spf-optimizer.md
+++ b/docs/spf-optimizer.md
@@ -178,6 +178,10 @@ could exceed 512 bytes, and will require EDNS or a TCP request.
 3. Dnscontrol does not warn if the number of lookups exceeds 10.
 We hope to implement this some day.
 
+4. The `redirect:` directive is only partially implemented.  We only
+handle the case where redirect is the last item in the SPF record.
+In which case, it is equivalent to `include:`.
+
 
 ## Advanced Technique: Interactive SPF Debugger
 

--- a/pkg/spflib/parse_test.go
+++ b/pkg/spflib/parse_test.go
@@ -40,3 +40,31 @@ func TestParseWithDoubleSpaces(t *testing.T) {
 	}
 	t.Log(rec.Print())
 }
+
+func TestParseRedirectNotLast(t *testing.T) {
+	// Make sure redirect:foo fails if it isn't the last item.
+	dnsres, err := NewCache("testdata-dns1.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = Parse(strings.Join([]string{"v=spf1",
+		"redirect:servers.mcsv.net",
+		"~all"}, " "), dnsres)
+	if err == nil {
+		t.Fatal("should fail")
+	}
+}
+
+func TestParseRedirectLast(t *testing.T) {
+	dnsres, err := NewCache("testdata-dns1.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	rec, err := Parse(strings.Join([]string{"v=spf1",
+		"ip4:198.252.206.0/24",
+		"redirect:servers.mcsv.net"}, " "), dnsres)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Log(rec.Print())
+}


### PR DESCRIPTION
SPF has `include:` and `redirect:` directives.

We only implement the easiest edge-case of redirect, which is when it is the last item in the SPF record. In this situation it is equivalent to `include:`.