### PR TITLE
Rename provider handles to *Provider

### DIFF
--- a/providers/activedir/activedirProvider.go
+++ b/providers/activedir/activedirProvider.go
@@ -9,7 +9,7 @@ import (
 )
 
 // This is the struct that matches either (or both) of the Registrar and/or DNSProvider interfaces:
-type activedirAPI struct {
+type activedirProvider struct {
 	adServer string
 	fake     bool
 	psOut    string
@@ -50,7 +50,7 @@ func newDNS(config map[string]string, metadata json.RawMessage) (providers.DNSSe
 		psLog = "powershell.log"
 	}
 
-	p := &activedirAPI{psLog: psLog, psOut: psOut, fake: fake}
+	p := &activedirProvider{psLog: psLog, psOut: psOut, fake: fake}
 	if fake {
 		return p, nil
 	}

--- a/providers/activedir/domains.go
+++ b/providers/activedir/domains.go
@@ -23,7 +23,7 @@ type RecordConfigJSON struct {
 	TTL  uint32 `json:"timetolive"`
 }
 
-func (c *activedirAPI) GetNameservers(string) ([]*models.Nameserver, error) {
+func (c *activedirProvider) GetNameservers(string) ([]*models.Nameserver, error) {
 	// TODO: If using AD for publicly hosted zones, probably pull these from config.
 	return nil, nil
 }
@@ -38,7 +38,7 @@ var supportedTypes = map[string]bool{
 }
 
 // GetZoneRecords gets the records of a zone and returns them in RecordConfig format.
-func (c *activedirAPI) GetZoneRecords(domain string) (models.Records, error) {
+func (c *activedirProvider) GetZoneRecords(domain string) (models.Records, error) {
 	foundRecords, err := c.getExistingRecords(domain)
 	if err != nil {
 		return nil, fmt.Errorf("c.getExistingRecords(%q) failed: %v", domain, err)
@@ -47,7 +47,7 @@ func (c *activedirAPI) GetZoneRecords(domain string) (models.Records, error) {
 }
 
 // GetDomainCorrections gets existing records, diffs them against existing, and returns corrections.
-func (c *activedirAPI) GetDomainCorrections(dc *models.DomainConfig) ([]*models.Correction, error) {
+func (c *activedirProvider) GetDomainCorrections(dc *models.DomainConfig) ([]*models.Correction, error) {
 
 	dc.Filter(func(r *models.RecordConfig) bool {
 		if r.Type == "NS" && r.Name == "@" {
@@ -100,7 +100,7 @@ func zoneDumpFilename(domainname string) string {
 }
 
 // readZoneDump reads a pre-existing zone dump from adzonedump.*.json.
-func (c *activedirAPI) readZoneDump(domainname string) ([]byte, error) {
+func (c *activedirProvider) readZoneDump(domainname string) ([]byte, error) {
 	// File not found is considered an error.
 	dat, err := utfutil.ReadFile(zoneDumpFilename(domainname), utfutil.WINDOWS)
 	if err != nil {
@@ -111,17 +111,17 @@ func (c *activedirAPI) readZoneDump(domainname string) ([]byte, error) {
 }
 
 // powerShellLogCommand logs to flagPsLog that a PowerShell command is going to be run.
-func (c *activedirAPI) logCommand(command string) error {
+func (c *activedirProvider) logCommand(command string) error {
 	return c.logHelper(fmt.Sprintf("# %s\r\n%s\r\n", time.Now().UTC(), strings.TrimSpace(command)))
 }
 
 // powerShellLogOutput logs to flagPsLog that a PowerShell command is going to be run.
-func (c *activedirAPI) logOutput(s string) error {
+func (c *activedirProvider) logOutput(s string) error {
 	return c.logHelper(fmt.Sprintf("OUTPUT: START\r\n%s\r\nOUTPUT: END\r\n", s))
 }
 
 // powerShellLogErr logs that a PowerShell command had an error.
-func (c *activedirAPI) logErr(e error) error {
+func (c *activedirProvider) logErr(e error) error {
 	err := c.logHelper(fmt.Sprintf("ERROR: %v\r\r", e)) // Log error to powershell.log
 	if err != nil {
 		return err // Bubble up error created in logHelper
@@ -129,7 +129,7 @@ func (c *activedirAPI) logErr(e error) error {
 	return e // Bubble up original error
 }
 
-func (c *activedirAPI) logHelper(s string) error {
+func (c *activedirProvider) logHelper(s string) error {
 	logfile, err := os.OpenFile(c.psLog, os.O_APPEND|os.O_RDWR|os.O_CREATE, 0660)
 	if err != nil {
 		return fmt.Errorf("error: Can not create/append to %#v: %v", c.psLog, err)
@@ -145,7 +145,7 @@ func (c *activedirAPI) logHelper(s string) error {
 }
 
 // powerShellRecord records that a PowerShell command should be executed later.
-func (c *activedirAPI) powerShellRecord(command string) error {
+func (c *activedirProvider) powerShellRecord(command string) error {
 	recordfile, err := os.OpenFile(c.psOut, os.O_APPEND|os.O_RDWR|os.O_CREATE, 0660)
 	if err != nil {
 		return fmt.Errorf("can not create/append to %#v: %v", c.psOut, err)
@@ -157,7 +157,7 @@ func (c *activedirAPI) powerShellRecord(command string) error {
 	return recordfile.Close()
 }
 
-func (c *activedirAPI) getExistingRecords(domainname string) ([]*models.RecordConfig, error) {
+func (c *activedirProvider) getExistingRecords(domainname string) ([]*models.RecordConfig, error) {
 	// Get the JSON either from adzonedump or by running a PowerShell script.
 	data, err := c.getRecords(domainname)
 	if err != nil {
@@ -221,7 +221,7 @@ func (r *RecordConfigJSON) unpackRecord(origin string) (rc *models.RecordConfig,
 }
 
 // powerShellDump runs a PowerShell command to get a dump of all records in a DNS zone.
-func (c *activedirAPI) generatePowerShellZoneDump(domainname string) string {
+func (c *activedirProvider) generatePowerShellZoneDump(domainname string) string {
 	cmdTxt := `@("REPLACE_WITH_ZONE") | %{
 Get-DnsServerResourceRecord -ComputerName REPLACE_WITH_COMPUTER_NAME -ZoneName $_ | select hostname,recordtype,@{n="timestamp";e={$_.timestamp.tostring()}},@{n="timetolive";e={$_.timetolive.totalseconds}},@{n="recorddata";e={($_.recorddata.ipv4address,$_.recorddata.ipv6address,$_.recorddata.HostNameAlias,$_.recorddata.NameServer,"unsupported_record_type" -ne $null)[0]-as [string]}} | ConvertTo-Json > REPLACE_WITH_FILENAMEPREFIX.REPLACE_WITH_ZONE.json
 }`
@@ -232,7 +232,7 @@ Get-DnsServerResourceRecord -ComputerName REPLACE_WITH_COMPUTER_NAME -ZoneName $
 }
 
 // generatePowerShellCreate generates PowerShell commands to ADD a record.
-func (c *activedirAPI) generatePowerShellCreate(domainname string, rec *models.RecordConfig) string {
+func (c *activedirProvider) generatePowerShellCreate(domainname string, rec *models.RecordConfig) string {
 	content := rec.GetTargetField()
 	text := "\r\n" // Skip a line.
 	funcSuffix := rec.Type
@@ -263,7 +263,7 @@ func (c *activedirAPI) generatePowerShellCreate(domainname string, rec *models.R
 }
 
 // generatePowerShellModify generates PowerShell commands to MODIFY a record.
-func (c *activedirAPI) generatePowerShellModify(domainname, recName, recType, oldContent, newContent string, oldTTL, newTTL uint32) string {
+func (c *activedirProvider) generatePowerShellModify(domainname, recName, recType, oldContent, newContent string, oldTTL, newTTL uint32) string {
 
 	var queryField, queryContent string
 	queryContent = `"` + oldContent + `"`
@@ -317,7 +317,7 @@ func (c *activedirAPI) generatePowerShellModify(domainname, recName, recType, ol
 	return text
 }
 
-func (c *activedirAPI) generatePowerShellDelete(domainname, recName, recType, content string) string {
+func (c *activedirProvider) generatePowerShellDelete(domainname, recName, recType, content string) string {
 	text := fmt.Sprintf(`echo "DELETE %s %s %s"`, recType, recName, content)
 	text += "\r\n"
 	text += `Remove-DnsServerResourceRecord -Force -ComputerName "%s" -ZoneName "%s" -Name "%s" -RRType "%s" -RecordData "%s"`
@@ -325,7 +325,7 @@ func (c *activedirAPI) generatePowerShellDelete(domainname, recName, recType, co
 	return fmt.Sprintf(text, c.adServer, domainname, recName, recType, content)
 }
 
-func (c *activedirAPI) createRec(domainname string, cre diff.Correlation) []*models.Correction {
+func (c *activedirProvider) createRec(domainname string, cre diff.Correlation) []*models.Correction {
 	rec := cre.Desired
 	arr := []*models.Correction{
 		{
@@ -337,7 +337,7 @@ func (c *activedirAPI) createRec(domainname string, cre diff.Correlation) []*mod
 	return arr
 }
 
-func (c *activedirAPI) modifyRec(domainname string, m diff.Correlation) *models.Correction {
+func (c *activedirProvider) modifyRec(domainname string, m diff.Correlation) *models.Correction {
 	old, rec := m.Existing, m.Desired
 	return &models.Correction{
 		Msg: m.String(),
@@ -347,7 +347,7 @@ func (c *activedirAPI) modifyRec(domainname string, m diff.Correlation) *models.
 	}
 }
 
-func (c *activedirAPI) deleteRec(domainname string, cor diff.Correlation) *models.Correction {
+func (c *activedirProvider) deleteRec(domainname string, cor diff.Correlation) *models.Correction {
 	rec := cor.Existing
 	return &models.Correction{
 		Msg: cor.String(),

--- a/providers/activedir/domains_test.go
+++ b/providers/activedir/domains_test.go
@@ -15,7 +15,7 @@ func makeRC(label, domain, target string, rc models.RecordConfig) *models.Record
 
 func TestGetExistingRecords(t *testing.T) {
 
-	cf := &activedirAPI{}
+	cf := &activedirProvider{}
 
 	cf.fake = true
 	actual, err := cf.getExistingRecords("test2")

--- a/providers/activedir/getzones_other.go
+++ b/providers/activedir/getzones_other.go
@@ -2,14 +2,14 @@
 
 package activedir
 
-func (c *activedirAPI) getRecords(domainname string) ([]byte, error) {
+func (c *activedirProvider) getRecords(domainname string) ([]byte, error) {
 	if !c.fake {
 		panic("Can not happen: PowerShell on non-windows")
 	}
 	return c.readZoneDump(domainname)
 }
 
-func (c *activedirAPI) powerShellDoCommand(command string, shouldLog bool) error {
+func (c *activedirProvider) powerShellDoCommand(command string, shouldLog bool) error {
 	if !c.fake {
 		panic("Can not happen: PowerShell on non-windows")
 	}

--- a/providers/axfrddns/axfrddnsProvider.go
+++ b/providers/axfrddns/axfrddnsProvider.go
@@ -50,8 +50,8 @@ var features = providers.DocumentationNotes{
 	providers.CanGetZones:            providers.Can(),
 }
 
-// AxfrDdns stores the client info for the provider.
-type AxfrDdns struct {
+// axfrddnsProvider stores the client info for the provider.
+type axfrddnsProvider struct {
 	rand        *rand.Rand
 	master      string
 	nameservers []*models.Nameserver
@@ -63,7 +63,7 @@ func initAxfrDdns(config map[string]string, providermeta json.RawMessage) (provi
 	// config -- the key/values from creds.json
 	// providermeta -- the json blob from NewReq('name', 'TYPE', providermeta)
 	var err error
-	api := &AxfrDdns{
+	api := &axfrddnsProvider{
 		rand: rand.New(rand.NewSource(int64(time.Now().Nanosecond()))),
 	}
 	param := &Param{}
@@ -161,12 +161,12 @@ func readKey(raw string, kind string) (*Key, error) {
 }
 
 // GetNameservers returns the nameservers for a domain.
-func (c *AxfrDdns) GetNameservers(domain string) ([]*models.Nameserver, error) {
+func (c *axfrddnsProvider) GetNameservers(domain string) ([]*models.Nameserver, error) {
 	return c.nameservers, nil
 }
 
 // FetchZoneRecords gets the records of a zone and returns them in dns.RR format.
-func (c *AxfrDdns) FetchZoneRecords(domain string) ([]dns.RR, error) {
+func (c *axfrddnsProvider) FetchZoneRecords(domain string) ([]dns.RR, error) {
 
 	transfer := new(dns.Transfer)
 	transfer.DialTimeout = dnsTimeout
@@ -203,7 +203,7 @@ func (c *AxfrDdns) FetchZoneRecords(domain string) ([]dns.RR, error) {
 }
 
 // GetZoneRecords gets the records of a zone and returns them in RecordConfig format.
-func (c *AxfrDdns) GetZoneRecords(domain string) (models.Records, error) {
+func (c *axfrddnsProvider) GetZoneRecords(domain string) (models.Records, error) {
 
 	rawRecords, err := c.FetchZoneRecords(domain)
 	if err != nil {
@@ -254,7 +254,7 @@ func (c *AxfrDdns) GetZoneRecords(domain string) (models.Records, error) {
 }
 
 // GetDomainCorrections returns a list of corrections to update a domain.
-func (c *AxfrDdns) GetDomainCorrections(dc *models.DomainConfig) ([]*models.Correction, error) {
+func (c *axfrddnsProvider) GetDomainCorrections(dc *models.DomainConfig) ([]*models.Correction, error) {
 	dc.Punycode()
 
 	foundRecords, err := c.GetZoneRecords(dc.Name)

--- a/providers/bind/bindProvider.go
+++ b/providers/bind/bindProvider.go
@@ -51,7 +51,7 @@ var features = providers.DocumentationNotes{
 func initBind(config map[string]string, providermeta json.RawMessage) (providers.DNSServiceProvider, error) {
 	// config -- the key/values from creds.json
 	// meta -- the json blob from NewReq('name', 'TYPE', meta)
-	api := &Bind{
+	api := &bindProvider{
 		directory: config["directory"],
 	}
 	if api.directory == "" {
@@ -92,8 +92,8 @@ func (s SoaInfo) String() string {
 	return fmt.Sprintf("%s %s %d %d %d %d %d %d", s.Ns, s.Mbox, s.Serial, s.Refresh, s.Retry, s.Expire, s.Minttl, s.TTL)
 }
 
-// Bind is the provider handle for the Bind driver.
-type Bind struct {
+// bindProvider is the provider handle for the bindProvider driver.
+type bindProvider struct {
 	DefaultNS     []string `json:"default_ns"`
 	DefaultSoa    SoaInfo  `json:"default_soa"`
 	nameservers   []*models.Nameserver
@@ -103,7 +103,7 @@ type Bind struct {
 }
 
 // GetNameservers returns the nameservers for a domain.
-func (c *Bind) GetNameservers(string) ([]*models.Nameserver, error) {
+func (c *bindProvider) GetNameservers(string) ([]*models.Nameserver, error) {
 	var r []string
 	for _, j := range c.nameservers {
 		r = append(r, j.Name)
@@ -112,7 +112,7 @@ func (c *Bind) GetNameservers(string) ([]*models.Nameserver, error) {
 }
 
 // ListZones returns all the zones in an account
-func (c *Bind) ListZones() ([]string, error) {
+func (c *bindProvider) ListZones() ([]string, error) {
 	if _, err := os.Stat(c.directory); os.IsNotExist(err) {
 		return nil, fmt.Errorf("directory %q does not exist", c.directory)
 	}
@@ -130,7 +130,7 @@ func (c *Bind) ListZones() ([]string, error) {
 }
 
 // GetZoneRecords gets the records of a zone and returns them in RecordConfig format.
-func (c *Bind) GetZoneRecords(domain string) (models.Records, error) {
+func (c *bindProvider) GetZoneRecords(domain string) (models.Records, error) {
 	foundRecords := models.Records{}
 
 	if _, err := os.Stat(c.directory); os.IsNotExist(err) {
@@ -170,7 +170,7 @@ func (c *Bind) GetZoneRecords(domain string) (models.Records, error) {
 }
 
 // GetDomainCorrections returns a list of corrections to update a domain.
-func (c *Bind) GetDomainCorrections(dc *models.DomainConfig) ([]*models.Correction, error) {
+func (c *bindProvider) GetDomainCorrections(dc *models.DomainConfig) ([]*models.Correction, error) {
 	dc.Punycode()
 
 	comments := make([]string, 0, 5)

--- a/providers/cloudflare/cloudflareProvider.go
+++ b/providers/cloudflare/cloudflareProvider.go
@@ -57,8 +57,8 @@ func init() {
 	providers.RegisterCustomRecordType("CF_TEMP_REDIRECT", "CLOUDFLAREAPI", "")
 }
 
-// cloudflareAPI is the handle for API calls.
-type cloudflareAPI struct {
+// cloudflareProvider is the handle for API calls.
+type cloudflareProvider struct {
 	APIKey          string `json:"apikey"`
 	APIToken        string `json:"apitoken"`
 	APIUser         string `json:"apiuser"`
@@ -82,7 +82,7 @@ func labelMatches(label string, matches []string) bool {
 }
 
 // GetNameservers returns the nameservers for a domain.
-func (c *cloudflareAPI) GetNameservers(domain string) ([]*models.Nameserver, error) {
+func (c *cloudflareProvider) GetNameservers(domain string) ([]*models.Nameserver, error) {
 	if c.domainIndex == nil {
 		if err := c.fetchDomainList(); err != nil {
 			return nil, err
@@ -96,7 +96,7 @@ func (c *cloudflareAPI) GetNameservers(domain string) ([]*models.Nameserver, err
 }
 
 // ListZones returns a list of the DNS zones.
-func (c *cloudflareAPI) ListZones() ([]string, error) {
+func (c *cloudflareProvider) ListZones() ([]string, error) {
 	if err := c.fetchDomainList(); err != nil {
 		return nil, err
 	}
@@ -108,7 +108,7 @@ func (c *cloudflareAPI) ListZones() ([]string, error) {
 }
 
 // GetZoneRecords gets the records of a zone and returns them in RecordConfig format.
-func (c *cloudflareAPI) GetZoneRecords(domain string) (models.Records, error) {
+func (c *cloudflareProvider) GetZoneRecords(domain string) (models.Records, error) {
 	id, err := c.getDomainID(domain)
 	if err != nil {
 		return nil, err
@@ -125,7 +125,7 @@ func (c *cloudflareAPI) GetZoneRecords(domain string) (models.Records, error) {
 	return records, nil
 }
 
-func (c *cloudflareAPI) getDomainID(name string) (string, error) {
+func (c *cloudflareProvider) getDomainID(name string) (string, error) {
 	if c.domainIndex == nil {
 		if err := c.fetchDomainList(); err != nil {
 			return "", err
@@ -139,7 +139,7 @@ func (c *cloudflareAPI) getDomainID(name string) (string, error) {
 }
 
 // GetDomainCorrections returns a list of corrections to update a domain.
-func (c *cloudflareAPI) GetDomainCorrections(dc *models.DomainConfig) ([]*models.Correction, error) {
+func (c *cloudflareProvider) GetDomainCorrections(dc *models.DomainConfig) ([]*models.Correction, error) {
 	id, err := c.getDomainID(dc.Name)
 	if err != nil {
 		return nil, err
@@ -270,7 +270,7 @@ func checkNSModifications(dc *models.DomainConfig) {
 	dc.Records = newList
 }
 
-func (c *cloudflareAPI) checkUniversalSSL(dc *models.DomainConfig, id string) (changed bool, newState bool, err error) {
+func (c *cloudflareProvider) checkUniversalSSL(dc *models.DomainConfig, id string) (changed bool, newState bool, err error) {
 	expectedStr := dc.Metadata[metaUniversalSSL]
 	if expectedStr == "" {
 		return false, false, fmt.Errorf("metadata not set")
@@ -309,7 +309,7 @@ func checkProxyVal(v string) (string, error) {
 	return v, nil
 }
 
-func (c *cloudflareAPI) preprocessConfig(dc *models.DomainConfig) error {
+func (c *cloudflareProvider) preprocessConfig(dc *models.DomainConfig) error {
 
 	// Determine the default proxy setting.
 	var defProxy string
@@ -414,7 +414,7 @@ func (c *cloudflareAPI) preprocessConfig(dc *models.DomainConfig) error {
 }
 
 func newCloudflare(m map[string]string, metadata json.RawMessage) (providers.DNSServiceProvider, error) {
-	api := &cloudflareAPI{}
+	api := &cloudflareProvider{}
 	api.APIUser, api.APIKey, api.APIToken = m["apiuser"], m["apikey"], m["apitoken"]
 	// check api keys from creds json file
 	if api.APIToken == "" && (api.APIKey == "" || api.APIUser == "") {
@@ -611,7 +611,7 @@ func getProxyMetadata(r *models.RecordConfig) map[string]string {
 }
 
 // EnsureDomainExists returns an error of domain does not exist.
-func (c *cloudflareAPI) EnsureDomainExists(domain string) error {
+func (c *cloudflareProvider) EnsureDomainExists(domain string) error {
 	if _, ok := c.domainIndex[domain]; ok {
 		return nil
 	}

--- a/providers/cloudflare/preprocess_test.go
+++ b/providers/cloudflare/preprocess_test.go
@@ -27,7 +27,7 @@ func makeRCmeta(meta map[string]string) *models.RecordConfig {
 }
 
 func TestPreprocess_BoolValidation(t *testing.T) {
-	cf := &cloudflareAPI{}
+	cf := &cloudflareProvider{}
 
 	domain := newDomainConfig()
 	domain.Records = append(domain.Records, makeRCmeta(map[string]string{metaProxy: "on"}))
@@ -49,7 +49,7 @@ func TestPreprocess_BoolValidation(t *testing.T) {
 }
 
 func TestPreprocess_BoolValidation_Fails(t *testing.T) {
-	cf := &cloudflareAPI{}
+	cf := &cloudflareProvider{}
 	domain := newDomainConfig()
 	domain.Records = append(domain.Records, &models.RecordConfig{Metadata: map[string]string{metaProxy: "true"}})
 	err := cf.preprocessConfig(domain)
@@ -59,7 +59,7 @@ func TestPreprocess_BoolValidation_Fails(t *testing.T) {
 }
 
 func TestPreprocess_DefaultProxy(t *testing.T) {
-	cf := &cloudflareAPI{}
+	cf := &cloudflareProvider{}
 	domain := newDomainConfig()
 	domain.Metadata[metaProxyDefault] = "full"
 	domain.Records = append(domain.Records, makeRCmeta(map[string]string{metaProxy: "on"}))
@@ -78,7 +78,7 @@ func TestPreprocess_DefaultProxy(t *testing.T) {
 }
 
 func TestPreprocess_DefaultProxy_Validation(t *testing.T) {
-	cf := &cloudflareAPI{}
+	cf := &cloudflareProvider{}
 	domain := newDomainConfig()
 	domain.Metadata[metaProxyDefault] = "true"
 	err := cf.preprocessConfig(domain)
@@ -100,7 +100,7 @@ func TestIpRewriting(t *testing.T) {
 		// inside range and proxied
 		{"1.2.3.4", "255.255.255.4", "full"},
 	}
-	cf := &cloudflareAPI{}
+	cf := &cloudflareProvider{}
 	domain := newDomainConfig()
 	cf.ipConversions = []transform.IPConversion{{
 		Low:      net.ParseIP("1.2.3.0"),

--- a/providers/cloudns/api.go
+++ b/providers/cloudns/api.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Api layer for CloDNS
-type api struct {
+type cloudnsProvider struct {
 	domainIndex      map[string]string
 	nameserversNames []string
 	creds            struct {
@@ -81,7 +81,7 @@ var allowedTTLValues = []uint32{
 	2419200, // 4 weeks
 }
 
-func (c *api) fetchAvailableNameservers() error {
+func (c *cloudnsProvider) fetchAvailableNameservers() error {
 	c.nameserversNames = nil
 
 	var bodyString, err = c.get("/dns/available-name-servers.json", requestParams{})
@@ -101,7 +101,7 @@ func (c *api) fetchAvailableNameservers() error {
 	return nil
 }
 
-func (c *api) fetchDomainList() error {
+func (c *cloudnsProvider) fetchDomainList() error {
 	c.domainIndex = map[string]string{}
 	rowsPerPage := 100
 	page := 1
@@ -129,7 +129,7 @@ func (c *api) fetchDomainList() error {
 	return nil
 }
 
-func (c *api) createDomain(domain string) error {
+func (c *cloudnsProvider) createDomain(domain string) error {
 	params := requestParams{
 		"domain-name": domain,
 		"zone-type":   "master",
@@ -140,7 +140,7 @@ func (c *api) createDomain(domain string) error {
 	return nil
 }
 
-func (c *api) createRecord(domainID string, rec requestParams) error {
+func (c *cloudnsProvider) createRecord(domainID string, rec requestParams) error {
 	rec["domain-name"] = domainID
 	if _, err := c.get("/dns/add-record.json", rec); err != nil {
 		return fmt.Errorf("failed create record (ClouDNS): %s", err)
@@ -148,7 +148,7 @@ func (c *api) createRecord(domainID string, rec requestParams) error {
 	return nil
 }
 
-func (c *api) deleteRecord(domainID string, recordID string) error {
+func (c *cloudnsProvider) deleteRecord(domainID string, recordID string) error {
 	params := requestParams{
 		"domain-name": domainID,
 		"record-id":   recordID,
@@ -159,7 +159,7 @@ func (c *api) deleteRecord(domainID string, recordID string) error {
 	return nil
 }
 
-func (c *api) modifyRecord(domainID string, recordID string, rec requestParams) error {
+func (c *cloudnsProvider) modifyRecord(domainID string, recordID string, rec requestParams) error {
 	rec["domain-name"] = domainID
 	rec["record-id"] = recordID
 	if _, err := c.get("/dns/mod-record.json", rec); err != nil {
@@ -168,7 +168,7 @@ func (c *api) modifyRecord(domainID string, recordID string, rec requestParams) 
 	return nil
 }
 
-func (c *api) getRecords(id string) ([]domainRecord, error) {
+func (c *cloudnsProvider) getRecords(id string) ([]domainRecord, error) {
 	params := requestParams{"domain-name": id}
 
 	var bodyString, err = c.get("/dns/records.json", params)
@@ -186,7 +186,7 @@ func (c *api) getRecords(id string) ([]domainRecord, error) {
 	return records, nil
 }
 
-func (c *api) get(endpoint string, params requestParams) ([]byte, error) {
+func (c *cloudnsProvider) get(endpoint string, params requestParams) ([]byte, error) {
 	client := &http.Client{}
 	req, _ := http.NewRequest("GET", "https://api.cloudns.net"+endpoint, nil)
 	q := req.URL.Query()

--- a/providers/cloudns/cloudnsProvider.go
+++ b/providers/cloudns/cloudnsProvider.go
@@ -24,7 +24,7 @@ Info required in `creds.json`:
 
 // NewCloudns creates the provider.
 func NewCloudns(m map[string]string, metadata json.RawMessage) (providers.DNSServiceProvider, error) {
-	c := &api{}
+	c := &cloudnsProvider{}
 
 	c.creds.id, c.creds.password = m["auth-id"], m["auth-password"]
 	if c.creds.id == "" || c.creds.password == "" {
@@ -57,7 +57,7 @@ func init() {
 }
 
 // GetNameservers returns the nameservers for a domain.
-func (c *api) GetNameservers(domain string) ([]*models.Nameserver, error) {
+func (c *cloudnsProvider) GetNameservers(domain string) ([]*models.Nameserver, error) {
 	if len(c.nameserversNames) == 0 {
 		c.fetchAvailableNameservers()
 	}
@@ -65,7 +65,7 @@ func (c *api) GetNameservers(domain string) ([]*models.Nameserver, error) {
 }
 
 // GetDomainCorrections returns the corrections for a domain.
-func (c *api) GetDomainCorrections(dc *models.DomainConfig) ([]*models.Correction, error) {
+func (c *cloudnsProvider) GetDomainCorrections(dc *models.DomainConfig) ([]*models.Correction, error) {
 	dc, err := dc.Copy()
 	if err != nil {
 		return nil, err
@@ -150,7 +150,7 @@ func (c *api) GetDomainCorrections(dc *models.DomainConfig) ([]*models.Correctio
 }
 
 // GetZoneRecords gets the records of a zone and returns them in RecordConfig format.
-func (c *api) GetZoneRecords(domain string) (models.Records, error) {
+func (c *cloudnsProvider) GetZoneRecords(domain string) (models.Records, error) {
 	records, err := c.getRecords(domain)
 	if err != nil {
 		return nil, err
@@ -163,7 +163,7 @@ func (c *api) GetZoneRecords(domain string) (models.Records, error) {
 }
 
 // EnsureDomainExists returns an error if domain doesn't exist.
-func (c *api) EnsureDomainExists(domain string) error {
+func (c *cloudnsProvider) EnsureDomainExists(domain string) error {
 	if err := c.fetchDomainList(); err != nil {
 		return err
 	}

--- a/providers/cscglobal/api.go
+++ b/providers/cscglobal/api.go
@@ -13,7 +13,7 @@ const apiBase = "https://apis.cscglobal.com/dbs/api/v2"
 
 // Api layer for CSC Global
 
-type api struct {
+type cscglobalProvider struct {
 	key          string
 	token        string
 	notifyEmails []string
@@ -55,7 +55,7 @@ type domainRecord struct {
 	Nameserver []string `json:"nameservers"`
 }
 
-func (c *api) getNameservers(domain string) ([]string, error) {
+func (c *cscglobalProvider) getNameservers(domain string) ([]string, error) {
 	var bodyString, err = c.get("/domains/" + domain)
 	if err != nil {
 		return nil, err
@@ -71,7 +71,7 @@ func (c *api) getNameservers(domain string) ([]string, error) {
 	return ns, nil
 }
 
-func (c *api) updateNameservers(ns []string, domain string) error {
+func (c *cscglobalProvider) updateNameservers(ns []string, domain string) error {
 	req := nsModRequest{
 		Domain:      domain,
 		NameServers: ns,
@@ -103,7 +103,7 @@ func (c *api) updateNameservers(ns []string, domain string) error {
 	return nil
 }
 
-func (c *api) put(endpoint string, requestBody []byte) ([]byte, error) {
+func (c *cscglobalProvider) put(endpoint string, requestBody []byte) ([]byte, error) {
 	client := &http.Client{}
 	req, _ := http.NewRequest("PUT", apiBase+endpoint, bytes.NewReader(requestBody))
 
@@ -137,7 +137,7 @@ func (c *api) put(endpoint string, requestBody []byte) ([]byte, error) {
 		req.Host, req.URL.RequestURI())
 }
 
-func (c *api) get(endpoint string) ([]byte, error) {
+func (c *cscglobalProvider) get(endpoint string) ([]byte, error) {
 	client := &http.Client{}
 	req, _ := http.NewRequest("GET", apiBase+endpoint, nil)
 

--- a/providers/cscglobal/cscglobalProvider.go
+++ b/providers/cscglobal/cscglobalProvider.go
@@ -24,7 +24,7 @@ func init() {
 }
 
 func newCscGlobal(m map[string]string) (providers.Registrar, error) {
-	api := &api{}
+	api := &cscglobalProvider{}
 
 	api.key, api.token = m["api-key"], m["user-token"]
 	if api.key == "" || api.token == "" {
@@ -39,7 +39,7 @@ func newCscGlobal(m map[string]string) (providers.Registrar, error) {
 }
 
 // GetRegistrarCorrections gathers corrections that would being n to match dc.
-func (c *api) GetRegistrarCorrections(dc *models.DomainConfig) ([]*models.Correction, error) {
+func (c *cscglobalProvider) GetRegistrarCorrections(dc *models.DomainConfig) ([]*models.Correction, error) {
 	nss, err := c.getNameservers(dc.Name)
 	if err != nil {
 		return nil, err

--- a/providers/desec/desecProvider.go
+++ b/providers/desec/desecProvider.go
@@ -21,7 +21,7 @@ Info required in `creds.json`:
 
 // NewDeSec creates the provider.
 func NewDeSec(m map[string]string, metadata json.RawMessage) (providers.DNSServiceProvider, error) {
-	c := &api{}
+	c := &desecProvider{}
 	c.creds.token = m["auth-token"]
 	if c.creds.token == "" {
 		return nil, fmt.Errorf("missing deSEC auth-token")
@@ -60,11 +60,11 @@ func init() {
 }
 
 // GetNameservers returns the nameservers for a domain.
-func (c *api) GetNameservers(domain string) ([]*models.Nameserver, error) {
+func (c *desecProvider) GetNameservers(domain string) ([]*models.Nameserver, error) {
 	return models.ToNameservers(defaultNameServerNames)
 }
 
-func (c *api) GetDomainCorrections(dc *models.DomainConfig) ([]*models.Correction, error) {
+func (c *desecProvider) GetDomainCorrections(dc *models.DomainConfig) ([]*models.Correction, error) {
 	existing, err := c.GetZoneRecords(dc.Name)
 	if err != nil {
 		return nil, err
@@ -82,7 +82,7 @@ func (c *api) GetDomainCorrections(dc *models.DomainConfig) ([]*models.Correctio
 }
 
 // GetZoneRecords gets the records of a zone and returns them in RecordConfig format.
-func (c *api) GetZoneRecords(domain string) (models.Records, error) {
+func (c *desecProvider) GetZoneRecords(domain string) (models.Records, error) {
 	records, err := c.getRecords(domain)
 	if err != nil {
 		return nil, err
@@ -97,7 +97,7 @@ func (c *api) GetZoneRecords(domain string) (models.Records, error) {
 }
 
 // EnsureDomainExists returns an error if domain doesn't exist.
-func (c *api) EnsureDomainExists(domain string) error {
+func (c *desecProvider) EnsureDomainExists(domain string) error {
 	if err := c.fetchDomainList(); err != nil {
 		return err
 	}
@@ -147,7 +147,7 @@ func PrepDesiredRecords(dc *models.DomainConfig, minTTL uint32) {
 // a list of functions to call to actually make the desired
 // correction, and a message to output to the user when the change is
 // made.
-func (c *api) GenerateDomainCorrections(dc *models.DomainConfig, existing models.Records) ([]*models.Correction, error) {
+func (c *desecProvider) GenerateDomainCorrections(dc *models.DomainConfig, existing models.Records) ([]*models.Correction, error) {
 
 	var corrections = []*models.Correction{}
 

--- a/providers/desec/protocol.go
+++ b/providers/desec/protocol.go
@@ -14,7 +14,7 @@ import (
 const apiBase = "https://desec.io/api/v1"
 
 // Api layer for desec
-type api struct {
+type desecProvider struct {
 	domainIndex      map[string]uint32
 	nameserversNames []string
 	creds            struct {
@@ -59,7 +59,7 @@ type errorResponse struct {
 	Detail string `json:"detail"`
 }
 
-func (c *api) fetchDomainList() error {
+func (c *desecProvider) fetchDomainList() error {
 	c.domainIndex = map[string]uint32{}
 	var dr []domainObject
 	endpoint := "/domains/"
@@ -79,7 +79,7 @@ func (c *api) fetchDomainList() error {
 	return nil
 }
 
-func (c *api) getRecords(domain string) ([]resourceRecord, error) {
+func (c *desecProvider) getRecords(domain string) ([]resourceRecord, error) {
 	endpoint := "/domains/%s/rrsets/"
 	var rrs []rrResponse
 	var rrsNew []resourceRecord
@@ -105,7 +105,7 @@ func (c *api) getRecords(domain string) ([]resourceRecord, error) {
 	return rrsNew, nil
 }
 
-func (c *api) createDomain(domain string) error {
+func (c *desecProvider) createDomain(domain string) error {
 	endpoint := "/domains/"
 	pl := domainObject{Name: domain}
 	byt, _ := json.Marshal(pl)
@@ -125,7 +125,7 @@ func (c *api) createDomain(domain string) error {
 }
 
 //upsertRR will create or override the RRSet with the provided resource record.
-func (c *api) upsertRR(rr []resourceRecord, domain string) error {
+func (c *desecProvider) upsertRR(rr []resourceRecord, domain string) error {
 	endpoint := fmt.Sprintf("/domains/%s/rrsets/", domain)
 	byt, _ := json.Marshal(rr)
 	if _, err := c.post(endpoint, "PUT", byt); err != nil {
@@ -134,7 +134,7 @@ func (c *api) upsertRR(rr []resourceRecord, domain string) error {
 	return nil
 }
 
-func (c *api) deleteRR(domain, shortname, t string) error {
+func (c *desecProvider) deleteRR(domain, shortname, t string) error {
 	endpoint := fmt.Sprintf("/domains/%s/rrsets/%s/%s/", domain, shortname, t)
 	if _, err := c.get(endpoint, "DELETE"); err != nil {
 		return fmt.Errorf("failed delete rrset (deSEC): %v", err)
@@ -142,7 +142,7 @@ func (c *api) deleteRR(domain, shortname, t string) error {
 	return nil
 }
 
-func (c *api) get(endpoint, method string) ([]byte, error) {
+func (c *desecProvider) get(endpoint, method string) ([]byte, error) {
 	retrycnt := 0
 retry:
 	client := &http.Client{}
@@ -175,7 +175,7 @@ retry:
 	return bodyString, nil
 }
 
-func (c *api) post(endpoint, method string, payload []byte) ([]byte, error) {
+func (c *desecProvider) post(endpoint, method string, payload []byte) ([]byte, error) {
 	retrycnt := 0
 retry:
 	client := &http.Client{}

--- a/providers/digitalocean/digitaloceanProvider.go
+++ b/providers/digitalocean/digitaloceanProvider.go
@@ -24,8 +24,8 @@ Info required in `creds.json`:
 
 */
 
-// digitaloceanAPI is the handle for operations.
-type digitaloceanAPI struct {
+// digitaloceanProvider is the handle for operations.
+type digitaloceanProvider struct {
 	client *godo.Client
 }
 
@@ -48,7 +48,7 @@ func NewDo(m map[string]string, metadata json.RawMessage) (providers.DNSServiceP
 	)
 	client := godo.NewClient(oauthClient)
 
-	api := &digitaloceanAPI{client: client}
+	api := &digitaloceanProvider{client: client}
 
 	// Get a domain to validate the token
 	_, resp, err := api.client.Domains.List(ctx, &godo.ListOptions{PerPage: 1})
@@ -78,7 +78,7 @@ func init() {
 }
 
 // EnsureDomainExists returns an error if domain doesn't exist.
-func (api *digitaloceanAPI) EnsureDomainExists(domain string) error {
+func (api *digitaloceanProvider) EnsureDomainExists(domain string) error {
 	ctx := context.Background()
 	_, resp, err := api.client.Domains.Get(ctx, domain)
 	if resp.StatusCode == http.StatusNotFound {
@@ -92,12 +92,12 @@ func (api *digitaloceanAPI) EnsureDomainExists(domain string) error {
 }
 
 // GetNameservers returns the nameservers for domain.
-func (api *digitaloceanAPI) GetNameservers(domain string) ([]*models.Nameserver, error) {
+func (api *digitaloceanProvider) GetNameservers(domain string) ([]*models.Nameserver, error) {
 	return models.ToNameservers(defaultNameServerNames)
 }
 
 // GetZoneRecords gets the records of a zone and returns them in RecordConfig format.
-func (api *digitaloceanAPI) GetZoneRecords(domain string) (models.Records, error) {
+func (api *digitaloceanProvider) GetZoneRecords(domain string) (models.Records, error) {
 	records, err := getRecords(api, domain)
 	if err != nil {
 		return nil, err
@@ -116,7 +116,7 @@ func (api *digitaloceanAPI) GetZoneRecords(domain string) (models.Records, error
 }
 
 // GetDomainCorrections returns a list of corretions for the  domain.
-func (api *digitaloceanAPI) GetDomainCorrections(dc *models.DomainConfig) ([]*models.Correction, error) {
+func (api *digitaloceanProvider) GetDomainCorrections(dc *models.DomainConfig) ([]*models.Correction, error) {
 	ctx := context.Background()
 	dc.Punycode()
 
@@ -175,7 +175,7 @@ func (api *digitaloceanAPI) GetDomainCorrections(dc *models.DomainConfig) ([]*mo
 	return corrections, nil
 }
 
-func getRecords(api *digitaloceanAPI, name string) ([]godo.DomainRecord, error) {
+func getRecords(api *digitaloceanProvider, name string) ([]godo.DomainRecord, error) {
 	ctx := context.Background()
 
 	records := []godo.DomainRecord{}

--- a/providers/dnsimple/dnsimpleProvider.go
+++ b/providers/dnsimple/dnsimpleProvider.go
@@ -47,20 +47,20 @@ var defaultNameServerNames = []string{
 	"ns4.dnsimple.com",
 }
 
-// dnsimpleAPI is the handle for this provider.
-type dnsimpleAPI struct {
+// dnsimpleProvider is the handle for this provider.
+type dnsimpleProvider struct {
 	AccountToken string // The account access token
 	BaseURL      string // An alternate base URI
 	accountID    string // Account id cache
 }
 
 // GetNameservers returns the name servers for a domain.
-func (c *dnsimpleAPI) GetNameservers(domainName string) ([]*models.Nameserver, error) {
+func (c *dnsimpleProvider) GetNameservers(domainName string) ([]*models.Nameserver, error) {
 	return models.ToNameservers(defaultNameServerNames)
 }
 
 // GetZoneRecords gets the records of a zone and returns them in RecordConfig format.
-func (c *dnsimpleAPI) GetZoneRecords(domain string) (models.Records, error) {
+func (c *dnsimpleProvider) GetZoneRecords(domain string) (models.Records, error) {
 	records, err := c.getRecords(domain)
 	if err != nil {
 		return nil, err
@@ -123,7 +123,7 @@ func (c *dnsimpleAPI) GetZoneRecords(domain string) (models.Records, error) {
 }
 
 // GetDomainCorrections returns corrections that update a domain.
-func (c *dnsimpleAPI) GetDomainCorrections(dc *models.DomainConfig) ([]*models.Correction, error) {
+func (c *dnsimpleProvider) GetDomainCorrections(dc *models.DomainConfig) ([]*models.Correction, error) {
 	corrections := []*models.Correction{}
 	err := dc.Punycode()
 	if err != nil {
@@ -191,7 +191,7 @@ func removeNS(records models.Records) models.Records {
 }
 
 // GetRegistrarCorrections returns corrections that update a domain's registrar.
-func (c *dnsimpleAPI) GetRegistrarCorrections(dc *models.DomainConfig) ([]*models.Correction, error) {
+func (c *dnsimpleProvider) GetRegistrarCorrections(dc *models.DomainConfig) ([]*models.Correction, error) {
 	corrections := []*models.Correction{}
 
 	nameServers, err := c.getNameservers(dc.Name)
@@ -222,7 +222,7 @@ func (c *dnsimpleAPI) GetRegistrarCorrections(dc *models.DomainConfig) ([]*model
 }
 
 // getDNSSECCorrections returns corrections that update a domain's DNSSEC state.
-func (c *dnsimpleAPI) getDNSSECCorrections(dc *models.DomainConfig) ([]*models.Correction, error) {
+func (c *dnsimpleProvider) getDNSSECCorrections(dc *models.DomainConfig) ([]*models.Correction, error) {
 	enabled, err := c.getDnssec(dc.Name)
 	if err != nil {
 		return nil, err
@@ -251,7 +251,7 @@ func (c *dnsimpleAPI) getDNSSECCorrections(dc *models.DomainConfig) ([]*models.C
 
 // DNSimple calls
 
-func (c *dnsimpleAPI) getClient() *dnsimpleapi.Client {
+func (c *dnsimpleProvider) getClient() *dnsimpleapi.Client {
 	ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: c.AccountToken})
 	tc := oauth2.NewClient(context.Background(), ts)
 
@@ -265,7 +265,7 @@ func (c *dnsimpleAPI) getClient() *dnsimpleapi.Client {
 	return client
 }
 
-func (c *dnsimpleAPI) getAccountID() (string, error) {
+func (c *dnsimpleProvider) getAccountID() (string, error) {
 	if c.accountID == "" {
 		client := c.getClient()
 		whoamiResponse, err := client.Identity.Whoami(context.Background())
@@ -280,7 +280,7 @@ func (c *dnsimpleAPI) getAccountID() (string, error) {
 	return c.accountID, nil
 }
 
-func (c *dnsimpleAPI) getRecords(domainName string) ([]dnsimpleapi.ZoneRecord, error) {
+func (c *dnsimpleProvider) getRecords(domainName string) ([]dnsimpleapi.ZoneRecord, error) {
 	client := c.getClient()
 
 	accountID, err := c.getAccountID()
@@ -308,7 +308,7 @@ func (c *dnsimpleAPI) getRecords(domainName string) ([]dnsimpleapi.ZoneRecord, e
 	return recs, nil
 }
 
-func (c *dnsimpleAPI) getDnssec(domainName string) (bool, error) {
+func (c *dnsimpleProvider) getDnssec(domainName string) (bool, error) {
 	var (
 		client    *dnsimpleapi.Client
 		accountID string
@@ -329,7 +329,7 @@ func (c *dnsimpleAPI) getDnssec(domainName string) (bool, error) {
 	return dnssecResponse.Data.Enabled, nil
 }
 
-func (c *dnsimpleAPI) enableDnssec(domainName string) (bool, error) {
+func (c *dnsimpleProvider) enableDnssec(domainName string) (bool, error) {
 	var (
 		client    *dnsimpleapi.Client
 		accountID string
@@ -350,7 +350,7 @@ func (c *dnsimpleAPI) enableDnssec(domainName string) (bool, error) {
 	return dnssecResponse.Data.Enabled, nil
 }
 
-func (c *dnsimpleAPI) disableDnssec(domainName string) (bool, error) {
+func (c *dnsimpleProvider) disableDnssec(domainName string) (bool, error) {
 	var (
 		client    *dnsimpleapi.Client
 		accountID string
@@ -374,7 +374,7 @@ func (c *dnsimpleAPI) disableDnssec(domainName string) (bool, error) {
 // Returns the name server names that should be used. If the domain is registered
 // then this method will return the delegation name servers. If this domain
 // is hosted only, then it will return the default DNSimple name servers.
-func (c *dnsimpleAPI) getNameservers(domainName string) ([]string, error) {
+func (c *dnsimpleProvider) getNameservers(domainName string) ([]string, error) {
 	client := c.getClient()
 
 	accountID, err := c.getAccountID()
@@ -400,7 +400,7 @@ func (c *dnsimpleAPI) getNameservers(domainName string) ([]string, error) {
 }
 
 // Returns a function that can be invoked to change the delegation of the domain to the given name server names.
-func (c *dnsimpleAPI) updateNameserversFunc(nameServerNames []string, domainName string) func() error {
+func (c *dnsimpleProvider) updateNameserversFunc(nameServerNames []string, domainName string) func() error {
 	return func() error {
 		client := c.getClient()
 
@@ -421,7 +421,7 @@ func (c *dnsimpleAPI) updateNameserversFunc(nameServerNames []string, domainName
 }
 
 // Returns a function that can be invoked to create a record in a zone.
-func (c *dnsimpleAPI) createRecordFunc(rc *models.RecordConfig, domainName string) func() error {
+func (c *dnsimpleProvider) createRecordFunc(rc *models.RecordConfig, domainName string) func() error {
 	return func() error {
 		client := c.getClient()
 
@@ -446,7 +446,7 @@ func (c *dnsimpleAPI) createRecordFunc(rc *models.RecordConfig, domainName strin
 }
 
 // Returns a function that can be invoked to delete a record in a zone.
-func (c *dnsimpleAPI) deleteRecordFunc(recordID int64, domainName string) func() error {
+func (c *dnsimpleProvider) deleteRecordFunc(recordID int64, domainName string) func() error {
 	return func() error {
 		client := c.getClient()
 
@@ -466,7 +466,7 @@ func (c *dnsimpleAPI) deleteRecordFunc(recordID int64, domainName string) func()
 }
 
 // Returns a function that can be invoked to update a record in a zone.
-func (c *dnsimpleAPI) updateRecordFunc(old *dnsimpleapi.ZoneRecord, rc *models.RecordConfig, domainName string) func() error {
+func (c *dnsimpleProvider) updateRecordFunc(old *dnsimpleapi.ZoneRecord, rc *models.RecordConfig, domainName string) func() error {
 	return func() error {
 		client := c.getClient()
 
@@ -493,7 +493,7 @@ func (c *dnsimpleAPI) updateRecordFunc(old *dnsimpleapi.ZoneRecord, rc *models.R
 }
 
 // ListZones returns all the zones in an account
-func (c *dnsimpleAPI) ListZones() ([]string, error) {
+func (c *dnsimpleProvider) ListZones() ([]string, error) {
 	client := c.getClient()
 	accountID, err := c.getAccountID()
 	if err != nil {
@@ -531,8 +531,8 @@ func newDsp(conf map[string]string, metadata json.RawMessage) (providers.DNSServ
 	return newProvider(conf, metadata)
 }
 
-func newProvider(m map[string]string, metadata json.RawMessage) (*dnsimpleAPI, error) {
-	api := &dnsimpleAPI{}
+func newProvider(m map[string]string, metadata json.RawMessage) (*dnsimpleProvider, error) {
+	api := &dnsimpleProvider{}
 	api.AccountToken = m["token"]
 	if api.AccountToken == "" {
 		return nil, fmt.Errorf("missing DNSimple token")

--- a/providers/doh/api.go
+++ b/providers/doh/api.go
@@ -7,11 +7,11 @@ import (
 	"github.com/babolivier/go-doh-client"
 )
 
-type api struct {
+type dohProvider struct {
 	host string
 }
 
-func (c *api) getNameservers(domain string) ([]string, error) {
+func (c *dohProvider) getNameservers(domain string) ([]string, error) {
 	resolver := doh.Resolver{
 		Host:  c.host,
 		Class: doh.IN,
@@ -31,6 +31,6 @@ func (c *api) getNameservers(domain string) ([]string, error) {
 	return ns, nil
 }
 
-func (c *api) updateNameservers(ns []string, domain string) error {
+func (c *dohProvider) updateNameservers(ns []string, domain string) error {
 	return fmt.Errorf("DNS-over-HTTPS 'Registrar' is read only, changes must be applied to %s manually", domain)
 }

--- a/providers/doh/dohProvider.go
+++ b/providers/doh/dohProvider.go
@@ -22,7 +22,7 @@ func init() {
 }
 
 func newDNSOverHTTPS(m map[string]string) (providers.Registrar, error) {
-	api := &api{
+	api := &dohProvider{
 		host: m["host"],
 	}
 	if api.host == "" {
@@ -32,7 +32,7 @@ func newDNSOverHTTPS(m map[string]string) (providers.Registrar, error) {
 }
 
 // GetRegistrarCorrections gathers corrections that would being n to match dc.
-func (c *api) GetRegistrarCorrections(dc *models.DomainConfig) ([]*models.Correction, error) {
+func (c *dohProvider) GetRegistrarCorrections(dc *models.DomainConfig) ([]*models.Correction, error) {
 	nss, err := c.getNameservers(dc.Name)
 	if err != nil {
 		return nil, err

--- a/providers/gandi_v5/gandi_v5Provider.go
+++ b/providers/gandi_v5/gandi_v5Provider.go
@@ -58,8 +58,8 @@ var features = providers.DocumentationNotes{
 
 // Section 2: Define the API client.
 
-// gandiv5API is the gandiv5API handle used to store any client-related state.
-type gandiv5API struct {
+// gandiv5Provider is the gandiv5Provider handle used to store any client-related state.
+type gandiv5Provider struct {
 	apikey    string
 	sharingid string
 	debug     bool
@@ -76,8 +76,8 @@ func newReg(conf map[string]string) (providers.Registrar, error) {
 }
 
 // newHelper generates a handle.
-func newHelper(m map[string]string, metadata json.RawMessage) (*gandiv5API, error) {
-	api := &gandiv5API{}
+func newHelper(m map[string]string, metadata json.RawMessage) (*gandiv5Provider, error) {
+	api := &gandiv5Provider{}
 	api.apikey = m["apikey"]
 	if api.apikey == "" {
 		return nil, fmt.Errorf("missing Gandi apikey")
@@ -105,7 +105,7 @@ func newHelper(m map[string]string, metadata json.RawMessage) (*gandiv5API, erro
 
 // GetDomainCorrections get the current and existing records,
 // post-process them, and generate corrections.
-func (client *gandiv5API) GetDomainCorrections(dc *models.DomainConfig) ([]*models.Correction, error) {
+func (client *gandiv5Provider) GetDomainCorrections(dc *models.DomainConfig) ([]*models.Correction, error) {
 	existing, err := client.GetZoneRecords(dc.Name)
 	if err != nil {
 		return nil, err
@@ -118,7 +118,7 @@ func (client *gandiv5API) GetDomainCorrections(dc *models.DomainConfig) ([]*mode
 
 // GetZoneRecords gathers the DNS records and converts them to
 // dnscontrol's format.
-func (client *gandiv5API) GetZoneRecords(domain string) (models.Records, error) {
+func (client *gandiv5Provider) GetZoneRecords(domain string) (models.Records, error) {
 	g := gandi.NewLiveDNSClient(client.apikey, gandi.Config{SharingID: client.sharingid, Debug: client.debug})
 
 	// Get all the existing records:
@@ -187,7 +187,7 @@ func PrepDesiredRecords(dc *models.DomainConfig) {
 // a list of functions to call to actually make the desired
 // correction, and a message to output to the user when the change is
 // made.
-func (client *gandiv5API) GenerateDomainCorrections(dc *models.DomainConfig, existing models.Records) ([]*models.Correction, error) {
+func (client *gandiv5Provider) GenerateDomainCorrections(dc *models.DomainConfig, existing models.Records) ([]*models.Correction, error) {
 	if client.debug {
 		debugRecords("GenDC input", existing)
 	}
@@ -321,7 +321,7 @@ func gatherAffectedLabels(groups map[models.RecordKey][]string) (labels map[stri
 // Section 3: Registrar-related functions
 
 // GetNameservers returns a list of nameservers for domain.
-func (client *gandiv5API) GetNameservers(domain string) ([]*models.Nameserver, error) {
+func (client *gandiv5Provider) GetNameservers(domain string) ([]*models.Nameserver, error) {
 	g := gandi.NewLiveDNSClient(client.apikey, gandi.Config{SharingID: client.sharingid, Debug: client.debug})
 	nameservers, err := g.GetDomainNS(domain)
 	if err != nil {
@@ -331,7 +331,7 @@ func (client *gandiv5API) GetNameservers(domain string) ([]*models.Nameserver, e
 }
 
 // GetRegistrarCorrections returns a list of corrections for this registrar.
-func (client *gandiv5API) GetRegistrarCorrections(dc *models.DomainConfig) ([]*models.Correction, error) {
+func (client *gandiv5Provider) GetRegistrarCorrections(dc *models.DomainConfig) ([]*models.Correction, error) {
 	gd := gandi.NewDomainClient(client.apikey, gandi.Config{SharingID: client.sharingid, Debug: client.debug})
 
 	existingNs, err := gd.GetNameServers(dc.Name)

--- a/providers/hedns/hednsProvider.go
+++ b/providers/hedns/hednsProvider.go
@@ -82,8 +82,8 @@ const (
 	errorImproperDelegation = "This zone does not appear to be properly delegated to our nameservers."
 )
 
-// HDNSProvider stores login credentials and represents and API connection
-type HDNSProvider struct {
+// hednsProvider stores login credentials and represents and API connection
+type hednsProvider struct {
 	Username        string
 	Password        string
 	TfaSecret       string
@@ -117,7 +117,7 @@ func newHDNSProvider(cfg map[string]string, _ json.RawMessage) (providers.DNSSer
 	}
 
 	// Perform the initial login
-	client := &HDNSProvider{
+	client := &hednsProvider{
 		Username:        username,
 		Password:        password,
 		TfaSecret:       totpSecret,
@@ -134,7 +134,7 @@ func newHDNSProvider(cfg map[string]string, _ json.RawMessage) (providers.DNSSer
 }
 
 // ListZones list all zones on this provider.
-func (c *HDNSProvider) ListZones() ([]string, error) {
+func (c *hednsProvider) ListZones() ([]string, error) {
 	domainsMap, err := c.listDomains()
 	if err != nil {
 		return nil, err
@@ -152,7 +152,7 @@ func (c *HDNSProvider) ListZones() ([]string, error) {
 }
 
 // EnsureDomainExists creates the domain if it does not exist.
-func (c *HDNSProvider) EnsureDomainExists(domain string) error {
+func (c *hednsProvider) EnsureDomainExists(domain string) error {
 	domains, err := c.ListZones()
 	if err != nil {
 		return err
@@ -168,12 +168,12 @@ func (c *HDNSProvider) EnsureDomainExists(domain string) error {
 }
 
 // GetNameservers returns the default HDNS nameservers.
-func (c *HDNSProvider) GetNameservers(_ string) ([]*models.Nameserver, error) {
+func (c *hednsProvider) GetNameservers(_ string) ([]*models.Nameserver, error) {
 	return models.ToNameservers(defaultNameservers)
 }
 
 // GetDomainCorrections returns a list of corrections for the  domain.
-func (c *HDNSProvider) GetDomainCorrections(dc *models.DomainConfig) ([]*models.Correction, error) {
+func (c *hednsProvider) GetDomainCorrections(dc *models.DomainConfig) ([]*models.Correction, error) {
 	var corrections []*models.Correction
 
 	err := dc.Punycode()
@@ -245,7 +245,7 @@ func (c *HDNSProvider) GetDomainCorrections(dc *models.DomainConfig) ([]*models.
 }
 
 // GetZoneRecords returns all the records for the given domain
-func (c *HDNSProvider) GetZoneRecords(domain string) (models.Records, error) {
+func (c *hednsProvider) GetZoneRecords(domain string) (models.Records, error) {
 	var zoneRecords []*models.RecordConfig
 
 	// Get Domain ID
@@ -344,7 +344,7 @@ func (c *HDNSProvider) GetZoneRecords(domain string) (models.Records, error) {
 	return zoneRecords, err
 }
 
-func (c *HDNSProvider) authResumeSession() (authenticated bool, requiresTfa bool, err error) {
+func (c *hednsProvider) authResumeSession() (authenticated bool, requiresTfa bool, err error) {
 	response, err := c.httpClient.Get(apiEndpoint)
 	if err != nil {
 		return false, false, err
@@ -367,7 +367,7 @@ func (c *HDNSProvider) authResumeSession() (authenticated bool, requiresTfa bool
 	return authenticated, requiresTfa, err
 }
 
-func (c *HDNSProvider) authUsernameAndPassword() (authenticated bool, requiresTfa bool, err error) {
+func (c *hednsProvider) authUsernameAndPassword() (authenticated bool, requiresTfa bool, err error) {
 	// Login with username and password
 	response, err := c.httpClient.PostForm(apiEndpoint, url.Values{
 		"email":  {c.Username},
@@ -397,7 +397,7 @@ func (c *HDNSProvider) authUsernameAndPassword() (authenticated bool, requiresTf
 	return authenticated, requiresTfa, err
 }
 
-func (c *HDNSProvider) auth2FA() (authenticated bool, err error) {
+func (c *hednsProvider) auth2FA() (authenticated bool, err error) {
 
 	if c.TfaValue == "" && c.TfaSecret == "" {
 		return false, fmt.Errorf("account requires two-factor authentication but neither totp or totp-key were provided")
@@ -435,7 +435,7 @@ func (c *HDNSProvider) auth2FA() (authenticated bool, err error) {
 	return authenticated, err
 }
 
-func (c *HDNSProvider) authenticate() error {
+func (c *hednsProvider) authenticate() error {
 
 	if c.SessionFilePath != "" {
 		_ = c.loadSessionFile()
@@ -475,7 +475,7 @@ func (c *HDNSProvider) authenticate() error {
 	return err
 }
 
-func (c *HDNSProvider) listDomains() (map[string]uint64, error) {
+func (c *hednsProvider) listDomains() (map[string]uint64, error) {
 	response, err := c.httpClient.Get(apiEndpoint)
 	if err != nil {
 		return nil, err
@@ -512,7 +512,7 @@ func (c *HDNSProvider) listDomains() (map[string]uint64, error) {
 	return domains, err
 }
 
-func (c *HDNSProvider) createDomain(domain string) error {
+func (c *hednsProvider) createDomain(domain string) error {
 	values := url.Values{
 		"action":     {"add_zone"},
 		"retmain":    {"0"},
@@ -530,7 +530,7 @@ func (c *HDNSProvider) createDomain(domain string) error {
 	return err
 }
 
-func (c *HDNSProvider) editZoneRecord(rc *models.RecordConfig, create bool) error {
+func (c *hednsProvider) editZoneRecord(rc *models.RecordConfig, create bool) error {
 	values := url.Values{
 		"account":             {},
 		"menu":                {"edit_zone"},
@@ -583,7 +583,7 @@ func (c *HDNSProvider) editZoneRecord(rc *models.RecordConfig, create bool) erro
 	return err
 }
 
-func (c *HDNSProvider) deleteZoneRecord(rc *models.RecordConfig) error {
+func (c *hednsProvider) deleteZoneRecord(rc *models.RecordConfig) error {
 	values := url.Values{
 		"menu":                  {"edit_zone"},
 		"hosted_dns_zoneid":     {strconv.FormatUint(rc.Original.(Record).ZoneID, 10)},
@@ -603,7 +603,7 @@ func (c *HDNSProvider) deleteZoneRecord(rc *models.RecordConfig) error {
 	return err
 }
 
-func (c *HDNSProvider) generateCredentialHash() string {
+func (c *hednsProvider) generateCredentialHash() string {
 	hash := sha1.New()
 	hash.Write([]byte(c.Username))
 	hash.Write([]byte(c.Password))
@@ -611,7 +611,7 @@ func (c *HDNSProvider) generateCredentialHash() string {
 	return fmt.Sprintf("%x", hash.Sum(nil))
 }
 
-func (c *HDNSProvider) saveSessionFile() error {
+func (c *hednsProvider) saveSessionFile() error {
 	cookieDomain, err := url.Parse(apiEndpoint)
 	if err != nil {
 		return err
@@ -631,7 +631,7 @@ func (c *HDNSProvider) saveSessionFile() error {
 	return err
 }
 
-func (c *HDNSProvider) loadSessionFile() error {
+func (c *hednsProvider) loadSessionFile() error {
 	cookieDomain, err := url.Parse(apiEndpoint)
 	if err != nil {
 		return err
@@ -668,7 +668,7 @@ func (c *HDNSProvider) loadSessionFile() error {
 	return err
 }
 
-func (c *HDNSProvider) parseResponseForDocumentAndErrors(response *http.Response) (document *goquery.Document, err error) {
+func (c *hednsProvider) parseResponseForDocumentAndErrors(response *http.Response) (document *goquery.Document, err error) {
 	var ignoredErrorMessages = [...]string{
 		errorImproperDelegation,
 	}

--- a/providers/hetzner/api.go
+++ b/providers/hetzner/api.go
@@ -14,7 +14,7 @@ const (
 	baseURL = "https://dns.hetzner.com/api/v1"
 )
 
-type api struct {
+type hetznerProvider struct {
 	apiKey             string
 	zones              map[string]zone
 	requestRateLimiter requestRateLimiter
@@ -29,7 +29,7 @@ func checkIsLockedSystemRecord(record record) error {
 	return nil
 }
 
-func (api *api) createRecord(record record) error {
+func (api *hetznerProvider) createRecord(record record) error {
 	if err := checkIsLockedSystemRecord(record); err != nil {
 		return err
 	}
@@ -44,14 +44,14 @@ func (api *api) createRecord(record record) error {
 	return api.request("/records", "POST", request, nil)
 }
 
-func (api *api) createZone(name string) error {
+func (api *hetznerProvider) createZone(name string) error {
 	request := createZoneRequest{
 		Name: name,
 	}
 	return api.request("/zones", "POST", request, nil)
 }
 
-func (api *api) deleteRecord(record record) error {
+func (api *hetznerProvider) deleteRecord(record record) error {
 	if err := checkIsLockedSystemRecord(record); err != nil {
 		return err
 	}
@@ -60,7 +60,7 @@ func (api *api) deleteRecord(record record) error {
 	return api.request(url, "DELETE", nil, nil)
 }
 
-func (api *api) getAllRecords(domain string) ([]record, error) {
+func (api *hetznerProvider) getAllRecords(domain string) ([]record, error) {
 	zone, err := api.getZone(domain)
 	if err != nil {
 		return nil, err
@@ -94,7 +94,7 @@ func (api *api) getAllRecords(domain string) ([]record, error) {
 	return records, nil
 }
 
-func (api *api) getAllZones() error {
+func (api *hetznerProvider) getAllZones() error {
 	if api.zones != nil {
 		return nil
 	}
@@ -119,7 +119,7 @@ func (api *api) getAllZones() error {
 	return nil
 }
 
-func (api *api) getZone(name string) (*zone, error) {
+func (api *hetznerProvider) getZone(name string) (*zone, error) {
 	if err := api.getAllZones(); err != nil {
 		return nil, err
 	}
@@ -130,7 +130,7 @@ func (api *api) getZone(name string) (*zone, error) {
 	return &zone, nil
 }
 
-func (api *api) request(endpoint string, method string, request interface{}, target interface{}) error {
+func (api *hetznerProvider) request(endpoint string, method string, request interface{}, target interface{}) error {
 	var requestBody io.Reader
 	if request != nil {
 		requestBodySerialised, err := json.Marshal(request)
@@ -179,13 +179,13 @@ func (api *api) request(endpoint string, method string, request interface{}, tar
 	}
 }
 
-func (api *api) startRateLimited() {
+func (api *hetznerProvider) startRateLimited() {
 	// Simulate a request that is getting a 429 response.
 	api.requestRateLimiter.afterRequest()
 	api.requestRateLimiter.bumpDelay()
 }
 
-func (api *api) updateRecord(record record) error {
+func (api *hetznerProvider) updateRecord(record record) error {
 	if err := checkIsLockedSystemRecord(record); err != nil {
 		return err
 	}

--- a/providers/hetzner/hetznerProvider.go
+++ b/providers/hetzner/hetznerProvider.go
@@ -34,7 +34,7 @@ func New(settings map[string]string, _ json.RawMessage) (providers.DNSServicePro
 		return nil, fmt.Errorf("missing HETZNER api_key")
 	}
 
-	api := &api{}
+	api := &hetznerProvider{}
 
 	api.apiKey = settings["api_key"]
 
@@ -46,7 +46,7 @@ func New(settings map[string]string, _ json.RawMessage) (providers.DNSServicePro
 }
 
 // EnsureDomainExists creates the domain if it does not exist.
-func (api *api) EnsureDomainExists(domain string) error {
+func (api *hetznerProvider) EnsureDomainExists(domain string) error {
 	domains, err := api.ListZones()
 	if err != nil {
 		return err
@@ -62,7 +62,7 @@ func (api *api) EnsureDomainExists(domain string) error {
 }
 
 // GetDomainCorrections returns the corrections for a domain.
-func (api *api) GetDomainCorrections(dc *models.DomainConfig) ([]*models.Correction, error) {
+func (api *hetznerProvider) GetDomainCorrections(dc *models.DomainConfig) ([]*models.Correction, error) {
 	dc, err := dc.Copy()
 	if err != nil {
 		return nil, err
@@ -135,7 +135,7 @@ func (api *api) GetDomainCorrections(dc *models.DomainConfig) ([]*models.Correct
 }
 
 // GetNameservers returns the nameservers for a domain.
-func (api *api) GetNameservers(domain string) ([]*models.Nameserver, error) {
+func (api *hetznerProvider) GetNameservers(domain string) ([]*models.Nameserver, error) {
 	zone, err := api.getZone(domain)
 	if err != nil {
 		return nil, err
@@ -148,7 +148,7 @@ func (api *api) GetNameservers(domain string) ([]*models.Nameserver, error) {
 }
 
 // GetZoneRecords gets the records of a zone and returns them in RecordConfig format.
-func (api *api) GetZoneRecords(domain string) (models.Records, error) {
+func (api *hetznerProvider) GetZoneRecords(domain string) (models.Records, error) {
 	records, err := api.getAllRecords(domain)
 	if err != nil {
 		return nil, err
@@ -161,7 +161,7 @@ func (api *api) GetZoneRecords(domain string) (models.Records, error) {
 }
 
 // ListZones lists the zones on this account.
-func (api *api) ListZones() ([]string, error) {
+func (api *hetznerProvider) ListZones() ([]string, error) {
 	if err := api.getAllZones(); err != nil {
 		return nil, err
 	}

--- a/providers/internetbs/api.go
+++ b/providers/internetbs/api.go
@@ -10,7 +10,7 @@ import (
 
 // Api layer for Internet.bs
 
-type api struct {
+type internetbsProvider struct {
 	key      string
 	password string
 }
@@ -28,7 +28,7 @@ type domainRecord struct {
 	Nameserver []string `json:"nameserver"`
 }
 
-func (c *api) getNameservers(domain string) ([]string, error) {
+func (c *internetbsProvider) getNameservers(domain string) ([]string, error) {
 	var bodyString, err = c.get("/Domain/Info", requestParams{"Domain": domain})
 	if err != nil {
 		return []string{}, fmt.Errorf("failed fetching nameservers list (Internet.bs): %s", err)
@@ -40,7 +40,7 @@ func (c *api) getNameservers(domain string) ([]string, error) {
 	return ns, nil
 }
 
-func (c *api) updateNameservers(ns []string, domain string) error {
+func (c *internetbsProvider) updateNameservers(ns []string, domain string) error {
 	rec := requestParams{}
 	rec["Domain"] = domain
 	rec["Ns_list"] = strings.Join(ns, ",")
@@ -50,7 +50,7 @@ func (c *api) updateNameservers(ns []string, domain string) error {
 	return nil
 }
 
-func (c *api) get(endpoint string, params requestParams) ([]byte, error) {
+func (c *internetbsProvider) get(endpoint string, params requestParams) ([]byte, error) {
 	client := &http.Client{}
 	req, _ := http.NewRequest("GET", "https://api.internet.bs/"+endpoint, nil)
 	q := req.URL.Query()

--- a/providers/internetbs/internetbsProvider.go
+++ b/providers/internetbs/internetbsProvider.go
@@ -24,7 +24,7 @@ func init() {
 }
 
 func newInternetBs(m map[string]string) (providers.Registrar, error) {
-	api := &api{}
+	api := &internetbsProvider{}
 
 	api.key, api.password = m["api-key"], m["password"]
 	if api.key == "" || api.password == "" {
@@ -35,7 +35,7 @@ func newInternetBs(m map[string]string) (providers.Registrar, error) {
 }
 
 // GetRegistrarCorrections gathers corrections that would being n to match dc.
-func (c *api) GetRegistrarCorrections(dc *models.DomainConfig) ([]*models.Correction, error) {
+func (c *internetbsProvider) GetRegistrarCorrections(dc *models.DomainConfig) ([]*models.Correction, error) {
 	nss, err := c.getNameservers(dc.Name)
 	if err != nil {
 		return nil, err

--- a/providers/linode/api.go
+++ b/providers/linode/api.go
@@ -15,7 +15,7 @@ const (
 	domainsPath    = "domains"
 )
 
-func (c *linodeAPI) fetchDomainList() error {
+func (c *linodeProvider) fetchDomainList() error {
 	c.domainIndex = map[string]int{}
 	page := 1
 	for {
@@ -35,7 +35,7 @@ func (c *linodeAPI) fetchDomainList() error {
 	return nil
 }
 
-func (c *linodeAPI) getRecords(id int) ([]domainRecord, error) {
+func (c *linodeProvider) getRecords(id int) ([]domainRecord, error) {
 	records := []domainRecord{}
 	page := 1
 	for {
@@ -56,7 +56,7 @@ func (c *linodeAPI) getRecords(id int) ([]domainRecord, error) {
 	return records, nil
 }
 
-func (c *linodeAPI) createRecord(domainID int, rec *recordEditRequest) (*domainRecord, error) {
+func (c *linodeProvider) createRecord(domainID int, rec *recordEditRequest) (*domainRecord, error) {
 	endpoint := fmt.Sprintf("%s/%d/records", domainsPath, domainID)
 
 	req, err := c.newRequest(http.MethodPost, endpoint, rec)
@@ -84,7 +84,7 @@ func (c *linodeAPI) createRecord(domainID int, rec *recordEditRequest) (*domainR
 	return record, nil
 }
 
-func (c *linodeAPI) modifyRecord(domainID, recordID int, rec *recordEditRequest) error {
+func (c *linodeProvider) modifyRecord(domainID, recordID int, rec *recordEditRequest) error {
 	endpoint := fmt.Sprintf("%s/%d/records/%d", domainsPath, domainID, recordID)
 
 	req, err := c.newRequest(http.MethodPut, endpoint, rec)
@@ -104,7 +104,7 @@ func (c *linodeAPI) modifyRecord(domainID, recordID int, rec *recordEditRequest)
 	return nil
 }
 
-func (c *linodeAPI) deleteRecord(domainID, recordID int) error {
+func (c *linodeProvider) deleteRecord(domainID, recordID int) error {
 	endpoint := fmt.Sprintf("%s/%d/records/%d", domainsPath, domainID, recordID)
 	req, err := c.newRequest(http.MethodDelete, endpoint, nil)
 	if err != nil {
@@ -123,7 +123,7 @@ func (c *linodeAPI) deleteRecord(domainID, recordID int) error {
 	return nil
 }
 
-func (c *linodeAPI) newRequest(method, endpoint string, body interface{}) (*http.Request, error) {
+func (c *linodeProvider) newRequest(method, endpoint string, body interface{}) (*http.Request, error) {
 	rel, err := url.Parse(endpoint)
 	if err != nil {
 		return nil, err
@@ -149,7 +149,7 @@ func (c *linodeAPI) newRequest(method, endpoint string, body interface{}) (*http
 	return req, nil
 }
 
-func (c *linodeAPI) get(endpoint string, target interface{}) error {
+func (c *linodeProvider) get(endpoint string, target interface{}) error {
 	req, err := c.newRequest(http.MethodGet, endpoint, nil)
 	if err != nil {
 		return err
@@ -166,7 +166,7 @@ func (c *linodeAPI) get(endpoint string, target interface{}) error {
 	return decoder.Decode(target)
 }
 
-func (c *linodeAPI) handleErrors(resp *http.Response) error {
+func (c *linodeProvider) handleErrors(resp *http.Response) error {
 	defer resp.Body.Close()
 	decoder := json.NewDecoder(resp.Body)
 

--- a/providers/linode/linodeProvider.go
+++ b/providers/linode/linodeProvider.go
@@ -43,8 +43,8 @@ var allowedTTLValues = []uint32{
 
 var srvRegexp = regexp.MustCompile(`^_(?P<Service>\w+)\.\_(?P<Protocol>\w+)$`)
 
-// linodeAPI is the handle for this provider.
-type linodeAPI struct {
+// linodeProvider is the handle for this provider.
+type linodeProvider struct {
 	client      *http.Client
 	baseURL     *url.URL
 	domainIndex map[string]int
@@ -75,7 +75,7 @@ func NewLinode(m map[string]string, metadata json.RawMessage) (providers.DNSServ
 		return nil, fmt.Errorf("invalid base URL for Linode")
 	}
 
-	api := &linodeAPI{client: client, baseURL: baseURL}
+	api := &linodeProvider{client: client, baseURL: baseURL}
 
 	// Get a domain to validate the token
 	if err := api.fetchDomainList(); err != nil {
@@ -97,12 +97,12 @@ func init() {
 }
 
 // GetNameservers returns the nameservers for a domain.
-func (api *linodeAPI) GetNameservers(domain string) ([]*models.Nameserver, error) {
+func (api *linodeProvider) GetNameservers(domain string) ([]*models.Nameserver, error) {
 	return models.ToNameservers(defaultNameServerNames)
 }
 
 // GetZoneRecords gets the records of a zone and returns them in RecordConfig format.
-func (api *linodeAPI) GetZoneRecords(domain string) (models.Records, error) {
+func (api *linodeProvider) GetZoneRecords(domain string) (models.Records, error) {
 	return nil, fmt.Errorf("not implemented")
 	// This enables the get-zones subcommand.
 	// Implement this by extracting the code from GetDomainCorrections into
@@ -110,7 +110,7 @@ func (api *linodeAPI) GetZoneRecords(domain string) (models.Records, error) {
 }
 
 // GetDomainCorrections returns the corrections for a domain.
-func (api *linodeAPI) GetDomainCorrections(dc *models.DomainConfig) ([]*models.Correction, error) {
+func (api *linodeProvider) GetDomainCorrections(dc *models.DomainConfig) ([]*models.Correction, error) {
 	dc, err := dc.Copy()
 	if err != nil {
 		return nil, err

--- a/providers/namecheap/namecheapProvider.go
+++ b/providers/namecheap/namecheapProvider.go
@@ -19,8 +19,8 @@ import (
 // NamecheapDefaultNs lists the default nameservers for this provider.
 var NamecheapDefaultNs = []string{"dns1.registrar-servers.com", "dns2.registrar-servers.com"}
 
-// namecheapAPI is the handle for this provider.
-type namecheapAPI struct {
+// namecheapProvider is the handle for this provider.
+type namecheapProvider struct {
 	APIKEY  string
 	APIUser string
 	client  *nc.Client
@@ -55,8 +55,8 @@ func newReg(conf map[string]string) (providers.Registrar, error) {
 	return newProvider(conf, nil)
 }
 
-func newProvider(m map[string]string, metadata json.RawMessage) (*namecheapAPI, error) {
-	api := &namecheapAPI{}
+func newProvider(m map[string]string, metadata json.RawMessage) (*namecheapProvider, error) {
+	api := &namecheapProvider{}
 	api.APIUser, api.APIKEY = m["apiuser"], m["apikey"]
 	if api.APIKEY == "" || api.APIUser == "" {
 		return nil, fmt.Errorf("missing Namecheap apikey and apiuser")
@@ -107,7 +107,7 @@ func doWithRetry(f func() error) {
 }
 
 // GetZoneRecords gets the records of a zone and returns them in RecordConfig format.
-func (n *namecheapAPI) GetZoneRecords(domain string) (models.Records, error) {
+func (n *namecheapProvider) GetZoneRecords(domain string) (models.Records, error) {
 	return nil, fmt.Errorf("not implemented")
 	// This enables the get-zones subcommand.
 	// Implement this by extracting the code from GetDomainCorrections into
@@ -115,7 +115,7 @@ func (n *namecheapAPI) GetZoneRecords(domain string) (models.Records, error) {
 }
 
 // GetDomainCorrections returns the corrections for the domain.
-func (n *namecheapAPI) GetDomainCorrections(dc *models.DomainConfig) ([]*models.Correction, error) {
+func (n *namecheapProvider) GetDomainCorrections(dc *models.DomainConfig) ([]*models.Correction, error) {
 	dc.Punycode()
 	sld, tld := splitDomain(dc.Name)
 	var records *nc.DomainDNSGetHostsResult
@@ -215,7 +215,7 @@ func (n *namecheapAPI) GetDomainCorrections(dc *models.DomainConfig) ([]*models.
 	return corrections, nil
 }
 
-func (n *namecheapAPI) generateRecords(dc *models.DomainConfig) error {
+func (n *namecheapProvider) generateRecords(dc *models.DomainConfig) error {
 
 	var recs []nc.DomainDNSHost
 
@@ -250,13 +250,13 @@ func (n *namecheapAPI) generateRecords(dc *models.DomainConfig) error {
 }
 
 // GetNameservers returns the nameservers for a domain.
-func (n *namecheapAPI) GetNameservers(domainName string) ([]*models.Nameserver, error) {
+func (n *namecheapProvider) GetNameservers(domainName string) ([]*models.Nameserver, error) {
 	// return default namecheap nameservers
 	return models.ToNameservers(NamecheapDefaultNs)
 }
 
 // GetRegistrarCorrections returns corrections to update nameservers.
-func (n *namecheapAPI) GetRegistrarCorrections(dc *models.DomainConfig) ([]*models.Correction, error) {
+func (n *namecheapProvider) GetRegistrarCorrections(dc *models.DomainConfig) ([]*models.Correction, error) {
 	var info *nc.DomainInfo
 	var err error
 	doWithRetry(func() error {

--- a/providers/namedotcom/namedotcomProvider.go
+++ b/providers/namedotcom/namedotcomProvider.go
@@ -12,8 +12,8 @@ import (
 
 const defaultAPIBase = "api.name.com"
 
-// namedotcomAPI describes a connection to the NDC API.
-type namedotcomAPI struct {
+// namedotcomProvider describes a connection to the NDC API.
+type namedotcomProvider struct {
 	APIUrl  string `json:"apiurl"`
 	APIUser string `json:"apiuser"`
 	APIKey  string `json:"apikey"`
@@ -39,8 +39,8 @@ func newDsp(conf map[string]string, meta json.RawMessage) (providers.DNSServiceP
 	return newProvider(conf)
 }
 
-func newProvider(conf map[string]string) (*namedotcomAPI, error) {
-	api := &namedotcomAPI{
+func newProvider(conf map[string]string) (*namedotcomProvider, error) {
+	api := &namedotcomProvider{
 		client: namecom.New(conf["apiuser"], conf["apikey"]),
 	}
 	api.client.Server = conf["apiurl"]

--- a/providers/namedotcom/nameservers.go
+++ b/providers/namedotcom/nameservers.go
@@ -13,7 +13,7 @@ import (
 var nsRegex = regexp.MustCompile(`ns([1-4])[a-z]{3}\.name\.com`)
 
 // GetNameservers gets the nameservers set on a domain.
-func (n *namedotcomAPI) GetNameservers(domain string) ([]*models.Nameserver, error) {
+func (n *namedotcomProvider) GetNameservers(domain string) ([]*models.Nameserver, error) {
 	// This is an interesting edge case. Name.com expects you to SET the nameservers to ns[1-4].name.com,
 	// but it will internally set it to ns1xyz.name.com, where xyz is a uniqueish 3 letters.
 	// In order to avoid endless loops, we will use the unique nameservers if present, or else the generic ones if not.
@@ -31,7 +31,7 @@ func (n *namedotcomAPI) GetNameservers(domain string) ([]*models.Nameserver, err
 	return models.ToNameservers(toUse)
 }
 
-func (n *namedotcomAPI) getNameserversRaw(domain string) ([]string, error) {
+func (n *namedotcomProvider) getNameserversRaw(domain string) ([]string, error) {
 	request := &namecom.GetDomainRequest{
 		DomainName: domain,
 	}
@@ -46,7 +46,7 @@ func (n *namedotcomAPI) getNameserversRaw(domain string) ([]string, error) {
 }
 
 // GetRegistrarCorrections gathers corrections that would being n to match dc.
-func (n *namedotcomAPI) GetRegistrarCorrections(dc *models.DomainConfig) ([]*models.Correction, error) {
+func (n *namedotcomProvider) GetRegistrarCorrections(dc *models.DomainConfig) ([]*models.Correction, error) {
 	nss, err := n.getNameserversRaw(dc.Name)
 	if err != nil {
 		return nil, err
@@ -70,7 +70,7 @@ func (n *namedotcomAPI) GetRegistrarCorrections(dc *models.DomainConfig) ([]*mod
 	return nil, nil
 }
 
-func (n *namedotcomAPI) updateNameservers(ns []string, domain string) func() error {
+func (n *namedotcomProvider) updateNameservers(ns []string, domain string) func() error {
 	return func() error {
 		request := &namecom.SetNameserversRequest{
 			DomainName:  domain,

--- a/providers/namedotcom/records.go
+++ b/providers/namedotcom/records.go
@@ -20,7 +20,7 @@ var defaultNameservers = []*models.Nameserver{
 }
 
 // GetZoneRecords gets the records of a zone and returns them in RecordConfig format.
-func (n *namedotcomAPI) GetZoneRecords(domain string) (models.Records, error) {
+func (n *namedotcomProvider) GetZoneRecords(domain string) (models.Records, error) {
 	records, err := n.getRecords(domain)
 	if err != nil {
 		return nil, err
@@ -35,7 +35,7 @@ func (n *namedotcomAPI) GetZoneRecords(domain string) (models.Records, error) {
 }
 
 // GetDomainCorrections gathers correctios that would bring n to match dc.
-func (n *namedotcomAPI) GetDomainCorrections(dc *models.DomainConfig) ([]*models.Correction, error) {
+func (n *namedotcomProvider) GetDomainCorrections(dc *models.DomainConfig) ([]*models.Correction, error) {
 	dc.Punycode()
 
 	actual, err := n.GetZoneRecords(dc.Name)
@@ -128,7 +128,7 @@ func toRecord(r *namecom.Record, origin string) *models.RecordConfig {
 	return rc
 }
 
-func (n *namedotcomAPI) getRecords(domain string) ([]*namecom.Record, error) {
+func (n *namedotcomProvider) getRecords(domain string) ([]*namecom.Record, error) {
 	var (
 		err      error
 		records  []*namecom.Record
@@ -158,7 +158,7 @@ func (n *namedotcomAPI) getRecords(domain string) ([]*namecom.Record, error) {
 	return records, nil
 }
 
-func (n *namedotcomAPI) createRecord(rc *models.RecordConfig, domain string) error {
+func (n *namedotcomProvider) createRecord(rc *models.RecordConfig, domain string) error {
 	record := &namecom.Record{
 		DomainName: domain,
 		Host:       rc.GetLabel(),
@@ -218,7 +218,7 @@ func decodeTxt(s string) []string {
 	return []string{s}
 }
 
-func (n *namedotcomAPI) deleteRecord(id int32, domain string) error {
+func (n *namedotcomProvider) deleteRecord(id int32, domain string) error {
 	request := &namecom.DeleteRecordRequest{
 		DomainName: domain,
 		ID:         id,

--- a/providers/namedotcom/zones.go
+++ b/providers/namedotcom/zones.go
@@ -5,7 +5,7 @@ import (
 )
 
 // ListZones returns all the zones in an account
-func (c *namedotcomAPI) ListZones() ([]string, error) {
+func (c *namedotcomProvider) ListZones() ([]string, error) {
 	var names []string
 	var page int32
 

--- a/providers/netcup/api.go
+++ b/providers/netcup/api.go
@@ -12,7 +12,7 @@ const (
 	endpoint = "https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON"
 )
 
-type api struct {
+type netcupProvider struct {
 	domainIndex      map[string]string
 	nameserversNames []string
 	credentials      struct {
@@ -22,7 +22,7 @@ type api struct {
 	}
 }
 
-func (api *api) createRecord(domain string, rec *record) error {
+func (api *netcupProvider) createRecord(domain string, rec *record) error {
 	rec.Delete = false
 	data := paramUpdateRecords{
 		Key:            api.credentials.apikey,
@@ -40,7 +40,7 @@ func (api *api) createRecord(domain string, rec *record) error {
 	return nil
 }
 
-func (api *api) deleteRecord(domain string, rec *record) error {
+func (api *netcupProvider) deleteRecord(domain string, rec *record) error {
 	rec.Delete = true
 	data := paramUpdateRecords{
 		Key:            api.credentials.apikey,
@@ -58,7 +58,7 @@ func (api *api) deleteRecord(domain string, rec *record) error {
 	return nil
 }
 
-func (api *api) modifyRecord(domain string, rec *record) error {
+func (api *netcupProvider) modifyRecord(domain string, rec *record) error {
 	rec.Delete = false
 	data := paramUpdateRecords{
 		Key:            api.credentials.apikey,
@@ -76,7 +76,7 @@ func (api *api) modifyRecord(domain string, rec *record) error {
 	return nil
 }
 
-func (api *api) getRecords(domain string) ([]record, error) {
+func (api *netcupProvider) getRecords(domain string) ([]record, error) {
 	data := paramGetRecords{
 		Key:            api.credentials.apikey,
 		SessionID:      api.credentials.sessionID,
@@ -93,7 +93,7 @@ func (api *api) getRecords(domain string) ([]record, error) {
 	return resp.Records, nil
 }
 
-func (api *api) login(apikey, password, customernumber string) error {
+func (api *netcupProvider) login(apikey, password, customernumber string) error {
 	data := paramLogin{
 		Key:            apikey,
 		Password:       password,
@@ -112,7 +112,7 @@ func (api *api) login(apikey, password, customernumber string) error {
 	return nil
 }
 
-func (api *api) logout() error {
+func (api *netcupProvider) logout() error {
 	data := paramLogout{
 		Key:            api.credentials.apikey,
 		SessionID:      api.credentials.sessionID,
@@ -126,7 +126,7 @@ func (api *api) logout() error {
 	return nil
 }
 
-func (api *api) get(action string, params interface{}) (json.RawMessage, error) {
+func (api *netcupProvider) get(action string, params interface{}) (json.RawMessage, error) {
 	reqParam := request{
 		Action: action,
 		Param:  params,

--- a/providers/netcup/netcupProvider.go
+++ b/providers/netcup/netcupProvider.go
@@ -30,7 +30,7 @@ func New(settings map[string]string, _ json.RawMessage) (providers.DNSServicePro
 		return nil, fmt.Errorf("missing netcup login parameters")
 	}
 
-	api := &api{}
+	api := &netcupProvider{}
 	err := api.login(settings["api-key"], settings["api-password"], settings["customer-number"])
 	if err != nil {
 		return nil, fmt.Errorf("login to netcup DNS failed, please check your credentials: %v", err)
@@ -39,7 +39,7 @@ func New(settings map[string]string, _ json.RawMessage) (providers.DNSServicePro
 }
 
 // GetZoneRecords gets the records of a zone and returns them in RecordConfig format.
-func (api *api) GetZoneRecords(domain string) (models.Records, error) {
+func (api *netcupProvider) GetZoneRecords(domain string) (models.Records, error) {
 	records, err := api.getRecords(domain)
 	if err != nil {
 		return nil, err
@@ -54,7 +54,7 @@ func (api *api) GetZoneRecords(domain string) (models.Records, error) {
 // GetNameservers returns the nameservers for a domain.
 // As netcup doesn't support setting nameservers over this API, these are static.
 // Domains not managed by netcup DNS will return an error
-func (api *api) GetNameservers(domain string) ([]*models.Nameserver, error) {
+func (api *netcupProvider) GetNameservers(domain string) ([]*models.Nameserver, error) {
 	return models.ToNameservers([]string{
 		"root-dns.netcup.net",
 		"second-dns.netcup.net",
@@ -63,7 +63,7 @@ func (api *api) GetNameservers(domain string) ([]*models.Nameserver, error) {
 }
 
 // GetDomainCorrections returns the corrections for a domain.
-func (api *api) GetDomainCorrections(dc *models.DomainConfig) ([]*models.Correction, error) {
+func (api *netcupProvider) GetDomainCorrections(dc *models.DomainConfig) ([]*models.Correction, error) {
 	dc, err := dc.Copy()
 	if err != nil {
 		return nil, err

--- a/providers/octodns/octodnsProvider.go
+++ b/providers/octodns/octodnsProvider.go
@@ -46,7 +46,7 @@ var features = providers.DocumentationNotes{
 func initProvider(config map[string]string, providermeta json.RawMessage) (providers.DNSServiceProvider, error) {
 	// config -- the key/values from creds.json
 	// meta -- the json blob from NewReq('name', 'TYPE', meta)
-	api := &Provider{
+	api := &octodnsProvider{
 		directory: config["directory"],
 	}
 	if api.directory == "" {
@@ -66,8 +66,8 @@ func init() {
 	providers.RegisterDomainServiceProviderType("OCTODNS", initProvider, features)
 }
 
-// Provider is the provider handle for the OctoDNS driver.
-type Provider struct {
+// octodnsProvider is the provider handle for the OctoDNS driver.
+type octodnsProvider struct {
 	//DefaultNS   []string `json:"default_ns"`
 	//DefaultSoa  SoaInfo  `json:"default_soa"`
 	//nameservers []*models.Nameserver
@@ -75,12 +75,12 @@ type Provider struct {
 }
 
 // GetNameservers returns the nameservers for a domain.
-func (c *Provider) GetNameservers(string) ([]*models.Nameserver, error) {
+func (c *octodnsProvider) GetNameservers(string) ([]*models.Nameserver, error) {
 	return nil, nil
 }
 
 // GetZoneRecords gets the records of a zone and returns them in RecordConfig format.
-func (c *Provider) GetZoneRecords(domain string) (models.Records, error) {
+func (c *octodnsProvider) GetZoneRecords(domain string) (models.Records, error) {
 	return nil, fmt.Errorf("not implemented")
 	// This enables the get-zones subcommand.
 	// Implement this by extracting the code from GetDomainCorrections into
@@ -88,7 +88,7 @@ func (c *Provider) GetZoneRecords(domain string) (models.Records, error) {
 }
 
 // GetDomainCorrections returns a list of corrections to update a domain.
-func (c *Provider) GetDomainCorrections(dc *models.DomainConfig) ([]*models.Correction, error) {
+func (c *octodnsProvider) GetDomainCorrections(dc *models.DomainConfig) ([]*models.Correction, error) {
 	dc.Punycode()
 	// Phase 1: Copy everything to []*models.RecordConfig:
 	//    expectedRecords < dc.Records[i]

--- a/providers/opensrs/opensrsProvider.go
+++ b/providers/opensrs/opensrsProvider.go
@@ -30,8 +30,8 @@ var defaultNameServerNames = []string{
 	"ns3.systemdns.com",
 }
 
-// opensrsAPI is the api handle.
-type opensrsAPI struct {
+// opensrsProvider is the api handle.
+type opensrsProvider struct {
 	UserName string // reseller user name
 	APIKey   string // API Key
 
@@ -40,12 +40,12 @@ type opensrsAPI struct {
 }
 
 // GetNameservers returns a list of nameservers.
-func (c *opensrsAPI) GetNameservers(domainName string) ([]*models.Nameserver, error) {
+func (c *opensrsProvider) GetNameservers(domainName string) ([]*models.Nameserver, error) {
 	return models.ToNameservers(defaultNameServerNames)
 }
 
 // GetRegistrarCorrections returns a list of corrections for a registrar.
-func (c *opensrsAPI) GetRegistrarCorrections(dc *models.DomainConfig) ([]*models.Correction, error) {
+func (c *opensrsProvider) GetRegistrarCorrections(dc *models.DomainConfig) ([]*models.Correction, error) {
 	corrections := []*models.Correction{}
 
 	nameServers, err := c.getNameservers(dc.Name)
@@ -77,14 +77,14 @@ func (c *opensrsAPI) GetRegistrarCorrections(dc *models.DomainConfig) ([]*models
 
 // OpenSRS calls
 
-func (c *opensrsAPI) getClient() *opensrs.Client {
+func (c *opensrsProvider) getClient() *opensrs.Client {
 	return c.client
 }
 
 // Returns the name server names that should be used. If the domain is registered
 // then this method will return the delegation name servers. If this domain
 // is hosted only, then it will return the default OpenSRS name servers.
-func (c *opensrsAPI) getNameservers(domainName string) ([]string, error) {
+func (c *opensrsProvider) getNameservers(domainName string) ([]string, error) {
 	client := c.getClient()
 
 	status, err := client.Domains.GetDomain(domainName, "status", 1)
@@ -103,7 +103,7 @@ func (c *opensrsAPI) getNameservers(domainName string) ([]string, error) {
 }
 
 // Returns a function that can be invoked to change the delegation of the domain to the given name server names.
-func (c *opensrsAPI) updateNameserversFunc(nameServerNames []string, domainName string) func() error {
+func (c *opensrsProvider) updateNameserversFunc(nameServerNames []string, domainName string) func() error {
 	return func() error {
 		client := c.getClient()
 
@@ -121,8 +121,8 @@ func newReg(conf map[string]string) (providers.Registrar, error) {
 	return newProvider(conf, nil)
 }
 
-func newProvider(m map[string]string, metadata json.RawMessage) (*opensrsAPI, error) {
-	api := &opensrsAPI{}
+func newProvider(m map[string]string, metadata json.RawMessage) (*opensrsProvider, error) {
+	api := &opensrsProvider{}
 	api.APIKey = m["apikey"]
 
 	if api.APIKey == "" {

--- a/providers/powerdns/dnssec.go
+++ b/providers/powerdns/dnssec.go
@@ -8,7 +8,7 @@ import (
 )
 
 // getDNSSECCorrections returns corrections that update a domain's DNSSEC state.
-func (api *PowerDNS) getDNSSECCorrections(dc *models.DomainConfig) ([]*models.Correction, error) {
+func (api *powerdnsProvider) getDNSSECCorrections(dc *models.DomainConfig) ([]*models.Correction, error) {
 	cryptokeys, getErr := api.client.Cryptokeys().ListCryptokeys(context.Background(), api.ServerName, dc.Name)
 	if getErr != nil {
 		return nil, getErr
@@ -52,7 +52,7 @@ func (api *PowerDNS) getDNSSECCorrections(dc *models.DomainConfig) ([]*models.Co
 }
 
 // enableDnssec creates a active and published cryptokey on this domain
-func (api *PowerDNS) enableDnssec(domain string) (bool, error) {
+func (api *powerdnsProvider) enableDnssec(domain string) (bool, error) {
 	// if there is now key, create one and enable it
 	_, err := api.client.Cryptokeys().CreateCryptokey(context.Background(), api.ServerName, domain, cryptokeys.Cryptokey{
 		KeyType:   "csk",
@@ -66,7 +66,7 @@ func (api *PowerDNS) enableDnssec(domain string) (bool, error) {
 }
 
 // removeDnssec removes the cryptokey from this zone
-func (api *PowerDNS) removeDnssec(domain string, keyID int) (bool, error) {
+func (api *powerdnsProvider) removeDnssec(domain string, keyID int) (bool, error) {
 	err := api.client.Cryptokeys().DeleteCryptokey(context.Background(), api.ServerName, domain, keyID)
 	if err != nil {
 		return false, err

--- a/providers/powerdns/powerdnsProvider.go
+++ b/providers/powerdns/powerdnsProvider.go
@@ -34,8 +34,8 @@ func init() {
 	providers.RegisterDomainServiceProviderType("POWERDNS", NewProvider, features)
 }
 
-// PowerDNS represents the PowerDNS DNSServiceProvider.
-type PowerDNS struct {
+// powerdnsProvider represents the powerdnsProvider DNSServiceProvider.
+type powerdnsProvider struct {
 	client         pdns.Client
 	APIKey         string
 	APIUrl         string
@@ -48,7 +48,7 @@ type PowerDNS struct {
 
 // NewProvider initializes a PowerDNS DNSServiceProvider.
 func NewProvider(m map[string]string, metadata json.RawMessage) (providers.DNSServiceProvider, error) {
-	api := &PowerDNS{}
+	api := &powerdnsProvider{}
 
 	api.APIKey = m["apiKey"]
 	if api.APIKey == "" {
@@ -91,7 +91,7 @@ func NewProvider(m map[string]string, metadata json.RawMessage) (providers.DNSSe
 }
 
 // GetNameservers returns the nameservers for a domain.
-func (api *PowerDNS) GetNameservers(string) ([]*models.Nameserver, error) {
+func (api *powerdnsProvider) GetNameservers(string) ([]*models.Nameserver, error) {
 	var r []string
 	for _, j := range api.nameservers {
 		r = append(r, j.Name)
@@ -100,7 +100,7 @@ func (api *PowerDNS) GetNameservers(string) ([]*models.Nameserver, error) {
 }
 
 // ListZones returns all the zones in an account
-func (api *PowerDNS) ListZones() ([]string, error) {
+func (api *powerdnsProvider) ListZones() ([]string, error) {
 	var result []string
 	zones, err := api.client.Zones().ListZones(context.Background(), api.ServerName)
 	if err != nil {
@@ -113,7 +113,7 @@ func (api *PowerDNS) ListZones() ([]string, error) {
 }
 
 // GetZoneRecords gets the records of a zone and returns them in RecordConfig format.
-func (api *PowerDNS) GetZoneRecords(domain string) (models.Records, error) {
+func (api *powerdnsProvider) GetZoneRecords(domain string) (models.Records, error) {
 	zone, err := api.client.Zones().GetZone(context.Background(), api.ServerName, domain)
 	if err != nil {
 		return nil, err
@@ -139,7 +139,7 @@ func (api *PowerDNS) GetZoneRecords(domain string) (models.Records, error) {
 }
 
 // GetDomainCorrections returns a list of corrections to update a domain.
-func (api *PowerDNS) GetDomainCorrections(dc *models.DomainConfig) ([]*models.Correction, error) {
+func (api *powerdnsProvider) GetDomainCorrections(dc *models.DomainConfig) ([]*models.Correction, error) {
 	var corrections []*models.Correction
 
 	// record corrections
@@ -205,7 +205,7 @@ func (api *PowerDNS) GetDomainCorrections(dc *models.DomainConfig) ([]*models.Co
 }
 
 // EnsureDomainExists adds a domain to the DNS service if it does not exist
-func (api *PowerDNS) EnsureDomainExists(domain string) error {
+func (api *powerdnsProvider) EnsureDomainExists(domain string) error {
 	if _, err := api.client.Zones().GetZone(context.Background(), api.ServerName, domain+"."); err != nil {
 		if e, ok := err.(pdnshttp.ErrUnexpectedStatus); ok {
 			if e.StatusCode != http.StatusNotFound {

--- a/providers/softlayer/softlayerProvider.go
+++ b/providers/softlayer/softlayerProvider.go
@@ -16,8 +16,8 @@ import (
 	"github.com/StackExchange/dnscontrol/v3/providers"
 )
 
-// SoftLayer is the protocol handle for this provider.
-type SoftLayer struct {
+// softlayerProvider is the protocol handle for this provider.
+type softlayerProvider struct {
 	Session *session.Session
 }
 
@@ -39,7 +39,7 @@ func newReg(conf map[string]string, _ json.RawMessage) (providers.DNSServiceProv
 
 	// s.Debug = true
 
-	api := &SoftLayer{
+	api := &softlayerProvider{
 		Session: s,
 	}
 
@@ -47,13 +47,13 @@ func newReg(conf map[string]string, _ json.RawMessage) (providers.DNSServiceProv
 }
 
 // GetNameservers returns the nameservers for a domain.
-func (s *SoftLayer) GetNameservers(domain string) ([]*models.Nameserver, error) {
+func (s *softlayerProvider) GetNameservers(domain string) ([]*models.Nameserver, error) {
 	// Always use the same nameservers for softlayer
 	return models.ToNameservers([]string{"ns1.softlayer.com", "ns2.softlayer.com"})
 }
 
 // GetZoneRecords gets the records of a zone and returns them in RecordConfig format.
-func (s *SoftLayer) GetZoneRecords(domain string) (models.Records, error) {
+func (s *softlayerProvider) GetZoneRecords(domain string) (models.Records, error) {
 	return nil, fmt.Errorf("not implemented")
 	// This enables the get-zones subcommand.
 	// Implement this by extracting the code from GetDomainCorrections into
@@ -61,7 +61,7 @@ func (s *SoftLayer) GetZoneRecords(domain string) (models.Records, error) {
 }
 
 // GetDomainCorrections returns corrections to update a domain.
-func (s *SoftLayer) GetDomainCorrections(dc *models.DomainConfig) ([]*models.Correction, error) {
+func (s *softlayerProvider) GetDomainCorrections(dc *models.DomainConfig) ([]*models.Correction, error) {
 	corrections := []*models.Correction{}
 
 	domain, err := s.getDomain(&dc.Name)
@@ -107,7 +107,7 @@ func (s *SoftLayer) GetDomainCorrections(dc *models.DomainConfig) ([]*models.Cor
 	return corrections, nil
 }
 
-func (s *SoftLayer) getDomain(name *string) (*datatypes.Dns_Domain, error) {
+func (s *softlayerProvider) getDomain(name *string) (*datatypes.Dns_Domain, error) {
 	domains, err := services.GetAccountService(s.Session).
 		Filter(filter.Path("domains.name").Eq(name).Build()).
 		Mask("resourceRecords").
@@ -126,7 +126,7 @@ func (s *SoftLayer) getDomain(name *string) (*datatypes.Dns_Domain, error) {
 	return &domains[0], nil
 }
 
-func (s *SoftLayer) getExistingRecords(domain *datatypes.Dns_Domain) ([]*models.RecordConfig, error) {
+func (s *softlayerProvider) getExistingRecords(domain *datatypes.Dns_Domain) ([]*models.RecordConfig, error) {
 	actual := []*models.RecordConfig{}
 
 	for _, record := range domain.ResourceRecords {
@@ -184,7 +184,7 @@ func (s *SoftLayer) getExistingRecords(domain *datatypes.Dns_Domain) ([]*models.
 	return actual, nil
 }
 
-func (s *SoftLayer) createRecordFunc(desired *models.RecordConfig, domain *datatypes.Dns_Domain) func() error {
+func (s *softlayerProvider) createRecordFunc(desired *models.RecordConfig, domain *datatypes.Dns_Domain) func() error {
 	var ttl, preference, domainID int = verifyMinTTL(int(desired.TTL)), int(desired.MxPreference), *domain.Id
 	var weight, priority, port int = int(desired.SrvWeight), int(desired.SrvPriority), int(desired.SrvPort)
 	var host, data, newType string = desired.GetLabel(), desired.GetTargetField(), desired.Type
@@ -243,7 +243,7 @@ func (s *SoftLayer) createRecordFunc(desired *models.RecordConfig, domain *datat
 	}
 }
 
-func (s *SoftLayer) deleteRecordFunc(resID int) func() error {
+func (s *softlayerProvider) deleteRecordFunc(resID int) func() error {
 	// seems to be no problem deleting MX and SRV records via common interface
 	return func() error {
 		_, err := services.GetDnsDomainResourceRecordService(s.Session).
@@ -254,7 +254,7 @@ func (s *SoftLayer) deleteRecordFunc(resID int) func() error {
 	}
 }
 
-func (s *SoftLayer) updateRecordFunc(existing *datatypes.Dns_Domain_ResourceRecord, desired *models.RecordConfig) func() error {
+func (s *softlayerProvider) updateRecordFunc(existing *datatypes.Dns_Domain_ResourceRecord, desired *models.RecordConfig) func() error {
 	var ttl, preference int = verifyMinTTL(int(desired.TTL)), int(desired.MxPreference)
 	var priority, weight, port int = int(desired.SrvPriority), int(desired.SrvWeight), int(desired.SrvPort)
 

--- a/providers/vultr/vultrProvider.go
+++ b/providers/vultr/vultrProvider.go
@@ -40,8 +40,8 @@ func init() {
 	providers.RegisterDomainServiceProviderType("VULTR", NewProvider, features)
 }
 
-// Provider represents the Vultr DNSServiceProvider.
-type Provider struct {
+// vultrProvider represents the Vultr DNSServiceProvider.
+type vultrProvider struct {
 	client *govultr.Client
 	token  string
 }
@@ -63,11 +63,11 @@ func NewProvider(m map[string]string, metadata json.RawMessage) (providers.DNSSe
 	client.SetUserAgent("dnscontrol")
 
 	_, err := client.Account.GetInfo(context.Background())
-	return &Provider{client, token}, err
+	return &vultrProvider{client, token}, err
 }
 
 // GetZoneRecords gets the records of a zone and returns them in RecordConfig format.
-func (api *Provider) GetZoneRecords(domain string) (models.Records, error) {
+func (api *vultrProvider) GetZoneRecords(domain string) (models.Records, error) {
 	records, err := api.client.DNSRecord.List(context.Background(), domain)
 	if err != nil {
 		return nil, err
@@ -86,7 +86,7 @@ func (api *Provider) GetZoneRecords(domain string) (models.Records, error) {
 }
 
 // GetDomainCorrections gets the corrections for a DomainConfig.
-func (api *Provider) GetDomainCorrections(dc *models.DomainConfig) ([]*models.Correction, error) {
+func (api *vultrProvider) GetDomainCorrections(dc *models.DomainConfig) ([]*models.Correction, error) {
 	dc.Punycode()
 
 	curRecords, err := api.GetZoneRecords(dc.Name)
@@ -138,12 +138,12 @@ func (api *Provider) GetDomainCorrections(dc *models.DomainConfig) ([]*models.Co
 }
 
 // GetNameservers gets the Vultr nameservers for a domain
-func (api *Provider) GetNameservers(domain string) ([]*models.Nameserver, error) {
+func (api *vultrProvider) GetNameservers(domain string) ([]*models.Nameserver, error) {
 	return models.ToNameservers(defaultNS)
 }
 
 // EnsureDomainExists adds a domain to the Vutr DNS service if it does not exist
-func (api *Provider) EnsureDomainExists(domain string) error {
+func (api *vultrProvider) EnsureDomainExists(domain string) error {
 	if ok, err := api.isDomainInAccount(domain); err != nil {
 		return err
 	} else if ok {
@@ -154,7 +154,7 @@ func (api *Provider) EnsureDomainExists(domain string) error {
 	return api.client.DNSDomain.Create(context.Background(), domain, "0.0.0.0")
 }
 
-func (api *Provider) isDomainInAccount(domain string) (bool, error) {
+func (api *vultrProvider) isDomainInAccount(domain string) (bool, error) {
 	domains, err := api.client.DNSDomain.List(context.Background())
 	if err != nil {
 		return false, err


### PR DESCRIPTION
```

git co .
git co master
git br -D tlim_rename || true
git co -b tlim_rename
gorename -v -from '"github.com/StackExchange/dnscontrol/v3/providers/activedir".activedirAPI' -to 'activedirProvider'
gorename -v -from '"github.com/StackExchange/dnscontrol/v3/providers/axfrddns".AxfrDdns' -to 'axfrddnsProvider'
gorename -v -from '"github.com/StackExchange/dnscontrol/v3/providers/azuredns".azurednsAPI' -to 'azurednsProvider'
gorename -v -from '"github.com/StackExchange/dnscontrol/v3/providers/bind".Bind' -to 'bindProvider'
gorename -v -from '"github.com/StackExchange/dnscontrol/v3/providers/cloudflare".cloudflareAPI' -to 'cloudflareProvider'
gorename -v -from '"github.com/StackExchange/dnscontrol/v3/providers/cloudns".api' -to 'cloudnsProvider'
gorename -v -from '"github.com/StackExchange/dnscontrol/v3/providers/cscglobal".api' -to 'cscglobalProvider'
gorename -v -from '"github.com/StackExchange/dnscontrol/v3/providers/desec".api' -to 'desecProvider'
gorename -v -from '"github.com/StackExchange/dnscontrol/v3/providers/digitalocean".digitaloceanAPI' -to 'digitaloceanProvider'
gorename -v -from '"github.com/StackExchange/dnscontrol/v3/providers/dnsimple".dnsimpleAPI' -to 'dnsimpleProvider'
gorename -v -from '"github.com/StackExchange/dnscontrol/v3/providers/doh".api' -to 'dohProvider'
gorename -v -from '"github.com/StackExchange/dnscontrol/v3/providers/gandi_v5".gandiv5API' -to 'gandiv5Provider'
gorename -v -from '"github.com/StackExchange/dnscontrol/v3/providers/gcloud".gcloudAPI' -to 'gcloudProvider'
gorename -v -from '"github.com/StackExchange/dnscontrol/v3/providers/hedns".HDNSProvider' -to 'hednsProvider'
gorename -v -from '"github.com/StackExchange/dnscontrol/v3/providers/hetzner".api' -to 'hetznerProvider'
gorename -v -from '"github.com/StackExchange/dnscontrol/v3/providers/internetbs".api' -to 'internetbsProvider'
gorename -v -from '"github.com/StackExchange/dnscontrol/v3/providers/linode".linodeAPI' -to 'linodeProvider'
gorename -v -from '"github.com/StackExchange/dnscontrol/v3/providers/namecheap".namecheapAPI' -to 'namecheapProvider'
gorename -v -from '"github.com/StackExchange/dnscontrol/v3/providers/namedotcom".namedotcomAPI' -to 'namedotcomProvider'
gorename -v -from '"github.com/StackExchange/dnscontrol/v3/providers/netcup".api' -to 'netcupProvider'
gorename -v -from '"github.com/StackExchange/dnscontrol/v3/providers/octodns".Provider' -to 'octodnsProvider'
gorename -v -from '"github.com/StackExchange/dnscontrol/v3/providers/opensrs".opensrsAPI' -to 'opensrsProvider'
gorename -v -from '"github.com/StackExchange/dnscontrol/v3/providers/powerdns".PowerDNS' -to 'powerdnsProvider'
gorename -v -from '"github.com/StackExchange/dnscontrol/v3/providers/route53".route53API' -to 'route53Provider'
gorename -v -from '"github.com/StackExchange/dnscontrol/v3/providers/softlayer".SoftLayer' -to 'softlayerProvider'
gorename -v -from '"github.com/StackExchange/dnscontrol/v3/providers/vultr".Provider' -to 'vultrProvider'
find . -name \*.go -print0 | xargs -0 gofmt -w
```

FYI: `exoscale` and `inwx` already meet the new nomenclature. 