### PR TITLE
LIVEDNS-GANDI: Fix ability to remove empty TXT record

### DIFF
--- a/providers/gandi/livedns.go
+++ b/providers/gandi/livedns.go
@@ -199,6 +199,9 @@ func (c *liveClient) recordConfigFromInfo(infos []*gandiliverecord.Info, origin 
 			for _, txt := range info.Values {
 				parsed = append(parsed, models.StripQuotes(txt))
 			}
+			if len(parsed) == 0 {
+				parsed = append(parsed, "")
+			}
 			err := rc.SetTargetTXTs(parsed)
 			if err != nil {
 				panic(errors.Wrapf(err, "recordConfigFromInfo=TXT failed"))


### PR DESCRIPTION
Before this change:
an empty TXT record on the DNS server, not present in the local definition, triggers a slice out of range index error in `models.SetTargetTXTs`.

This ensures that `SetTargetTXTs` is not called with an empty slice from the Gandi LiveDNS provider.

This specific case occurred in my case because of an empty _acme-challenge TXT record left by a separate LetsEncrypt call (so not present in my local definition file). Removing this record is appropriate; dnscontrol not crashing on this was not.

It seemed more appropriate to me to fix this from the calling code (Gandi's).
Maybe should it be rather in `SetTargetTXTs` to ensure in a more general case, that the slice is not empty before using it? Like this:

```diff
diff --git models/t_txt.go models/t_txt.go
@@ -15,7 +15,11 @@ func (rc *RecordConfig) SetTargetTXT(s string) error {
 
 // SetTargetTXTs sets the TXT fields when there are many strings.
 func (rc *RecordConfig) SetTargetTXTs(s []string) error {
-       rc.SetTarget(s[0])
+       if len(s) > 0 {
+               rc.SetTarget(s[0])
+       } else {
+               rc.SetTarget("")
+       }
```