### PR TITLE
Support for all characters < u00FF

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -58,6 +58,7 @@ require (
 	golang.org/x/oauth2 v0.0.0-20201109201403-9fd604954f58
 	golang.org/x/sync v0.0.0-20201008141435-b3e1573b7520 // indirect
 	golang.org/x/sys v0.0.0-20201018121011-98379d014ca7 // indirect
+	golang.org/x/text v0.3.3
 	golang.org/x/tools v0.0.0-20201017001424-6003fad69a88 // indirect
 	google.golang.org/api v0.33.0
 	google.golang.org/appengine v1.6.7 // indirect

--- a/integrationTest/integration_test.go
+++ b/integrationTest/integration_test.go
@@ -551,6 +551,19 @@ func only(n ...string) onlyFilter {
 	return onlyFilter{names: n}
 }
 
+// makeRange returns a string made up of chars from ascii code a to b.
+func makeRange(a, b uint8) string {
+	buf := make([]byte, b-a+1)
+	n := 0
+	amt := int(b) - int(a) + 1
+	for ; amt > 0; amt-- {
+		buf[n] = byte(a)
+		n++
+		a++
+	}
+	return string(buf)
+}
+
 //
 
 func makeTests(t *testing.T) []*TestGroup {
@@ -692,6 +705,22 @@ func makeTests(t *testing.T) []*TestGroup {
 			// These providers strip whitespace at the end of TXT records.
 			// TODO(tal): Add a check for this in normalize/validate.go
 			tc("Change a TXT with ws at end", txt("foo", "with space at end  ")),
+		),
+
+		testgroup("full byte range TXT",
+			// The RFCs permit TXT strings with any value 1..255. While
+			// possibly not a good thing, let's track which providers
+			// support it.
+			only("GCLOUD"),
+			// These providers do not support this:
+			//not("BIND", "ROUTE53", "NAMEDOTCOM", "CLOUDFLAREAPI", "DIGITALOCEAN", "GANDI_V5"),
+			tc("txt with 1..255 values",
+				txt("long1", makeRange(1, 127)),
+				txt("long2", makeRange(128, 255)),
+			),
+			tc("txtmulti with 1..255 values",
+				txtmulti("long1", []string{makeRange(1, 127), makeRange(128, 255)}),
+			),
 		),
 
 		testgroup("empty TXT",


### PR DESCRIPTION
TXT records should be able to support any character from \u0000 to \u00FF, but because of how runes past utf8.runeSelf are stored, this wasn't possible previously.  By interpreting all TXT records as Latin-1, we get conversion to proper byte sequences that can be stored in DNS records.