### PR TITLE
CLOUDFLARE: get-zones now outputs "orange cloud" status

### DIFF
--- a/commands/getZones.go
+++ b/commands/getZones.go
@@ -50,7 +50,7 @@ The columns in --format=tsv are:
    TTL
    Record Type (A, AAAA, CNAME, etc.)
    Target and arguments (quoted like in a zonefile)
-   Either empty or a comma-separated list of properties like "CF_PROXY_ON=true"
+   Either empty or a comma-separated list of properties like "cloudflare_proxy=true"
 
 The --ttl flag only applies to zone/js/djs formats.
 
@@ -234,7 +234,7 @@ func GetZone(args GetZoneArgs) error {
 				cfproxy := ""
 				if cp, ok := rec.Metadata["cloudflare_proxy"]; ok {
 					if cp == "true" {
-						cfproxy = "\tCF_PROXY_ON=true"
+						cfproxy = "\tcloudflare_proxy=true"
 					}
 				}
 

--- a/commands/getZones.go
+++ b/commands/getZones.go
@@ -50,6 +50,7 @@ The columns in --format=tsv are:
    TTL
    Record Type (A, AAAA, CNAME, etc.)
    Target and arguments (quoted like in a zonefile)
+   Either empty or a comma-separated list of properties like "CF_PROXY_ON=true"
 
 The --ttl flag only applies to zone/js/djs formats.
 
@@ -93,7 +94,7 @@ ARGUMENTS:
    provider: The name of the provider (second parameter to NewDnsProvider() in dnsconfig.js)
 
 EXAMPLES:
-   dnscontrol get-zones myr53 ROUTE53 
+   dnscontrol get-zones myr53 ROUTE53
    dnscontrol get-zones --out=/dev/null myr53 ROUTE53`,
 	}
 }())
@@ -229,8 +230,16 @@ func GetZone(args GetZoneArgs) error {
 
 		case "tsv":
 			for _, rec := range recs {
-				fmt.Fprintf(w, "%s\t%s\t%d\tIN\t%s\t%s\n",
-					rec.NameFQDN, rec.Name, rec.TTL, rec.Type, rec.GetTargetCombined())
+
+				cfproxy := ""
+				if cp, ok := rec.Metadata["cloudflare_proxy"]; ok {
+					if cp == "true" {
+						cfproxy = "\tCF_PROXY_ON=true"
+					}
+				}
+
+				fmt.Fprintf(w, "%s\t%s\t%d\tIN\t%s\t%s%s\n",
+					rec.NameFQDN, rec.Name, rec.TTL, rec.Type, rec.GetTargetCombined(), cfproxy)
 			}
 
 		default:
@@ -249,6 +258,13 @@ func formatDsl(zonename string, rec *models.RecordConfig, defaultTTL uint32) str
 	if rec.TTL != defaultTTL && rec.TTL != 0 {
 		ttl = rec.TTL
 		ttlop = fmt.Sprintf(", TTL(%d)", ttl)
+	}
+
+	cfproxy := ""
+	if cp, ok := rec.Metadata["cloudflare_proxy"]; ok {
+		if cp == "true" {
+			cfproxy = ", CF_PROXY_ON"
+		}
 	}
 
 	switch rec.Type { // #rtype_variations
@@ -286,7 +302,7 @@ func formatDsl(zonename string, rec *models.RecordConfig, defaultTTL uint32) str
 		target = "'" + target + "'"
 	}
 
-	return fmt.Sprintf("%s('%s', %s%s)", rec.Type, rec.Name, target, ttlop)
+	return fmt.Sprintf("%s('%s', %s%s%s)", rec.Type, rec.Name, target, cfproxy, ttlop)
 }
 
 func makeCaa(rec *models.RecordConfig, ttlop string) string {

--- a/docs/get-zones.md
+++ b/docs/get-zones.md
@@ -82,7 +82,7 @@ The columns in `--format=tsv` are:
     TTL
     Record Type (A, AAAA, CNAME, etc.)
     Target and arguments (quoted like in a zonefile)
-    Either empty or a comma-separated list of properties like "CF_PROXY_ON=true"
+    Either empty or a comma-separated list of properties like "cloudflare_proxy=true"
 
 The `--ttl` flag only applies to zone/js/djs formats.
 

--- a/docs/get-zones.md
+++ b/docs/get-zones.md
@@ -82,6 +82,7 @@ The columns in `--format=tsv` are:
     TTL
     Record Type (A, AAAA, CNAME, etc.)
     Target and arguments (quoted like in a zonefile)
+    Either empty or a comma-separated list of properties like "CF_PROXY_ON=true"
 
 The `--ttl` flag only applies to zone/js/djs formats.
 

--- a/pkg/prettyzone/prettyzone.go
+++ b/pkg/prettyzone/prettyzone.go
@@ -134,8 +134,16 @@ func (z *ZoneGenData) generateZoneFileHelper(w io.Writer) error {
 		// the remaining line
 		target := rr.GetTargetCombined()
 
-		fmt.Fprintf(w, "%s%s\n",
-			prefix, formatLine([]int{10, 5, 2, 5, 0}, []string{name, ttl, "IN", typeStr, target}))
+		// comment
+		comment := ""
+		if cp, ok := rr.Metadata["cloudflare_proxy"]; ok {
+			if cp == "true" {
+				comment = " ; CF_PROXY_ON"
+			}
+		}
+
+		fmt.Fprintf(w, "%s%s%s\n",
+			prefix, formatLine([]int{10, 5, 2, 5, 0}, []string{name, ttl, "IN", typeStr, target}), comment)
 	}
 	return nil
 }

--- a/providers/cloudflare/cloudflareProvider.go
+++ b/providers/cloudflare/cloudflareProvider.go
@@ -121,6 +121,14 @@ func (c *cloudflareProvider) GetZoneRecords(domain string) (models.Records, erro
 		if rec.TTL == 1 {
 			rec.TTL = 0
 		}
+		// Store the proxy status ("orange cloud") for use by get-zones:
+		m := getProxyMetadata(rec)
+		if p, ok := m["proxy"]; ok {
+			if rec.Metadata == nil {
+				rec.Metadata = map[string]string{}
+			}
+			rec.Metadata["cloudflare_proxy"] = p
+		}
 	}
 	return records, nil
 }


### PR DESCRIPTION
Fixes https://github.com/StackExchange/dnscontrol/issues/629

NOTE: The branch name refers to the wrong bugid.