### PR TITLE
Allow TXTMulti for provider Hetzner

### DIFF
--- a/providers/hetzner/hetznerProvider.go
+++ b/providers/hetzner/hetznerProvider.go
@@ -22,7 +22,7 @@ var features = providers.DocumentationNotes{
 	providers.CanUseSRV:              providers.Can(),
 	providers.CanUseSSHFP:            providers.Cannot(),
 	providers.CanUseTLSA:             providers.Cannot(),
-	providers.CanUseTXTMulti:         providers.Cannot(),
+	providers.CanUseTXTMulti:         providers.Can(),
 }
 
 func init() {


### PR DESCRIPTION
**Issue**
The Hetzner provider doesn't allow TXTMulti. Hence, creating DKIM TXT records with >255 bytes fails. 

**Solution**
In that PR I just enabled TXTMulti. For testing purposes I've successfully created, updated and verified a DKIM record against the Hetzner DNS API. Even the verification with a DKIM record checker succeeded. Therefore, I propose to enable TXTMulti for the provider. 