### PR TITLE
Fix octodns: constant 4294967295 overflows int (Issue #736)

### DIFF
--- a/providers/octodns/octoyaml/read.go
+++ b/providers/octodns/octoyaml/read.go
@@ -12,7 +12,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"math"
 	"reflect"
 	"strconv"
 
@@ -263,8 +262,8 @@ func decodeTTL(ttl interface{}) (uint32, error) {
 		return uint32(t), fmt.Errorf("decodeTTL failed to parse (%s): %w", s, err)
 	case int:
 		i := ttl.(int)
-		if i < 0 || i > math.MaxUint32 {
-			return 0, fmt.Errorf("ttl won't fit in 32-bits (%d)", i)
+		if i < 0 {
+			return 0, fmt.Errorf("ttl cannot be negative (%d)", i)
 		}
 		return uint32(i), nil
 	}


### PR DESCRIPTION
This fixes Issue #736 and was build tested with Go 1.14.2 on

- FreeBSD 12.1/i386
- FreeBSD 12.1/amd64
- FreeBSD 11.3/i386
- FreeBSD 11.3/amd64

https://ports.bluelife.at/builds/20200507-09:37:34.38360/