### PR TITLE
Tests: check that RRtype record creation does fail

### DIFF
--- a/docs/_includes/matrix.html
+++ b/docs/_includes/matrix.html
@@ -939,8 +939,8 @@
 		<td class="success">
 			<i class="fa fa-check text-success" aria-hidden="true"></i>
 		</td>
-		<td class="info">
-			<i class="fa fa-circle-o text-info" aria-hidden="true"></i>
+		<td class="success">
+			<i class="fa fa-check text-success" aria-hidden="true"></i>
 		</td>
 		<td class="info">
 			<i class="fa fa-circle-o text-info" aria-hidden="true"></i>
@@ -952,8 +952,8 @@
 		<td class="info">
 			<i class="fa fa-circle-o text-info" aria-hidden="true"></i>
 		</td>
-		<td class="info">
-			<i class="fa fa-circle-o text-info" aria-hidden="true"></i>
+		<td class="success">
+			<i class="fa fa-check text-success" aria-hidden="true"></i>
 		</td>
 		<td><i class="fa fa-minus dim"></i></td>
 		<td class="info">

--- a/integrationTest/integration_test.go
+++ b/integrationTest/integration_test.go
@@ -422,7 +422,7 @@ func makeTests(t *testing.T) []*TestCase {
 	// PTR
 	if !providers.ProviderHasCapability(*providerToRun, providers.CanUsePTR) {
 		tests = append(tests, tc("Empty"),
-			shouldFail("PTR should fail", ptr(4, "foo.com")),
+			shouldFail("PTR should fail", ptr("4", "foo.com")),
 		)
 	} else {
 		tests = append(tests, tc("Empty"),

--- a/providers/gcloud/gcloudProvider.go
+++ b/providers/gcloud/gcloudProvider.go
@@ -108,7 +108,7 @@ func (g *gcloud) loadZoneInfo() error {
 // ListZones returns the list of zones (domains) in this account.
 func (g *gcloud) ListZones() ([]string, error) {
 	var zones []string
-	for i, _ := range g.zones {
+	for i := range g.zones {
 		zones = append(zones, strings.TrimSuffix(i, "."))
 	}
 	return zones, nil


### PR DESCRIPTION
Rather than skip tests for things we assert will fail, test that they
actually will fail.

This might have portability problems across providers, but it works for
the one I've been using.  Someone with a rig designed to test all the
different providers should try this out.  :)