### PR TITLE
gandi/livedns: Print actual changes to be pushed

### DIFF
--- a/providers/gandi/livedns.go
+++ b/providers/gandi/livedns.go
@@ -103,11 +103,26 @@ func (c *liveClient) GetDomainCorrections(dc *models.DomainConfig) ([]*models.Co
 	differ := diff.New(dc)
 
 	_, create, del, mod := differ.IncrementalDiff(foundRecords)
-	if len(create)+len(del)+len(mod) > 0 {
+
+	buf := &bytes.Buffer{}
+	// Print a list of changes. Generate an actual change that is the zone
+	changes := false
+	for _, i := range create {
+		changes = true
+		fmt.Fprintln(buf, i)
+	}
+	for _, i := range del {
+		changes = true
+		fmt.Fprintln(buf, i)
+	}
+	for _, i := range mod {
+		changes = true
+		fmt.Fprintln(buf, i)
+	}
+
+	if changes {
 		message := fmt.Sprintf("Setting dns records for %s:", dc.Name)
-		for _, record := range dc.Records {
-			message += "\n" + record.GetTargetCombined()
-		}
+		message += "\n" + buf.String()
 		return []*models.Correction{
 			{
 				Msg: message,


### PR DESCRIPTION
Currently, preview & push actions print all domain records values that will be pushed:

    $ dnscontrol preview
    ----- DNS Provider: gandi...1 correction
    #1: Setting dns records for example.com:
    mail.example.com.
    1.2.3.4
    "ga"
    "bu"
    "zo"

With this change, it would only show what changes from current remote state (and other provider plugins do - this feels more consistent):

    $ dnscontrol preview
    ----- DNS Provider: gandi...1 correction
    #1: Setting dns records for example.com:
    CREATE TXT ga.example.com "ga" ttl=10800
    MODIFY TXT bu.example.com "bu" ttl=10800
    DELETE TXT meu.example.com "meu" ttl=10800