### PR TITLE
testing Go 1.14

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Set up Go 1.15.3
       uses: actions/setup-go@v2
       with:
-        go-version: ^1.14.10
+        go-version: "1.14.10"
 
     - name: Build binaries
       run: go run build/build.go

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Set up Go 1.15.3
       uses: actions/setup-go@v2
       with:
-        go-version: ^1.14
+        go-version: ^1.14.10
 
     - name: Build binaries
       run: go run build/build.go

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Set up Go 1.15.3
       uses: actions/setup-go@v2
       with:
-        go-version: ^1.15.3
+        go-version: ^1.14
 
     - name: Build binaries
       run: go run build/build.go


### PR DESCRIPTION
running `go run build/build.go` produces an error indicating go 1.14 is required, testing that