### PR TITLE
Integration tests: add Digital Ocean, Gandi V5

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
     needs: build
     strategy:
       matrix:
-        provider: [AZURE_DNS, BIND, CLOUDFLAREAPI, GCLOUD, NAMEDOTCOM, ROUTE53]
+        provider: [AZURE_DNS, BIND, CLOUDFLAREAPI, DIGITALOCEAN, GANDI_V5, GCLOUD, HEXONET, NAMEDOTCOM, ROUTE53]
     steps:
     - name: Checkout repo
       uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        provider: [AZURE_DNS, BIND, CLOUDFLAREAPI, DIGITALOCEAN, GANDI_V5, GCLOUD, HEXONET, NAMEDOTCOM, ROUTE53]
+        provider: [AZURE_DNS, BIND, CLOUDFLAREAPI, DIGITALOCEAN, GANDI, GCLOUD, HEXONET, NAMEDOTCOM, ROUTE53]
     steps:
     - name: Checkout repo
       uses: actions/checkout@v2
@@ -50,6 +50,10 @@ jobs:
         AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
         CF_DOMAIN: dnscontroltest-cf.com
         CF_TOKEN: ${{ secrets.CF_TOKEN }}
+        DO_DOMAIN : dnscontrol-do.com
+        DO_TOKEN : ${{ secrets.DO_TOKEN }}
+        GANDI_DOMAIN : dnscontroltest-gandi.com
+        GANDI_KEY : ${{ secrets.GANDI_KEY }}
         GCLOUD_DOMAIN: dnscontroltest-gcloud.com
         GCLOUD_TYPE: service_account
         GCLOUD_EMAIL: dnscontrol@dnscontrol-dev.iam.gserviceaccount.com

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        provider: [AZURE_DNS, BIND, CLOUDFLAREAPI, DIGITALOCEAN, GANDI, GCLOUD, NAMEDOTCOM, ROUTE53]
+        provider: [AZURE_DNS, BIND, CLOUDFLAREAPI, DIGITALOCEAN, GANDI_V5, GCLOUD, NAMEDOTCOM, ROUTE53]
     steps:
     - name: Checkout repo
       uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,8 +52,8 @@ jobs:
         CF_TOKEN: ${{ secrets.CF_TOKEN }}
         DO_DOMAIN : dnscontrol-do.com
         DO_TOKEN : ${{ secrets.DO_TOKEN }}
-        GANDI_DOMAIN : dnscontroltest-gandi.com
-        GANDI_KEY : ${{ secrets.GANDI_KEY }}
+        GANDI_V5_DOMAIN : dnscontroltest-gandilivedns.com
+        GANDI_V5_APIKEY : ${{ secrets.GANDI_V5_APIKEY }}
         GCLOUD_DOMAIN: dnscontroltest-gcloud.com
         GCLOUD_TYPE: service_account
         GCLOUD_EMAIL: dnscontrol@dnscontrol-dev.iam.gserviceaccount.com

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        provider: [AZURE_DNS, BIND, CLOUDFLAREAPI, DIGITALOCEAN, GANDI, GCLOUD, HEXONET, NAMEDOTCOM, ROUTE53]
+        provider: [AZURE_DNS, BIND, CLOUDFLAREAPI, DIGITALOCEAN, GANDI, GCLOUD, NAMEDOTCOM, ROUTE53]
     steps:
     - name: Checkout repo
       uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     strategy:
+      fail-fast: false
       matrix:
         provider: [AZURE_DNS, BIND, CLOUDFLAREAPI, DIGITALOCEAN, GANDI_V5, GCLOUD, HEXONET, NAMEDOTCOM, ROUTE53]
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,6 +29,8 @@ jobs:
       fail-fast: false
       matrix:
         provider: [AZURE_DNS, BIND, CLOUDFLAREAPI, DIGITALOCEAN, GANDI_V5, GCLOUD, NAMEDOTCOM, ROUTE53]
+        exclude:
+        - provider: DIGITALOCEAN  # remove when #636 is fixed
     steps:
     - name: Checkout repo
       uses: actions/checkout@v2


### PR DESCRIPTION
Follow-up to https://github.com/StackExchange/dnscontrol/pull/930: adding additional integration tests for contributor-supported DNS providers:

* DIGITALOCEAN   (there's a ratelimit that makes this fail occasionally- note that integration tests aren't blocking release)
* GANDI_V5

(separate PR coming for [HEXONET](https://stackexchange.github.io/dnscontrol/providers/hexonet))