### PR TITLE
Fix #702: Spurious null MX changes on CloudFlare

### DIFF
--- a/integrationTest/integration_test.go
+++ b/integrationTest/integration_test.go
@@ -610,7 +610,7 @@ func makeTests(t *testing.T) []*TestGroup {
 		),
 
 		testgroup("Null MX",
-			only("BIND", "CLOUDFLAREAPI", "GCLOUD", "ROUTE53"), // Not all providers support RFC 7505
+			not("AZURE_DNS", "GANDI_V5", "NAMEDOTCOM", "DIGITALOCEAN"), // These providers don't support RFC 7505
 			tc("Null MX", mx("@", 0, ".")),
 		),
 

--- a/integrationTest/integration_test.go
+++ b/integrationTest/integration_test.go
@@ -610,7 +610,7 @@ func makeTests(t *testing.T) []*TestGroup {
 		),
 
 		testgroup("Null MX",
-			only("CLOUDFLAREAPI"), // Other providers might support this, CF definitely does
+			only("BIND", "CLOUDFLAREAPI", "GCLOUD", "ROUTE53"), // Not all providers support RFC 7505
 			tc("Null MX", mx("@", 0, ".")),
 		),
 

--- a/integrationTest/integration_test.go
+++ b/integrationTest/integration_test.go
@@ -609,6 +609,11 @@ func makeTests(t *testing.T) []*TestGroup {
 			tc("Record pointing to @", mx("foo", 8, "**current-domain**")),
 		),
 
+		testgroup("Null MX",
+			only("CLOUDFLAREAPI"), // Other providers might support this, CF definitely does
+			tc("Null MX", mx("@", 0, ".")),
+		),
+
 		testgroup("NS",
 			not("DNSIMPLE", "EXOSCALE"),
 			// DNSIMPLE: Does not support NS records nor subdomains.

--- a/providers/cloudflare/cloudflareProvider.go
+++ b/providers/cloudflare/cloudflareProvider.go
@@ -541,7 +541,7 @@ type cfRecord struct {
 func (c *cfRecord) nativeToRecord(domain string) *models.RecordConfig {
 	// normalize cname,mx,ns records with dots to be consistent with our config format.
 	if c.Type == "CNAME" || c.Type == "MX" || c.Type == "NS" || c.Type == "SRV" {
-		c.Content = dnsutil.AddOrigin(c.Content+".", domain)
+		c.Content = dnsutil.AddOrigin(strings.TrimSuffix(c.Content, ".")+".", domain)
 	}
 
 	rc := &models.RecordConfig{

--- a/providers/cloudflare/cloudflareProvider.go
+++ b/providers/cloudflare/cloudflareProvider.go
@@ -541,7 +541,9 @@ type cfRecord struct {
 func (c *cfRecord) nativeToRecord(domain string) *models.RecordConfig {
 	// normalize cname,mx,ns records with dots to be consistent with our config format.
 	if c.Type == "CNAME" || c.Type == "MX" || c.Type == "NS" || c.Type == "SRV" {
-		c.Content = dnsutil.AddOrigin(strings.TrimSuffix(c.Content, ".")+".", domain)
+		if c.Content != "." {
+			c.Content = c.Content + "."
+		}
 	}
 
 	rc := &models.RecordConfig{


### PR DESCRIPTION
When the CloudFlare provider syncs, it adds an extraneous `.` to the retrieved record's target, if the target is just a `.` (e.g. for an RFC 7505 null MX of `MX('@', 0, '.')`).  This PR ensures that the `.` is only added to targets that don't already have one.