### PR TITLE
get-zones: Improve TTL handling when provider has magic TTLs

### DIFF
--- a/commands/getZones.go
+++ b/commands/getZones.go
@@ -165,7 +165,7 @@ func GetZone(args GetZoneArgs) error {
 			if defaultTTL == 0 {
 				defaultTTL = prettyzone.MostCommonTTL(recs)
 			}
-			if defaultTTL != models.DefaultTTL {
+			if defaultTTL != models.DefaultTTL && defaultTTL != 0 {
 				fmt.Fprintf(w, "\n\tDefaultTTL(%d)", defaultTTL)
 			}
 			for _, rec := range recs {

--- a/pkg/prettyzone/prettyzone.go
+++ b/pkg/prettyzone/prettyzone.go
@@ -79,6 +79,9 @@ func PrettySort(records models.Records, origin string, defaultTTL uint32, commen
 		DefaultTTL: defaultTTL,
 		Comments:   comments,
 	}
+	if z.DefaultTTL == 0 {
+		z.DefaultTTL = 300
+	}
 	z.Records = nil
 	for _, r := range records {
 		z.Records = append(z.Records, r)
@@ -92,6 +95,9 @@ func (z *zoneGenData) generateZoneFileHelper(w io.Writer) error {
 	nameShortPrevious := ""
 
 	sort.Sort(z)
+	if z.DefaultTTL == 0 {
+		z.DefaultTTL = 300
+	}
 	fmt.Fprintln(w, "$TTL", z.DefaultTTL)
 	for _, comment := range z.Comments {
 		for _, line := range strings.Split(comment, "\n") {


### PR DESCRIPTION
If a provider considers ttl=0 to be magic, the output of get-zones makes more sense now.