### PR TITLE
INWX: Guard against single-quote TXT targets and split the integration test

### DIFF
--- a/integrationTest/integration_test.go
+++ b/integrationTest/integration_test.go
@@ -683,7 +683,10 @@ func makeTests(t *testing.T) []*TestGroup {
 			tc("Create 1 TXT as array", txtmulti("foo", []string{"simple"})), // Same as non-TXTMulti
 			clear(),
 			tc("Create a 255-byte TXT", txt("foo", strings.Repeat("A", 255))),
-			clear(),
+		),
+
+		testgroup("single TXT with single-quote",
+			not("INWX"),
 			tc("Create TXT with single-quote", txt("foo", "blah`blah")),
 		),
 


### PR DESCRIPTION
Fixes #954 by splitting out the single-quote TXT integration test and by adding an additional check to the INWX provider to fail if there are TXT records with single-quotes.