### PR TITLE
Remove default inwx nameservers due to deprecation

### DIFF
--- a/providers/inwx/inwxProvider.go
+++ b/providers/inwx/inwxProvider.go
@@ -40,7 +40,7 @@ type inwxAPI struct {
 }
 
 // InwxDefaultNs contains the default INWX nameservers.
-var InwxDefaultNs = []string{"ns.inwx.de", "ns2.inwx.de", "ns3.inwx.eu", "ns4.inwx.com", "ns5.inwx.net"}
+var InwxDefaultNs = []string{"ns.inwx.de", "ns2.inwx.de", "ns3.inwx.eu"}
 
 // InwxSandboxDefaultNs contains the default INWX nameservers in the sandbox / OTE.
 var InwxSandboxDefaultNs = []string{"ns.ote.inwx.de", "ns2.ote.inwx.de"}


### PR DESCRIPTION
ns4 and ns5 are being deprecated, therefore removing them, see: https://www.inwx.de/en/news/604/important-nameserver-changes