### PR TITLE
HETZNER: implement the provider for Hetzner DNS Console

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -11,6 +11,7 @@ providers/dnsimple @aeden
 providers/gandi_v5 @TomOnTime
 # providers/gcloud
 providers/hedns @rblenkinsopp
+providers/hetzner @das7pad
 providers/hexonet @papakai
 providers/internetbs @pragmaton
 providers/inwx @svenpeter42

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Currently supported DNS providers:
  - Exoscale
  - Gandi
  - Google DNS
+ - Hetzner
  - HEXONET
  - Hurricane Electric DNS
  - INWX

--- a/docs/_includes/matrix.html
+++ b/docs/_includes/matrix.html
@@ -21,6 +21,7 @@
 	<th class="rotate"><div><span>GANDI_V5</span></div></th>
 	<th class="rotate"><div><span>GCLOUD</span></div></th>
 	<th class="rotate"><div><span>HEDNS</span></div></th>
+	<th class="rotate"><div><span>HETZNER</span></div></th>
 	<th class="rotate"><div><span>HEXONET</span></div></th>
 	<th class="rotate"><div><span>INTERNETBS</span></div></th>
 	<th class="rotate"><div><span>INWX</span></div></th>
@@ -82,6 +83,9 @@
 		</td>
 		<td class="success">
 			<i class="fa fa-check text-success" aria-hidden="true"></i>
+		</td>
+		<td class="danger">
+			<i class="fa fa-times text-danger" aria-hidden="true"></i>
 		</td>
 		<td class="danger">
 			<i class="fa fa-times text-danger" aria-hidden="true"></i>
@@ -166,6 +170,9 @@
 		</td>
 		<td class="danger">
 			<i class="fa fa-times text-danger" aria-hidden="true"></i>
+		</td>
+		<td class="success">
+			<i class="fa fa-check text-success" aria-hidden="true"></i>
 		</td>
 		<td class="success">
 			<i class="fa fa-check text-success" aria-hidden="true"></i>
@@ -272,6 +279,9 @@
 		<td class="danger">
 			<i class="fa fa-times text-danger" aria-hidden="true"></i>
 		</td>
+		<td class="danger">
+			<i class="fa fa-times text-danger" aria-hidden="true"></i>
+		</td>
 		<td class="success">
 			<i class="fa fa-check text-success" aria-hidden="true"></i>
 		</td>
@@ -353,6 +363,9 @@
 		<td class="success">
 			<i class="fa fa-check text-success" aria-hidden="true"></i>
 		</td>
+		<td class="danger">
+			<i class="fa fa-times text-danger" aria-hidden="true"></i>
+		</td>
 		<td class="danger" data-toggle="tooltip" data-container="body" data-placement="top" title="Using ALIAS is possible through our extended DNS (X-DNS) service. Feel free to get in touch with us.">
 			<i class="fa has-tooltip fa-times text-danger" aria-hidden="true"></i>
 		</td>
@@ -416,6 +429,7 @@
 		</td>
 		<td><i class="fa fa-minus dim"></i></td>
 		<td><i class="fa fa-minus dim"></i></td>
+		<td><i class="fa fa-minus dim"></i></td>
 		<td class="info" data-toggle="tooltip" data-container="body" data-placement="top" title="Supported by INWX but not implemented yet.">
 			<i class="fa fa-circle-o text-info" aria-hidden="true"></i>
 		</td>
@@ -465,6 +479,9 @@
 			<i class="fa fa-check text-success" aria-hidden="true"></i>
 		</td>
 		<td><i class="fa fa-minus dim"></i></td>
+		<td class="success">
+			<i class="fa fa-check text-success" aria-hidden="true"></i>
+		</td>
 		<td class="success">
 			<i class="fa fa-check text-success" aria-hidden="true"></i>
 		</td>
@@ -550,6 +567,9 @@
 		<td class="success">
 			<i class="fa fa-check text-success" aria-hidden="true"></i>
 		</td>
+		<td class="danger">
+			<i class="fa fa-times text-danger" aria-hidden="true"></i>
+		</td>
 		<td class="success">
 			<i class="fa fa-check text-success" aria-hidden="true"></i>
 		</td>
@@ -617,6 +637,7 @@
 		</td>
 		<td><i class="fa fa-minus dim"></i></td>
 		<td><i class="fa fa-minus dim"></i></td>
+		<td><i class="fa fa-minus dim"></i></td>
 		<td class="success">
 			<i class="fa fa-check text-success" aria-hidden="true"></i>
 		</td>
@@ -666,6 +687,9 @@
 		<td><i class="fa fa-minus dim"></i></td>
 		<td class="success" data-toggle="tooltip" data-container="body" data-placement="top" title="SRV records with empty targets are not supported">
 			<i class="fa has-tooltip fa-check text-success" aria-hidden="true"></i>
+		</td>
+		<td class="success">
+			<i class="fa fa-check text-success" aria-hidden="true"></i>
 		</td>
 		<td class="success">
 			<i class="fa fa-check text-success" aria-hidden="true"></i>
@@ -753,6 +777,9 @@
 		<td class="success">
 			<i class="fa fa-check text-success" aria-hidden="true"></i>
 		</td>
+		<td class="danger">
+			<i class="fa fa-times text-danger" aria-hidden="true"></i>
+		</td>
 		<td><i class="fa fa-minus dim"></i></td>
 		<td><i class="fa fa-minus dim"></i></td>
 		<td class="success">
@@ -811,6 +838,9 @@
 			<i class="fa fa-check text-success" aria-hidden="true"></i>
 		</td>
 		<td><i class="fa fa-minus dim"></i></td>
+		<td class="danger">
+			<i class="fa fa-times text-danger" aria-hidden="true"></i>
+		</td>
 		<td class="danger">
 			<i class="fa fa-times text-danger" aria-hidden="true"></i>
 		</td>
@@ -873,6 +903,9 @@
 		<td class="success">
 			<i class="fa fa-check text-success" aria-hidden="true"></i>
 		</td>
+		<td class="danger">
+			<i class="fa fa-times text-danger" aria-hidden="true"></i>
+		</td>
 		<td class="success">
 			<i class="fa fa-check text-success" aria-hidden="true"></i>
 		</td>
@@ -918,6 +951,7 @@
 		<td><i class="fa fa-minus dim"></i></td>
 		<td><i class="fa fa-minus dim"></i></td>
 		<td><i class="fa fa-minus dim"></i></td>
+		<td><i class="fa fa-minus dim"></i></td>
 		<td class="danger" data-toggle="tooltip" data-container="body" data-placement="top" title="Using ALIAS is possible through our extended DNS (X-DNS) service. Feel free to get in touch with us.">
 			<i class="fa has-tooltip fa-times text-danger" aria-hidden="true"></i>
 		</td>
@@ -945,6 +979,7 @@
 		<td class="success">
 			<i class="fa fa-check text-success" aria-hidden="true"></i>
 		</td>
+		<td><i class="fa fa-minus dim"></i></td>
 		<td><i class="fa fa-minus dim"></i></td>
 		<td><i class="fa fa-minus dim"></i></td>
 		<td><i class="fa fa-minus dim"></i></td>
@@ -1002,6 +1037,9 @@
 		<td class="danger">
 			<i class="fa fa-times text-danger" aria-hidden="true"></i>
 		</td>
+		<td class="danger">
+			<i class="fa fa-times text-danger" aria-hidden="true"></i>
+		</td>
 		<td><i class="fa fa-minus dim"></i></td>
 		<td><i class="fa fa-minus dim"></i></td>
 		<td class="info" data-toggle="tooltip" data-container="body" data-placement="top" title="DS records are only supported at the apex and require a different API call that hasn&#39;t been implemented yet.">
@@ -1053,6 +1091,9 @@
 			<i class="fa has-tooltip fa-times text-danger" aria-hidden="true"></i>
 		</td>
 		<td><i class="fa fa-minus dim"></i></td>
+		<td class="success">
+			<i class="fa fa-check text-success" aria-hidden="true"></i>
+		</td>
 		<td class="success">
 			<i class="fa fa-check text-success" aria-hidden="true"></i>
 		</td>
@@ -1135,6 +1176,9 @@
 		</td>
 		<td class="danger" data-toggle="tooltip" data-container="body" data-placement="top" title="Can only manage domains registered through their service">
 			<i class="fa has-tooltip fa-times text-danger" aria-hidden="true"></i>
+		</td>
+		<td class="success">
+			<i class="fa fa-check text-success" aria-hidden="true"></i>
 		</td>
 		<td class="success">
 			<i class="fa fa-check text-success" aria-hidden="true"></i>
@@ -1247,6 +1291,9 @@
 		<td class="success">
 			<i class="fa fa-check text-success" aria-hidden="true"></i>
 		</td>
+		<td class="success">
+			<i class="fa fa-check text-success" aria-hidden="true"></i>
+		</td>
 		<td class="danger">
 			<i class="fa fa-times text-danger" aria-hidden="true"></i>
 		</td>
@@ -1314,6 +1361,9 @@
 		<td><i class="fa fa-minus dim"></i></td>
 		<td class="info">
 			<i class="fa fa-circle-o text-info" aria-hidden="true"></i>
+		</td>
+		<td class="success">
+			<i class="fa fa-check text-success" aria-hidden="true"></i>
 		</td>
 		<td class="success">
 			<i class="fa fa-check text-success" aria-hidden="true"></i>

--- a/docs/_providers/hetzner.md
+++ b/docs/_providers/hetzner.md
@@ -45,7 +45,29 @@ Create a new API Key in the
 
 ## Caveats
 
+### SOA
+
 Hetzner DNS Console does not allow changing the SOA record via their API.
 There is an alternative method using an import of a full BIND file, but this
  approach does not play nice with incremental changes or ignored records.
 At this time you cannot update SOA records via DNSControl.
+
+### Rate Limiting
+
+In case you are frequently seeing messages about being rate-limited:
+
+{% highlight txt %}
+WARNING: request rate-limited, constant back-off is now at 1s.
+{% endhighlight %}
+
+You may want to enable the `rate_limited` mode by default.
+
+In your `creds.json` for all `HETZNER` provider entries:
+{% highlight json %}
+{
+  "hetzner": {
+    "rate_limited": "true",
+    "api_key": "your-api-key"
+  }
+}
+{% endhighlight %}

--- a/docs/_providers/hetzner.md
+++ b/docs/_providers/hetzner.md
@@ -1,0 +1,51 @@
+---
+name: Hetzner DNS Console
+title: Hetzner DNS Console
+layout: default
+jsId: HETZNER
+---
+
+# Hetzner DNS Console Provider
+
+## Configuration
+
+In your credentials file, you must provide a
+[Hetzner API Key](https://dns.hetzner.com/settings/api-token).
+
+{% highlight json %}
+{
+  "hetzner": {
+    "api_key": "your-api-key"
+  }
+}
+{% endhighlight %}
+
+## Metadata
+
+This provider does not recognize any special metadata fields unique to Hetzner
+ DNS Console.
+
+## Usage
+
+Example Javascript:
+
+{% highlight js %}
+var REG_NONE = NewRegistrar('none', 'NONE');
+var HETZNER = NewDnsProvider("hetzner", "HETZNER");
+
+D("example.tld", REG_NONE, DnsProvider(HETZNER),
+    A("test","1.2.3.4")
+);
+{%endhighlight%}
+
+## Activation
+
+Create a new API Key in the
+[Hetzner DNS Console](https://dns.hetzner.com/settings/api-token).
+
+## Caveats
+
+Hetzner DNS Console does not allow changing the SOA record via their API.
+There is an alternative method using an import of a full BIND file, but this
+ approach does not play nice with incremental changes or ignored records.
+At this time you cannot update SOA records via DNSControl.

--- a/docs/provider-list.md
+++ b/docs/provider-list.md
@@ -81,6 +81,7 @@ Maintainers of contributed providers:
 * `EXOSCALE` @pierre-emmanuelJ
 * `GANDI_V5` @TomOnTime
 * `HEDNS` @rblenkinsopp
+* `HETZNER` @das7pad
 * `HEXONET` @papakai
 * `INTERNETBS` @pragmaton
 * `INWX` @svenpeter42

--- a/integrationTest/integration_test.go
+++ b/integrationTest/integration_test.go
@@ -693,7 +693,7 @@ func makeTests(t *testing.T) []*TestGroup {
 		),
 
 		testgroup("empty TXT",
-			not("CLOUDFLAREAPI", "HEXONET", "INWX", "NETCUP"),
+			not("CLOUDFLAREAPI", "HETZNER", "HEXONET", "INWX", "NETCUP"),
 			tc("TXT with empty str", txt("foo1", "")),
 			// https://github.com/StackExchange/dnscontrol/issues/598
 			// We decided that permitting the TXT target to be an empty

--- a/integrationTest/providers.json
+++ b/integrationTest/providers.json
@@ -71,7 +71,8 @@
   },
   "HETZNER": {
     "api_key": "$HETZNER_API_KEY",
-    "domain": "$HETZNER_DOMAIN"
+    "domain": "$HETZNER_DOMAIN",
+    "rate_limited": "true"
   },
   "HEXONET": {
     "apientity": "$HEXONET_ENTITY",

--- a/integrationTest/providers.json
+++ b/integrationTest/providers.json
@@ -69,6 +69,10 @@
     "totp-key": "$HEDNS_TOTP_SECRET",
     "username": "$HEDNS_USERNAME"
   },
+  "HETZNER": {
+    "api_key": "$HETZNER_API_KEY",
+    "domain": "$HETZNER_DOMAIN"
+  },
   "HEXONET": {
     "apientity": "$HEXONET_ENTITY",
     "apilogin": "$HEXONET_UID",

--- a/providers/_all/all.go
+++ b/providers/_all/all.go
@@ -18,6 +18,7 @@ import (
 	_ "github.com/StackExchange/dnscontrol/v3/providers/gandi_v5"
 	_ "github.com/StackExchange/dnscontrol/v3/providers/gcloud"
 	_ "github.com/StackExchange/dnscontrol/v3/providers/hedns"
+	_ "github.com/StackExchange/dnscontrol/v3/providers/hetzner"
 	_ "github.com/StackExchange/dnscontrol/v3/providers/hexonet"
 	_ "github.com/StackExchange/dnscontrol/v3/providers/internetbs"
 	_ "github.com/StackExchange/dnscontrol/v3/providers/inwx"

--- a/providers/hetzner/api.go
+++ b/providers/hetzner/api.go
@@ -179,6 +179,12 @@ func (api *api) request(endpoint string, method string, request interface{}, tar
 	}
 }
 
+func (api *api) startRateLimited() {
+	// Simulate a request that is getting a 429 response.
+	api.requestRateLimiter.afterRequest()
+	api.requestRateLimiter.bumpDelay()
+}
+
 func (api *api) updateRecord(record record) error {
 	if err := checkIsLockedSystemRecord(record); err != nil {
 		return err

--- a/providers/hetzner/api.go
+++ b/providers/hetzner/api.go
@@ -199,34 +199,34 @@ type requestRateLimiter struct {
 	lastRequest time.Time
 }
 
-func (rateLimiter *requestRateLimiter) afterRequest() {
-	rateLimiter.lastRequest = time.Now()
+func (requestRateLimiter *requestRateLimiter) afterRequest() {
+	requestRateLimiter.lastRequest = time.Now()
 }
 
-func (rateLimiter *requestRateLimiter) beforeRequest() {
-	if rateLimiter.delay == 0 {
+func (requestRateLimiter *requestRateLimiter) beforeRequest() {
+	if requestRateLimiter.delay == 0 {
 		return
 	}
-	time.Sleep(time.Until(rateLimiter.lastRequest.Add(rateLimiter.delay)))
+	time.Sleep(time.Until(requestRateLimiter.lastRequest.Add(requestRateLimiter.delay)))
 }
 
-func (rateLimiter *requestRateLimiter) bumpDelay() string {
+func (requestRateLimiter *requestRateLimiter) bumpDelay() string {
 	var backoffType string
-	if rateLimiter.delay == 0 {
+	if requestRateLimiter.delay == 0 {
 		// At the time this provider was implemented (2020-10-18),
 		//  one request per second could go though when rate-limited.
-		rateLimiter.delay = time.Second
+		requestRateLimiter.delay = time.Second
 		backoffType = "constant"
 	} else {
 		// The initial assumption of 1 req/s may no hold true forever.
 		// Future proof this provider, use exponential back-off.
-		rateLimiter.delay = rateLimiter.delay * 2
+		requestRateLimiter.delay = requestRateLimiter.delay * 2
 		backoffType = "exponential"
 	}
 	return backoffType
 }
 
-func (rateLimiter *requestRateLimiter) handleRateLimitedRequest() {
-	backoffType := rateLimiter.bumpDelay()
-	fmt.Println(fmt.Sprintf("WARNING: request rate-limited, %s back-off is now at %s.", backoffType, rateLimiter.delay))
+func (requestRateLimiter *requestRateLimiter) handleRateLimitedRequest() {
+	backoffType := requestRateLimiter.bumpDelay()
+	fmt.Println(fmt.Sprintf("WARNING: request rate-limited, %s back-off is now at %s.", backoffType, requestRateLimiter.delay))
 }

--- a/providers/hetzner/hetznerProvider.go
+++ b/providers/hetzner/hetznerProvider.go
@@ -3,9 +3,9 @@ package hetzner
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/StackExchange/dnscontrol/v3/pkg/diff"
 
 	"github.com/StackExchange/dnscontrol/v3/models"
+	"github.com/StackExchange/dnscontrol/v3/pkg/diff"
 	"github.com/StackExchange/dnscontrol/v3/providers"
 )
 
@@ -31,7 +31,7 @@ func init() {
 // New creates a new API handle.
 func New(settings map[string]string, _ json.RawMessage) (providers.DNSServiceProvider, error) {
 	if settings["api_key"] == "" {
-		return nil, fmt.Errorf("missing HETZNER API Key")
+		return nil, fmt.Errorf("missing HETZNER api_key")
 	}
 
 	api := &api{}
@@ -78,6 +78,7 @@ func (api *api) GetDomainCorrections(dc *models.DomainConfig) ([]*models.Correct
 
 	// Normalize
 	models.PostProcessRecords(existingRecords)
+
 	differ := diff.New(dc)
 	_, create, del, modify, err := differ.IncrementalDiff(existingRecords)
 	if err != nil {
@@ -94,7 +95,7 @@ func (api *api) GetDomainCorrections(dc *models.DomainConfig) ([]*models.Correct
 	for _, m := range del {
 		record := m.Existing.Original.(*Record)
 		corr := &models.Correction{
-			Msg: fmt.Sprintf("%s, HETZNER ID: %s", m.String(), record.Id),
+			Msg: m.String(),
 			F: func() error {
 				return api.deleteRecord(*record)
 			},
@@ -118,7 +119,7 @@ func (api *api) GetDomainCorrections(dc *models.DomainConfig) ([]*models.Correct
 		record := fromRecordConfig(m.Desired, zone)
 		record.Id = id
 		corr := &models.Correction{
-			Msg: fmt.Sprintf("%s, HETZNER ID: %s", m.String(), id),
+			Msg: m.String(),
 			F: func() error {
 				return api.updateRecord(*record)
 			},

--- a/providers/hetzner/hetznerProvider.go
+++ b/providers/hetzner/hetznerProvider.go
@@ -38,6 +38,10 @@ func New(settings map[string]string, _ json.RawMessage) (providers.DNSServicePro
 
 	api.apiKey = settings["api_key"]
 
+	if settings["rate_limited"] == "true" {
+		api.requestRateLimiter.bumpDelay()
+	}
+
 	return api, nil
 }
 

--- a/providers/hetzner/hetznerProvider.go
+++ b/providers/hetzner/hetznerProvider.go
@@ -39,7 +39,7 @@ func New(settings map[string]string, _ json.RawMessage) (providers.DNSServicePro
 	api.apiKey = settings["api_key"]
 
 	if settings["rate_limited"] == "true" {
-		api.requestRateLimiter.bumpDelay()
+		api.startRateLimited()
 	}
 
 	return api, nil

--- a/providers/hetzner/hetznerProvider.go
+++ b/providers/hetzner/hetznerProvider.go
@@ -1,0 +1,168 @@
+package hetzner
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/StackExchange/dnscontrol/v3/pkg/diff"
+
+	"github.com/StackExchange/dnscontrol/v3/models"
+	"github.com/StackExchange/dnscontrol/v3/providers"
+)
+
+var features = providers.DocumentationNotes{
+	providers.DocCreateDomains:       providers.Can(),
+	providers.DocDualHost:            providers.Can(),
+	providers.DocOfficiallySupported: providers.Cannot(),
+	providers.CanGetZones:            providers.Can(),
+	providers.CanUseAlias:            providers.Cannot(),
+	providers.CanUseCAA:              providers.Can(),
+	providers.CanUseDS:               providers.Cannot(),
+	providers.CanUsePTR:              providers.Cannot(),
+	providers.CanUseSRV:              providers.Can(),
+	providers.CanUseSSHFP:            providers.Cannot(),
+	providers.CanUseTLSA:             providers.Cannot(),
+	providers.CanUseTXTMulti:         providers.Cannot(),
+}
+
+func init() {
+	providers.RegisterDomainServiceProviderType("HETZNER", New, features)
+}
+
+// New creates a new API handle.
+func New(settings map[string]string, _ json.RawMessage) (providers.DNSServiceProvider, error) {
+	if settings["api_key"] == "" {
+		return nil, fmt.Errorf("missing HETZNER API Key")
+	}
+
+	api := &api{}
+
+	api.apiKey = settings["api_key"]
+
+	return api, nil
+}
+
+// EnsureDomainExists creates the domain if it does not exist.
+func (api *api) EnsureDomainExists(domain string) error {
+	domains, err := api.ListZones()
+	if err != nil {
+		return err
+	}
+
+	for _, d := range domains {
+		if d == domain {
+			return nil
+		}
+	}
+
+	return api.createZone(domain)
+}
+
+// GetDomainCorrections returns the corrections for a domain.
+func (api *api) GetDomainCorrections(dc *models.DomainConfig) ([]*models.Correction, error) {
+	dc, err := dc.Copy()
+	if err != nil {
+		return nil, err
+	}
+
+	err = dc.Punycode()
+	if err != nil {
+		return nil, err
+	}
+	domain := dc.Name
+
+	// Get existing records
+	existingRecords, err := api.GetZoneRecords(domain)
+	if err != nil {
+		return nil, err
+	}
+
+	// Normalize
+	models.PostProcessRecords(existingRecords)
+	differ := diff.New(dc)
+	_, create, del, modify, err := differ.IncrementalDiff(existingRecords)
+	if err != nil {
+		return nil, err
+	}
+
+	var corrections []*models.Correction
+
+	zone, err := api.getZone(domain)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, m := range del {
+		record := m.Existing.Original.(*Record)
+		corr := &models.Correction{
+			Msg: fmt.Sprintf("%s, HETZNER ID: %s", m.String(), record.Id),
+			F: func() error {
+				return api.deleteRecord(*record)
+			},
+		}
+		corrections = append(corrections, corr)
+	}
+
+	for _, m := range create {
+		record := fromRecordConfig(m.Desired, zone)
+		corr := &models.Correction{
+			Msg: m.String(),
+			F: func() error {
+				return api.createRecord(*record)
+			},
+		}
+		corrections = append(corrections, corr)
+	}
+
+	for _, m := range modify {
+		id := m.Existing.Original.(*Record).Id
+		record := fromRecordConfig(m.Desired, zone)
+		record.Id = id
+		corr := &models.Correction{
+			Msg: fmt.Sprintf("%s, HETZNER ID: %s", m.String(), id),
+			F: func() error {
+				return api.updateRecord(*record)
+			},
+		}
+		corrections = append(corrections, corr)
+	}
+
+	return corrections, nil
+}
+
+// GetNameservers returns the nameservers for a domain.
+func (api *api) GetNameservers(domain string) ([]*models.Nameserver, error) {
+	zone, err := api.getZone(domain)
+	if err != nil {
+		return nil, err
+	}
+	nameserver := make([]*models.Nameserver, len(zone.NameServers))
+	for i := range zone.NameServers {
+		nameserver[i] = &models.Nameserver{Name: zone.NameServers[i]}
+	}
+	return nameserver, nil
+}
+
+// GetZoneRecords gets the records of a zone and returns them in RecordConfig format.
+func (api *api) GetZoneRecords(domain string) (models.Records, error) {
+	records, err := api.getAllRecords(domain)
+	if err != nil {
+		return nil, err
+	}
+	existingRecords := make([]*models.RecordConfig, len(records))
+	for i := range records {
+		existingRecords[i] = toRecordConfig(domain, &records[i])
+	}
+	return existingRecords, nil
+}
+
+// ListZones lists the zones on this account.
+func (api *api) ListZones() ([]string, error) {
+	if err := api.getAllZones(); err != nil {
+		return nil, err
+	}
+	var zones []string
+	for i := range api.zones {
+		zones = append(zones, i)
+	}
+	return zones, nil
+}

--- a/providers/hetzner/hetznerProvider.go
+++ b/providers/hetzner/hetznerProvider.go
@@ -97,7 +97,7 @@ func (api *api) GetDomainCorrections(dc *models.DomainConfig) ([]*models.Correct
 	}
 
 	for _, m := range del {
-		record := m.Existing.Original.(*Record)
+		record := m.Existing.Original.(*record)
 		corr := &models.Correction{
 			Msg: m.String(),
 			F: func() error {
@@ -119,9 +119,9 @@ func (api *api) GetDomainCorrections(dc *models.DomainConfig) ([]*models.Correct
 	}
 
 	for _, m := range modify {
-		id := m.Existing.Original.(*Record).Id
+		id := m.Existing.Original.(*record).ID
 		record := fromRecordConfig(m.Desired, zone)
-		record.Id = id
+		record.ID = id
 		corr := &models.Correction{
 			Msg: m.String(),
 			F: func() error {

--- a/providers/hetzner/types.go
+++ b/providers/hetzner/types.go
@@ -50,7 +50,7 @@ type Zone struct {
 	TTL         int      `json:"ttl"`
 }
 
-func fromRecordConfig(in *models.RecordConfig, zone Zone) *Record {
+func fromRecordConfig(in *models.RecordConfig, zone *Zone) *Record {
 	ttl := int(in.TTL)
 	record := &Record{
 		Name:   in.GetLabel(),

--- a/providers/hetzner/types.go
+++ b/providers/hetzner/types.go
@@ -9,7 +9,7 @@ type createRecordRequest struct {
 	TTL    int    `json:"ttl"`
 	Type   string `json:"type"`
 	Value  string `json:"value"`
-	ZoneId string `json:"zone_id"`
+	ZoneID string `json:"zone_id"`
 }
 
 type createZoneRequest struct {
@@ -17,7 +17,7 @@ type createZoneRequest struct {
 }
 
 type getAllRecordsResponse struct {
-	Records []Record `json:"records"`
+	Records []record `json:"records"`
 	Meta    struct {
 		Pagination struct {
 			LastPage int `json:"last_page"`
@@ -26,7 +26,7 @@ type getAllRecordsResponse struct {
 }
 
 type getAllZonesResponse struct {
-	Zones []Zone `json:"zones"`
+	Zones []zone `json:"zones"`
 	Meta  struct {
 		Pagination struct {
 			LastPage int `json:"last_page"`
@@ -34,30 +34,30 @@ type getAllZonesResponse struct {
 	} `json:"meta"`
 }
 
-type Record struct {
-	Id     string `json:"id"`
+type record struct {
+	ID     string `json:"id"`
 	Name   string `json:"name"`
 	TTL    *int   `json:"ttl"`
 	Type   string `json:"type"`
 	Value  string `json:"value"`
-	ZoneId string `json:"zone_id"`
+	ZoneID string `json:"zone_id"`
 }
 
-type Zone struct {
-	Id          string   `json:"id"`
+type zone struct {
+	ID          string   `json:"id"`
 	Name        string   `json:"name"`
 	NameServers []string `json:"ns"`
 	TTL         int      `json:"ttl"`
 }
 
-func fromRecordConfig(in *models.RecordConfig, zone *Zone) *Record {
+func fromRecordConfig(in *models.RecordConfig, zone *zone) *record {
 	ttl := int(in.TTL)
-	record := &Record{
+	record := &record{
 		Name:   in.GetLabel(),
 		Type:   in.Type,
 		Value:  in.GetTargetField(),
 		TTL:    &ttl,
-		ZoneId: zone.Id,
+		ZoneID: zone.ID,
 	}
 
 	switch record.Type {
@@ -74,7 +74,7 @@ func fromRecordConfig(in *models.RecordConfig, zone *Zone) *Record {
 	return record
 }
 
-func toRecordConfig(domain string, record *Record) *models.RecordConfig {
+func toRecordConfig(domain string, record *record) *models.RecordConfig {
 	rc := &models.RecordConfig{
 		Type:     record.Type,
 		TTL:      uint32(*record.TTL),

--- a/providers/hetzner/types.go
+++ b/providers/hetzner/types.go
@@ -1,0 +1,88 @@
+package hetzner
+
+import (
+	"github.com/StackExchange/dnscontrol/v3/models"
+)
+
+type createRecordRequest struct {
+	Name   string `json:"name"`
+	TTL    int    `json:"ttl"`
+	Type   string `json:"type"`
+	Value  string `json:"value"`
+	ZoneId string `json:"zone_id"`
+}
+
+type createZoneRequest struct {
+	Name string `json:"name"`
+}
+
+type getAllRecordsResponse struct {
+	Records []Record `json:"records"`
+	Meta    struct {
+		Pagination struct {
+			LastPage int `json:"last_page"`
+		} `json:"pagination"`
+	} `json:"meta"`
+}
+
+type getAllZonesResponse struct {
+	Zones []Zone `json:"zones"`
+	Meta  struct {
+		Pagination struct {
+			LastPage int `json:"last_page"`
+		} `json:"pagination"`
+	} `json:"meta"`
+}
+
+type Record struct {
+	Id     string `json:"id"`
+	Name   string `json:"name"`
+	TTL    *int   `json:"ttl"`
+	Type   string `json:"type"`
+	Value  string `json:"value"`
+	ZoneId string `json:"zone_id"`
+}
+
+type Zone struct {
+	Id          string   `json:"id"`
+	Name        string   `json:"name"`
+	NameServers []string `json:"ns"`
+	TTL         int      `json:"ttl"`
+}
+
+func fromRecordConfig(in *models.RecordConfig, zone Zone) *Record {
+	ttl := int(in.TTL)
+	record := &Record{
+		Name:   in.GetLabel(),
+		Type:   in.Type,
+		Value:  in.GetTargetField(),
+		TTL:    &ttl,
+		ZoneId: zone.Id,
+	}
+
+	switch record.Type {
+	case "TXT":
+		// Cannot use `in.GetTargetCombined()` for TXTs:
+		// Their validation would complain about a missing `;`.
+		// Test case: single_TXT:Create_a_255-byte_TXT
+		// {"error":{"message":"422 Unprocessable Entity: missing: ; ","code":422}}
+		record.Value = in.GetTargetField()
+	default:
+		record.Value = in.GetTargetCombined()
+	}
+
+	return record
+}
+
+func toRecordConfig(domain string, record *Record) *models.RecordConfig {
+	rc := &models.RecordConfig{
+		Type:     record.Type,
+		TTL:      uint32(*record.TTL),
+		Original: record,
+	}
+	rc.SetLabel(record.Name, domain)
+
+	_ = rc.PopulateFromString(record.Type, record.Value, domain)
+
+	return rc
+}


### PR DESCRIPTION
This PR is implementing the first revision of the Provider for the Hetzner DNS Console service.

https://www.hetzner.com/dns-console
API schema: https://dns.hetzner.com/api-docs
Supported/Non-supported records are listed here https://docs.hetzner.com/dns-console/dns/general/supported-dns-record-types (they are also listed in the API schema https://dns.hetzner.com/api-docs#operation/CreateRecord)

It was pretty straight forward to implement (for a non-gopher), thanks for the detailed instructions.

Their API supports bulk creation and updating, but not bulk deletion. A follow-up PR could group corrections, but I am afraid this will add a lot of complexity, considering that we probably have to chunk them too.

Some record types are currently marked as not supported, incl. SOA records for which I added a special case in order to run the integration tests -- the clear process is not allowed to delete the existing SOA record. Most of the non-supported record types are available for updating in uploading a BIND zone file. Do you think we should change the correction mechanism of this provider to just use the BIND upload instead of incremental changes? As far as I can tell this does not play nice with records that are ignored/managed externally to dnscontrol.

In regards to maintaining this provider, I am not sure how much I can contribute in maintaining it, given that I am new to go and have very litte experience with the tooling around it. What do you think about asking the maintainers of the Hetzner go-libraries to step in? https://github.com/hetznercloud

Closes https://github.com/StackExchange/dnscontrol/issues/715