### PR TITLE
Add CanUseTXTMulti to GANDI_V5 provider

### DIFF
--- a/providers/gandi_v5/gandi_v5Provider.go
+++ b/providers/gandi_v5/gandi_v5Provider.go
@@ -46,6 +46,7 @@ var features = providers.DocumentationNotes{
 	providers.CanUseSRV:              providers.Can(),
 	providers.CanUseSSHFP:            providers.Can(),
 	providers.CanUseTLSA:             providers.Can(),
+	providers.CanUseTXTMulti:         providers.Can(),
 	providers.CantUseNOPURGE:         providers.Cannot(),
 	providers.DocCreateDomains:       providers.Cannot("Can only manage domains registered through their service"),
 	providers.DocOfficiallySupported: providers.Cannot(),


### PR DESCRIPTION
Encountered this while trying to push a long TXT record with GANDI_V5.  The provider accepts it but reformats it into a compatible multi-TXT record.  Unfortunately, this results in every subsequent `dnscontrol preview` to indicate that the TXT record does not match.  `dnscontrol push` will also update this record with every call.

With this patch, I'm able to push the TXT record as expected, and preview after push indicates no more changes as expected.

`cd integrationTest && go test` passes