### PR TITLE
Run builds on PRs targeting master branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,23 @@
+name: build
+
+on: 
+  pull_request:
+    branches: [ $default-branch ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Checkout repo
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ^1.15.3
+
+    - name: Build binaries
+      run: go run build/build.go

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: ^1.15.3
+        go-version: ^1.15
 
     - name: Build binaries
       run: go run build/build.go

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: build
 
 on: 
   pull_request:
-    branches: [ $default-branch ]
+    branches: [ master ]
 
 jobs:
   build:


### PR DESCRIPTION
As a precursor to [automating the entire release process](https://github.com/StackExchange/dnscontrol/pull/789), this simple workflow will just run all the builds for all PRs targeting the master branch.

Simultaneously, let's add a "Require status checks to pass before merging" [branch protection rule](https://github.com/StackExchange/dnscontrol/settings/branch_protection_rules/new).

This will prevent PRs from getting merged to `master` if they [break any of the builds](https://github.com/StackExchange/dnscontrol/commit/bb6aecc9ada34488f3d69ad1bcd5648f5d273bee).

