### PR TITLE
Add AWS_PROFILE functionality for Route53 provider

### DIFF
--- a/docs/_providers/route53.md
+++ b/docs/_providers/route53.md
@@ -36,6 +36,13 @@ $ export AWS_SESSION_TOKEN=ZZZZZZZZ
 }
 {% endhighlight %}
 
+Alternatively if you want to used [named profiles](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html) you need to export the following variables
+
+```
+$ export AWS_SDK_LOAD_CONFIG=1 
+$ export AWS_PROFILE=ZZZZZZZZ
+```
+
 You can find some other ways to authenticate to Route53 in the [go sdk configuration](https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html).
 
 ## Metadata

--- a/providers/route53/route53Provider.go
+++ b/providers/route53/route53Provider.go
@@ -47,7 +47,7 @@ func newRoute53(m map[string]string, metadata json.RawMessage) (*route53Provider
 	if keyID != "" || secretKey != "" {
 		config.Credentials = credentials.NewStaticCredentials(keyID, secretKey, tokenID)
 	}
-	sess := session.New(config)
+	sess := session.Must(session.NewSession(config))
 
 	var dls *string = nil
 	if val, ok := m["DelegationSet"]; ok {


### PR DESCRIPTION
This will allow users to specify credentials via AWS_PROFILE.
The following variables need to be exported.

```
AWS_SDK_LOAD_CONFIG=1 
AWS_PROFILE=<wanted profile>
```