### PR TITLE
Update privider-list.md

### DIFF
--- a/docs/_includes/matrix.html
+++ b/docs/_includes/matrix.html
@@ -38,8 +38,8 @@
 		<td class="success">
 			<i class="fa fa-check text-success" aria-hidden="true"></i>
 		</td>
-		<td class="danger">
-			<i class="fa fa-times text-danger" aria-hidden="true"></i>
+		<td class="success">
+			<i class="fa fa-check text-success" aria-hidden="true"></i>
 		</td>
 		<td class="success">
 			<i class="fa fa-check text-success" aria-hidden="true"></i>

--- a/docs/provider-list.md
+++ b/docs/provider-list.md
@@ -26,7 +26,7 @@ title: Service Providers
 </p>
 <p>
   An empty space may indicate the feature is not supported by a provider, or it may simply mean
-  the feature has not been investigated and implemented yet. If a feature you need is missing from 
+  the feature has not been investigated and implemented yet. If a feature you need is missing from
   a provider that supports it, we'd love your contribution to ensure it works correctly and add it to this matrix.
 </p>
 <p>If a feature is definitively not supported for whatever reason, we would also like a PR to clarify why it is not supported, and fill in this entire matrix.</p>
@@ -45,6 +45,16 @@ Official support means:
 * New features will work on these providers (unless the provider does not support it).
 * StackOverflow maintains test accounts with those providers for running integration tests.
 
+Current owners are:
+
+* `ACTIVEDIRECTORY_PS` @tlimoncelli
+* `AZURE_DNS` @vatsalyagoel
+* `BIND` @tlimoncelli
+* `CLOUDFLAREAPI` @tlimoncelli
+* `GCLOUD` @tlimoncelli
+* `NAMEDOTCOM` @tlimoncelli
+* `ROUTE53` @tlimoncelli
+
 ### Providers with "contributor support"
 
 The other providers are supported by community members, usually the
@@ -61,18 +71,23 @@ provided to help community members support their code independently.
 
 Maintainers of contributed providers:
 
-* ClouDNS @pragmaton
-* digital ocean @Deraen
-* dnsimple @aeden
-* gandi @TomOnTime
-* HEXONET @papakai
-* Internet.bs @pragmaton
-* Linode @koesie10
-* namecheap @captncraig
-* ns1 @captncraig
-* OVH @masterzen
-* Vultr @geek1011
-* Azure DNS @vatsalyagoel
+* `CLOUDNS` @pragmaton
+* `DIGITALOCEAN` @Deraen
+* `DNSIMPLE` @aeden
+* `EXOSCALE` @pierre-emmanuelJ
+* `GANDI_V5` @TomOnTime
+* `GANDI-LIVEDNS` (going away in 3.0)
+* `GANDI` (going away in 3.0)
+* `HEXONET` @papakai
+* `INTERNETBS` @pragmaton
+* `LINODE` @koesie10
+* `NAMECHEAP` @captncraig
+* `NS1` @captncraig
+* `OCTODNS` @TomOnTime
+* `OPENSRS` @pierre-emmanuelJ
+* `OVH` @masterzen
+* `SOFTLAYER`@jamielennox
+* `VULTR` @geek1011
 
 ### Requested providers
 

--- a/providers/azuredns/azureDnsProvider.go
+++ b/providers/azuredns/azureDnsProvider.go
@@ -53,7 +53,7 @@ var features = providers.DocumentationNotes{
 	providers.CanUseAlias:            providers.Cannot("Only supported for Azure Resources. Not yet implemented"),
 	providers.DocCreateDomains:       providers.Can(),
 	providers.DocDualHost:            providers.Can("Azure does not permit modifying the existing NS records, only adding/removing additional records."),
-	providers.DocOfficiallySupported: providers.Cannot(),
+	providers.DocOfficiallySupported: providers.Can(),
 	providers.CanUsePTR:              providers.Can(),
 	providers.CanUseSRV:              providers.Can(),
 	providers.CanUseTXTMulti:         providers.Can(),


### PR DESCRIPTION
* AZUREDNS is now an officially supported provider
* Update missing providers (https://github.com/StackExchange/dnscontrol/issues/632)
  * Missing providers: OPENSRS, SOFTLAYER

Fixes https://github.com/StackExchange/dnscontrol/issues/632

CC:
* @vatsalyagoel 
* @pierre-emmanuelJ
* @jamielennox