### PR TITLE
Provider support for DS records as children only

### DIFF
--- a/integrationTest/integration_test.go
+++ b/integrationTest/integration_test.go
@@ -850,6 +850,25 @@ func makeTests(t *testing.T) []*TestGroup {
 			tc("add 2 more DS", ds("foo", 2, 13, 4, "ADIGEST"), ds("@", 65535, 5, 4, "ADIGEST"), ds("@", 65535, 253, 4, "ADIGEST")),
 		),
 
+		testgroup("DS (children only)",
+			requires(providers.CanUseDSForChildren),
+			// Use a valid digest value here, because GCLOUD (which implements this capability) verifies
+			// the value passed in is a valid digest. RFC 4034, s5.1.4 specifies SHA1 as the only digest
+			// algo at present, i.e. only hexadecimal values currently usable.
+			tc("create DS", ds("child", 1, 13, 1, "0123456789ABCDEF")),
+			tc("modify field 1", ds("child", 65535, 13, 1, "0123456789ABCDEF")),
+			tc("modify field 3", ds("child", 65535, 13, 2, "0123456789ABCDEF")),
+			tc("modify field 2+3", ds("child", 65535, 1, 4, "0123456789ABCDEF")),
+			tc("modify field 2", ds("child", 65535, 3, 4, "0123456789ABCDEF")),
+			tc("modify field 2", ds("child", 65535, 254, 4, "0123456789ABCDEF")),
+			tc("delete 1, create 1", ds("another-child", 2, 13, 4, "0123456789ABCDEF")),
+			tc("add 2 more DS",
+				ds("another-child", 2, 13, 4, "0123456789ABCDEF"),
+				ds("another-child", 65535, 5, 4, "0123456789ABCDEF"),
+				ds("another-child", 65535, 253, 4, "0123456789ABCDEF"),
+			),
+		),
+
 		//
 		// Pseudo rtypes:
 		//

--- a/pkg/normalize/capabilities_test.go
+++ b/pkg/normalize/capabilities_test.go
@@ -55,7 +55,9 @@ func TestCapabilitiesAreFiltered(t *testing.T) {
 
 	capIntsToNames := make(map[int]string, len(providerCapabilityChecks))
 	for _, pair := range providerCapabilityChecks {
-		capIntsToNames[int(pair.cap)] = pair.rType
+		for _, cap := range pair.caps {
+			capIntsToNames[int(cap)] = pair.rType
+		}
 	}
 
 	for _, capName := range constantNames {

--- a/providers/capabilities.go
+++ b/providers/capabilities.go
@@ -18,8 +18,13 @@ const (
 	// CanUseCAA indicates the provider can handle CAA records
 	CanUseCAA
 
-	// CanUseDS indicates that the provider can handle DS record types
+	// CanUseDS indicates that the provider can handle DS record types. This
+	// implies CanUseDSForChildren without specifying the latter explicitly.
 	CanUseDS
+
+	// CanUseDSForChildren indicates the provider can handle DS record types, but
+	// only for children records, not at the root of the zone.
+	CanUseDSForChildren
 
 	// CanUsePTR indicates the provider can handle PTR records
 	CanUsePTR

--- a/providers/capability_string.go
+++ b/providers/capability_string.go
@@ -11,25 +11,26 @@ func _() {
 	_ = x[CanUseAlias-0]
 	_ = x[CanUseCAA-1]
 	_ = x[CanUseDS-2]
-	_ = x[CanUsePTR-3]
-	_ = x[CanUseNAPTR-4]
-	_ = x[CanUseSRV-5]
-	_ = x[CanUseSSHFP-6]
-	_ = x[CanUseTLSA-7]
-	_ = x[CanUseTXTMulti-8]
-	_ = x[CanAutoDNSSEC-9]
-	_ = x[CantUseNOPURGE-10]
-	_ = x[DocOfficiallySupported-11]
-	_ = x[DocDualHost-12]
-	_ = x[DocCreateDomains-13]
-	_ = x[CanUseRoute53Alias-14]
-	_ = x[CanGetZones-15]
-	_ = x[CanUseAzureAlias-16]
+	_ = x[CanUseDSForChildren-3]
+	_ = x[CanUsePTR-4]
+	_ = x[CanUseNAPTR-5]
+	_ = x[CanUseSRV-6]
+	_ = x[CanUseSSHFP-7]
+	_ = x[CanUseTLSA-8]
+	_ = x[CanUseTXTMulti-9]
+	_ = x[CanAutoDNSSEC-10]
+	_ = x[CantUseNOPURGE-11]
+	_ = x[DocOfficiallySupported-12]
+	_ = x[DocDualHost-13]
+	_ = x[DocCreateDomains-14]
+	_ = x[CanUseRoute53Alias-15]
+	_ = x[CanGetZones-16]
+	_ = x[CanUseAzureAlias-17]
 }
 
-const _Capability_name = "CanUseAliasCanUseCAACanUseDSCanUsePTRCanUseNAPTRCanUseSRVCanUseSSHFPCanUseTLSACanUseTXTMultiCanAutoDNSSECCantUseNOPURGEDocOfficiallySupportedDocDualHostDocCreateDomainsCanUseRoute53AliasCanGetZonesCanUseAzureAlias"
+const _Capability_name = "CanUseAliasCanUseCAACanUseDSCanUseDSForChildrenCanUsePTRCanUseNAPTRCanUseSRVCanUseSSHFPCanUseTLSACanUseTXTMultiCanAutoDNSSECCantUseNOPURGEDocOfficiallySupportedDocDualHostDocCreateDomainsCanUseRoute53AliasCanGetZonesCanUseAzureAlias"
 
-var _Capability_index = [...]uint8{0, 11, 20, 28, 37, 48, 57, 68, 78, 92, 105, 119, 141, 152, 168, 186, 197, 213}
+var _Capability_index = [...]uint8{0, 11, 20, 28, 47, 56, 67, 76, 87, 97, 111, 124, 138, 160, 171, 187, 205, 216, 232}
 
 func (i Capability) String() string {
 	if i >= Capability(len(_Capability_index)-1) {

--- a/providers/gcloud/gcloudProvider.go
+++ b/providers/gcloud/gcloudProvider.go
@@ -16,7 +16,7 @@ import (
 
 var features = providers.DocumentationNotes{
 	providers.CanGetZones:            providers.Can(),
-	providers.CanUseDS:               providers.Can(),
+	providers.CanUseDSForChildren:    providers.Can(),
 	providers.CanUseCAA:              providers.Can(),
 	providers.CanUsePTR:              providers.Can(),
 	providers.CanUseSRV:              providers.Can(),


### PR DESCRIPTION
This functionality is required by the GCLOUD provider, which supports
recordsets of type DS but only for child records of the zone, to enable
further delegation. It does not support them at the apex of the zone (@)
because Google Cloud DNS is not itself a registrar which needs to model
this information.

A related change (14ff68b151b5db1f24bcdaccb30b6fa95897940a, #760) was
previously introduced to enable DS support in Google, which broke
integration tests with this provider.

To cleanly support this, we introduce a new provider capability
CanUseDSForChildren and appropriate integration tests. Further, it is no
longer possible to verify a provider has the proper capabilities for a
zone simply by existence of particular records; we adapt the capability
checks to enable inspection of the individual recordsets where this is
required.

Closes #762