### PR TITLE
Update CNAME.md

### DIFF
--- a/docs/_functions/domain/CNAME.md
+++ b/docs/_functions/domain/CNAME.md
@@ -17,7 +17,7 @@ Target should be a string representing the CNAME target. If it is a single label
 D("example.com", REGISTRAR, DnsProvider("R53"),
   CNAME("foo", "google.com."), // foo.example.com -> google.com
   CNAME("abc", "@"), // abc.example.com -> example.com
-  CNAME("def", "test.subdomain"), // def.example.com -> test.subdomain.example.com
+  CNAME("def", "test"), // def.example.com -> test.example.com
 );
 
 {%endhighlight%}


### PR DESCRIPTION
The current example
```
CNAME("def", "test.subdomain"), // def.example.com -> test.subdomain.example.com
```
is invalid (raises a validation error, "ERROR: in CNAME def.example.com: target (test.subdomain) must end with a (.)")
