### PR TITLE
Fix issues from go vet

### DIFF
--- a/pkg/acme/registration.go
+++ b/pkg/acme/registration.go
@@ -54,8 +54,8 @@ func (c *certManager) createAccount(email string) (*Account, error) {
 
 type Account struct {
 	Email        string                 `json:"email"`
-	key          *ecdsa.PrivateKey      `json:"-"`
 	Registration *registration.Resource `json:"registration"`
+	key          *ecdsa.PrivateKey
 }
 
 func (a *Account) GetEmail() string {

--- a/providers/cloudflare/cloudflareProvider.go
+++ b/providers/cloudflare/cloudflareProvider.go
@@ -58,7 +58,7 @@ func init() {
 // CloudflareApi is the handle for API calls.
 type CloudflareApi struct {
 	ApiKey          string `json:"apikey"`
-	ApiToken        string `json:apitoken`
+	ApiToken        string `json:"apitoken"`
 	ApiUser         string `json:"apiuser"`
 	AccountID       string `json:"accountid"`
 	AccountName     string `json:"accountname"`

--- a/providers/route53/route53Provider.go
+++ b/providers/route53/route53Provider.go
@@ -106,7 +106,6 @@ func withRetry(f func() error) {
 			return
 		}
 	}
-	return
 }
 
 func (r *route53Provider) getZones() error {


### PR DESCRIPTION
* CloudFlare provider is missing quotes on a JSON struct tag.
* ACME package has a unnecessary JSON struct tag.
* Route53 provider has an unreachable return.