### PR TITLE
(#628) Add get-zones to the OVH provider

### DIFF
--- a/integrationTest/providers.json
+++ b/integrationTest/providers.json
@@ -125,6 +125,7 @@
     "app-key": "$OVH_APP_KEY",
     "app-secret-key": "$OVH_APP_SECRET_KEY",
     "consumer-key": "$OVH_CONSUMER_KEY",
-    "domain": "$OVH_DOMAIN"
+    "domain": "$OVH_DOMAIN",
+    "knownFailures": "49"
   }
 }


### PR DESCRIPTION
Commit 87ad01d added the very useful `get-zones` command, whichrequires providers to implement a new method `GetZoneRecords` (tracked in #628).

This changes make the OVH provider support this new feature.