### PR TITLE
Display file where error occurred

### DIFF
--- a/pkg/js/js.go
+++ b/pkg/js/js.go
@@ -110,7 +110,7 @@ func require(call otto.FunctionCall) otto.Value {
 	}
 
 	if err != nil {
-		throw(call.Otto, err.Error())
+		throw(call.Otto, fmt.Sprintf("File %s: %s", filepath.Base(relFile), err.Error()))
 	}
 
 	// Pop back to the old directory.


### PR DESCRIPTION
This is probably the easiest way to display the real file where the error occurred, without rewriting large parts of `ExecuteJavascript`. Function `throw()` expects an error as a string as second argument, where we can state in which file the error occurred in. In `relFile` there's always the filename what was about being run.

Output:
```text
executing dnsconfig.js: Error: File domain.tld.js: (anonymous): Line 13:1 Unexpected token ) (and 1 more errors)
```
(Tested with file which is being require'ed using `require_glob()`)

Edit: I'm aware I've opened the PR against branch `requirename`