### PR TITLE
DOCS: fix jsId for Netcup Provider

### DIFF
--- a/docs/_providers/netcup.md
+++ b/docs/_providers/netcup.md
@@ -2,7 +2,7 @@
 name: Netcup
 title: Netcup Provider
 layout: default
-jsId: Netcup
+jsId: NETCUP
 ---
 # Netcup Provider
 


### PR DESCRIPTION
According usage example jsId should be all uppercase