### PR TITLE
Test support for all characters < u00FF

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -58,6 +58,7 @@ require (
 	golang.org/x/oauth2 v0.0.0-20201109201403-9fd604954f58
 	golang.org/x/sync v0.0.0-20201008141435-b3e1573b7520 // indirect
 	golang.org/x/sys v0.0.0-20201018121011-98379d014ca7 // indirect
+	golang.org/x/text v0.3.3
 	golang.org/x/tools v0.0.0-20201017001424-6003fad69a88 // indirect
 	google.golang.org/api v0.33.0
 	google.golang.org/appengine v1.6.7 // indirect


### PR DESCRIPTION
TXT records should be able to support any character from \u0000 to \u00FF, but because of how runes past utf8.runeSelf are stored, this wasn't possible previously.  By interpreting all TXT records as Latin-1, we get conversion to proper byte sequences that can be stored in DNS records.