### PR TITLE
Add TTL to BIND SoaInfo struct

### DIFF
--- a/providers/bind/bindProvider.go
+++ b/providers/bind/bindProvider.go
@@ -85,10 +85,11 @@ type SoaInfo struct {
 	Retry   uint32 `json:"retry"`
 	Expire  uint32 `json:"expire"`
 	Minttl  uint32 `json:"minttl"`
+	TTL     uint32 `json:"ttl,omitempty"`
 }
 
 func (s SoaInfo) String() string {
-	return fmt.Sprintf("%s %s %d %d %d %d %d", s.Ns, s.Mbox, s.Serial, s.Refresh, s.Retry, s.Expire, s.Minttl)
+	return fmt.Sprintf("%s %s %d %d %d %d %d %d", s.Ns, s.Mbox, s.Serial, s.Refresh, s.Retry, s.Expire, s.Minttl, s.TTL)
 }
 
 // Bind is the provider handle for the Bind driver.

--- a/providers/bind/soa.go
+++ b/providers/bind/soa.go
@@ -9,7 +9,6 @@ func makeSoa(origin string, defSoa *SoaInfo, existing, desired *models.RecordCon
 	// or hardcoded defaults.
 	soaRec := models.RecordConfig{}
 	soaRec.SetLabel("@", origin)
-	soaRec.TTL = models.DefaultTTL
 
 	if defSoa == nil {
 		defSoa = &SoaInfo{}
@@ -22,6 +21,7 @@ func makeSoa(origin string, defSoa *SoaInfo, existing, desired *models.RecordCon
 		desired = &models.RecordConfig{}
 	}
 
+	soaRec.TTL = firstNonZero(desired.TTL, defSoa.TTL, existing.TTL, models.DefaultTTL)
 	soaRec.SetTargetSOA(
 		firstNonNull(desired.GetTargetField(), existing.GetTargetField(), defSoa.Ns, "DEFAULT_NOT_SET."),
 		firstNonNull(desired.SoaMbox, existing.SoaMbox, defSoa.Mbox, "DEFAULT_NOT_SET."),

--- a/providers/bind/soa_test.go
+++ b/providers/bind/soa_test.go
@@ -19,7 +19,7 @@ func Test_makeSoa(t *testing.T) {
 	}{
 		{
 			// If everything is blank, the hard-coded defaults should kick in.
-			&SoaInfo{"", "", 0, 0, 0, 0, 0},
+			&SoaInfo{"", "", 0, 0, 0, 0, 0, models.DefaultTTL},
 			&models.RecordConfig{Target: "", SoaMbox: "", SoaSerial: 0, SoaRefresh: 0, SoaRetry: 0, SoaExpire: 0, SoaMinttl: 0},
 			&models.RecordConfig{Target: "", SoaMbox: "", SoaSerial: 0, SoaRefresh: 0, SoaRetry: 0, SoaExpire: 0, SoaMinttl: 0},
 			&models.RecordConfig{Target: "DEFAULT_NOT_SET.", SoaMbox: "DEFAULT_NOT_SET.", SoaSerial: 1, SoaRefresh: 3600, SoaRetry: 600, SoaExpire: 604800, SoaMinttl: 1440},
@@ -27,7 +27,7 @@ func Test_makeSoa(t *testing.T) {
 		},
 		{
 			// If everything is filled, leave the desired values in place.
-			&SoaInfo{"ns.example.com", "root.example.com", 1, 2, 3, 4, 5},
+			&SoaInfo{"ns.example.com", "root.example.com", 1, 2, 3, 4, 5, models.DefaultTTL},
 			&models.RecordConfig{Target: "a", SoaMbox: "aa", SoaSerial: 10, SoaRefresh: 11, SoaRetry: 12, SoaExpire: 13, SoaMinttl: 14},
 			&models.RecordConfig{Target: "b", SoaMbox: "bb", SoaSerial: 15, SoaRefresh: 16, SoaRetry: 17, SoaExpire: 18, SoaMinttl: 19},
 			&models.RecordConfig{Target: "b", SoaMbox: "bb", SoaSerial: 15, SoaRefresh: 16, SoaRetry: 17, SoaExpire: 18, SoaMinttl: 19},
@@ -35,7 +35,7 @@ func Test_makeSoa(t *testing.T) {
 		},
 		{
 			// Test incrementing serial.
-			&SoaInfo{"ns.example.com", "root.example.com", 1, 2, 3, 4, 5},
+			&SoaInfo{"ns.example.com", "root.example.com", 1, 2, 3, 4, 5, models.DefaultTTL},
 			&models.RecordConfig{Target: "a", SoaMbox: "aa", SoaSerial: 2019022301, SoaRefresh: 11, SoaRetry: 12, SoaExpire: 13, SoaMinttl: 14},
 			&models.RecordConfig{Target: "b", SoaMbox: "bb", SoaSerial: 0, SoaRefresh: 16, SoaRetry: 17, SoaExpire: 18, SoaMinttl: 19},
 			&models.RecordConfig{Target: "b", SoaMbox: "bb", SoaSerial: 2019022301, SoaRefresh: 16, SoaRetry: 17, SoaExpire: 18, SoaMinttl: 19},
@@ -43,7 +43,7 @@ func Test_makeSoa(t *testing.T) {
 		},
 		{
 			// Test incrementing serial_2.
-			&SoaInfo{"ns.example.com", "root.example.com", 1, 2, 3, 4, 5},
+			&SoaInfo{"ns.example.com", "root.example.com", 1, 2, 3, 4, 5, models.DefaultTTL},
 			&models.RecordConfig{Target: "a", SoaMbox: "aa", SoaSerial: 0, SoaRefresh: 11, SoaRetry: 12, SoaExpire: 13, SoaMinttl: 14},
 			&models.RecordConfig{Target: "b", SoaMbox: "bb", SoaSerial: 2019022304, SoaRefresh: 16, SoaRetry: 17, SoaExpire: 18, SoaMinttl: 19},
 			&models.RecordConfig{Target: "b", SoaMbox: "bb", SoaSerial: 2019022304, SoaRefresh: 16, SoaRetry: 17, SoaExpire: 18, SoaMinttl: 19},
@@ -51,7 +51,7 @@ func Test_makeSoa(t *testing.T) {
 		},
 		{
 			// If there are gaps in existing or desired, fill in as appropriate.
-			&SoaInfo{"ns.example.com", "root.example.com", 1, 2, 3, 4, 5},
+			&SoaInfo{"ns.example.com", "root.example.com", 1, 2, 3, 4, 5, models.DefaultTTL},
 			&models.RecordConfig{Target: "", SoaMbox: "aa", SoaSerial: 0, SoaRefresh: 11, SoaRetry: 0, SoaExpire: 13, SoaMinttl: 0},
 			&models.RecordConfig{Target: "b", SoaMbox: "", SoaSerial: 15, SoaRefresh: 0, SoaRetry: 17, SoaExpire: 0, SoaMinttl: 19},
 			&models.RecordConfig{Target: "b", SoaMbox: "aa", SoaSerial: 15, SoaRefresh: 11, SoaRetry: 17, SoaExpire: 13, SoaMinttl: 19},
@@ -59,7 +59,7 @@ func Test_makeSoa(t *testing.T) {
 		},
 		{
 			// Gaps + existing==nil
-			&SoaInfo{"ns.example.com", "root.example.com", 1, 2, 3, 4, 5},
+			&SoaInfo{"ns.example.com", "root.example.com", 1, 2, 3, 4, 5, models.DefaultTTL},
 			nil,
 			&models.RecordConfig{Target: "b", SoaMbox: "", SoaSerial: 15, SoaRefresh: 0, SoaRetry: 17, SoaExpire: 0, SoaMinttl: 19},
 			&models.RecordConfig{Target: "b", SoaMbox: "root.example.com", SoaSerial: 15, SoaRefresh: 2, SoaRetry: 17, SoaExpire: 4, SoaMinttl: 19},
@@ -68,7 +68,7 @@ func Test_makeSoa(t *testing.T) {
 		{
 			// Gaps + desired==nil
 			// NB(tom): In the code as of 2020-02-23, desired will never be nil.
-			&SoaInfo{"ns.example.com", "root.example.com", 1, 2, 3, 4, 5},
+			&SoaInfo{"ns.example.com", "root.example.com", 1, 2, 3, 4, 5, models.DefaultTTL},
 			&models.RecordConfig{Target: "", SoaMbox: "aa", SoaSerial: 0, SoaRefresh: 11, SoaRetry: 0, SoaExpire: 13, SoaMinttl: 0},
 			nil,
 			&models.RecordConfig{Target: "ns.example.com", SoaMbox: "aa", SoaSerial: 1, SoaRefresh: 11, SoaRetry: 3, SoaExpire: 13, SoaMinttl: 5},


### PR DESCRIPTION
I've been working on adding an SOA record type to BIND, but I saw #802 and figured I can pull that work out and see if it works as I did it.

Let me know if there's anything I missed or need to do different.

I've tested on my own with changing `DEFAULTS(DefaultTTL())` and it has properly caught changes.