### PR TITLE
Route53 uses a custom record type for SPF

### DIFF
--- a/providers/route53/route53Provider.go
+++ b/providers/route53/route53Provider.go
@@ -377,10 +377,14 @@ func nativeToRecords(set *r53.ResourceRecordSet, origin string) []*models.Record
 			switch rtype := *set.Type; rtype {
 			case "SOA":
 				continue
+			case "SPF":
+				// route53 uses a custom record type for SPF
+				rtype = "TXT"
+				fallthrough
 			default:
 				rc := &models.RecordConfig{TTL: uint32(*set.TTL)}
 				rc.SetLabelFromFQDN(unescape(set.Name), origin)
-				if err := rc.PopulateFromString(*set.Type, *rec.Value, origin); err != nil {
+				if err := rc.PopulateFromString(rtype, *rec.Value, origin); err != nil {
 					panic(fmt.Errorf("unparsable record received from R53: %w", err))
 				}
 				results = append(results, rc)


### PR DESCRIPTION
Much like OVH Route53 when queried returns SPF records as their own
type. This small change transcribes the SPF type to TXT

See: https://github.com/StackExchange/dnscontrol/issues/446
See: https://github.com/StackExchange/dnscontrol/blob/644ba70e87bf21997d9d2f020216f90b3876359d/providers/ovh/ovhProvider.go#L169-L172