### PR TITLE
dnsimple: bug-fix SSHFP, add multi TXT support

### DIFF
--- a/commands/commands.go
+++ b/commands/commands.go
@@ -33,8 +33,8 @@ var _ = cmd(catDebug, &cli.Command{
 	Name:  "version",
 	Usage: "Print version information",
 	Action: func(c *cli.Context) error {
-    _, err := fmt.Println(version)
-    return err
+		_, err := fmt.Println(version)
+		return err
 	},
 })
 

--- a/docs/_includes/matrix.html
+++ b/docs/_includes/matrix.html
@@ -549,7 +549,9 @@
 			<i class="fa fa-check text-success" aria-hidden="true"></i>
 		</td>
 		<td><i class="fa fa-minus dim"></i></td>
-		<td><i class="fa fa-minus dim"></i></td>
+		<td class="success">
+			<i class="fa fa-check text-success" aria-hidden="true"></i>
+		</td>
 		<td><i class="fa fa-minus dim"></i></td>
 		<td><i class="fa fa-minus dim"></i></td>
 		<td><i class="fa fa-minus dim"></i></td>
@@ -631,7 +633,9 @@
 		<td><i class="fa fa-minus dim"></i></td>
 		<td><i class="fa fa-minus dim"></i></td>
 		<td><i class="fa fa-minus dim"></i></td>
-		<td><i class="fa fa-minus dim"></i></td>
+		<td class="success">
+			<i class="fa fa-check text-success" aria-hidden="true"></i>
+		</td>
 		<td><i class="fa fa-minus dim"></i></td>
 		<td><i class="fa fa-minus dim"></i></td>
 		<td class="success">

--- a/providers/dnsimple/dnsimpleProvider.go
+++ b/providers/dnsimple/dnsimpleProvider.go
@@ -495,7 +495,7 @@ func getTargetRecordPriority(rc *models.RecordConfig) int {
 func quoteDNSString(unquoted string) string {
 	b, err := json.Marshal(unquoted)
 	if err != nil {
-		panic(fmt.Errorf("enable to marshal to JSON: %q", unquoted))
+		panic(fmt.Errorf("unable to marshal to JSON: %q", unquoted))
 	}
 	return string(b)
 }


### PR DESCRIPTION
The default logic for encoding SSHFP records was dropping the key and
hash algorithms and just posting the content, the `Can` check didn't
stop attempts to use SSHFP.  So, implement SSHFP support.

DNSimple support multiple DNS strings in a TXT record, by representing
the payload as quoted strings already.  This doesn't appear to be
documented, but it does actually work.