### PR TITLE
vendor: Update govultr to v0.1.7

### DIFF
--- a/vendor/github.com/vultr/govultr/CHANGELOG.md
+++ b/vendor/github.com/vultr/govultr/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Change Log
 
+## [v0.1.7](https://github.com/vultr/govultr/compare/v0.1.6..v0.1.7) (2019-11-11)
+### Enhancement
+*  Version number was missing in v0.1.6 - Attempt was made to fix however it will not work. Cutting new release to remedy this.
+
+
+## [v0.1.6](https://github.com/vultr/govultr/compare/v0.1.5..v0.1.6) (2019-11-07)
+### Enhancement
+*  Retry rate-limited requests with exponential backoff[#28](https://github.com/vultr/govultr/pull/28)
+
+## [v0.1.5](https://github.com/vultr/govultr/compare/v0.1.4..v0.1.5) (2019-10-16)
+### Enhancement
+*  Whitelisting public endpoints that do not require the api key[#24](https://github.com/vultr/govultr/pull/24)
+
+## [v0.1.4](https://github.com/vultr/govultr/compare/v0.1.3..v0.1.4) (2019-07-14)
+### Bug Fixes
+* Fix panic on request failure [#20](https://github.com/vultr/govultr/pull/20)
+
 ## [v0.1.3](https://github.com/vultr/govultr/compare/v0.1.2..v0.1.3) (2019-06-13)
 ### Features
 * added `GetVc2zList` to Plans to retrieve `high-frequency compute` plans [#13](https://github.com/vultr/govultr/pull/13)

--- a/vendor/github.com/vultr/govultr/go.mod
+++ b/vendor/github.com/vultr/govultr/go.mod
@@ -1,3 +1,5 @@
 module github.com/vultr/govultr
 
 go 1.12
+
+require github.com/hashicorp/go-retryablehttp v0.6.3

--- a/vendor/github.com/vultr/govultr/go.sum
+++ b/vendor/github.com/vultr/govultr/go.sum
@@ -1,0 +1,12 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/hashicorp/go-cleanhttp v0.5.1 h1:dH3aiDG9Jvb5r5+bYHsikaOUIpcM0xvgMXVoDkXMzJM=
+github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
+github.com/hashicorp/go-hclog v0.9.2 h1:CG6TE5H9/JXsFWJCfoIVpKFIkFe6ysEuHirp4DxCsHI=
+github.com/hashicorp/go-hclog v0.9.2/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrjA0H7acj2lQ=
+github.com/hashicorp/go-retryablehttp v0.6.3 h1:tuulM+WnToeqa05z83YLmKabZxrySOmJAd4mJ+s2Nfg=
+github.com/hashicorp/go-retryablehttp v0.6.3/go.mod h1:vAew36LZh98gCBJNLH42IQ1ER/9wtLZZ8meHqQvEYWY=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
+github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=

--- a/vendor/github.com/vultr/govultr/govultr.go
+++ b/vendor/github.com/vultr/govultr/govultr.go
@@ -4,20 +4,39 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
 	"time"
+
+	"github.com/hashicorp/go-retryablehttp"
 )
 
 const (
-	version     = "0.1.3"
+	version     = "0.1.7"
 	defaultBase = "https://api.vultr.com"
 	userAgent   = "govultr/" + version
 	rateLimit   = 600 * time.Millisecond
+	retryLimit  = 3
 )
+
+// whiteListURI is an array of endpoints that should not have the API Key passed to them
+var whiteListURI = [12]string{"/v1/regions/availability",
+	"/v1/app/list",
+	"/v1/os/list",
+	"/v1/plans/list",
+	"/v1/plans/list_baremetal",
+	"/v1/plans/list_vc2",
+	"/v1/plans/list_vc2z",
+	"/v1/plans/list_vdc2",
+	"/v1/regions/list",
+	"/v1/regions/availability_vc2",
+	"/v1/regions/availability_vdc2",
+	"/v1/regions/availability_baremetal",
+}
 
 // APIKey contains a users API Key for interacting with the API
 type APIKey struct {
@@ -28,7 +47,7 @@ type APIKey struct {
 // Client manages interaction with the Vultr V1 API
 type Client struct {
 	// Http Client used to interact with the Vultr V1 API
-	client *http.Client
+	client *retryablehttp.Client
 
 	// BASE URL for APIs
 	BaseURL *url.URL
@@ -38,9 +57,6 @@ type Client struct {
 
 	// API Key
 	APIKey APIKey
-
-	// API Rate Limit - Vultr rate limits based on time
-	RateLimit time.Duration
 
 	// Services used to interact with the API
 	Account         AccountService
@@ -82,11 +98,16 @@ func NewClient(httpClient *http.Client, key string) *Client {
 	baseURL, _ := url.Parse(defaultBase)
 
 	client := &Client{
-		client:    httpClient,
+		client:    retryablehttp.NewClient(),
 		BaseURL:   baseURL,
 		UserAgent: userAgent,
-		RateLimit: rateLimit,
 	}
+
+	client.client.HTTPClient = httpClient
+	client.client.Logger = nil
+	client.client.ErrorHandler = client.vultrErrorHandler
+	client.SetRetryLimit(retryLimit)
+	client.SetRateLimit(rateLimit)
 
 	client.Account = &AccountServiceHandler{client}
 	client.API = &APIServiceHandler{client}
@@ -141,6 +162,13 @@ func (c *Client) NewRequest(ctx context.Context, method, uri string, body url.Va
 	}
 
 	req.Header.Add("API-key", c.APIKey.key)
+	for _, v := range whiteListURI {
+		if v == uri {
+			req.Header.Del("API-key")
+			break
+		}
+	}
+
 	req.Header.Add("User-Agent", c.UserAgent)
 	req.Header.Add("Accept", "application/json")
 
@@ -156,14 +184,18 @@ func (c *Client) NewRequest(ctx context.Context, method, uri string, body url.Va
 // have their own implements of unmarshal.
 func (c *Client) DoWithContext(ctx context.Context, r *http.Request, data interface{}) error {
 
-	// Sleep this call
-	time.Sleep(c.RateLimit)
+	rreq, err := retryablehttp.FromRequest(r)
 
-	req := r.WithContext(ctx)
-	res, err := c.client.Do(req)
+	if err != nil {
+		return err
+	}
+
+	rreq = rreq.WithContext(ctx)
+
+	res, err := c.client.Do(rreq)
 
 	if c.onRequestCompleted != nil {
-		c.onRequestCompleted(req, res)
+		c.onRequestCompleted(r, res)
 	}
 
 	if err != nil {
@@ -206,9 +238,11 @@ func (c *Client) SetBaseURL(baseURL string) error {
 	return nil
 }
 
-// SetRateLimit Overrides the default rateLimit
+// SetRateLimit Overrides the default rateLimit. For performance, exponential
+// backoff is used with the minimum wait being 2/3rds the time provided.
 func (c *Client) SetRateLimit(time time.Duration) {
-	c.RateLimit = time
+	c.client.RetryWaitMin = time / 3 * 2
+	c.client.RetryWaitMax = time
 }
 
 // SetUserAgent Overrides the default UserAgent
@@ -219,4 +253,21 @@ func (c *Client) SetUserAgent(ua string) {
 // OnRequestCompleted sets the API request completion callback
 func (c *Client) OnRequestCompleted(rc RequestCompletionCallback) {
 	c.onRequestCompleted = rc
+}
+
+// SetRetryLimit overrides the default RetryLimit
+func (c *Client) SetRetryLimit(n int) {
+	c.client.RetryMax = n
+}
+
+func (c *Client) vultrErrorHandler(resp *http.Response, err error, numTries int) (*http.Response, error) {
+	if resp == nil {
+		return nil, fmt.Errorf("gave up after %d attempts, last error unavailable (resp == nil)", c.client.RetryMax+1)
+	}
+
+	buf, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("gave up after %d attempts, last error unavailable (error reading response body: %v)", c.client.RetryMax+1, err)
+	}
+	return nil, fmt.Errorf("gave up after %d attempts, last error: %#v", c.client.RetryMax+1, strings.TrimSpace(string(buf)))
 }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -994,10 +994,10 @@
 			"revisionTime": "2018-01-06T19:10:48Z"
 		},
 		{
-			"checksumSHA1": "IXgi3wJQDZY+XCMilbQzAWiOW94=",
+			"checksumSHA1": "hhJWopkGY99e2m+yQbXz7sEIkRc=",
 			"path": "github.com/vultr/govultr",
-			"revision": "4cfc19dfc3d058d94348267969d9a27551ff7476",
-			"revisionTime": "2019-07-14T13:33:55Z"
+			"revision": "fc01711c7c4ef2e578341e5ae462ab4d15d3d3b0",
+			"revisionTime": "2019-11-12T14:12:07Z"
 		},
 		{
 			"checksumSHA1": "IfxQifbQRgrRHdhHayFeF699/5U=",


### PR DESCRIPTION
v0.1.7 adds retries when requests exceed the rate limit.