### PR TITLE
Fix inconsistent matching in diff

### DIFF
--- a/providers/diff/diff_test.go
+++ b/providers/diff/diff_test.go
@@ -281,8 +281,15 @@ func TestCaas(t *testing.T) {
 
 	// this will pass or fail depending on the ordering. Not ok.
 	desired[0].SetTargetCAA(3, "issue", "letsencrypt.org.")
-	desired[2].SetTargetCAA(3, "issue", "amazon.com.")
-	desired[1].SetTargetCAA(3, "issuewild", "letsencrypt.org.")
+	desired[1].SetTargetCAA(3, "issue", "amazon.com.")
+	desired[2].SetTargetCAA(3, "issuewild", "letsencrypt.org.")
+
+	checkLengthsFull(t, existing, desired, 3, 0, 0, 0, false, nil)
+
+	// Make sure it passes with a different ordering. Not ok.
+	desired[2].SetTargetCAA(3, "issue", "letsencrypt.org.")
+	desired[1].SetTargetCAA(3, "issue", "amazon.com.")
+	desired[0].SetTargetCAA(3, "issuewild", "letsencrypt.org.")
 
 	checkLengthsFull(t, existing, desired, 3, 0, 0, 0, false, nil)
 }

--- a/providers/diff/diff_test.go
+++ b/providers/diff/diff_test.go
@@ -262,3 +262,27 @@ func TestInvalidGlobIgnoredRecord(t *testing.T) {
 
 	checkLengthsFull(t, existing, desired, 0, 1, 0, 0, false, []string{"www1", "www2", "[.www3"})
 }
+
+// from https://github.com/StackExchange/dnscontrol/issues/552
+func TestCaas(t *testing.T) {
+	existing := []*models.RecordConfig{
+		myRecord("test CAA 1 1.1.1.1"),
+		myRecord("test CAA 1 1.1.1.1"),
+		myRecord("test CAA 1 1.1.1.1"),
+	}
+	desired := []*models.RecordConfig{
+		myRecord("test CAA 1 1.1.1.1"),
+		myRecord("test CAA 1 1.1.1.1"),
+		myRecord("test CAA 1 1.1.1.1"),
+	}
+	existing[0].SetTargetCAA(3, "issue", "letsencrypt.org.")
+	existing[1].SetTargetCAA(3, "issue", "amazon.com.")
+	existing[2].SetTargetCAA(3, "issuewild", "letsencrypt.org.")
+
+	// this will pass or fail depending on the ordering. Not ok.
+	desired[0].SetTargetCAA(3, "issue", "letsencrypt.org.")
+	desired[2].SetTargetCAA(3, "issue", "amazon.com.")
+	desired[1].SetTargetCAA(3, "issuewild", "letsencrypt.org.")
+
+	checkLengthsFull(t, existing, desired, 3, 0, 0, 0, false, nil)
+}


### PR DESCRIPTION
Fixes #552 

Scenario is when you have multiple records that share a Type/Name/Target, but have other fields that differ. In this case, ordering matters and sometimes you get never-ending changes.

Adds a first pass to find perfect matches before trying to make pairs based on target.