### PR TITLE
INWX: Support creating domains

### DIFF
--- a/docs/_includes/matrix.html
+++ b/docs/_includes/matrix.html
@@ -77,6 +77,9 @@
 		<td class="danger">
 			<i class="fa fa-times text-danger" aria-hidden="true"></i>
 		</td>
+		<td class="danger">
+			<i class="fa fa-times text-danger" aria-hidden="true"></i>
+		</td>
 		<td class="success">
 			<i class="fa fa-check text-success" aria-hidden="true"></i>
 		</td>
@@ -914,6 +917,7 @@
 		<td><i class="fa fa-minus dim"></i></td>
 		<td><i class="fa fa-minus dim"></i></td>
 		<td><i class="fa fa-minus dim"></i></td>
+		<td><i class="fa fa-minus dim"></i></td>
 		<td class="danger" data-toggle="tooltip" data-container="body" data-placement="top" title="Using ALIAS is possible through our extended DNS (X-DNS) service. Feel free to get in touch with us.">
 			<i class="fa has-tooltip fa-times text-danger" aria-hidden="true"></i>
 		</td>
@@ -941,6 +945,7 @@
 		<td class="success">
 			<i class="fa fa-check text-success" aria-hidden="true"></i>
 		</td>
+		<td><i class="fa fa-minus dim"></i></td>
 		<td><i class="fa fa-minus dim"></i></td>
 		<td><i class="fa fa-minus dim"></i></td>
 		<td><i class="fa fa-minus dim"></i></td>
@@ -1143,8 +1148,8 @@
 		<td class="danger">
 			<i class="fa fa-times text-danger" aria-hidden="true"></i>
 		</td>
-		<td class="info" data-toggle="tooltip" data-container="body" data-placement="top" title="Supported by INWX but not implemented yet.">
-			<i class="fa fa-circle-o text-info" aria-hidden="true"></i>
+		<td class="success" data-toggle="tooltip" data-container="body" data-placement="top" title="Does only create domain in nameserver and does not order domain.">
+			<i class="fa has-tooltip fa-check text-success" aria-hidden="true"></i>
 		</td>
 		<td class="danger">
 			<i class="fa fa-times text-danger" aria-hidden="true"></i>
@@ -1196,6 +1201,9 @@
 		</td>
 		<td class="danger">
 			<i class="fa fa-times text-danger" aria-hidden="true"></i>
+		</td>
+		<td class="success">
+			<i class="fa fa-check text-success" aria-hidden="true"></i>
 		</td>
 		<td class="success">
 			<i class="fa fa-check text-success" aria-hidden="true"></i>

--- a/docs/_includes/matrix.html
+++ b/docs/_includes/matrix.html
@@ -1148,8 +1148,8 @@
 		<td class="danger">
 			<i class="fa fa-times text-danger" aria-hidden="true"></i>
 		</td>
-		<td class="success" data-toggle="tooltip" data-container="body" data-placement="top" title="Does only create domain in nameserver and does not order domain.">
-			<i class="fa has-tooltip fa-check text-success" aria-hidden="true"></i>
+		<td class="success">
+			<i class="fa fa-check text-success" aria-hidden="true"></i>
 		</td>
 		<td class="danger">
 			<i class="fa fa-times text-danger" aria-hidden="true"></i>

--- a/providers/inwx/inwxProvider.go
+++ b/providers/inwx/inwxProvider.go
@@ -33,7 +33,7 @@ Additional settings available in `creds.json`:
 
 */
 
-// InwxDefaultNs contains the default INWX nameservers.
+// InwxProductionDefaultNs contains the default INWX nameservers.
 var InwxProductionDefaultNs = []string{"ns.inwx.de", "ns2.inwx.de", "ns3.inwx.eu"}
 
 // InwxSandboxDefaultNs contains the default INWX nameservers in the sandbox / OTE.
@@ -53,7 +53,7 @@ var features = providers.DocumentationNotes{
 	providers.CanAutoDNSSEC:          providers.Unimplemented("Supported by INWX but not implemented yet."),
 	providers.DocOfficiallySupported: providers.Cannot(),
 	providers.DocDualHost:            providers.Can(),
-	providers.DocCreateDomains:       providers.Can("Does only create domain in nameserver and does not order domain."),
+	providers.DocCreateDomains:       providers.Can(),
 	providers.CanGetZones:            providers.Can(),
 	providers.CanUseAzureAlias:       providers.Cannot(),
 }
@@ -252,7 +252,7 @@ func (api *inwxAPI) GetDomainCorrections(dc *models.DomainConfig) ([]*models.Cor
 	return corrections, nil
 }
 
-// getDefaultNameservers returns back string map with default nameservers  based on e.g. sandbox mode.
+// getDefaultNameservers returns string map with default nameservers based on e.g. sandbox mode.
 func (api *inwxAPI) getDefaultNameservers() []string {
 	if api.sandbox {
 		return InwxSandboxDefaultNs

--- a/providers/inwx/inwxProvider.go
+++ b/providers/inwx/inwxProvider.go
@@ -256,9 +256,8 @@ func (api *inwxAPI) GetDomainCorrections(dc *models.DomainConfig) ([]*models.Cor
 func (api *inwxAPI) getDefaultNameservers() []string {
 	if api.sandbox {
 		return InwxSandboxDefaultNs
-	} else {
-		return InwxProductionDefaultNs
 	}
+	return InwxProductionDefaultNs
 }
 
 // GetNameservers returns the default nameservers for INWX.


### PR DESCRIPTION
This adds support of `create-domains` for INWX.

INWX has two ways for "adding" domains:
- Adding domain to INWX as registrar
- Adding domain to INWX as only nameserver. (While INWX prohibits using their nameserver for external domains, it's technically still possible)

This implementation checks and adds domains to the nameserver only and does not register/order domains in this approach.