### PR TITLE
deSEC: Supports PTR records

### DIFF
--- a/providers/desec/desecProvider.go
+++ b/providers/desec/desecProvider.go
@@ -45,7 +45,7 @@ var features = providers.DocumentationNotes{
 	providers.CanUseSSHFP:            providers.Can(),
 	providers.CanUseCAA:              providers.Can(),
 	providers.CanUseTLSA:             providers.Can(),
-	providers.CanUsePTR:              providers.Unimplemented(),
+	providers.CanUsePTR:              providers.Can(),
 	providers.CanGetZones:            providers.Can(),
 	providers.CanAutoDNSSEC:          providers.Cannot(),
 }


### PR DESCRIPTION
### PR Goal
Enable PTR support for `deSEC` provider


I looked at the definition of the provider and also at the API and couldn't see why it wouldn't work properly, then I built `dnscontrol` with the `providers.Can()` flag for `CanUsePTR` and it worked out of box.

### Example

* Creation
```
$ ./dnscontrol-test push
******************** Domain: 1.2.3.4.5.6.7.8.9.a.b.c.ip6.arpa
----- Getting nameservers from: desec
----- DNS Provider: desec...1 correction
#1: Changes:
CREATE PTR 0.1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.1.0.0.0.1.2.3.4.5.6.7.8.9.a.b.c.ip6.arpa fr-par01.bb.example.com. ttl=3600
CREATE PTR 0.3.0.0.0.0.0.0.0.0.0.0.0.0.0.0.1.0.0.0.1.2.3.4.5.6.7.8.9.a.b.c.ip6.arpa de-dus01.bb.example.com. ttl=3600
CREATE PTR 0.f.3.9.9.4.e.f.f.f.2.3.1.1.2.0.a.0.b.0.1.2.3.4.5.6.7.8.9.a.b.c.ip6.arpa md.example.com. ttl=3600
CREATE PTR c.a.d.2.0.0.0.0.0.0.0.0.0.0.0.0.0.1.0.0.1.2.3.4.5.6.7.8.9.a.b.c.ip6.arpa test.example.com. ttl=3600
CREATE PTR 3.5.0.0.0.0.0.0.0.0.0.0.0.0.0.0.f.f.0.0.1.2.3.4.5.6.7.8.9.a.b.c.ip6.arpa ns.example.com. ttl=3600
CREATE PTR 0.2.0.0.0.0.0.0.0.0.0.0.0.0.0.0.1.0.0.0.1.2.3.4.5.6.7.8.9.a.b.c.ip6.arpa de-fra01.example.com. ttl=3600
CREATE PTR 1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.b.0.1.2.3.4.5.6.7.8.9.a.b.c.ip6.arpa gva.example.com. ttl=3600
CREATE PTR 1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.f.f.0.0.1.2.3.4.5.6.7.8.9.a.b.c.ip6.arpa ping.example.com. ttl=3600
CREATE PTR 2.4.0.0.0.0.0.0.0.0.0.0.0.0.0.0.1.0.b.0.1.2.3.4.5.6.7.8.9.a.b.c.ip6.arpa host.example.com. ttl=3600

SUCCESS!
----- Registrar: none...0 corrections
Done. 1 corrections.
```

* Deletion
```
$ ./dnscontrol-test push
******************** Domain: 1.2.3.4.5.6.7.8.9.a.b.c.ip6.arpa
----- Getting nameservers from: desec
----- DNS Provider: desec...1 correction
#1: Changes:
DELETE PTR 0.1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.1.0.0.0.1.2.3.4.5.6.7.8.9.a.b.c.ip6.arpa fr-par01.bb.example.com. ttl=3600
DELETE PTR 0.f.3.9.9.4.e.f.f.f.2.3.1.1.2.0.a.0.b.0.1.2.3.4.5.6.7.8.9.a.b.c.ip6.arpa de-dus01.bb.example.com. ttl=3600
DELETE PTR 1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.b.0.1.2.3.4.5.6.7.8.9.a.b.c.ip6.arpa md.example.com. ttl=3600
DELETE PTR 1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.f.f.0.0.1.2.3.4.5.6.7.8.9.a.b.c.ip6.arpa test.example.com. ttl=3600
DELETE PTR c.a.d.2.0.0.0.0.0.0.0.0.0.0.0.0.0.1.0.0.1.2.3.4.5.6.7.8.9.a.b.c.ip6.arpa ns.example.com. ttl=3600
DELETE PTR 0.2.0.0.0.0.0.0.0.0.0.0.0.0.0.0.1.0.0.0.1.2.3.4.5.6.7.8.9.a.b.c.ip6.arpa de-fra01.example.com. ttl=3600
DELETE PTR 0.3.0.0.0.0.0.0.0.0.0.0.0.0.0.0.1.0.0.0.1.2.3.4.5.6.7.8.9.a.b.c.ip6.arpa gva.example.com. ttl=3600
DELETE PTR 2.4.0.0.0.0.0.0.0.0.0.0.0.0.0.0.1.0.b.0.1.2.3.4.5.6.7.8.9.a.b.c.ip6.arpa ping.example.com. ttl=3600
DELETE PTR 3.5.0.0.0.0.0.0.0.0.0.0.0.0.0.0.f.f.0.0.1.2.3.4.5.6.7.8.9.a.b.c.ip6.arpa host.example.com. ttl=3600

SUCCESS!
----- Registrar: none...0 corrections
Done. 1 corrections.
```

* Preview (with PTR records created)
```
$ ./dnscontrol-test preview
******************** Domain: 1.2.3.4.5.6.7.8.9.a.b.c.ip6.arpa
----- Getting nameservers from: desec
----- DNS Provider: desec...0 corrections
----- Registrar: none...0 corrections
Done. 0 corrections.
```
Please let me know if I overlooked something obvious, mentioning @D3luxee as contributor of the provider.