### PR TITLE
Set TTL to 1 for Cloudflare page rules

### DIFF
--- a/providers/cloudflare/cloudflareProvider.go
+++ b/providers/cloudflare/cloudflareProvider.go
@@ -384,6 +384,7 @@ func (c *CloudflareAPI) preprocessConfig(dc *models.DomainConfig) error {
 			}
 			rec.SetTarget(fmt.Sprintf("%s,%d,%d", rec.GetTargetField(), currentPrPrio, code))
 			currentPrPrio++
+			rec.TTL = 1
 			rec.Type = "PAGE_RULE"
 		}
 	}


### PR DESCRIPTION
As discussed in #809, the TTL always came back as `1` in the `dnscontrol preview` command, but it's always being "set" to `120`. This resulted in there _always_ being a difference:

```
******************** Domain: example.net
----- Getting nameservers from: cloudflare
----- DNS Provider: cloudflare...1 correction
#1: MODIFY PAGE_RULE example.net: (*example.net/*,https://example.com,1,301 ttl=1) -> (*example.net/*,https://example.com,1,301 ttl=120)
----- Registrar: none...0 corrections
Done. 1 correction.
```

This PR fixes that transgression, and makes sure there's no differences  in the page rules if they haven't been edited:

```
******************** Domain: example.net
----- Getting nameservers from: cloudflare
----- DNS Provider: cloudflare...0 corrections
----- Registrar: none...0 corrections
Done. 0 corrections.
```

---

Closes #809 

h/t for the pointers @cipriancraciun, appreciate it! 😄 