### PR TITLE
Fix for incomplete results from Azure DNS in fetchRecordSets #770

### DIFF
--- a/providers/azuredns/azureDnsProvider.go
+++ b/providers/azuredns/azureDnsProvider.go
@@ -518,15 +518,18 @@ func (a *azureDNSProvider) fetchRecordSets(zoneName string) ([]*adns.RecordSet, 
 	var records []*adns.RecordSet
 	ctx, cancel := context.WithTimeout(context.Background(), 6000*time.Second)
 	defer cancel()
-	recordsIterator, recordsErr := a.recordsClient.ListAllByDNSZoneComplete(ctx, *a.resourceGroup, zoneName, to.Int32Ptr(1000), "")
+	recordsIterator, recordsErr := a.recordsClient.ListAllByDNSZone(ctx, *a.resourceGroup, zoneName, to.Int32Ptr(1000), "")
 	if recordsErr != nil {
 		return nil, recordsErr
 	}
-	recordsResult := recordsIterator.Response()
 
-	for _, r := range *recordsResult.Value {
-		record := r
-		records = append(records, &record)
+	for recordsIterator.NotDone() {
+		recordsResult := recordsIterator.Response()
+		for _, r := range *recordsResult.Value {
+			record := r
+			records = append(records, &record)
+		}
+		recordsIterator.NextWithContext(ctx)
 	}
 
 	return records, nil


### PR DESCRIPTION
Resolves #770 
Issue: https://github.com/StackExchange/dnscontrol/issues/770

## Tests (for this specific issue)

No code changes and default version of github.com/Azure/azure-sdk-for-go v43.3.0+incompatible. dnscontrol is trying to add the same set of domains (pagination doesn't work):

```
$ ./dnscontrol-Darwin preview
******************** Domain: companydomain123456.com
----- Getting nameservers from: azuredns
----- DNS Provider: azuredns...13 corrections
#1: CREATE CNAME record-cname-499.companydomain123456.com apple.com. ttl=300
#2: CREATE CNAME record-cname-500.companydomain123456.com apple.com. ttl=300
#3: CREATE CNAME record-cname-501.companydomain123456.com apple.com. ttl=300
#4: CREATE CNAME record-cname-502.companydomain123456.com apple.com. ttl=300
#5: CREATE CNAME record-cname-503.companydomain123456.com apple.com. ttl=300
#6: CREATE CNAME record-cname-504.companydomain123456.com apple.com. ttl=300
#7: CREATE CNAME record-cname-505.companydomain123456.com apple.com. ttl=300
#8: CREATE CNAME record-cname-506.companydomain123456.com apple.com. ttl=300
#9: CREATE CNAME record-cname-507.companydomain123456.com apple.com. ttl=300
#10: CREATE CNAME record-cname-508.companydomain123456.com apple.com. ttl=300
#11: CREATE CNAME record-cname-509.companydomain123456.com apple.com. ttl=300
#12: CREATE CNAME record-cname-510.companydomain123456.com apple.com. ttl=300
#13: CREATE CNAME record-cname-511.companydomain123456.com apple.com. ttl=300
----- Registrar: none...0 corrections
Done. 13 corrections.

$ ./dnscontrol-Darwin push
******************** Domain: companydomain123456.com
----- Getting nameservers from: azuredns
----- DNS Provider: azuredns...13 corrections
#1: CREATE CNAME record-cname-499.companydomain123456.com apple.com. ttl=300
SUCCESS!
#2: CREATE CNAME record-cname-500.companydomain123456.com apple.com. ttl=300
SUCCESS!
#3: CREATE CNAME record-cname-501.companydomain123456.com apple.com. ttl=300
SUCCESS!
#4: CREATE CNAME record-cname-502.companydomain123456.com apple.com. ttl=300
SUCCESS!
#5: CREATE CNAME record-cname-503.companydomain123456.com apple.com. ttl=300
SUCCESS!
#6: CREATE CNAME record-cname-504.companydomain123456.com apple.com. ttl=300
SUCCESS!
#7: CREATE CNAME record-cname-505.companydomain123456.com apple.com. ttl=300
SUCCESS!
#8: CREATE CNAME record-cname-506.companydomain123456.com apple.com. ttl=300
SUCCESS!
#9: CREATE CNAME record-cname-507.companydomain123456.com apple.com. ttl=300
SUCCESS!
#10: CREATE CNAME record-cname-508.companydomain123456.com apple.com. ttl=300
SUCCESS!
#11: CREATE CNAME record-cname-509.companydomain123456.com apple.com. ttl=300
SUCCESS!
#12: CREATE CNAME record-cname-510.companydomain123456.com apple.com. ttl=300
SUCCESS!
#13: CREATE CNAME record-cname-511.companydomain123456.com apple.com. ttl=300
SUCCESS!
----- Registrar: none...0 corrections
Done. 13 corrections.

$ ./dnscontrol-Darwin push
******************** Domain: companydomain123456.com
----- Getting nameservers from: azuredns
----- DNS Provider: azuredns...13 corrections
#1: CREATE CNAME record-cname-499.companydomain123456.com apple.com. ttl=300
SUCCESS!
#2: CREATE CNAME record-cname-500.companydomain123456.com apple.com. ttl=300
SUCCESS!
#3: CREATE CNAME record-cname-501.companydomain123456.com apple.com. ttl=300
^C
```

Changed code and default version of github.com/Azure/azure-sdk-for-go v43.3.0+incompatible. Looks good, pagination works.

```
$ ./dnscontrol-Darwin preview
******************** Domain: companydomain123456.com
----- Getting nameservers from: azuredns
----- DNS Provider: azuredns...0 corrections
----- Registrar: none...0 corrections
Done. 0 corrections.
```

Adding a new record. Works perfectly, no any changes on a second run.

```
$ dnscontrol-Darwin push
******************** Domain: companydomain123456.com
----- Getting nameservers from: azuredns
----- DNS Provider: azuredns...1 correction
#1: CREATE CNAME record-cname-512.companydomain123456.com apple.com. ttl=300
SUCCESS!
----- Registrar: none...0 corrections
Done. 1 corrections.

$ dnscontrol-Darwin push
******************** Domain: companydomain123456.com
----- Getting nameservers from: azuredns
----- DNS Provider: azuredns...0 corrections
----- Registrar: none...0 corrections
Done. 0 corrections.
```
