### PR TITLE
Fix for Azure DNS Provider with >100 Zones

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ adzonedump.*
 stack.sh
 .idea/
 *.nupkg
+.DS_Store


### PR DESCRIPTION
Resolves #792

Before changes (all domains were created previously by running `dnscontrol create-domains`):
```text
******************** Domain: zone-100-7930ba393bb96a6fb30f62e75d593f46.com
----- Getting nameservers from: azuredns
----- DNS Provider: azuredns...1 correction
#1: CREATE A record-001.zone-100-7930ba393bb96a6fb30f62e75d593f46.com 1.1.1.1 ttl=300
SUCCESS!
----- Registrar: none...0 corrections
******************** Domain: zone-101-469eb2223790512426e52607b9029f93.com
----- Getting nameservers from: azuredns
Domain zone-101-469eb2223790512426e52607b9029f93.com not found in you Azure account
```

After (first run):
```
******************** Domain: zone-199-7b34b3adb50bac550114bb963a1bac88.com
----- Getting nameservers from: azuredns
----- DNS Provider: azuredns...1 correction
#1: CREATE A record-001.zone-199-7b34b3adb50bac550114bb963a1bac88.com 1.1.1.1 ttl=300
SUCCESS!
----- Registrar: none...0 corrections
******************** Domain: zone-200-2d994aaaf808423e05b2a888d7047973.com
----- Getting nameservers from: azuredns
----- DNS Provider: azuredns...1 correction
#1: CREATE A record-001.zone-200-2d994aaaf808423e05b2a888d7047973.com 1.1.1.1 ttl=300
SUCCESS!
----- Registrar: none...0 corrections
Done. 100 corrections.
```

Second run:
```
******************** Domain: zone-198-b6ab0b0a145d7648a6af91c48225be1e.com
----- Getting nameservers from: azuredns
----- DNS Provider: azuredns...0 corrections
----- Registrar: none...0 corrections
******************** Domain: zone-199-7b34b3adb50bac550114bb963a1bac88.com
----- Getting nameservers from: azuredns
----- DNS Provider: azuredns...0 corrections
----- Registrar: none...0 corrections
******************** Domain: zone-200-2d994aaaf808423e05b2a888d7047973.com
----- Getting nameservers from: azuredns
----- DNS Provider: azuredns...0 corrections
----- Registrar: none...0 corrections
Done. 0 corrections.
```
