### PR TITLE
print-ir: print validation warnings/errors to stderr

### DIFF
--- a/commands/printIR.go
+++ b/commands/printIR.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"encoding/json"
 	"fmt"
+	"log"
 	"os"
 
 	"github.com/urfave/cli/v2"
@@ -83,13 +84,13 @@ func PrintValidationErrors(errs []error) (fatal bool) {
 	if len(errs) == 0 {
 		return false
 	}
-	fmt.Printf("%d Validation errors:\n", len(errs))
+	log.Printf("%d Validation errors:\n", len(errs))
 	for _, err := range errs {
 		if _, ok := err.(normalize.Warning); ok {
-			fmt.Printf("WARNING: %s\n", err)
+			log.Printf("WARNING: %s\n", err)
 		} else {
 			fatal = true
-			fmt.Printf("ERROR: %s\n", err)
+			log.Printf("ERROR: %s\n", err)
 		}
 	}
 	return


### PR DESCRIPTION
currently, any validation warnings are printed to stdout, which means commands like `dnscontrol print-ir | jq` fails because the output isn't valid JSON.

by writing these to stderr instead (by using `log.Printf` instead of `fmt.Printf`), the errors are still printed, but won't cause JSON parsing of stdout to fail.