### PR TITLE
Adding note about existing Azure DNS dual host support being limited

### DIFF
--- a/providers/azuredns/azureDnsProvider.go
+++ b/providers/azuredns/azureDnsProvider.go
@@ -4,13 +4,14 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
+	"time"
+
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/StackExchange/dnscontrol/models"
 	"github.com/StackExchange/dnscontrol/providers"
 	"github.com/StackExchange/dnscontrol/providers/diff"
 	"github.com/pkg/errors"
-	"strings"
-	"time"
 
 	adns "github.com/Azure/azure-sdk-for-go/services/dns/mgmt/2018-05-01/dns"
 	aauth "github.com/Azure/go-autorest/autorest/azure/auth"
@@ -52,7 +53,7 @@ func newAzureDns(m map[string]string, metadata json.RawMessage) (*azureDnsProvid
 var features = providers.DocumentationNotes{
 	providers.CanUseAlias:            providers.Cannot("Only supported for Azure Resources. Not yet implemented"),
 	providers.DocCreateDomains:       providers.Can(),
-	providers.DocDualHost:            providers.Can(),
+	providers.DocDualHost:            providers.Can("Azure does not permit modifying the existing NS records, only adding/removing additional records."),
 	providers.DocOfficiallySupported: providers.Cannot(),
 	providers.CanUsePTR:              providers.Can(),
 	providers.CanUseSRV:              providers.Can(),


### PR DESCRIPTION
https://stackexchange.github.io/dnscontrol/provider-list indicates that Azure supports dual host.

Azure permits _adding_ new NS records at the apex, but it does not support modifying or deleting the default NS records for the zone.

I think this means that Dual Host compatibility is partial and should be reflected as such in the docs.

Also `gofmt` rearranged the imports, sorry.