### PR TITLE
Run integration tests as part of build checks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Run unit tests
       run: go test ./...
 
-    - name: Run integration test for BIND provider
+    - name: Run integration tests for BIND provider
       run: go test -v -verbose -provider BIND
 
     - name: Build binaries

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,5 +25,12 @@ jobs:
     - name: Run integration tests for BIND provider
       run: go test -v -verbose -provider BIND
 
+    - name: Run integration test for ROUTE53 provider
+      run: go test -v -verbose -provider ROUTE53
+      env:
+        R53_DOMAIN: dnscontroltest-r53.com
+        R53_KEY_ID: ${{ secrets.R53_KEY_ID }}
+        R53_KEY: ${{ secrets.R53_KEY }}
+
     - name: Build binaries
       run: go run build/build.go

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,9 +23,11 @@ jobs:
       run: go test ./...
 
     - name: Run integration tests for BIND provider
+      working-directory: integrationTest
       run: go test -v -verbose -provider BIND
 
     - name: Run integration test for ROUTE53 provider
+      working-directory: integrationTest
       run: go test -v -verbose -provider ROUTE53
       env:
         R53_DOMAIN: dnscontroltest-r53.com

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,5 +22,8 @@ jobs:
     - name: Run unit tests
       run: go test ./...
 
+    - name: Run integration test for BIND provider
+      run: go test -v -verbose -provider BIND
+
     - name: Build binaries
       run: go run build/build.go


### PR DESCRIPTION
Following up on https://github.com/StackExchange/dnscontrol/pull/922 and https://github.com/StackExchange/dnscontrol/pull/927, this also runs a set of integration tests as part of build checks.

Branch protection of `master` is in place, i.e. changes which break any of the integration tests can't be merged.

[Repo secrets](https://github.com/StackExchange/dnscontrol/settings/secrets) added as necessary.
