### PR TITLE
gandi/livedns: Mark support for multi TXT records

### DIFF
--- a/providers/gandi/livedns.go
+++ b/providers/gandi/livedns.go
@@ -22,6 +22,7 @@ var liveFeatures = providers.DocumentationNotes{
 	providers.CanUseCAA:              providers.Can(),
 	providers.CanUsePTR:              providers.Can(),
 	providers.CanUseSRV:              providers.Can(),
+	providers.CanUseTXTMulti:         providers.Can(),
 	providers.CantUseNOPURGE:         providers.Cannot(),
 	providers.DocCreateDomains:       providers.Cannot("Can only manage domains registered through their service"),
 	providers.DocOfficiallySupported: providers.Cannot(),


### PR DESCRIPTION
It seems it does support them.