### PR TITLE
Add _mta-sts to labels allowed to have an underscore

### DIFF
--- a/pkg/normalize/validate.go
+++ b/pkg/normalize/validate.go
@@ -92,6 +92,7 @@ var labelUnderscores = []string{
 	"_dmarc",
 	"_domainkey",
 	"_jabber",
+	"_mta-sts",
 	"_sip",
 	"_xmpp",
 }


### PR DESCRIPTION
Although `_mta-sts` is normally used with a `TXT` record it can also be used with a `CNAME` record to delegate the authority.

See sections 3.1 and 8.2 of [RFC8461](https://www.rfc-editor.org/rfc/rfc8461.txt) for details.