### PR TITLE
Revert "Add support to GCLOUD provider for DS records"

### DIFF
--- a/providers/capabilities.go
+++ b/providers/capabilities.go
@@ -18,7 +18,7 @@ const (
 	// CanUseCAA indicates the provider can handle CAA records
 	CanUseCAA
 
-	// CanUseDS indicates that the provider can handle DS record types
+	// CanUseDs indicates that the provider can handle DS record types
 	CanUseDS
 
 	// CanUsePTR indicates the provider can handle PTR records

--- a/providers/gcloud/gcloudProvider.go
+++ b/providers/gcloud/gcloudProvider.go
@@ -16,7 +16,6 @@ import (
 
 var features = providers.DocumentationNotes{
 	providers.CanGetZones:            providers.Can(),
-	providers.CanUseDS:               providers.Can(),
 	providers.CanUseCAA:              providers.Can(),
 	providers.CanUsePTR:              providers.Can(),
 	providers.CanUseSRV:              providers.Can(),


### PR DESCRIPTION
Reverts StackExchange/dnscontrol#760

Sadly I spoke too soon. I'm seeing errors when I run this test:

```
$ go test -v -verbose -provider GCLOUD -start 24 -end 24 -run TestDNSProviders
=== RUN   TestDNSProviders
=== RUN   TestDNSProviders/dnscontroltest-gcloud.com
=== RUN   TestDNSProviders/dnscontroltest-gcloud.com/Clean_Slate:Empty
    TestDNSProviders/dnscontroltest-gcloud.com/Clean_Slate:Empty: integration_test.go:179: DELETE NS dnscontroltest-gcloud.com ns1.example.com. ttl=300
        DELETE NS dnscontroltest-gcloud.com ns2.example.com. ttl=300
        
=== RUN   TestDNSProviders/dnscontroltest-gcloud.com/24:DS:create_DS
    TestDNSProviders/dnscontroltest-gcloud.com/24:DS:create_DS: integration_test.go:179: CREATE DS dnscontroltest-gcloud.com 1 13 1 ADIGEST ttl=300
        
    TestDNSProviders/dnscontroltest-gcloud.com/24:DS:create_DS: integration_test.go:183: googleapi: Error 400: Invalid value for 'entity.change.additions[0].rrdata[0]': '1 13 1 ADIGEST', invalid
=== RUN   TestDNSProviders/dnscontroltest-gcloud.com/Post_cleanup:Empty
--- FAIL: TestDNSProviders (2.38s)
    --- FAIL: TestDNSProviders/dnscontroltest-gcloud.com (1.56s)
        --- PASS: TestDNSProviders/dnscontroltest-gcloud.com/Clean_Slate:Empty (1.12s)
        --- FAIL: TestDNSProviders/dnscontroltest-gcloud.com/24:DS:create_DS (0.31s)
        --- PASS: TestDNSProviders/dnscontroltest-gcloud.com/Post_cleanup:Empty (0.13s)
FAIL
exit status 1
FAIL	github.com/StackExchange/dnscontrol/v3/integrationTest	2.694s
```