### PR TITLE
HETZNER: fix retry of POST/PUT requests -- rebuild request body

### DIFF
--- a/providers/hetzner/api.go
+++ b/providers/hetzner/api.go
@@ -131,21 +131,21 @@ func (api *hetznerProvider) getZone(name string) (*zone, error) {
 }
 
 func (api *hetznerProvider) request(endpoint string, method string, request interface{}, target interface{}) error {
-	var requestBody io.Reader
-	if request != nil {
-		requestBodySerialised, err := json.Marshal(request)
+	for {
+		var requestBody io.Reader
+		if request != nil {
+			requestBodySerialised, err := json.Marshal(request)
+			if err != nil {
+				return err
+			}
+			requestBody = bytes.NewBuffer(requestBodySerialised)
+		}
+		req, err := http.NewRequest(method, baseURL+endpoint, requestBody)
 		if err != nil {
 			return err
 		}
-		requestBody = bytes.NewBuffer(requestBodySerialised)
-	}
-	req, err := http.NewRequest(method, baseURL+endpoint, requestBody)
-	if err != nil {
-		return err
-	}
-	req.Header.Add("Auth-API-Token", api.apiKey)
+		req.Header.Add("Auth-API-Token", api.apiKey)
 
-	for {
 		api.requestRateLimiter.beforeRequest()
 		resp, err := http.DefaultClient.Do(req)
 		api.requestRateLimiter.afterRequest()


### PR DESCRIPTION
Followup for #904 

Previously for any retry the request body was already consumed and
 the server received an empty body.
Which in turn results in a response with a status code of 400 for the retied request.

This is best reviewed with white-space changes ignored: https://github.com/StackExchange/dnscontrol/pull/926/files?diff=unified&w=1