### PR TITLE
 Upgraded Azure SDK to 39.1.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.13
 
 require (
 	cloud.google.com/go v0.41.1-0.20190703172311-335e9e09b93e // indirect
-	github.com/Azure/azure-sdk-for-go v32.6.0+incompatible
+	github.com/Azure/azure-sdk-for-go v39.1.0+incompatible
 	github.com/Azure/go-autorest/autorest v0.9.4 // indirect
 	github.com/Azure/go-autorest/autorest/azure/auth v0.4.2
 	github.com/Azure/go-autorest/autorest/to v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,6 @@ cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMT
 cloud.google.com/go v0.38.0/go.mod h1:990N+gfupTy94rShfmMCWGDn0LpTmnzTp2qbd1dvSRU=
 cloud.google.com/go v0.41.1-0.20190703172311-335e9e09b93e h1:E4NknbTPW+1SVNhlxaJolqh+W5FM4q7KsiR2zv8tVNg=
 cloud.google.com/go v0.41.1-0.20190703172311-335e9e09b93e/go.mod h1:05T3xsDVUIfRZP+EM2ftPky59P2i67FhEj6hjkpO5GE=
-github.com/Azure/azure-sdk-for-go v32.6.0+incompatible h1:PgaVceWF5idtJajyt1rzq1cep6eRPJ8+8hs4GnNzTo0=
-github.com/Azure/azure-sdk-for-go v32.6.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
 github.com/Azure/azure-sdk-for-go v39.1.0+incompatible h1:ZwZgxG+8jLMJbY2NN1e8wiqE+/j4GiuHEc7U5wvPR94=
 github.com/Azure/azure-sdk-for-go v39.1.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
 github.com/Azure/go-autorest/autorest v0.9.0/go.mod h1:xyHB1BMZT0cuDHU7I0+g046+BFDTQ8rEZB0s4Yfa6bI=

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,8 @@ cloud.google.com/go v0.41.1-0.20190703172311-335e9e09b93e h1:E4NknbTPW+1SVNhlxaJ
 cloud.google.com/go v0.41.1-0.20190703172311-335e9e09b93e/go.mod h1:05T3xsDVUIfRZP+EM2ftPky59P2i67FhEj6hjkpO5GE=
 github.com/Azure/azure-sdk-for-go v32.6.0+incompatible h1:PgaVceWF5idtJajyt1rzq1cep6eRPJ8+8hs4GnNzTo0=
 github.com/Azure/azure-sdk-for-go v32.6.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
+github.com/Azure/azure-sdk-for-go v39.1.0+incompatible h1:ZwZgxG+8jLMJbY2NN1e8wiqE+/j4GiuHEc7U5wvPR94=
+github.com/Azure/azure-sdk-for-go v39.1.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
 github.com/Azure/go-autorest/autorest v0.9.0/go.mod h1:xyHB1BMZT0cuDHU7I0+g046+BFDTQ8rEZB0s4Yfa6bI=
 github.com/Azure/go-autorest/autorest v0.9.3/go.mod h1:GsRuLYvwzLjjjRoWEIyMUaYq8GNUx2nRB378IPt/1p0=
 github.com/Azure/go-autorest/autorest v0.9.4 h1:1cM+NmKw91+8h5vfjgzK4ZGLuN72k87XVZBWyGwNjUM=

--- a/integrationTest/integration_test.go
+++ b/integrationTest/integration_test.go
@@ -566,7 +566,7 @@ func makeTests(t *testing.T) []*TestCase {
 	)
 
 	// TXT (empty)
-	if !(*providerToRun == "CLOUDFLAREAPI" || *providerToRun == "AZURE_DNS") {
+	if *providerToRun != "CLOUDFLAREAPI" {
 		tests = append(tests, tc("Empty"),
 			tc("TXT with empty str", txt("foo1", "")),
 		)

--- a/integrationTest/integration_test.go
+++ b/integrationTest/integration_test.go
@@ -566,7 +566,7 @@ func makeTests(t *testing.T) []*TestCase {
 	)
 
 	// TXT (empty)
-	if *providerToRun != "CLOUDFLAREAPI" {
+	if !(*providerToRun == "CLOUDFLAREAPI" || *providerToRun == "AZURE_DNS") {
 		tests = append(tests, tc("Empty"),
 			tc("TXT with empty str", txt("foo1", "")),
 		)

--- a/providers/azuredns/azureDnsProvider.go
+++ b/providers/azuredns/azureDnsProvider.go
@@ -377,7 +377,10 @@ func recordToNative(recordKey models.RecordKey, recordConfig []*models.RecordCon
 			if recordSet.TxtRecords == nil {
 				recordSet.TxtRecords = &[]adns.TxtRecord{}
 			}
-			*recordSet.TxtRecords = append(*recordSet.TxtRecords, adns.TxtRecord{Value: &rec.TxtStrings})
+			// Empty TXT record needs to have no value set in it's properties
+			if rec.TxtStrings[0] != "" {
+				*recordSet.TxtRecords = append(*recordSet.TxtRecords, adns.TxtRecord{Value: &rec.TxtStrings})
+			}
 		case "MX":
 			if recordSet.MxRecords == nil {
 				recordSet.MxRecords = &[]adns.MxRecord{}

--- a/providers/azuredns/azureDnsProvider.go
+++ b/providers/azuredns/azureDnsProvider.go
@@ -79,8 +79,9 @@ func (a *azureDnsProvider) getZones() error {
 	}
 	zonesResult := zonesIterator.Response()
 	for _, z := range *zonesResult.Value {
+		zone := z
 		domain := strings.TrimSuffix(*z.Name, ".")
-		a.zones[domain] = &z
+		a.zones[domain] = &zone
 	}
 
 	return nil
@@ -266,7 +267,7 @@ func nativeToRecords(set *adns.RecordSet, origin string) []*models.RecordConfig 
 	var results []*models.RecordConfig
 	switch rtype := *set.Type; rtype {
 	case "Microsoft.Network/dnszones/A":
-		if *set.ARecords != nil {
+		if set.ARecords != nil {
 			for _, rec := range *set.ARecords {
 				rc := &models.RecordConfig{TTL: uint32(*set.TTL)}
 				rc.SetLabelFromFQDN(*set.Fqdn, origin)
@@ -276,7 +277,7 @@ func nativeToRecords(set *adns.RecordSet, origin string) []*models.RecordConfig 
 			}
 		}
 	case "Microsoft.Network/dnszones/AAAA":
-		if *set.AaaaRecords != nil {
+		if set.AaaaRecords != nil {
 			for _, rec := range *set.AaaaRecords {
 				rc := &models.RecordConfig{TTL: uint32(*set.TTL)}
 				rc.SetLabelFromFQDN(*set.Fqdn, origin)

--- a/vendor/github.com/Azure/azure-sdk-for-go/services/dns/mgmt/2018-05-01/dns/client.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/services/dns/mgmt/2018-05-01/dns/client.go
@@ -41,7 +41,8 @@ func New(subscriptionID string) BaseClient {
 	return NewWithBaseURI(DefaultBaseURI, subscriptionID)
 }
 
-// NewWithBaseURI creates an instance of the BaseClient client.
+// NewWithBaseURI creates an instance of the BaseClient client using a custom endpoint.  Use this when interacting with
+// an Azure cloud that uses a non-standard base URI (sovereign clouds, Azure stack).
 func NewWithBaseURI(baseURI string, subscriptionID string) BaseClient {
 	return BaseClient{
 		Client:         autorest.NewClientWithUserAgent(UserAgent()),

--- a/vendor/github.com/Azure/azure-sdk-for-go/services/dns/mgmt/2018-05-01/dns/recordsets.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/services/dns/mgmt/2018-05-01/dns/recordsets.go
@@ -35,7 +35,8 @@ func NewRecordSetsClient(subscriptionID string) RecordSetsClient {
 	return NewRecordSetsClientWithBaseURI(DefaultBaseURI, subscriptionID)
 }
 
-// NewRecordSetsClientWithBaseURI creates an instance of the RecordSetsClient client.
+// NewRecordSetsClientWithBaseURI creates an instance of the RecordSetsClient client using a custom endpoint.  Use this
+// when interacting with an Azure cloud that uses a non-standard base URI (sovereign clouds, Azure stack).
 func NewRecordSetsClientWithBaseURI(baseURI string, subscriptionID string) RecordSetsClient {
 	return RecordSetsClient{NewWithBaseURI(baseURI, subscriptionID)}
 }

--- a/vendor/github.com/Azure/azure-sdk-for-go/services/dns/mgmt/2018-05-01/dns/resourcereference.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/services/dns/mgmt/2018-05-01/dns/resourcereference.go
@@ -35,7 +35,9 @@ func NewResourceReferenceClient(subscriptionID string) ResourceReferenceClient {
 	return NewResourceReferenceClientWithBaseURI(DefaultBaseURI, subscriptionID)
 }
 
-// NewResourceReferenceClientWithBaseURI creates an instance of the ResourceReferenceClient client.
+// NewResourceReferenceClientWithBaseURI creates an instance of the ResourceReferenceClient client using a custom
+// endpoint.  Use this when interacting with an Azure cloud that uses a non-standard base URI (sovereign clouds, Azure
+// stack).
 func NewResourceReferenceClientWithBaseURI(baseURI string, subscriptionID string) ResourceReferenceClient {
 	return ResourceReferenceClient{NewWithBaseURI(baseURI, subscriptionID)}
 }

--- a/vendor/github.com/Azure/azure-sdk-for-go/services/dns/mgmt/2018-05-01/dns/zones.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/services/dns/mgmt/2018-05-01/dns/zones.go
@@ -35,7 +35,8 @@ func NewZonesClient(subscriptionID string) ZonesClient {
 	return NewZonesClientWithBaseURI(DefaultBaseURI, subscriptionID)
 }
 
-// NewZonesClientWithBaseURI creates an instance of the ZonesClient client.
+// NewZonesClientWithBaseURI creates an instance of the ZonesClient client using a custom endpoint.  Use this when
+// interacting with an Azure cloud that uses a non-standard base URI (sovereign clouds, Azure stack).
 func NewZonesClientWithBaseURI(baseURI string, subscriptionID string) ZonesClient {
 	return ZonesClient{NewWithBaseURI(baseURI, subscriptionID)}
 }

--- a/vendor/github.com/Azure/azure-sdk-for-go/version/version.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/version/version.go
@@ -18,4 +18,4 @@ package version
 // Changes may cause incorrect behavior and will be lost if the code is regenerated.
 
 // Number contains the semantic version of this SDK.
-const Number = "v32.6.0"
+const Number = "v39.1.0"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,6 +1,6 @@
 # cloud.google.com/go v0.41.1-0.20190703172311-335e9e09b93e
 cloud.google.com/go/compute/metadata
-# github.com/Azure/azure-sdk-for-go v32.6.0+incompatible
+# github.com/Azure/azure-sdk-for-go v39.1.0+incompatible
 github.com/Azure/azure-sdk-for-go/services/dns/mgmt/2018-05-01/dns
 github.com/Azure/azure-sdk-for-go/version
 # github.com/Azure/go-autorest/autorest v0.9.4


### PR DESCRIPTION
Actions #619 
Upgraded Azure SDK to 39.1.0
Empty string not accepted using default API Call. Changed for that particular case
Some other fixes for #616 #615 

go get -u github.com/Azure/azure-sdk-for-go
go mod tidy