### PR TITLE
HETZNER: create and modify multiple records in batches

### DIFF
--- a/providers/hetzner/api.go
+++ b/providers/hetzner/api.go
@@ -29,6 +29,32 @@ func checkIsLockedSystemRecord(record record) error {
 	return nil
 }
 
+func (api *hetznerProvider) bulkCreateRecords(records []record) error {
+	for _, record := range records {
+		if err := checkIsLockedSystemRecord(record); err != nil {
+			return err
+		}
+	}
+
+	request := bulkCreateRecordsRequest{
+		Records: records,
+	}
+	return api.request("/records/bulk", "POST", request, nil)
+}
+
+func (api *hetznerProvider) bulkUpdateRecords(records []record) error {
+	for _, record := range records {
+		if err := checkIsLockedSystemRecord(record); err != nil {
+			return err
+		}
+	}
+
+	request := bulkUpdateRecordsRequest{
+		Records: records,
+	}
+	return api.request("/records/bulk", "PUT", request, nil)
+}
+
 func (api *hetznerProvider) createRecord(record record) error {
 	if err := checkIsLockedSystemRecord(record); err != nil {
 		return err

--- a/providers/hetzner/types.go
+++ b/providers/hetzner/types.go
@@ -4,6 +4,14 @@ import (
 	"github.com/StackExchange/dnscontrol/v3/models"
 )
 
+type bulkCreateRecordsRequest struct {
+	Records []record `json:"records"`
+}
+
+type bulkUpdateRecordsRequest struct {
+	Records []record `json:"records"`
+}
+
 type createRecordRequest struct {
 	Name   string `json:"name"`
 	TTL    int    `json:"ttl"`


### PR DESCRIPTION
Followup for #904 

The Hetzner DNS Console API supports bulk creation and modification of records. Unfortunately they do not support bulk deletion yet. 

https://dns.hetzner.com/api-docs#operation/BulkCreateRecords
https://dns.hetzner.com/api-docs#operation/BulkUpdateRecords

This PR is implementing the api wrapper and refactoring the creation/modification of records to use the new methods.

Shall I remove the old, now unused methods and types in this PR as well?

<details>
<summary> preview </summary>

```
******************** Domain: testing1.dev
----- Getting nameservers from: HETZNER
----- DNS Provider: HETZNER...2 corrections
#1: Batch creation of records:
        CREATE A new.testing1.dev 1.2.3.4 ttl=300
        CREATE A new1.testing1.dev 1.2.3.4 ttl=300
        CREATE A new2.testing1.dev 1.2.3.4 ttl=300
#2: Batch modification of records:
        MODIFY A test.testing1.dev: (1.2.3.4 ttl=300) -> (1.2.3.42 ttl=300)
        MODIFY A test1.testing1.dev: (1.2.3.4 ttl=300) -> (1.2.3.42 ttl=300)
        MODIFY A test2.testing1.dev: (1.2.3.4 ttl=300) -> (1.2.3.42 ttl=300)
----- Registrar: none...0 corrections
Done. 2 corrections.
```
</details>

<details>
<summary> snippet from integration tests showing fast push and slow deletion </summary>
 
```
        --- PASS: TestDNSProviders/testing1.dev/15:pager101:99_records (5.85s)
=== RUN   TestDNSProviders/testing1.dev/15:pager101:100_records
        --- PASS: TestDNSProviders/testing1.dev/15:pager101:100_records (3.96s)
=== RUN   TestDNSProviders/testing1.dev/15:pager101:101_records
        --- PASS: TestDNSProviders/testing1.dev/15:pager101:101_records (3.99s)
=== RUN   TestDNSProviders/testing1.dev/Post_cleanup:Empty#14
        --- PASS: TestDNSProviders/testing1.dev/Post_cleanup:Empty#14 (176.33s)

```
</details>