### PR TITLE
NEW PROVIDER: ClouDNS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,6 +2,7 @@
 providers/azuredns @vatsalyagoel
 providers/bind @tlimoncelli
 # providers/cloudflare
+providers/cloudns @pragmaton
 providers/digitalocean @Deraen
 providers/dnsimple @aeden
 providers/gandi @TomOnTime

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Currently supported DNS providers:
  - Azure DNS
  - BIND
  - Cloudflare
+ - ClouDNS
  - DigitalOcean
  - DNSimple
  - Exoscale

--- a/docs/_providers/cloudns.md
+++ b/docs/_providers/cloudns.md
@@ -1,0 +1,58 @@
+---
+name: ClouDNS
+title: ClouDNS Provider
+layout: default
+jsId: CLOUDNS
+---
+# ClouDNS Provider
+
+## Configuration
+In your credentials file, you must provide your [Api user ID and password](https://asia.cloudns.net/wiki/article/42/). 
+
+Current version of provider doesn't support `sub-auth-id` or  `sub-auth-user`. 
+
+{% highlight json %}
+{
+  "cloudns": {
+    "auth-id": "12345",
+    "auth-password": "your-password"
+  }
+}
+{% endhighlight %}
+
+## Metadata
+This provider does not recognize any special metadata fields unique to ClouDNS.
+
+## Usage
+Example Javascript:
+
+{% highlight js %}
+var REG_NONE = NewRegistrar('none', 'NONE')
+var CLOUDNS = NewDnsProvider("cloudns", "CLOUDNS");
+
+D("example.tld", REG_NONE, DnsProvider(CLOUDNS),
+    A("test","1.2.3.4")
+);
+{%endhighlight%}
+
+## Activation
+[Create Auth ID](https://asia.cloudns.net/api-settings/).  Only paid account can use API
+
+## Caveats
+ClouDNS does not allow all TTLs, but only a specific subset of TTLs. The following [TTLs are supported](https://asia.cloudns.net/wiki/article/188/):
+- 60  (1 minute)
+- 300 (5 minutes)
+- 900 (15 minutes)
+- 1800 (30 minutes)
+- 3600 (1 hour)
+- 21600 (6 hours)
+- 43200 (12 hours)
+- 86400 (1 day)
+- 172800 (2 days)
+- 259200 (3 days)
+- 604800 (1 week)
+- 1209600 (2 weeks)
+- 2419200 (4 weeks)
+
+The provider will automatically round up your TTL to one of these values. For example, 350 seconds would become 900
+seconds, but 300 seconds would stay 300 seconds. 

--- a/docs/provider-list.md
+++ b/docs/provider-list.md
@@ -61,6 +61,7 @@ provided to help community members support their code independently.
 
 Maintainers of contributed providers:
 
+* ClouDNS @pragmaton
 * digital ocean @Deraen
 * dnsimple @aeden
 * gandi @TomOnTime

--- a/integrationTest/providers.json
+++ b/integrationTest/providers.json
@@ -16,9 +16,9 @@
     "domain": "example.com"
   },
   "CLOUDNS": {
-    "auth-id": "3650",
-    "auth-password": "123456",
-    "domain": "pragmaticgeek.net"
+    "auth-id": "$CLOUDNS_AUTH_ID",
+    "auth-password": "$CLOUDNS_AUTH_PASSWORD",
+    "domain": "$CLOUDNS_DOMAIN"
   },
 
   "CLOUDFLAREAPI_OLD": {

--- a/integrationTest/providers.json
+++ b/integrationTest/providers.json
@@ -18,7 +18,8 @@
   "CLOUDNS": {
     "auth-id": "$CLOUDNS_AUTH_ID",
     "auth-password": "$CLOUDNS_AUTH_PASSWORD",
-    "domain": "$CLOUDNS_DOMAIN"
+    "domain": "$CLOUDNS_DOMAIN",
+    "knownFailures": "53"
   },
 
   "CLOUDFLAREAPI_OLD": {

--- a/integrationTest/providers.json
+++ b/integrationTest/providers.json
@@ -15,6 +15,12 @@
   "BIND": {
     "domain": "example.com"
   },
+  "CLOUDNS": {
+    "auth-id": "3650",
+    "auth-password": "123456",
+    "domain": "pragmaticgeek.net"
+  },
+
   "CLOUDFLAREAPI_OLD": {
     "apikey": "$CF_KEY",
     "apiuser": "$CF_USER",

--- a/providers/_all/all.go
+++ b/providers/_all/all.go
@@ -7,6 +7,7 @@ import (
 	_ "github.com/StackExchange/dnscontrol/providers/azuredns"
 	_ "github.com/StackExchange/dnscontrol/providers/bind"
 	_ "github.com/StackExchange/dnscontrol/providers/cloudflare"
+	_ "github.com/StackExchange/dnscontrol/providers/cloudns"
 	_ "github.com/StackExchange/dnscontrol/providers/digitalocean"
 	_ "github.com/StackExchange/dnscontrol/providers/dnsimple"
 	_ "github.com/StackExchange/dnscontrol/providers/exoscale"

--- a/providers/cloudns/api.go
+++ b/providers/cloudns/api.go
@@ -1,0 +1,202 @@
+package cloudns
+
+import (
+	"encoding/json"
+	"github.com/pkg/errors"
+	"io/ioutil"
+	"net/http"
+	"strconv"
+)
+
+// LinodeApi is the handle for this provider.
+
+type Credentials struct {
+	id       string
+	password string
+}
+
+type CloudnsApi struct {
+	domainIndex map[string]string
+	creds       Credentials
+}
+
+func (c *CloudnsApi) fetchDomainList() error {
+	c.domainIndex = map[string]string{}
+	rowsPerPage := 100
+	page := 1
+	for {
+		var dr zoneResponse
+		params := requestParams{
+			"page":          strconv.Itoa(page),
+			"rows-per-page": strconv.Itoa(rowsPerPage),
+		}
+		endpoint := "/dns/list-zones.json"
+		var bodyString, err = c.get(endpoint, params)
+		if err != nil {
+			return errors.Errorf("Error fetching domain list from ClouDNS: %s", err)
+		}
+		json.Unmarshal(bodyString, &dr)
+
+		for _, domain := range dr {
+			c.domainIndex[domain.Name] = domain.Name
+		}
+		if len(dr) < rowsPerPage {
+			break
+		}
+		page++
+	}
+	return nil
+}
+
+func (c *CloudnsApi) createDomain(domain string) error {
+	params := requestParams{
+		"domain-name": domain,
+		"zone-type":   "master",
+	}
+	if _, err := c.get("/dns/register.json", params); err != nil {
+		return errors.Errorf("Error create domain  ClouDNS: %s", err)
+	}
+	return nil
+}
+
+func (c *CloudnsApi) createRecord(domainID string, rec requestParams) error {
+	rec["domain-name"] = domainID
+	if _, err := c.get("/dns/add-record.json", rec); err != nil {
+		return errors.Errorf("Error create record  ClouDNS: %s", err)
+	}
+	return nil
+}
+
+func (c *CloudnsApi) deleteRecord(domainID string, recordID string) error {
+	params := requestParams{
+		"domain-name": domainID,
+		"record-id":   recordID,
+	}
+	if _, err := c.get("/dns/delete-record.json", params); err != nil {
+		return errors.Errorf("Error delete record  ClouDNS: %s", err)
+	}
+	return nil
+}
+
+func (c *CloudnsApi) modifyRecord(domainID string, recordID string, rec requestParams) error {
+	rec["domain-name"] = domainID
+	rec["record-id"] = recordID
+	if _, err := c.get("/dns/mod-record.json", rec); err != nil {
+		return errors.Errorf("Error create update ClouDNS: %s", err)
+	}
+	return nil
+}
+
+func (c *CloudnsApi) getRecords(id string) ([]domainRecord, error) {
+	params := requestParams{"domain-name": id}
+
+	var bodyString, err = c.get("/dns/records.json", params)
+	if err != nil {
+		return nil, errors.Errorf("Error fetching record list from ClouDNS: %s", err)
+	}
+
+	var dr recordResponse
+	json.Unmarshal(bodyString, &dr)
+
+	var records []domainRecord
+	for _, rec := range dr {
+		records = append(records, rec)
+	}
+	return records, nil
+}
+
+func (c *CloudnsApi) get(endpoint string, params requestParams) ([]byte, error) {
+	client := &http.Client{}
+	req, _ := http.NewRequest("GET", "https://api.cloudns.net"+endpoint, nil)
+	q := req.URL.Query()
+
+	//TODO: Suport  sub-auth-id / sub-auth-user https://asia.cloudns.net/wiki/article/42/
+	// Add auth params
+	q.Add("auth-id", c.creds.id)
+	q.Add("auth-password", c.creds.password)
+
+	for pName, pValue := range params {
+		q.Add(pName, pValue)
+	}
+
+	req.URL.RawQuery = q.Encode()
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return []byte{}, err
+	}
+
+	bodyString, _ := ioutil.ReadAll(resp.Body)
+
+	// Got error from API ?
+	var errResp errorResponse
+	err = json.Unmarshal(bodyString, &errResp)
+	if errResp.Status == "Failed" {
+		return bodyString, errors.Errorf("ClouDNS API error: %s URL:%s%s ", errResp.Description, req.Host, req.URL.RequestURI())
+	}
+
+	return bodyString, nil
+}
+
+type requestParams map[string]string
+
+type errorResponse struct {
+	Status      string `json:"status"`
+	Description string `json:"statusDescription"`
+}
+
+type zoneRecord struct {
+	Name   string `json:"name"`
+	Type   string `json:"type"`
+	Status string `json:"status"`
+	Zone   string `json:"zone"`
+}
+
+type zoneResponse []zoneRecord
+
+type domainRecord struct {
+	ID       string `json:"id"`
+	Type     string `json:"type"`
+	Host     string `json:"host"`
+	Target   string `json:"record"`
+	Priority string `json:"priority"`
+	Weight   string `json:"weight"`
+	Port     string `json:"port"`
+	Service  string `json:"service"`
+	Protocol string `json:"protocol"`
+	TTL      string `json:"ttl"`
+	Status   int8   `json:"status"`
+}
+
+type recordResponse map[string]domainRecord
+
+var allowedTTLValues = []uint32{
+	60,      // 1 minute
+	300,     // 5 minutes
+	900,     // 15 minutes
+	1800,    // 30 minutes
+	3600,    // 1 hour
+	21600,   // 6 hours
+	43200,   // 12 hours
+	86400,   // 1 day
+	172800,  // 2 days
+	259200,  // 3 days
+	604800,  // 1 week
+	1209600, // 2 weeks
+	2419200, // 4 weeks
+}
+
+func fixTTL(ttl uint32) uint32 {
+	// if the TTL is larger than the largest allowed value, return the largest allowed value
+	if ttl > allowedTTLValues[len(allowedTTLValues)-1] {
+		return allowedTTLValues[len(allowedTTLValues)-1]
+	}
+
+	for _, v := range allowedTTLValues {
+		if v >= ttl {
+			return v
+		}
+	}
+
+	return allowedTTLValues[0]
+}

--- a/providers/cloudns/api.go
+++ b/providers/cloudns/api.go
@@ -56,6 +56,9 @@ type domainRecord struct {
 	Protocol string `json:"protocol"`
 	TTL      string `json:"ttl"`
 	Status   int8   `json:"status"`
+	CaaFlag  string `json:"caa_flag,omitempty"`
+	CaaTag   string `json:"caa_type,omitempty"`
+	CaaValue string `json:"caa_value,omitempty"`
 }
 
 type recordResponse map[string]domainRecord

--- a/providers/cloudns/api.go
+++ b/providers/cloudns/api.go
@@ -45,20 +45,23 @@ type zoneRecord struct {
 type zoneResponse []zoneRecord
 
 type domainRecord struct {
-	ID       string `json:"id"`
-	Type     string `json:"type"`
-	Host     string `json:"host"`
-	Target   string `json:"record"`
-	Priority string `json:"priority"`
-	Weight   string `json:"weight"`
-	Port     string `json:"port"`
-	Service  string `json:"service"`
-	Protocol string `json:"protocol"`
-	TTL      string `json:"ttl"`
-	Status   int8   `json:"status"`
-	CaaFlag  string `json:"caa_flag,omitempty"`
-	CaaTag   string `json:"caa_type,omitempty"`
-	CaaValue string `json:"caa_value,omitempty"`
+	ID               string `json:"id"`
+	Type             string `json:"type"`
+	Host             string `json:"host"`
+	Target           string `json:"record"`
+	Priority         string `json:"priority"`
+	Weight           string `json:"weight"`
+	Port             string `json:"port"`
+	Service          string `json:"service"`
+	Protocol         string `json:"protocol"`
+	TTL              string `json:"ttl"`
+	Status           int8   `json:"status"`
+	CaaFlag          string `json:"caa_flag,omitempty"`
+	CaaTag           string `json:"caa_type,omitempty"`
+	CaaValue         string `json:"caa_value,omitempty"`
+	TlsaUsage        string `json:"tlsa_usage,omitempty"`
+	TlsaSelector     string `json:"tlsa_selector,omitempty"`
+	TlsaMatchingType string `json:"tlsa_matching_type,omitempty"`
 }
 
 type recordResponse map[string]domainRecord

--- a/providers/cloudns/api.go
+++ b/providers/cloudns/api.go
@@ -62,6 +62,8 @@ type domainRecord struct {
 	TlsaUsage        string `json:"tlsa_usage,omitempty"`
 	TlsaSelector     string `json:"tlsa_selector,omitempty"`
 	TlsaMatchingType string `json:"tlsa_matching_type,omitempty"`
+	SshfpAlgorithm   string `json:"algorithm,omitempty"`
+	SshfpFingerprint string `json:"fp_type,omitempty"`
 }
 
 type recordResponse map[string]domainRecord

--- a/providers/cloudns/api.go
+++ b/providers/cloudns/api.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 )
 
-// LinodeApi is the handle for this provider.
+// Api layer for CloDNS
 
 type Credentials struct {
 	id       string
@@ -18,6 +18,54 @@ type Credentials struct {
 type CloudnsApi struct {
 	domainIndex map[string]string
 	creds       Credentials
+}
+
+type requestParams map[string]string
+
+type errorResponse struct {
+	Status      string `json:"status"`
+	Description string `json:"statusDescription"`
+}
+
+type zoneRecord struct {
+	Name   string `json:"name"`
+	Type   string `json:"type"`
+	Status string `json:"status"`
+	Zone   string `json:"zone"`
+}
+
+type zoneResponse []zoneRecord
+
+type domainRecord struct {
+	ID       string `json:"id"`
+	Type     string `json:"type"`
+	Host     string `json:"host"`
+	Target   string `json:"record"`
+	Priority string `json:"priority"`
+	Weight   string `json:"weight"`
+	Port     string `json:"port"`
+	Service  string `json:"service"`
+	Protocol string `json:"protocol"`
+	TTL      string `json:"ttl"`
+	Status   int8   `json:"status"`
+}
+
+type recordResponse map[string]domainRecord
+
+var allowedTTLValues = []uint32{
+	60,      // 1 minute
+	300,     // 5 minutes
+	900,     // 15 minutes
+	1800,    // 30 minutes
+	3600,    // 1 hour
+	21600,   // 6 hours
+	43200,   // 12 hours
+	86400,   // 1 day
+	172800,  // 2 days
+	259200,  // 3 days
+	604800,  // 1 week
+	1209600, // 2 weeks
+	2419200, // 4 weeks
 }
 
 func (c *CloudnsApi) fetchDomainList() error {
@@ -136,54 +184,6 @@ func (c *CloudnsApi) get(endpoint string, params requestParams) ([]byte, error) 
 	}
 
 	return bodyString, nil
-}
-
-type requestParams map[string]string
-
-type errorResponse struct {
-	Status      string `json:"status"`
-	Description string `json:"statusDescription"`
-}
-
-type zoneRecord struct {
-	Name   string `json:"name"`
-	Type   string `json:"type"`
-	Status string `json:"status"`
-	Zone   string `json:"zone"`
-}
-
-type zoneResponse []zoneRecord
-
-type domainRecord struct {
-	ID       string `json:"id"`
-	Type     string `json:"type"`
-	Host     string `json:"host"`
-	Target   string `json:"record"`
-	Priority string `json:"priority"`
-	Weight   string `json:"weight"`
-	Port     string `json:"port"`
-	Service  string `json:"service"`
-	Protocol string `json:"protocol"`
-	TTL      string `json:"ttl"`
-	Status   int8   `json:"status"`
-}
-
-type recordResponse map[string]domainRecord
-
-var allowedTTLValues = []uint32{
-	60,      // 1 minute
-	300,     // 5 minutes
-	900,     // 15 minutes
-	1800,    // 30 minutes
-	3600,    // 1 hour
-	21600,   // 6 hours
-	43200,   // 12 hours
-	86400,   // 1 day
-	172800,  // 2 days
-	259200,  // 3 days
-	604800,  // 1 week
-	1209600, // 2 weeks
-	2419200, // 4 weeks
 }
 
 func fixTTL(ttl uint32) uint32 {

--- a/providers/cloudns/cloudnsProvider.go
+++ b/providers/cloudns/cloudnsProvider.go
@@ -48,7 +48,7 @@ var features = providers.DocumentationNotes{
 	providers.CanUsePTR:   providers.Unimplemented(),
 	providers.CanUseSSHFP: providers.Unimplemented(),
 	providers.CanUseCAA:   providers.Can(),
-	providers.CanUseTLSA:  providers.Unimplemented(),
+	providers.CanUseTLSA:  providers.Can(),
 }
 
 func init() {
@@ -190,6 +190,14 @@ func toRc(dc *models.DomainConfig, r *domainRecord) *models.RecordConfig {
 		rc.CaaFlag = uint8(caaFlag)
 		rc.CaaTag = r.CaaTag
 		rc.SetTarget(r.CaaValue)
+	case "TLSA":
+		tlsaUsage, _ := strconv.ParseUint(r.TlsaUsage, 10, 32)
+		rc.TlsaUsage = uint8(tlsaUsage)
+		tlsaSelector, _ := strconv.ParseUint(r.TlsaSelector, 10, 32)
+		rc.TlsaSelector = uint8(tlsaSelector)
+		tlsaMatchingType, _ := strconv.ParseUint(r.TlsaMatchingType, 10, 32)
+		rc.TlsaMatchingType = uint8(tlsaMatchingType)
+		rc.SetTarget(r.Target)
 	default:
 		rc.SetTarget(r.Target)
 	}
@@ -211,7 +219,7 @@ func toReq(rc *models.RecordConfig) (requestParams, error) {
 	}
 
 	switch rc.Type { // #rtype_variations
-	case "A", "AAAA", "NS", "PTR", "TXT", "SOA", "TLSA", "ALIAS", "CNAME":
+	case "A", "AAAA", "NS", "PTR", "TXT", "SOA", "ALIAS", "CNAME":
 		// Nothing special.
 	case "MX":
 		req["priority"] = strconv.Itoa(int(rc.MxPreference))
@@ -223,6 +231,10 @@ func toReq(rc *models.RecordConfig) (requestParams, error) {
 		req["caa_flag"] = strconv.Itoa(int(rc.CaaFlag))
 		req["caa_type"] = rc.CaaTag
 		req["caa_value"] = rc.Target
+	case "TLSA":
+		req["tlsa_usage"] = strconv.Itoa(int(rc.TlsaUsage))
+		req["tlsa_selector"] = strconv.Itoa(int(rc.TlsaSelector))
+		req["tlsa_matching_type"] = strconv.Itoa(int(rc.TlsaMatchingType))
 	default:
 		msg := fmt.Sprintf("ClouDNS.toReq rtype %v unimplemented", rc.Type)
 		panic(msg)

--- a/providers/cloudns/cloudnsProvider.go
+++ b/providers/cloudns/cloudnsProvider.go
@@ -39,16 +39,15 @@ func NewCloudns(m map[string]string, metadata json.RawMessage) (providers.DNSSer
 }
 
 var features = providers.DocumentationNotes{
-	providers.DocDualHost:            providers.Cannot(),
+	providers.DocDualHost:            providers.Unimplemented(),
 	providers.DocOfficiallySupported: providers.Cannot(),
 	providers.DocCreateDomains:       providers.Can(),
 	providers.CanUseAlias:            providers.Can(),
 	providers.CanUseSRV:              providers.Can(),
-	// ClouDNS support all below, but not implemented yet
-	providers.CanUsePTR:   providers.Unimplemented(),
-	providers.CanUseSSHFP: providers.Unimplemented(),
-	providers.CanUseCAA:   providers.Can(),
-	providers.CanUseTLSA:  providers.Can(),
+	providers.CanUseSSHFP:            providers.Can(),
+	providers.CanUseCAA:              providers.Can(),
+	providers.CanUseTLSA:             providers.Can(),
+	providers.CanUsePTR:              providers.Unimplemented(),
 }
 
 func init() {
@@ -198,6 +197,12 @@ func toRc(dc *models.DomainConfig, r *domainRecord) *models.RecordConfig {
 		tlsaMatchingType, _ := strconv.ParseUint(r.TlsaMatchingType, 10, 32)
 		rc.TlsaMatchingType = uint8(tlsaMatchingType)
 		rc.SetTarget(r.Target)
+	case "SSHFP":
+		sshfpAlgorithm, _ := strconv.ParseUint(r.SshfpAlgorithm, 10, 32)
+		rc.SshfpAlgorithm = uint8(sshfpAlgorithm)
+		sshfpFingerprint, _ := strconv.ParseUint(r.SshfpFingerprint, 10, 32)
+		rc.SshfpFingerprint = uint8(sshfpFingerprint)
+		rc.SetTarget(r.Target)
 	default:
 		rc.SetTarget(r.Target)
 	}
@@ -235,6 +240,9 @@ func toReq(rc *models.RecordConfig) (requestParams, error) {
 		req["tlsa_usage"] = strconv.Itoa(int(rc.TlsaUsage))
 		req["tlsa_selector"] = strconv.Itoa(int(rc.TlsaSelector))
 		req["tlsa_matching_type"] = strconv.Itoa(int(rc.TlsaMatchingType))
+	case "SSHFP":
+		req["algorithm"] = strconv.Itoa(int(rc.SshfpAlgorithm))
+		req["fptype"] = strconv.Itoa(int(rc.SshfpFingerprint))
 	default:
 		msg := fmt.Sprintf("ClouDNS.toReq rtype %v unimplemented", rc.Type)
 		panic(msg)

--- a/providers/cloudns/cloudnsProvider.go
+++ b/providers/cloudns/cloudnsProvider.go
@@ -21,13 +21,6 @@ Info required in `creds.json`:
 
 */
 
-var defaultNameServerNames = []string{
-	"pns101.cloudns.net",
-	"pns102.cloudns.net",
-	"pns103.cloudns.net",
-	"pns104.cloudns.net",
-}
-
 // NewCloudns creates the provider.
 func NewCloudns(m map[string]string, metadata json.RawMessage) (providers.DNSServiceProvider, error) {
 	api := &CloudnsApi{}
@@ -64,7 +57,10 @@ func init() {
 
 // GetNameservers returns the nameservers for a domain.
 func (api *CloudnsApi) GetNameservers(domain string) ([]*models.Nameserver, error) {
-	return models.StringsToNameservers(defaultNameServerNames), nil
+	if len(api.nameserversNames) == 0 {
+		api.fetchAvailableNameservers()
+	}
+	return models.StringsToNameservers(api.nameserversNames), nil
 }
 
 // GetDomainCorrections returns the corrections for a domain.
@@ -91,7 +87,7 @@ func (api *CloudnsApi) GetDomainCorrections(dc *models.DomainConfig) ([]*models.
 		return nil, err
 	}
 
-	existingRecords := make([]*models.RecordConfig, len(records), len(records)+len(defaultNameServerNames))
+	existingRecords := make([]*models.RecordConfig, len(records), len(records)+len(api.nameserversNames))
 	for i := range records {
 		existingRecords[i] = toRc(dc, &records[i])
 	}


### PR DESCRIPTION
Fix #114  This is my first experience with Go, so any feedback will be valuable :)
Linode provider was used as base.

The tests pass. But TestDualProviders doesn't work with ClouDNS. ClouDNS do not allow you to create NS for ns1.otherdomain.tld But work fine for any "real" domain like ns1.otherdomain.com Can we change domain in test to COM ? If yes, should I make separate PR?