### PR TITLE
Be more consistent in API handle variable names

### DIFF
--- a/providers/activedir/activedirProvider.go
+++ b/providers/activedir/activedirProvider.go
@@ -9,7 +9,7 @@ import (
 )
 
 // This is the struct that matches either (or both) of the Registrar and/or DNSProvider interfaces:
-type adProvider struct {
+type activedirAPI struct {
 	adServer string
 	fake     bool
 	psOut    string
@@ -50,7 +50,7 @@ func newDNS(config map[string]string, metadata json.RawMessage) (providers.DNSSe
 		psLog = "powershell.log"
 	}
 
-	p := &adProvider{psLog: psLog, psOut: psOut, fake: fake}
+	p := &activedirAPI{psLog: psLog, psOut: psOut, fake: fake}
 	if fake {
 		return p, nil
 	}

--- a/providers/activedir/domains_test.go
+++ b/providers/activedir/domains_test.go
@@ -15,7 +15,7 @@ func makeRC(label, domain, target string, rc models.RecordConfig) *models.Record
 
 func TestGetExistingRecords(t *testing.T) {
 
-	cf := &adProvider{}
+	cf := &activedirAPI{}
 
 	cf.fake = true
 	actual, err := cf.getExistingRecords("test2")

--- a/providers/activedir/getzones_other.go
+++ b/providers/activedir/getzones_other.go
@@ -2,14 +2,14 @@
 
 package activedir
 
-func (c *adProvider) getRecords(domainname string) ([]byte, error) {
+func (c *activedirAPI) getRecords(domainname string) ([]byte, error) {
 	if !c.fake {
 		panic("Can not happen: PowerShell on non-windows")
 	}
 	return c.readZoneDump(domainname)
 }
 
-func (c *adProvider) powerShellDoCommand(command string, shouldLog bool) error {
+func (c *activedirAPI) powerShellDoCommand(command string, shouldLog bool) error {
 	if !c.fake {
 		panic("Can not happen: PowerShell on non-windows")
 	}

--- a/providers/azuredns/azureDnsProvider.go
+++ b/providers/azuredns/azureDnsProvider.go
@@ -17,7 +17,7 @@ import (
 	"github.com/StackExchange/dnscontrol/v3/providers"
 )
 
-type azureDNSProvider struct {
+type azurednsAPI struct {
 	zonesClient    *adns.ZonesClient
 	recordsClient  *adns.RecordSetsClient
 	zones          map[string]*adns.Zone
@@ -29,7 +29,7 @@ func newAzureDNSDsp(conf map[string]string, metadata json.RawMessage) (providers
 	return newAzureDNS(conf, metadata)
 }
 
-func newAzureDNS(m map[string]string, metadata json.RawMessage) (*azureDNSProvider, error) {
+func newAzureDNS(m map[string]string, metadata json.RawMessage) (*azurednsAPI, error) {
 	subID, rg := m["SubscriptionID"], m["ResourceGroup"]
 
 	zonesClient := adns.NewZonesClient(subID)
@@ -43,7 +43,7 @@ func newAzureDNS(m map[string]string, metadata json.RawMessage) (*azureDNSProvid
 
 	zonesClient.Authorizer = authorizer
 	recordsClient.Authorizer = authorizer
-	api := &azureDNSProvider{zonesClient: &zonesClient, recordsClient: &recordsClient, resourceGroup: to.StringPtr(rg), subscriptionID: to.StringPtr(subID)}
+	api := &azurednsAPI{zonesClient: &zonesClient, recordsClient: &recordsClient, resourceGroup: to.StringPtr(rg), subscriptionID: to.StringPtr(subID)}
 	err := api.getZones()
 	if err != nil {
 		return nil, err
@@ -72,7 +72,7 @@ func init() {
 	providers.RegisterCustomRecordType("AZURE_ALIAS", "AZURE_DNS", "")
 }
 
-func (a *azureDNSProvider) getExistingZones() (*adns.ZoneListResult, error) {
+func (a *azurednsAPI) getExistingZones() (*adns.ZoneListResult, error) {
 	// Please note — this function doesn't work with > 100 zones
 	// https://github.com/StackExchange/dnscontrol/issues/792
 	// Copied this code to getZones and ListZones and modified it for using a paging
@@ -87,7 +87,7 @@ func (a *azureDNSProvider) getExistingZones() (*adns.ZoneListResult, error) {
 	return &zonesResult, nil
 }
 
-func (a *azureDNSProvider) getZones() error {
+func (a *azurednsAPI) getZones() error {
 	a.zones = make(map[string]*adns.Zone)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 6000*time.Second)
@@ -119,7 +119,7 @@ func (e errNoExist) Error() string {
 	return fmt.Sprintf("Domain %s not found in you Azure account", e.domain)
 }
 
-func (a *azureDNSProvider) GetNameservers(domain string) ([]*models.Nameserver, error) {
+func (a *azurednsAPI) GetNameservers(domain string) ([]*models.Nameserver, error) {
 	zone, ok := a.zones[domain]
 	if !ok {
 		return nil, errNoExist{domain}
@@ -134,7 +134,7 @@ func (a *azureDNSProvider) GetNameservers(domain string) ([]*models.Nameserver, 
 	return models.ToNameserversStripTD(nss)
 }
 
-func (a *azureDNSProvider) ListZones() ([]string, error) {
+func (a *azurednsAPI) ListZones() ([]string, error) {
 	var zones []string
 
 	ctx, cancel := context.WithTimeout(context.Background(), 6000*time.Second)
@@ -158,7 +158,7 @@ func (a *azureDNSProvider) ListZones() ([]string, error) {
 }
 
 // GetZoneRecords gets the records of a zone and returns them in RecordConfig format.
-func (a *azureDNSProvider) GetZoneRecords(domain string) (models.Records, error) {
+func (a *azurednsAPI) GetZoneRecords(domain string) (models.Records, error) {
 	existingRecords, _, _, err := a.getExistingRecords(domain)
 	if err != nil {
 		return nil, err
@@ -166,7 +166,7 @@ func (a *azureDNSProvider) GetZoneRecords(domain string) (models.Records, error)
 	return existingRecords, nil
 }
 
-func (a *azureDNSProvider) getExistingRecords(domain string) (models.Records, []*adns.RecordSet, string, error) {
+func (a *azurednsAPI) getExistingRecords(domain string) (models.Records, []*adns.RecordSet, string, error) {
 	zone, ok := a.zones[domain]
 	if !ok {
 		return nil, nil, "", errNoExist{domain}
@@ -186,7 +186,7 @@ func (a *azureDNSProvider) getExistingRecords(domain string) (models.Records, []
 	return existingRecords, records, zoneName, nil
 }
 
-func (a *azureDNSProvider) GetDomainCorrections(dc *models.DomainConfig) ([]*models.Correction, error) {
+func (a *azurednsAPI) GetDomainCorrections(dc *models.DomainConfig) ([]*models.Correction, error) {
 	err := dc.Punycode()
 
 	if err != nil {
@@ -469,7 +469,7 @@ func nativeToRecords(set *adns.RecordSet, origin string) []*models.RecordConfig 
 	return results
 }
 
-func (a *azureDNSProvider) recordToNative(recordKey models.RecordKey, recordConfig []*models.RecordConfig) (*adns.RecordSet, adns.RecordType) {
+func (a *azurednsAPI) recordToNative(recordKey models.RecordKey, recordConfig []*models.RecordConfig) (*adns.RecordSet, adns.RecordType) {
 	recordSet := &adns.RecordSet{Type: to.StringPtr(recordKey.Type), RecordSetProperties: &adns.RecordSetProperties{}}
 	for _, rec := range recordConfig {
 		switch recordKey.Type {
@@ -529,7 +529,7 @@ func (a *azureDNSProvider) recordToNative(recordKey models.RecordKey, recordConf
 	return recordSet, nativeToRecordType(to.StringPtr(*recordSet.Type))
 }
 
-func (a *azureDNSProvider) fetchRecordSets(zoneName string) ([]*adns.RecordSet, error) {
+func (a *azurednsAPI) fetchRecordSets(zoneName string) ([]*adns.RecordSet, error) {
 	if zoneName == "" {
 		return nil, nil
 	}
@@ -553,7 +553,7 @@ func (a *azureDNSProvider) fetchRecordSets(zoneName string) ([]*adns.RecordSet, 
 	return records, nil
 }
 
-func (a *azureDNSProvider) EnsureDomainExists(domain string) error {
+func (a *azurednsAPI) EnsureDomainExists(domain string) error {
 	if _, ok := a.zones[domain]; ok {
 		return nil
 	}

--- a/providers/cloudflare/cloudflareProvider.go
+++ b/providers/cloudflare/cloudflareProvider.go
@@ -57,8 +57,8 @@ func init() {
 	providers.RegisterCustomRecordType("CF_TEMP_REDIRECT", "CLOUDFLAREAPI", "")
 }
 
-// api is the handle for API calls.
-type api struct {
+// cloudflareAPI is the handle for API calls.
+type cloudflareAPI struct {
 	APIKey          string `json:"apikey"`
 	APIToken        string `json:"apitoken"`
 	APIUser         string `json:"apiuser"`
@@ -82,7 +82,7 @@ func labelMatches(label string, matches []string) bool {
 }
 
 // GetNameservers returns the nameservers for a domain.
-func (c *api) GetNameservers(domain string) ([]*models.Nameserver, error) {
+func (c *cloudflareAPI) GetNameservers(domain string) ([]*models.Nameserver, error) {
 	if c.domainIndex == nil {
 		if err := c.fetchDomainList(); err != nil {
 			return nil, err
@@ -96,7 +96,7 @@ func (c *api) GetNameservers(domain string) ([]*models.Nameserver, error) {
 }
 
 // ListZones returns a list of the DNS zones.
-func (c *api) ListZones() ([]string, error) {
+func (c *cloudflareAPI) ListZones() ([]string, error) {
 	if err := c.fetchDomainList(); err != nil {
 		return nil, err
 	}
@@ -108,7 +108,7 @@ func (c *api) ListZones() ([]string, error) {
 }
 
 // GetZoneRecords gets the records of a zone and returns them in RecordConfig format.
-func (c *api) GetZoneRecords(domain string) (models.Records, error) {
+func (c *cloudflareAPI) GetZoneRecords(domain string) (models.Records, error) {
 	id, err := c.getDomainID(domain)
 	if err != nil {
 		return nil, err
@@ -125,7 +125,7 @@ func (c *api) GetZoneRecords(domain string) (models.Records, error) {
 	return records, nil
 }
 
-func (c *api) getDomainID(name string) (string, error) {
+func (c *cloudflareAPI) getDomainID(name string) (string, error) {
 	if c.domainIndex == nil {
 		if err := c.fetchDomainList(); err != nil {
 			return "", err
@@ -139,7 +139,7 @@ func (c *api) getDomainID(name string) (string, error) {
 }
 
 // GetDomainCorrections returns a list of corrections to update a domain.
-func (c *api) GetDomainCorrections(dc *models.DomainConfig) ([]*models.Correction, error) {
+func (c *cloudflareAPI) GetDomainCorrections(dc *models.DomainConfig) ([]*models.Correction, error) {
 	id, err := c.getDomainID(dc.Name)
 	if err != nil {
 		return nil, err
@@ -270,7 +270,7 @@ func checkNSModifications(dc *models.DomainConfig) {
 	dc.Records = newList
 }
 
-func (c *api) checkUniversalSSL(dc *models.DomainConfig, id string) (changed bool, newState bool, err error) {
+func (c *cloudflareAPI) checkUniversalSSL(dc *models.DomainConfig, id string) (changed bool, newState bool, err error) {
 	expectedStr := dc.Metadata[metaUniversalSSL]
 	if expectedStr == "" {
 		return false, false, fmt.Errorf("metadata not set")
@@ -309,7 +309,7 @@ func checkProxyVal(v string) (string, error) {
 	return v, nil
 }
 
-func (c *api) preprocessConfig(dc *models.DomainConfig) error {
+func (c *cloudflareAPI) preprocessConfig(dc *models.DomainConfig) error {
 
 	// Determine the default proxy setting.
 	var defProxy string
@@ -414,7 +414,7 @@ func (c *api) preprocessConfig(dc *models.DomainConfig) error {
 }
 
 func newCloudflare(m map[string]string, metadata json.RawMessage) (providers.DNSServiceProvider, error) {
-	api := &api{}
+	api := &cloudflareAPI{}
 	api.APIUser, api.APIKey, api.APIToken = m["apiuser"], m["apikey"], m["apitoken"]
 	// check api keys from creds json file
 	if api.APIToken == "" && (api.APIKey == "" || api.APIUser == "") {
@@ -611,7 +611,7 @@ func getProxyMetadata(r *models.RecordConfig) map[string]string {
 }
 
 // EnsureDomainExists returns an error of domain does not exist.
-func (c *api) EnsureDomainExists(domain string) error {
+func (c *cloudflareAPI) EnsureDomainExists(domain string) error {
 	if _, ok := c.domainIndex[domain]; ok {
 		return nil
 	}

--- a/providers/cloudflare/preprocess_test.go
+++ b/providers/cloudflare/preprocess_test.go
@@ -27,7 +27,7 @@ func makeRCmeta(meta map[string]string) *models.RecordConfig {
 }
 
 func TestPreprocess_BoolValidation(t *testing.T) {
-	cf := &api{}
+	cf := &cloudflareAPI{}
 
 	domain := newDomainConfig()
 	domain.Records = append(domain.Records, makeRCmeta(map[string]string{metaProxy: "on"}))
@@ -49,7 +49,7 @@ func TestPreprocess_BoolValidation(t *testing.T) {
 }
 
 func TestPreprocess_BoolValidation_Fails(t *testing.T) {
-	cf := &api{}
+	cf := &cloudflareAPI{}
 	domain := newDomainConfig()
 	domain.Records = append(domain.Records, &models.RecordConfig{Metadata: map[string]string{metaProxy: "true"}})
 	err := cf.preprocessConfig(domain)
@@ -59,7 +59,7 @@ func TestPreprocess_BoolValidation_Fails(t *testing.T) {
 }
 
 func TestPreprocess_DefaultProxy(t *testing.T) {
-	cf := &api{}
+	cf := &cloudflareAPI{}
 	domain := newDomainConfig()
 	domain.Metadata[metaProxyDefault] = "full"
 	domain.Records = append(domain.Records, makeRCmeta(map[string]string{metaProxy: "on"}))
@@ -78,7 +78,7 @@ func TestPreprocess_DefaultProxy(t *testing.T) {
 }
 
 func TestPreprocess_DefaultProxy_Validation(t *testing.T) {
-	cf := &api{}
+	cf := &cloudflareAPI{}
 	domain := newDomainConfig()
 	domain.Metadata[metaProxyDefault] = "true"
 	err := cf.preprocessConfig(domain)
@@ -100,7 +100,7 @@ func TestIpRewriting(t *testing.T) {
 		// inside range and proxied
 		{"1.2.3.4", "255.255.255.4", "full"},
 	}
-	cf := &api{}
+	cf := &cloudflareAPI{}
 	domain := newDomainConfig()
 	cf.ipConversions = []transform.IPConversion{{
 		Low:      net.ParseIP("1.2.3.0"),

--- a/providers/cloudflare/rest.go
+++ b/providers/cloudflare/rest.go
@@ -23,7 +23,7 @@ const (
 )
 
 // get list of domains for account. Cache so the ids can be looked up from domain name
-func (c *api) fetchDomainList() error {
+func (c *cloudflareAPI) fetchDomainList() error {
 	c.domainIndex = map[string]string{}
 	c.nameservers = map[string][]string{}
 	page := 1
@@ -50,7 +50,7 @@ func (c *api) fetchDomainList() error {
 }
 
 // get all records for a domain
-func (c *api) getRecordsForDomain(id string, domain string) ([]*models.RecordConfig, error) {
+func (c *cloudflareAPI) getRecordsForDomain(id string, domain string) ([]*models.RecordConfig, error) {
 	url := fmt.Sprintf(recordsURL, id)
 	page := 1
 	records := []*models.RecordConfig{}
@@ -77,7 +77,7 @@ func (c *api) getRecordsForDomain(id string, domain string) ([]*models.RecordCon
 }
 
 // create a correction to delete a record
-func (c *api) deleteRec(rec *cfRecord, domainID string) *models.Correction {
+func (c *cloudflareAPI) deleteRec(rec *cfRecord, domainID string) *models.Correction {
 	return &models.Correction{
 		Msg: fmt.Sprintf("DELETE record: %s %s %d %s (id=%s)", rec.Name, rec.Type, rec.TTL, rec.Content, rec.ID),
 		F: func() error {
@@ -93,7 +93,7 @@ func (c *api) deleteRec(rec *cfRecord, domainID string) *models.Correction {
 	}
 }
 
-func (c *api) createZone(domainName string) (string, error) {
+func (c *cloudflareAPI) createZone(domainName string) (string, error) {
 	type createZone struct {
 		Name string `json:"name"`
 
@@ -173,7 +173,7 @@ func cfSshfpData(rec *models.RecordConfig) *cfRecData {
 	}
 }
 
-func (c *api) createRec(rec *models.RecordConfig, domainID string) []*models.Correction {
+func (c *cloudflareAPI) createRec(rec *models.RecordConfig, domainID string) []*models.Correction {
 	type createRecord struct {
 		Name     string     `json:"name"`
 		Type     string     `json:"type"`
@@ -245,7 +245,7 @@ func (c *api) createRec(rec *models.RecordConfig, domainID string) []*models.Cor
 	return arr
 }
 
-func (c *api) modifyRecord(domainID, recID string, proxied bool, rec *models.RecordConfig) error {
+func (c *cloudflareAPI) modifyRecord(domainID, recID string, proxied bool, rec *models.RecordConfig) error {
 	if domainID == "" || recID == "" {
 		return fmt.Errorf("cannot modify record if domain or record id are empty")
 	}
@@ -302,7 +302,7 @@ func (c *api) modifyRecord(domainID, recID string, proxied bool, rec *models.Rec
 }
 
 // change universal ssl state
-func (c *api) changeUniversalSSL(domainID string, state bool) error {
+func (c *cloudflareAPI) changeUniversalSSL(domainID string, state bool) error {
 	type setUniversalSSL struct {
 		Enabled bool `json:"enabled"`
 	}
@@ -330,7 +330,7 @@ func (c *api) changeUniversalSSL(domainID string, state bool) error {
 }
 
 // change universal ssl state
-func (c *api) getUniversalSSL(domainID string) (bool, error) {
+func (c *cloudflareAPI) getUniversalSSL(domainID string) (bool, error) {
 	type universalSSLResponse struct {
 		Success  bool          `json:"success"`
 		Errors   []interface{} `json:"errors"`
@@ -368,7 +368,7 @@ func handleActionResponse(resp *http.Response, err error) (id string, e error) {
 	return result.Result.ID, nil
 }
 
-func (c *api) setHeaders(req *http.Request) {
+func (c *cloudflareAPI) setHeaders(req *http.Request) {
 	if len(c.APIToken) > 0 {
 		req.Header.Set("Authorization", "Bearer "+c.APIToken)
 	} else {
@@ -378,7 +378,7 @@ func (c *api) setHeaders(req *http.Request) {
 }
 
 // generic get handler. makes request and unmarshalls response to given interface
-func (c *api) get(endpoint string, target interface{}) error {
+func (c *cloudflareAPI) get(endpoint string, target interface{}) error {
 	req, err := http.NewRequest("GET", endpoint, nil)
 	if err != nil {
 		return err
@@ -398,7 +398,7 @@ func (c *api) get(endpoint string, target interface{}) error {
 	return decoder.Decode(target)
 }
 
-func (c *api) getPageRules(id string, domain string) ([]*models.RecordConfig, error) {
+func (c *cloudflareAPI) getPageRules(id string, domain string) ([]*models.RecordConfig, error) {
 	url := fmt.Sprintf(pageRulesURL, id)
 	data := pageRuleResponse{}
 	if err := c.get(url, &data); err != nil {
@@ -437,7 +437,7 @@ func (c *api) getPageRules(id string, domain string) ([]*models.RecordConfig, er
 	return recs, nil
 }
 
-func (c *api) deletePageRule(recordID, domainID string) error {
+func (c *cloudflareAPI) deletePageRule(recordID, domainID string) error {
 	endpoint := fmt.Sprintf(singlePageRuleURL, domainID, recordID)
 	req, err := http.NewRequest("DELETE", endpoint, nil)
 	if err != nil {
@@ -448,19 +448,19 @@ func (c *api) deletePageRule(recordID, domainID string) error {
 	return err
 }
 
-func (c *api) updatePageRule(recordID, domainID string, target string) error {
+func (c *cloudflareAPI) updatePageRule(recordID, domainID string, target string) error {
 	if err := c.deletePageRule(recordID, domainID); err != nil {
 		return err
 	}
 	return c.createPageRule(domainID, target)
 }
 
-func (c *api) createPageRule(domainID string, target string) error {
+func (c *cloudflareAPI) createPageRule(domainID string, target string) error {
 	endpoint := fmt.Sprintf(pageRulesURL, domainID)
 	return c.sendPageRule(endpoint, "POST", target)
 }
 
-func (c *api) sendPageRule(endpoint, method string, data string) error {
+func (c *cloudflareAPI) sendPageRule(endpoint, method string, data string) error {
 	// from to priority code
 	parts := strings.Split(data, ",")
 	priority, _ := strconv.Atoi(parts[2])

--- a/providers/digitalocean/digitaloceanProvider.go
+++ b/providers/digitalocean/digitaloceanProvider.go
@@ -24,8 +24,8 @@ Info required in `creds.json`:
 
 */
 
-// DoAPI is the handle for operations.
-type DoAPI struct {
+// digitaloceanAPI is the handle for operations.
+type digitaloceanAPI struct {
 	client *godo.Client
 }
 
@@ -48,7 +48,7 @@ func NewDo(m map[string]string, metadata json.RawMessage) (providers.DNSServiceP
 	)
 	client := godo.NewClient(oauthClient)
 
-	api := &DoAPI{client: client}
+	api := &digitaloceanAPI{client: client}
 
 	// Get a domain to validate the token
 	_, resp, err := api.client.Domains.List(ctx, &godo.ListOptions{PerPage: 1})
@@ -78,7 +78,7 @@ func init() {
 }
 
 // EnsureDomainExists returns an error if domain doesn't exist.
-func (api *DoAPI) EnsureDomainExists(domain string) error {
+func (api *digitaloceanAPI) EnsureDomainExists(domain string) error {
 	ctx := context.Background()
 	_, resp, err := api.client.Domains.Get(ctx, domain)
 	if resp.StatusCode == http.StatusNotFound {
@@ -92,12 +92,12 @@ func (api *DoAPI) EnsureDomainExists(domain string) error {
 }
 
 // GetNameservers returns the nameservers for domain.
-func (api *DoAPI) GetNameservers(domain string) ([]*models.Nameserver, error) {
+func (api *digitaloceanAPI) GetNameservers(domain string) ([]*models.Nameserver, error) {
 	return models.ToNameservers(defaultNameServerNames)
 }
 
 // GetZoneRecords gets the records of a zone and returns them in RecordConfig format.
-func (api *DoAPI) GetZoneRecords(domain string) (models.Records, error) {
+func (api *digitaloceanAPI) GetZoneRecords(domain string) (models.Records, error) {
 	records, err := getRecords(api, domain)
 	if err != nil {
 		return nil, err
@@ -116,7 +116,7 @@ func (api *DoAPI) GetZoneRecords(domain string) (models.Records, error) {
 }
 
 // GetDomainCorrections returns a list of corretions for the  domain.
-func (api *DoAPI) GetDomainCorrections(dc *models.DomainConfig) ([]*models.Correction, error) {
+func (api *digitaloceanAPI) GetDomainCorrections(dc *models.DomainConfig) ([]*models.Correction, error) {
 	ctx := context.Background()
 	dc.Punycode()
 
@@ -175,7 +175,7 @@ func (api *DoAPI) GetDomainCorrections(dc *models.DomainConfig) ([]*models.Corre
 	return corrections, nil
 }
 
-func getRecords(api *DoAPI, name string) ([]godo.DomainRecord, error) {
+func getRecords(api *digitaloceanAPI, name string) ([]godo.DomainRecord, error) {
 	ctx := context.Background()
 
 	records := []godo.DomainRecord{}

--- a/providers/dnsimple/dnsimpleProvider.go
+++ b/providers/dnsimple/dnsimpleProvider.go
@@ -47,20 +47,20 @@ var defaultNameServerNames = []string{
 	"ns4.dnsimple.com",
 }
 
-// DnsimpleAPI is the handle for this provider.
-type DnsimpleAPI struct {
+// dnsimpleAPI is the handle for this provider.
+type dnsimpleAPI struct {
 	AccountToken string // The account access token
 	BaseURL      string // An alternate base URI
 	accountID    string // Account id cache
 }
 
 // GetNameservers returns the name servers for a domain.
-func (c *DnsimpleAPI) GetNameservers(domainName string) ([]*models.Nameserver, error) {
+func (c *dnsimpleAPI) GetNameservers(domainName string) ([]*models.Nameserver, error) {
 	return models.ToNameservers(defaultNameServerNames)
 }
 
 // GetZoneRecords gets the records of a zone and returns them in RecordConfig format.
-func (c *DnsimpleAPI) GetZoneRecords(domain string) (models.Records, error) {
+func (c *dnsimpleAPI) GetZoneRecords(domain string) (models.Records, error) {
 	records, err := c.getRecords(domain)
 	if err != nil {
 		return nil, err
@@ -123,7 +123,7 @@ func (c *DnsimpleAPI) GetZoneRecords(domain string) (models.Records, error) {
 }
 
 // GetDomainCorrections returns corrections that update a domain.
-func (c *DnsimpleAPI) GetDomainCorrections(dc *models.DomainConfig) ([]*models.Correction, error) {
+func (c *dnsimpleAPI) GetDomainCorrections(dc *models.DomainConfig) ([]*models.Correction, error) {
 	corrections := []*models.Correction{}
 	err := dc.Punycode()
 	if err != nil {
@@ -191,7 +191,7 @@ func removeNS(records models.Records) models.Records {
 }
 
 // GetRegistrarCorrections returns corrections that update a domain's registrar.
-func (c *DnsimpleAPI) GetRegistrarCorrections(dc *models.DomainConfig) ([]*models.Correction, error) {
+func (c *dnsimpleAPI) GetRegistrarCorrections(dc *models.DomainConfig) ([]*models.Correction, error) {
 	corrections := []*models.Correction{}
 
 	nameServers, err := c.getNameservers(dc.Name)
@@ -222,7 +222,7 @@ func (c *DnsimpleAPI) GetRegistrarCorrections(dc *models.DomainConfig) ([]*model
 }
 
 // getDNSSECCorrections returns corrections that update a domain's DNSSEC state.
-func (c *DnsimpleAPI) getDNSSECCorrections(dc *models.DomainConfig) ([]*models.Correction, error) {
+func (c *dnsimpleAPI) getDNSSECCorrections(dc *models.DomainConfig) ([]*models.Correction, error) {
 	enabled, err := c.getDnssec(dc.Name)
 	if err != nil {
 		return nil, err
@@ -251,7 +251,7 @@ func (c *DnsimpleAPI) getDNSSECCorrections(dc *models.DomainConfig) ([]*models.C
 
 // DNSimple calls
 
-func (c *DnsimpleAPI) getClient() *dnsimpleapi.Client {
+func (c *dnsimpleAPI) getClient() *dnsimpleapi.Client {
 	ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: c.AccountToken})
 	tc := oauth2.NewClient(context.Background(), ts)
 
@@ -265,7 +265,7 @@ func (c *DnsimpleAPI) getClient() *dnsimpleapi.Client {
 	return client
 }
 
-func (c *DnsimpleAPI) getAccountID() (string, error) {
+func (c *dnsimpleAPI) getAccountID() (string, error) {
 	if c.accountID == "" {
 		client := c.getClient()
 		whoamiResponse, err := client.Identity.Whoami(context.Background())
@@ -280,7 +280,7 @@ func (c *DnsimpleAPI) getAccountID() (string, error) {
 	return c.accountID, nil
 }
 
-func (c *DnsimpleAPI) getRecords(domainName string) ([]dnsimpleapi.ZoneRecord, error) {
+func (c *dnsimpleAPI) getRecords(domainName string) ([]dnsimpleapi.ZoneRecord, error) {
 	client := c.getClient()
 
 	accountID, err := c.getAccountID()
@@ -308,7 +308,7 @@ func (c *DnsimpleAPI) getRecords(domainName string) ([]dnsimpleapi.ZoneRecord, e
 	return recs, nil
 }
 
-func (c *DnsimpleAPI) getDnssec(domainName string) (bool, error) {
+func (c *dnsimpleAPI) getDnssec(domainName string) (bool, error) {
 	var (
 		client    *dnsimpleapi.Client
 		accountID string
@@ -329,7 +329,7 @@ func (c *DnsimpleAPI) getDnssec(domainName string) (bool, error) {
 	return dnssecResponse.Data.Enabled, nil
 }
 
-func (c *DnsimpleAPI) enableDnssec(domainName string) (bool, error) {
+func (c *dnsimpleAPI) enableDnssec(domainName string) (bool, error) {
 	var (
 		client    *dnsimpleapi.Client
 		accountID string
@@ -350,7 +350,7 @@ func (c *DnsimpleAPI) enableDnssec(domainName string) (bool, error) {
 	return dnssecResponse.Data.Enabled, nil
 }
 
-func (c *DnsimpleAPI) disableDnssec(domainName string) (bool, error) {
+func (c *dnsimpleAPI) disableDnssec(domainName string) (bool, error) {
 	var (
 		client    *dnsimpleapi.Client
 		accountID string
@@ -374,7 +374,7 @@ func (c *DnsimpleAPI) disableDnssec(domainName string) (bool, error) {
 // Returns the name server names that should be used. If the domain is registered
 // then this method will return the delegation name servers. If this domain
 // is hosted only, then it will return the default DNSimple name servers.
-func (c *DnsimpleAPI) getNameservers(domainName string) ([]string, error) {
+func (c *dnsimpleAPI) getNameservers(domainName string) ([]string, error) {
 	client := c.getClient()
 
 	accountID, err := c.getAccountID()
@@ -400,7 +400,7 @@ func (c *DnsimpleAPI) getNameservers(domainName string) ([]string, error) {
 }
 
 // Returns a function that can be invoked to change the delegation of the domain to the given name server names.
-func (c *DnsimpleAPI) updateNameserversFunc(nameServerNames []string, domainName string) func() error {
+func (c *dnsimpleAPI) updateNameserversFunc(nameServerNames []string, domainName string) func() error {
 	return func() error {
 		client := c.getClient()
 
@@ -421,7 +421,7 @@ func (c *DnsimpleAPI) updateNameserversFunc(nameServerNames []string, domainName
 }
 
 // Returns a function that can be invoked to create a record in a zone.
-func (c *DnsimpleAPI) createRecordFunc(rc *models.RecordConfig, domainName string) func() error {
+func (c *dnsimpleAPI) createRecordFunc(rc *models.RecordConfig, domainName string) func() error {
 	return func() error {
 		client := c.getClient()
 
@@ -446,7 +446,7 @@ func (c *DnsimpleAPI) createRecordFunc(rc *models.RecordConfig, domainName strin
 }
 
 // Returns a function that can be invoked to delete a record in a zone.
-func (c *DnsimpleAPI) deleteRecordFunc(recordID int64, domainName string) func() error {
+func (c *dnsimpleAPI) deleteRecordFunc(recordID int64, domainName string) func() error {
 	return func() error {
 		client := c.getClient()
 
@@ -466,7 +466,7 @@ func (c *DnsimpleAPI) deleteRecordFunc(recordID int64, domainName string) func()
 }
 
 // Returns a function that can be invoked to update a record in a zone.
-func (c *DnsimpleAPI) updateRecordFunc(old *dnsimpleapi.ZoneRecord, rc *models.RecordConfig, domainName string) func() error {
+func (c *dnsimpleAPI) updateRecordFunc(old *dnsimpleapi.ZoneRecord, rc *models.RecordConfig, domainName string) func() error {
 	return func() error {
 		client := c.getClient()
 
@@ -493,7 +493,7 @@ func (c *DnsimpleAPI) updateRecordFunc(old *dnsimpleapi.ZoneRecord, rc *models.R
 }
 
 // ListZones returns all the zones in an account
-func (c *DnsimpleAPI) ListZones() ([]string, error) {
+func (c *dnsimpleAPI) ListZones() ([]string, error) {
 	client := c.getClient()
 	accountID, err := c.getAccountID()
 	if err != nil {
@@ -531,8 +531,8 @@ func newDsp(conf map[string]string, metadata json.RawMessage) (providers.DNSServ
 	return newProvider(conf, metadata)
 }
 
-func newProvider(m map[string]string, metadata json.RawMessage) (*DnsimpleAPI, error) {
-	api := &DnsimpleAPI{}
+func newProvider(m map[string]string, metadata json.RawMessage) (*dnsimpleAPI, error) {
+	api := &dnsimpleAPI{}
 	api.AccountToken = m["token"]
 	if api.AccountToken == "" {
 		return nil, fmt.Errorf("missing DNSimple token")

--- a/providers/gandi_v5/gandi_v5Provider.go
+++ b/providers/gandi_v5/gandi_v5Provider.go
@@ -58,8 +58,8 @@ var features = providers.DocumentationNotes{
 
 // Section 2: Define the API client.
 
-// api is the api handle used to store any client-related state.
-type api struct {
+// gandiv5API is the gandiv5API handle used to store any client-related state.
+type gandiv5API struct {
 	apikey    string
 	sharingid string
 	debug     bool
@@ -76,8 +76,8 @@ func newReg(conf map[string]string) (providers.Registrar, error) {
 }
 
 // newHelper generates a handle.
-func newHelper(m map[string]string, metadata json.RawMessage) (*api, error) {
-	api := &api{}
+func newHelper(m map[string]string, metadata json.RawMessage) (*gandiv5API, error) {
+	api := &gandiv5API{}
 	api.apikey = m["apikey"]
 	if api.apikey == "" {
 		return nil, fmt.Errorf("missing Gandi apikey")
@@ -105,7 +105,7 @@ func newHelper(m map[string]string, metadata json.RawMessage) (*api, error) {
 
 // GetDomainCorrections get the current and existing records,
 // post-process them, and generate corrections.
-func (client *api) GetDomainCorrections(dc *models.DomainConfig) ([]*models.Correction, error) {
+func (client *gandiv5API) GetDomainCorrections(dc *models.DomainConfig) ([]*models.Correction, error) {
 	existing, err := client.GetZoneRecords(dc.Name)
 	if err != nil {
 		return nil, err
@@ -118,7 +118,7 @@ func (client *api) GetDomainCorrections(dc *models.DomainConfig) ([]*models.Corr
 
 // GetZoneRecords gathers the DNS records and converts them to
 // dnscontrol's format.
-func (client *api) GetZoneRecords(domain string) (models.Records, error) {
+func (client *gandiv5API) GetZoneRecords(domain string) (models.Records, error) {
 	g := gandi.NewLiveDNSClient(client.apikey, gandi.Config{SharingID: client.sharingid, Debug: client.debug})
 
 	// Get all the existing records:
@@ -187,7 +187,7 @@ func PrepDesiredRecords(dc *models.DomainConfig) {
 // a list of functions to call to actually make the desired
 // correction, and a message to output to the user when the change is
 // made.
-func (client *api) GenerateDomainCorrections(dc *models.DomainConfig, existing models.Records) ([]*models.Correction, error) {
+func (client *gandiv5API) GenerateDomainCorrections(dc *models.DomainConfig, existing models.Records) ([]*models.Correction, error) {
 	if client.debug {
 		debugRecords("GenDC input", existing)
 	}
@@ -321,7 +321,7 @@ func gatherAffectedLabels(groups map[models.RecordKey][]string) (labels map[stri
 // Section 3: Registrar-related functions
 
 // GetNameservers returns a list of nameservers for domain.
-func (client *api) GetNameservers(domain string) ([]*models.Nameserver, error) {
+func (client *gandiv5API) GetNameservers(domain string) ([]*models.Nameserver, error) {
 	g := gandi.NewLiveDNSClient(client.apikey, gandi.Config{SharingID: client.sharingid, Debug: client.debug})
 	nameservers, err := g.GetDomainNS(domain)
 	if err != nil {
@@ -331,7 +331,7 @@ func (client *api) GetNameservers(domain string) ([]*models.Nameserver, error) {
 }
 
 // GetRegistrarCorrections returns a list of corrections for this registrar.
-func (client *api) GetRegistrarCorrections(dc *models.DomainConfig) ([]*models.Correction, error) {
+func (client *gandiv5API) GetRegistrarCorrections(dc *models.DomainConfig) ([]*models.Correction, error) {
 	gd := gandi.NewDomainClient(client.apikey, gandi.Config{SharingID: client.sharingid, Debug: client.debug})
 
 	existingNs, err := gd.GetNameServers(dc.Name)

--- a/providers/gcloud/gcloudProvider.go
+++ b/providers/gcloud/gcloudProvider.go
@@ -35,7 +35,7 @@ func init() {
 	providers.RegisterDomainServiceProviderType("GCLOUD", New, features)
 }
 
-type gcloud struct {
+type gcloudAPI struct {
 	client        *gdns.Service
 	project       string
 	nameServerSet *string
@@ -78,7 +78,7 @@ func New(cfg map[string]string, metadata json.RawMessage) (providers.DNSServiceP
 		nss = sPtr(val)
 	}
 
-	g := &gcloud{
+	g := &gcloudAPI{
 		client:        dcli,
 		nameServerSet: nss,
 		project:       cfg["project_id"],
@@ -86,7 +86,7 @@ func New(cfg map[string]string, metadata json.RawMessage) (providers.DNSServiceP
 	return g, g.loadZoneInfo()
 }
 
-func (g *gcloud) loadZoneInfo() error {
+func (g *gcloudAPI) loadZoneInfo() error {
 	if g.zones != nil {
 		return nil
 	}
@@ -108,7 +108,7 @@ func (g *gcloud) loadZoneInfo() error {
 }
 
 // ListZones returns the list of zones (domains) in this account.
-func (g *gcloud) ListZones() ([]string, error) {
+func (g *gcloudAPI) ListZones() ([]string, error) {
 	var zones []string
 	for i := range g.zones {
 		zones = append(zones, strings.TrimSuffix(i, "."))
@@ -116,11 +116,11 @@ func (g *gcloud) ListZones() ([]string, error) {
 	return zones, nil
 }
 
-func (g *gcloud) getZone(domain string) (*gdns.ManagedZone, error) {
+func (g *gcloudAPI) getZone(domain string) (*gdns.ManagedZone, error) {
 	return g.zones[domain+"."], nil
 }
 
-func (g *gcloud) GetNameservers(domain string) ([]*models.Nameserver, error) {
+func (g *gcloudAPI) GetNameservers(domain string) ([]*models.Nameserver, error) {
 	zone, err := g.getZone(domain)
 	if err != nil {
 		return nil, err
@@ -143,12 +143,12 @@ func keyForRec(r *models.RecordConfig) key {
 }
 
 // GetZoneRecords gets the records of a zone and returns them in RecordConfig format.
-func (g *gcloud) GetZoneRecords(domain string) (models.Records, error) {
+func (g *gcloudAPI) GetZoneRecords(domain string) (models.Records, error) {
 	existingRecords, _, _, err := g.getZoneSets(domain)
 	return existingRecords, err
 }
 
-func (g *gcloud) getZoneSets(domain string) (models.Records, map[key]*gdns.ResourceRecordSet, string, error) {
+func (g *gcloudAPI) getZoneSets(domain string) (models.Records, map[key]*gdns.ResourceRecordSet, string, error) {
 	rrs, zoneName, err := g.getRecords(domain)
 	if err != nil {
 		return nil, nil, "", err
@@ -165,7 +165,7 @@ func (g *gcloud) getZoneSets(domain string) (models.Records, map[key]*gdns.Resou
 	return existingRecords, oldRRs, zoneName, err
 }
 
-func (g *gcloud) GetDomainCorrections(dc *models.DomainConfig) ([]*models.Correction, error) {
+func (g *gcloudAPI) GetDomainCorrections(dc *models.DomainConfig) ([]*models.Correction, error) {
 	if err := dc.Punycode(); err != nil {
 		return nil, err
 	}
@@ -244,7 +244,7 @@ func nativeToRecord(set *gdns.ResourceRecordSet, rec, origin string) *models.Rec
 	return r
 }
 
-func (g *gcloud) getRecords(domain string) ([]*gdns.ResourceRecordSet, string, error) {
+func (g *gcloudAPI) getRecords(domain string) ([]*gdns.ResourceRecordSet, string, error) {
 	zone, err := g.getZone(domain)
 	if err != nil {
 		return nil, "", err
@@ -273,7 +273,7 @@ func (g *gcloud) getRecords(domain string) ([]*gdns.ResourceRecordSet, string, e
 	return sets, zone.Name, nil
 }
 
-func (g *gcloud) EnsureDomainExists(domain string) error {
+func (g *gcloudAPI) EnsureDomainExists(domain string) error {
 	z, err := g.getZone(domain)
 	if err != nil {
 		if _, ok := err.(errNoExist); !ok {

--- a/providers/linode/api.go
+++ b/providers/linode/api.go
@@ -15,7 +15,7 @@ const (
 	domainsPath    = "domains"
 )
 
-func (c *LinodeAPI) fetchDomainList() error {
+func (c *linodeAPI) fetchDomainList() error {
 	c.domainIndex = map[string]int{}
 	page := 1
 	for {
@@ -35,7 +35,7 @@ func (c *LinodeAPI) fetchDomainList() error {
 	return nil
 }
 
-func (c *LinodeAPI) getRecords(id int) ([]domainRecord, error) {
+func (c *linodeAPI) getRecords(id int) ([]domainRecord, error) {
 	records := []domainRecord{}
 	page := 1
 	for {
@@ -56,7 +56,7 @@ func (c *LinodeAPI) getRecords(id int) ([]domainRecord, error) {
 	return records, nil
 }
 
-func (c *LinodeAPI) createRecord(domainID int, rec *recordEditRequest) (*domainRecord, error) {
+func (c *linodeAPI) createRecord(domainID int, rec *recordEditRequest) (*domainRecord, error) {
 	endpoint := fmt.Sprintf("%s/%d/records", domainsPath, domainID)
 
 	req, err := c.newRequest(http.MethodPost, endpoint, rec)
@@ -84,7 +84,7 @@ func (c *LinodeAPI) createRecord(domainID int, rec *recordEditRequest) (*domainR
 	return record, nil
 }
 
-func (c *LinodeAPI) modifyRecord(domainID, recordID int, rec *recordEditRequest) error {
+func (c *linodeAPI) modifyRecord(domainID, recordID int, rec *recordEditRequest) error {
 	endpoint := fmt.Sprintf("%s/%d/records/%d", domainsPath, domainID, recordID)
 
 	req, err := c.newRequest(http.MethodPut, endpoint, rec)
@@ -104,7 +104,7 @@ func (c *LinodeAPI) modifyRecord(domainID, recordID int, rec *recordEditRequest)
 	return nil
 }
 
-func (c *LinodeAPI) deleteRecord(domainID, recordID int) error {
+func (c *linodeAPI) deleteRecord(domainID, recordID int) error {
 	endpoint := fmt.Sprintf("%s/%d/records/%d", domainsPath, domainID, recordID)
 	req, err := c.newRequest(http.MethodDelete, endpoint, nil)
 	if err != nil {
@@ -123,7 +123,7 @@ func (c *LinodeAPI) deleteRecord(domainID, recordID int) error {
 	return nil
 }
 
-func (c *LinodeAPI) newRequest(method, endpoint string, body interface{}) (*http.Request, error) {
+func (c *linodeAPI) newRequest(method, endpoint string, body interface{}) (*http.Request, error) {
 	rel, err := url.Parse(endpoint)
 	if err != nil {
 		return nil, err
@@ -149,7 +149,7 @@ func (c *LinodeAPI) newRequest(method, endpoint string, body interface{}) (*http
 	return req, nil
 }
 
-func (c *LinodeAPI) get(endpoint string, target interface{}) error {
+func (c *linodeAPI) get(endpoint string, target interface{}) error {
 	req, err := c.newRequest(http.MethodGet, endpoint, nil)
 	if err != nil {
 		return err
@@ -166,7 +166,7 @@ func (c *LinodeAPI) get(endpoint string, target interface{}) error {
 	return decoder.Decode(target)
 }
 
-func (c *LinodeAPI) handleErrors(resp *http.Response) error {
+func (c *linodeAPI) handleErrors(resp *http.Response) error {
 	defer resp.Body.Close()
 	decoder := json.NewDecoder(resp.Body)
 

--- a/providers/linode/linodeProvider.go
+++ b/providers/linode/linodeProvider.go
@@ -43,8 +43,8 @@ var allowedTTLValues = []uint32{
 
 var srvRegexp = regexp.MustCompile(`^_(?P<Service>\w+)\.\_(?P<Protocol>\w+)$`)
 
-// LinodeAPI is the handle for this provider.
-type LinodeAPI struct {
+// linodeAPI is the handle for this provider.
+type linodeAPI struct {
 	client      *http.Client
 	baseURL     *url.URL
 	domainIndex map[string]int
@@ -75,7 +75,7 @@ func NewLinode(m map[string]string, metadata json.RawMessage) (providers.DNSServ
 		return nil, fmt.Errorf("invalid base URL for Linode")
 	}
 
-	api := &LinodeAPI{client: client, baseURL: baseURL}
+	api := &linodeAPI{client: client, baseURL: baseURL}
 
 	// Get a domain to validate the token
 	if err := api.fetchDomainList(); err != nil {
@@ -97,12 +97,12 @@ func init() {
 }
 
 // GetNameservers returns the nameservers for a domain.
-func (api *LinodeAPI) GetNameservers(domain string) ([]*models.Nameserver, error) {
+func (api *linodeAPI) GetNameservers(domain string) ([]*models.Nameserver, error) {
 	return models.ToNameservers(defaultNameServerNames)
 }
 
 // GetZoneRecords gets the records of a zone and returns them in RecordConfig format.
-func (api *LinodeAPI) GetZoneRecords(domain string) (models.Records, error) {
+func (api *linodeAPI) GetZoneRecords(domain string) (models.Records, error) {
 	return nil, fmt.Errorf("not implemented")
 	// This enables the get-zones subcommand.
 	// Implement this by extracting the code from GetDomainCorrections into
@@ -110,7 +110,7 @@ func (api *LinodeAPI) GetZoneRecords(domain string) (models.Records, error) {
 }
 
 // GetDomainCorrections returns the corrections for a domain.
-func (api *LinodeAPI) GetDomainCorrections(dc *models.DomainConfig) ([]*models.Correction, error) {
+func (api *linodeAPI) GetDomainCorrections(dc *models.DomainConfig) ([]*models.Correction, error) {
 	dc, err := dc.Copy()
 	if err != nil {
 		return nil, err

--- a/providers/namecheap/namecheapProvider.go
+++ b/providers/namecheap/namecheapProvider.go
@@ -19,10 +19,10 @@ import (
 // NamecheapDefaultNs lists the default nameservers for this provider.
 var NamecheapDefaultNs = []string{"dns1.registrar-servers.com", "dns2.registrar-servers.com"}
 
-// Namecheap is the handle for this provider.
-type Namecheap struct {
-	ApiKey  string
-	ApiUser string
+// namecheapAPI is the handle for this provider.
+type namecheapAPI struct {
+	APIKEY  string
+	APIUser string
 	client  *nc.Client
 }
 
@@ -55,13 +55,13 @@ func newReg(conf map[string]string) (providers.Registrar, error) {
 	return newProvider(conf, nil)
 }
 
-func newProvider(m map[string]string, metadata json.RawMessage) (*Namecheap, error) {
-	api := &Namecheap{}
-	api.ApiUser, api.ApiKey = m["apiuser"], m["apikey"]
-	if api.ApiKey == "" || api.ApiUser == "" {
+func newProvider(m map[string]string, metadata json.RawMessage) (*namecheapAPI, error) {
+	api := &namecheapAPI{}
+	api.APIUser, api.APIKEY = m["apiuser"], m["apikey"]
+	if api.APIKEY == "" || api.APIUser == "" {
 		return nil, fmt.Errorf("missing Namecheap apikey and apiuser")
 	}
-	api.client = nc.NewClient(api.ApiUser, api.ApiKey, api.ApiUser)
+	api.client = nc.NewClient(api.APIUser, api.APIKEY, api.APIUser)
 	// if BaseURL is specified in creds, use that url
 	BaseURL, ok := m["BaseURL"]
 	if ok {
@@ -107,7 +107,7 @@ func doWithRetry(f func() error) {
 }
 
 // GetZoneRecords gets the records of a zone and returns them in RecordConfig format.
-func (n *Namecheap) GetZoneRecords(domain string) (models.Records, error) {
+func (n *namecheapAPI) GetZoneRecords(domain string) (models.Records, error) {
 	return nil, fmt.Errorf("not implemented")
 	// This enables the get-zones subcommand.
 	// Implement this by extracting the code from GetDomainCorrections into
@@ -115,7 +115,7 @@ func (n *Namecheap) GetZoneRecords(domain string) (models.Records, error) {
 }
 
 // GetDomainCorrections returns the corrections for the domain.
-func (n *Namecheap) GetDomainCorrections(dc *models.DomainConfig) ([]*models.Correction, error) {
+func (n *namecheapAPI) GetDomainCorrections(dc *models.DomainConfig) ([]*models.Correction, error) {
 	dc.Punycode()
 	sld, tld := splitDomain(dc.Name)
 	var records *nc.DomainDNSGetHostsResult
@@ -215,7 +215,7 @@ func (n *Namecheap) GetDomainCorrections(dc *models.DomainConfig) ([]*models.Cor
 	return corrections, nil
 }
 
-func (n *Namecheap) generateRecords(dc *models.DomainConfig) error {
+func (n *namecheapAPI) generateRecords(dc *models.DomainConfig) error {
 
 	var recs []nc.DomainDNSHost
 
@@ -250,13 +250,13 @@ func (n *Namecheap) generateRecords(dc *models.DomainConfig) error {
 }
 
 // GetNameservers returns the nameservers for a domain.
-func (n *Namecheap) GetNameservers(domainName string) ([]*models.Nameserver, error) {
+func (n *namecheapAPI) GetNameservers(domainName string) ([]*models.Nameserver, error) {
 	// return default namecheap nameservers
 	return models.ToNameservers(NamecheapDefaultNs)
 }
 
 // GetRegistrarCorrections returns corrections to update nameservers.
-func (n *Namecheap) GetRegistrarCorrections(dc *models.DomainConfig) ([]*models.Correction, error) {
+func (n *namecheapAPI) GetRegistrarCorrections(dc *models.DomainConfig) ([]*models.Correction, error) {
 	var info *nc.DomainInfo
 	var err error
 	doWithRetry(func() error {

--- a/providers/namedotcom/namedotcomProvider.go
+++ b/providers/namedotcom/namedotcomProvider.go
@@ -12,8 +12,8 @@ import (
 
 const defaultAPIBase = "api.name.com"
 
-// NameCom describes a connection to the NDC API.
-type NameCom struct {
+// namedotcomAPI describes a connection to the NDC API.
+type namedotcomAPI struct {
 	APIUrl  string `json:"apiurl"`
 	APIUser string `json:"apiuser"`
 	APIKey  string `json:"apikey"`
@@ -39,8 +39,8 @@ func newDsp(conf map[string]string, meta json.RawMessage) (providers.DNSServiceP
 	return newProvider(conf)
 }
 
-func newProvider(conf map[string]string) (*NameCom, error) {
-	api := &NameCom{
+func newProvider(conf map[string]string) (*namedotcomAPI, error) {
+	api := &namedotcomAPI{
 		client: namecom.New(conf["apiuser"], conf["apikey"]),
 	}
 	api.client.Server = conf["apiurl"]

--- a/providers/namedotcom/nameservers.go
+++ b/providers/namedotcom/nameservers.go
@@ -13,7 +13,7 @@ import (
 var nsRegex = regexp.MustCompile(`ns([1-4])[a-z]{3}\.name\.com`)
 
 // GetNameservers gets the nameservers set on a domain.
-func (n *NameCom) GetNameservers(domain string) ([]*models.Nameserver, error) {
+func (n *namedotcomAPI) GetNameservers(domain string) ([]*models.Nameserver, error) {
 	// This is an interesting edge case. Name.com expects you to SET the nameservers to ns[1-4].name.com,
 	// but it will internally set it to ns1xyz.name.com, where xyz is a uniqueish 3 letters.
 	// In order to avoid endless loops, we will use the unique nameservers if present, or else the generic ones if not.
@@ -31,7 +31,7 @@ func (n *NameCom) GetNameservers(domain string) ([]*models.Nameserver, error) {
 	return models.ToNameservers(toUse)
 }
 
-func (n *NameCom) getNameserversRaw(domain string) ([]string, error) {
+func (n *namedotcomAPI) getNameserversRaw(domain string) ([]string, error) {
 	request := &namecom.GetDomainRequest{
 		DomainName: domain,
 	}
@@ -46,7 +46,7 @@ func (n *NameCom) getNameserversRaw(domain string) ([]string, error) {
 }
 
 // GetRegistrarCorrections gathers corrections that would being n to match dc.
-func (n *NameCom) GetRegistrarCorrections(dc *models.DomainConfig) ([]*models.Correction, error) {
+func (n *namedotcomAPI) GetRegistrarCorrections(dc *models.DomainConfig) ([]*models.Correction, error) {
 	nss, err := n.getNameserversRaw(dc.Name)
 	if err != nil {
 		return nil, err
@@ -70,7 +70,7 @@ func (n *NameCom) GetRegistrarCorrections(dc *models.DomainConfig) ([]*models.Co
 	return nil, nil
 }
 
-func (n *NameCom) updateNameservers(ns []string, domain string) func() error {
+func (n *namedotcomAPI) updateNameservers(ns []string, domain string) func() error {
 	return func() error {
 		request := &namecom.SetNameserversRequest{
 			DomainName:  domain,

--- a/providers/namedotcom/records.go
+++ b/providers/namedotcom/records.go
@@ -20,7 +20,7 @@ var defaultNameservers = []*models.Nameserver{
 }
 
 // GetZoneRecords gets the records of a zone and returns them in RecordConfig format.
-func (n *NameCom) GetZoneRecords(domain string) (models.Records, error) {
+func (n *namedotcomAPI) GetZoneRecords(domain string) (models.Records, error) {
 	records, err := n.getRecords(domain)
 	if err != nil {
 		return nil, err
@@ -35,7 +35,7 @@ func (n *NameCom) GetZoneRecords(domain string) (models.Records, error) {
 }
 
 // GetDomainCorrections gathers correctios that would bring n to match dc.
-func (n *NameCom) GetDomainCorrections(dc *models.DomainConfig) ([]*models.Correction, error) {
+func (n *namedotcomAPI) GetDomainCorrections(dc *models.DomainConfig) ([]*models.Correction, error) {
 	dc.Punycode()
 
 	actual, err := n.GetZoneRecords(dc.Name)
@@ -128,7 +128,7 @@ func toRecord(r *namecom.Record, origin string) *models.RecordConfig {
 	return rc
 }
 
-func (n *NameCom) getRecords(domain string) ([]*namecom.Record, error) {
+func (n *namedotcomAPI) getRecords(domain string) ([]*namecom.Record, error) {
 	var (
 		err      error
 		records  []*namecom.Record
@@ -158,7 +158,7 @@ func (n *NameCom) getRecords(domain string) ([]*namecom.Record, error) {
 	return records, nil
 }
 
-func (n *NameCom) createRecord(rc *models.RecordConfig, domain string) error {
+func (n *namedotcomAPI) createRecord(rc *models.RecordConfig, domain string) error {
 	record := &namecom.Record{
 		DomainName: domain,
 		Host:       rc.GetLabel(),
@@ -218,7 +218,7 @@ func decodeTxt(s string) []string {
 	return []string{s}
 }
 
-func (n *NameCom) deleteRecord(id int32, domain string) error {
+func (n *namedotcomAPI) deleteRecord(id int32, domain string) error {
 	request := &namecom.DeleteRecordRequest{
 		DomainName: domain,
 		ID:         id,

--- a/providers/namedotcom/zones.go
+++ b/providers/namedotcom/zones.go
@@ -5,7 +5,7 @@ import (
 )
 
 // ListZones returns all the zones in an account
-func (c *NameCom) ListZones() ([]string, error) {
+func (c *namedotcomAPI) ListZones() ([]string, error) {
 	var names []string
 	var page int32
 

--- a/providers/opensrs/opensrsProvider.go
+++ b/providers/opensrs/opensrsProvider.go
@@ -30,22 +30,22 @@ var defaultNameServerNames = []string{
 	"ns3.systemdns.com",
 }
 
-// OpenSRSApi is the api handle.
-type OpenSRSApi struct {
+// opensrsAPI is the api handle.
+type opensrsAPI struct {
 	UserName string // reseller user name
-	ApiKey   string // API Key
+	APIKey   string // API Key
 
 	BaseURL string          // An alternate base URI
 	client  *opensrs.Client // Client
 }
 
 // GetNameservers returns a list of nameservers.
-func (c *OpenSRSApi) GetNameservers(domainName string) ([]*models.Nameserver, error) {
+func (c *opensrsAPI) GetNameservers(domainName string) ([]*models.Nameserver, error) {
 	return models.ToNameservers(defaultNameServerNames)
 }
 
 // GetRegistrarCorrections returns a list of corrections for a registrar.
-func (c *OpenSRSApi) GetRegistrarCorrections(dc *models.DomainConfig) ([]*models.Correction, error) {
+func (c *opensrsAPI) GetRegistrarCorrections(dc *models.DomainConfig) ([]*models.Correction, error) {
 	corrections := []*models.Correction{}
 
 	nameServers, err := c.getNameservers(dc.Name)
@@ -77,14 +77,14 @@ func (c *OpenSRSApi) GetRegistrarCorrections(dc *models.DomainConfig) ([]*models
 
 // OpenSRS calls
 
-func (c *OpenSRSApi) getClient() *opensrs.Client {
+func (c *opensrsAPI) getClient() *opensrs.Client {
 	return c.client
 }
 
 // Returns the name server names that should be used. If the domain is registered
 // then this method will return the delegation name servers. If this domain
 // is hosted only, then it will return the default OpenSRS name servers.
-func (c *OpenSRSApi) getNameservers(domainName string) ([]string, error) {
+func (c *opensrsAPI) getNameservers(domainName string) ([]string, error) {
 	client := c.getClient()
 
 	status, err := client.Domains.GetDomain(domainName, "status", 1)
@@ -103,7 +103,7 @@ func (c *OpenSRSApi) getNameservers(domainName string) ([]string, error) {
 }
 
 // Returns a function that can be invoked to change the delegation of the domain to the given name server names.
-func (c *OpenSRSApi) updateNameserversFunc(nameServerNames []string, domainName string) func() error {
+func (c *opensrsAPI) updateNameserversFunc(nameServerNames []string, domainName string) func() error {
 	return func() error {
 		client := c.getClient()
 
@@ -121,11 +121,11 @@ func newReg(conf map[string]string) (providers.Registrar, error) {
 	return newProvider(conf, nil)
 }
 
-func newProvider(m map[string]string, metadata json.RawMessage) (*OpenSRSApi, error) {
-	api := &OpenSRSApi{}
-	api.ApiKey = m["apikey"]
+func newProvider(m map[string]string, metadata json.RawMessage) (*opensrsAPI, error) {
+	api := &opensrsAPI{}
+	api.APIKey = m["apikey"]
 
-	if api.ApiKey == "" {
+	if api.APIKey == "" {
 		return nil, fmt.Errorf("openSRS apikey must be provided")
 	}
 
@@ -138,7 +138,7 @@ func newProvider(m map[string]string, metadata json.RawMessage) (*OpenSRSApi, er
 		api.BaseURL = m["baseurl"]
 	}
 
-	api.client = opensrs.NewClient(opensrs.NewApiKeyMD5Credentials(api.UserName, api.ApiKey))
+	api.client = opensrs.NewClient(opensrs.NewApiKeyMD5Credentials(api.UserName, api.APIKey))
 	if api.BaseURL != "" {
 		api.client.BaseURL = api.BaseURL
 	}

--- a/providers/route53/route53Provider.go
+++ b/providers/route53/route53Provider.go
@@ -19,7 +19,7 @@ import (
 	"github.com/StackExchange/dnscontrol/v3/providers"
 )
 
-type route53Provider struct {
+type route53API struct {
 	client          *r53.Route53
 	registrar       *r53d.Route53Domains
 	delegationSet   *string
@@ -35,7 +35,7 @@ func newRoute53Dsp(conf map[string]string, metadata json.RawMessage) (providers.
 	return newRoute53(conf, metadata)
 }
 
-func newRoute53(m map[string]string, metadata json.RawMessage) (*route53Provider, error) {
+func newRoute53(m map[string]string, metadata json.RawMessage) (*route53API, error) {
 	keyID, secretKey, tokenID := m["KeyId"], m["SecretKey"], m["Token"]
 
 	// Route53 uses a global endpoint and route53domains
@@ -56,7 +56,7 @@ func newRoute53(m map[string]string, metadata json.RawMessage) (*route53Provider
 		fmt.Printf("ROUTE53 DelegationSet %s configured\n", val)
 		dls = sPtr(val)
 	}
-	api := &route53Provider{client: r53.New(sess), registrar: r53d.New(sess), delegationSet: dls}
+	api := &route53API{client: r53.New(sess), registrar: r53d.New(sess), delegationSet: dls}
 	err := api.getZones()
 	if err != nil {
 		return nil, err
@@ -111,7 +111,7 @@ func withRetry(f func() error) {
 }
 
 // ListZones lists the zones on this account.
-func (r *route53Provider) ListZones() ([]string, error) {
+func (r *route53API) ListZones() ([]string, error) {
 	var zones []string
 	// Assumes r.zones was filled already by newRoute53().
 	for i := range r.zones {
@@ -120,7 +120,7 @@ func (r *route53Provider) ListZones() ([]string, error) {
 	return zones, nil
 }
 
-func (r *route53Provider) getZones() error {
+func (r *route53API) getZones() error {
 	var nextMarker *string
 	r.zones = make(map[string]*r53.HostedZone)
 	for {
@@ -157,7 +157,7 @@ func (e errNoExist) Error() string {
 	return fmt.Sprintf("Domain %s not found in your route 53 account", e.domain)
 }
 
-func (r *route53Provider) GetNameservers(domain string) ([]*models.Nameserver, error) {
+func (r *route53API) GetNameservers(domain string) ([]*models.Nameserver, error) {
 
 	zone, ok := r.zones[domain]
 	if !ok {
@@ -183,7 +183,7 @@ func (r *route53Provider) GetNameservers(domain string) ([]*models.Nameserver, e
 }
 
 // GetZoneRecords gets the records of a zone and returns them in RecordConfig format.
-func (r *route53Provider) GetZoneRecords(domain string) (models.Records, error) {
+func (r *route53API) GetZoneRecords(domain string) (models.Records, error) {
 
 	zone, ok := r.zones[domain]
 	if !ok {
@@ -203,7 +203,7 @@ func (r *route53Provider) GetZoneRecords(domain string) (models.Records, error) 
 	return existingRecords, nil
 }
 
-func (r *route53Provider) GetDomainCorrections(dc *models.DomainConfig) ([]*models.Correction, error) {
+func (r *route53API) GetDomainCorrections(dc *models.DomainConfig) ([]*models.Correction, error) {
 	dc.Punycode()
 
 	var corrections = []*models.Correction{}
@@ -431,7 +431,7 @@ func getZoneID(zone *r53.HostedZone, r *models.RecordConfig) string {
 	return zoneID
 }
 
-func (r *route53Provider) GetRegistrarCorrections(dc *models.DomainConfig) ([]*models.Correction, error) {
+func (r *route53API) GetRegistrarCorrections(dc *models.DomainConfig) ([]*models.Correction, error) {
 	corrections := []*models.Correction{}
 	actualSet, err := r.getRegistrarNameservers(&dc.Name)
 	if err != nil {
@@ -462,7 +462,7 @@ func (r *route53Provider) GetRegistrarCorrections(dc *models.DomainConfig) ([]*m
 	return corrections, nil
 }
 
-func (r *route53Provider) getRegistrarNameservers(domainName *string) ([]string, error) {
+func (r *route53API) getRegistrarNameservers(domainName *string) ([]string, error) {
 	var domainDetail *r53d.GetDomainDetailOutput
 	var err error
 	withRetry(func() error {
@@ -481,7 +481,7 @@ func (r *route53Provider) getRegistrarNameservers(domainName *string) ([]string,
 	return nameservers, nil
 }
 
-func (r *route53Provider) updateRegistrarNameservers(domainName string, nameservers []string) (*string, error) {
+func (r *route53API) updateRegistrarNameservers(domainName string, nameservers []string) (*string, error) {
 	servers := []*r53d.Nameserver{}
 	for i := range nameservers {
 		servers = append(servers, &r53d.Nameserver{Name: &nameservers[i]})
@@ -500,7 +500,7 @@ func (r *route53Provider) updateRegistrarNameservers(domainName string, nameserv
 	return domainUpdate.OperationId, nil
 }
 
-func (r *route53Provider) fetchRecordSets(zoneID *string) ([]*r53.ResourceRecordSet, error) {
+func (r *route53API) fetchRecordSets(zoneID *string) ([]*r53.ResourceRecordSet, error) {
 	if zoneID == nil || *zoneID == "" {
 		return nil, nil
 	}
@@ -545,7 +545,7 @@ func unescape(s *string) string {
 	return name
 }
 
-func (r *route53Provider) EnsureDomainExists(domain string) error {
+func (r *route53API) EnsureDomainExists(domain string) error {
 	if _, ok := r.zones[domain]; ok {
 		return nil
 	}


### PR DESCRIPTION
```
git co .
git co master
git br -D tlim_rename
git co -b tlim_rename
gorename -v -from '"github.com/StackExchange/dnscontrol/v3/providers/activedir".adProvider' -to 'activedirAPI'
gorename -v -from '"github.com/StackExchange/dnscontrol/v3/providers/route53".route53Provider' -to 'route53API'
gorename -v -from '"github.com/StackExchange/dnscontrol/v3/providers/gcloud".gcloud' -to 'gcloudAPI'
gorename -v -from '"github.com/StackExchange/dnscontrol/v3/providers/namedotcom".NameCom' -to 'namedotcomAPI'
gorename -v -from '"github.com/StackExchange/dnscontrol/v3/providers/cloudflare".api' -to 'cloudflareAPI'
gorename -v -from '"github.com/StackExchange/dnscontrol/v3/providers/digitalocean".DoAPI' -to 'digitaloceanAPI'
gorename -v -from '"github.com/StackExchange/dnscontrol/v3/providers/gandi_v5".api' -to 'gandiv5API'
gorename -v -from '"github.com/StackExchange/dnscontrol/v3/providers/azuredns".azureDNSProvider' -to 'azurednsAPI'

gorename -v -from '"github.com/StackExchange/dnscontrol/v3/providers/dnsimple".DnsimpleAPI' -to 'dnsimpleAPI'
gorename -v -from '"github.com/StackExchange/dnscontrol/v3/providers/linode".LinodeAPI' -to 'linodeAPI'
gorename -v -from '"github.com/StackExchange/dnscontrol/v3/providers/namecheap".Namecheap' -to 'namecheapAPI'
gorename -v -from '"github.com/StackExchange/dnscontrol/v3/providers/namecheap".namecheapAPI.ApiKey' -to 'APIKEY'
gorename -v -from '"github.com/StackExchange/dnscontrol/v3/providers/namecheap".namecheapAPI.ApiUser' -to 'APIUser'
gorename -v -from '"github.com/StackExchange/dnscontrol/v3/providers/opensrs".OpenSRSApi' -to 'opensrsAPI'
gorename -v -from '"github.com/StackExchange/dnscontrol/v3/providers/opensrs".opensrsAPI.ApiKey' -to 'APIKey'
```