### PR TITLE
ClouDNS: Return API error only when body unmarshals to errorResponse

### DIFF
--- a/providers/cloudns/api.go
+++ b/providers/cloudns/api.go
@@ -212,12 +212,10 @@ func (c *api) get(endpoint string, params requestParams) ([]byte, error) {
 	// Got error from API ?
 	var errResp errorResponse
 	err = json.Unmarshal(bodyString, &errResp)
-	if err != nil {
-		return []byte{}, err
-	}
-
-	if errResp.Status == "Failed" {
-		return bodyString, fmt.Errorf("ClouDNS API error: %s URL:%s%s ", errResp.Description, req.Host, req.URL.RequestURI())
+	if err == nil {
+		if errResp.Status == "Failed" {
+			return bodyString, fmt.Errorf("ClouDNS API error: %s URL:%s%s ", errResp.Description, req.Host, req.URL.RequestURI())
+		}
 	}
 
 	return bodyString, nil


### PR DESCRIPTION
This patch resolves the regression reported in #849. Go's `json.Unmarshal` would return a `json.UnmarshalTypeError` error when attempting to unmarshal successful responses to `cloudns.errorResponse`. I changed the behaviour to only return an error to the caller when this unmarshal operation does not fail, but I'm happy to revise this if another approach is preferred.