### PR TITLE
(#491) convert the OVH provider to models.ToNameservers

### DIFF
--- a/providers/ovh/ovhProvider.go
+++ b/providers/ovh/ovhProvider.go
@@ -69,7 +69,7 @@ func (c *ovhProvider) GetNameservers(domain string) ([]*models.Nameserver, error
 		return nil, err
 	}
 
-	return models.StringsToNameservers(ns), nil
+	return models.ToNameservers(ns)
 }
 
 type errNoExist struct {


### PR DESCRIPTION
As requested in #491, as OVH doesn't return dot-suffixed NS, therefore we can use `models.ToNameservers` in this provider (which incidentally this PR does). 