### PR TITLE
Use otto.Compile() instead Run() for better error msg

### DIFF
--- a/pkg/js/js.go
+++ b/pkg/js/js.go
@@ -106,7 +106,7 @@ func require(call otto.FunctionCall) otto.Value {
 		cmd := fmt.Sprintf(`JSON.parse(JSON.stringify(%s))`, string(data))
 		value, err = call.Otto.Run(cmd)
 	} else {
-		_, err = call.Otto.Run(string(data))
+		_, err = call.Otto.Compile(filepath.Base(relFile), string(data))
 	}
 
 	if err != nil {


### PR DESCRIPTION
Will result in:
```text
executing javascript: Error: domain.tld.js: Line 13:1 Unexpected token ) (and 1 more errors)
```