### PR TITLE
NS1: Revert enabling TXTMulti

### DIFF
--- a/providers/ns1/ns1provider.go
+++ b/providers/ns1/ns1provider.go
@@ -17,7 +17,7 @@ import (
 var docNotes = providers.DocumentationNotes{
 	providers.CanUseAlias:            providers.Can(),
 	providers.CanUsePTR:              providers.Can(),
-	providers.CanUseTXTMulti:         providers.Can(),
+	providers.CanUseTXTMulti:         providers.Cannot(),
 	providers.DocCreateDomains:       providers.Cannot(),
 	providers.DocOfficiallySupported: providers.Cannot(),
 	providers.DocDualHost:            providers.Can(),


### PR DESCRIPTION
#775 Reverted support for TXTMulti due to NS1 automatically converting TXTMulti records back to TXT