### PR TITLE
Add support to GCLOUD provider for DS records

### DIFF
--- a/providers/capabilities.go
+++ b/providers/capabilities.go
@@ -18,7 +18,7 @@ const (
 	// CanUseCAA indicates the provider can handle CAA records
 	CanUseCAA
 
-	// CanUseDs indicates that the provider can handle DS record types
+	// CanUseDS indicates that the provider can handle DS record types
 	CanUseDS
 
 	// CanUsePTR indicates the provider can handle PTR records

--- a/providers/gcloud/gcloudProvider.go
+++ b/providers/gcloud/gcloudProvider.go
@@ -16,6 +16,7 @@ import (
 
 var features = providers.DocumentationNotes{
 	providers.CanGetZones:            providers.Can(),
+	providers.CanUseDS:               providers.Can(),
 	providers.CanUseCAA:              providers.Can(),
 	providers.CanUsePTR:              providers.Can(),
 	providers.CanUseSRV:              providers.Can(),


### PR DESCRIPTION
The gcloud provider seems to behave correctly with DS resource records,
and is able to read and write them properly. I've enabled this in the
provider options.

Please let me know of any special tests or actions you'd like me to take to
enable this to be merged. Thanks.