### PR TITLE
ATTEMPT 1: Gracefully skip tests if the secrets are not available

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,7 @@ jobs:
         go-version: ^1.15
     - name: Run integration tests for ${{ matrix.provider }} provider
       working-directory: integrationTest
-      run: if [ x"${{ matrix.provider }}__CAN_SECRET" == x"true" ] ; then  go test -v -verbose -provider ${{ matrix.provider }} ; else echo 'SKIPPING: ${{ matrix.provider }} (Secrets not available to Actions)' ; fi
+      run: if [ "x$${{ matrix.provider }}__CAN_SECRET" = "xtrue" ] ; then  go test -v -verbose -provider ${{ matrix.provider }} ; else echo SKIPPING ; fi
       env:
 # Keep these sorted lexically: (i.e. ascii sorted)
         AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,6 +55,7 @@ jobs:
     - name: Run integration tests for ${{ matrix.provider }} provider
       working-directory: integrationTest
       run: go test -v -verbose -provider ${{ matrix.provider }}
+      if: ${{ secrets.I_CAN_SEE_SECRETS == 'true' }}
       env:
 # Keep these sorted lexically: (i.e. ascii sorted)
         AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,9 +54,18 @@ jobs:
         go-version: ^1.15
     - name: Run integration tests for ${{ matrix.provider }} provider
       working-directory: integrationTest
-      run: if [ "x$${{ matrix.provider }}__CAN_SECRET" = "xtrue" ] ; then  go test -v -verbose -provider ${{ matrix.provider }} ; else echo SKIPPING ; fi
+      run: if [ -n "$${{ matrix.provider }}__CAN_SECRET" ] ; then  go test -v -verbose -provider ${{ matrix.provider }} ; else echo SKIPPING ; fi
       env:
 # Keep these sorted lexically: (i.e. ascii sorted)
+        BIND__CAN_SECRET: ${{ secrets.BIND__CAN_SECRET }}
+        HEXONET__CAN_SECRET: "true"
+        AZURE_DNS__CAN_SECRET: "false"
+        CLOUDFLAREAPI__CAN_SECRET: ${{ secrets.CLOUDFLAREAPI__CAN_SECRET }}
+        GCLOUD__CAN_SECRET: ${{ secrets.GCLOUD__CAN_SECRET }}
+        NAMEDOTCOM__CAN_SECRET: ${{ secrets.NAMEDOTCOM__CAN_SECRET }}
+        ROUTE53__CAN_SECRET: ${{ secrets.ROUTE53__CAN_SECRET }}
+        DIGITALOCEAN__CAN_SECRET: ${{ secrets.DIGITALOCEAN__CAN_SECRET }}
+        GANDI_V5__CAN_SECRET: ${{ secrets.GANDI_V5__CAN_SECRET }}
         AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
         AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
         AZURE_DOMAIN: dnscontrol-azure.com

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,8 +55,9 @@ jobs:
     - name: Run integration tests for ${{ matrix.provider }} provider
       working-directory: integrationTest
       run: go test -v -verbose -provider ${{ matrix.provider }}
-      if: ${{ secrets.I_CAN_SEE_SECRETS == 'true' }}
+      if: ${{ env.I_CAN_SEE_SECRETS == 'true' }}
       env:
+        I_CAN_SEE_SECRETS: ${{ secrets.I_CAN_SEE_SECRETS }}
 # Keep these sorted lexically: (i.e. ascii sorted)
         AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
         AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,10 +54,8 @@ jobs:
         go-version: ^1.15
     - name: Run integration tests for ${{ matrix.provider }} provider
       working-directory: integrationTest
-      run: go test -v -verbose -provider ${{ matrix.provider }}
-      if: ${{ env.I_CAN_SEE_SECRETS == 'true' }}
+      run: if [ x"${{ matrix.provider }}__CAN_SECRET" == x"true" ] ; then  go test -v -verbose -provider ${{ matrix.provider }} ; else echo 'SKIPPING: ${{ matrix.provider }} (Secrets not available to Actions)' ; fi
       env:
-        I_CAN_SEE_SECRETS: ${{ secrets.I_CAN_SEE_SECRETS }}
 # Keep these sorted lexically: (i.e. ascii sorted)
         AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
         AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,16 +31,16 @@ jobs:
       fail-fast: false
       matrix:
         provider:
-# Providers that don't require secrets:
+# Providers that don't require secrets: (alphabetical)
         - BIND
         - HEXONET
-# Providers designated "officially supported":
+# Providers designated "officially supported": (alphabetical)
         - AZURE_DNS
         - CLOUDFLAREAPI
         - GCLOUD
         - NAMEDOTCOM
         - ROUTE53
-# All others:
+# All others: (alphabetical)
         - DIGITALOCEAN
         - GANDI_V5
     steps:
@@ -56,7 +56,7 @@ jobs:
       working-directory: integrationTest
       run: go test -v -verbose -provider ${{ matrix.provider }}
       env:
-# Keep these sorted lexically: (unix "sort" command order")
+# Keep these sorted lexically: (i.e. ascii sorted)
         AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
         AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
         AZURE_DOMAIN: dnscontrol-azure.com

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        provider: [AZURE_DNS, BIND, CLOUDFLAREAPI, DIGITALOCEAN, GANDI_V5, GCLOUD, HEXONET, NAMEDOTCOM, ROUTE53]
+        provider:
+# Providers that don't require secrets:
+        - BIND
+        - HEXONET
+# Providers designated "officially supported":
+        - AZURE_DNS
+        - CLOUDFLAREAPI
+        - GCLOUD
+        - NAMEDOTCOM
+        - ROUTE53
+# All others:
+        - DIGITALOCEAN
+        - GANDI_V5
     steps:
     - name: Checkout repo
       uses: actions/checkout@v2
@@ -44,31 +56,32 @@ jobs:
       working-directory: integrationTest
       run: go test -v -verbose -provider ${{ matrix.provider }}
       env:
-        AZURE_RESOURCE_GROUP: DNSControl
-        AZURE_DOMAIN: dnscontrol-azure.com
-        AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-        AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+# Keep these sorted lexically: (unix "sort" command order")
         AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
         AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
+        AZURE_DOMAIN: dnscontrol-azure.com
+        AZURE_RESOURCE_GROUP: DNSControl
+        AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+        AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
         CF_DOMAIN: dnscontroltest-cf.com
         CF_TOKEN: ${{ secrets.CF_TOKEN }}
         DO_DOMAIN : dnscontrol-do.com
         DO_TOKEN : ${{ secrets.DO_TOKEN }}
-        GANDI_V5_DOMAIN : dnscontroltest-gandilivedns.com
         GANDI_V5_APIKEY : ${{ secrets.GANDI_V5_APIKEY }}
+        GANDI_V5_DOMAIN : dnscontroltest-gandilivedns.com
         GCLOUD_DOMAIN: dnscontroltest-gcloud.com
-        GCLOUD_TYPE: service_account
         GCLOUD_EMAIL: dnscontrol@dnscontrol-dev.iam.gserviceaccount.com
-        GCLOUD_PROJECT: dnscontrol-dev
         GCLOUD_PRIVATEKEY: ${{ secrets.GCLOUD_PRIVATEKEY }}
+        GCLOUD_PROJECT: dnscontrol-dev
+        GCLOUD_TYPE: service_account
         HEXONET_DOMAIN : a-b-c-movies.com
         HEXONET_ENTITY : OTE
         HEXONET_PW : test.passw0rd
         HEXONET_UID : test.user
         NAMEDOTCOM_DOMAIN: dnscontrol-ndc.com
+        NAMEDOTCOM_KEY: ${{ secrets.NAMEDOTCOM_KEY }}
         NAMEDOTCOM_URL: api.name.com
         NAMEDOTCOM_USER: dnscontroltest
-        NAMEDOTCOM_KEY: ${{ secrets.NAMEDOTCOM_KEY }}
         R53_DOMAIN: dnscontroltest-r53.com
-        R53_KEY_ID: ${{ secrets.R53_KEY_ID }}
         R53_KEY: ${{ secrets.R53_KEY }}
+        R53_KEY_ID: ${{ secrets.R53_KEY_ID }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,41 +56,43 @@ jobs:
       working-directory: integrationTest
       run: if [ "$${{ matrix.provider }}__CAN_SECRET" = "true" ] ; then  go test -v -verbose -provider ${{ matrix.provider }} ; else echo SKIPPING ; fi
       env:
-# Keep these sorted lexically: (i.e. ascii sorted)
-        BIND__CAN_SECRET: ${{ secrets.BIND__CAN_SECRET }}
-        HEXONET__CAN_SECRET: "true"
-        AZURE_DNS__CAN_SECRET: "false"
+# These are used to determine if secrets are available to the runner.
+# "true" means no secrets are required for these tests.
+        AZURE_DNS__CAN_SECRET: ${{ secrets.AZURE_DNS__CAN_SECRET }}
+        BIND__CAN_SECRET: true
         CLOUDFLAREAPI__CAN_SECRET: ${{ secrets.CLOUDFLAREAPI__CAN_SECRET }}
-        GCLOUD__CAN_SECRET: ${{ secrets.GCLOUD__CAN_SECRET }}
-        NAMEDOTCOM__CAN_SECRET: ${{ secrets.NAMEDOTCOM__CAN_SECRET }}
-        ROUTE53__CAN_SECRET: ${{ secrets.ROUTE53__CAN_SECRET }}
         DIGITALOCEAN__CAN_SECRET: ${{ secrets.DIGITALOCEAN__CAN_SECRET }}
         GANDI_V5__CAN_SECRET: ${{ secrets.GANDI_V5__CAN_SECRET }}
-        AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
-        AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
-        AZURE_DOMAIN: dnscontrol-azure.com
+        GCLOUD__CAN_SECRET: ${{ secrets.GCLOUD__CAN_SECRET }}
+        HEXONET__CAN_SECRET: true
+        NAMEDOTCOM__CAN_SECRET: ${{ secrets.NAMEDOTCOM__CAN_SECRET }}
+        ROUTE53__CAN_SECRET: ${{ secrets.ROUTE53__CAN_SECRET }}
+# These extract the secrets that are used by the tests. (alphabetical)
         AZURE_RESOURCE_GROUP: DNSControl
+        AZURE_DOMAIN: dnscontrol-azure.com
         AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
         AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+        AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+        AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
         CF_DOMAIN: dnscontroltest-cf.com
         CF_TOKEN: ${{ secrets.CF_TOKEN }}
         DO_DOMAIN : dnscontrol-do.com
         DO_TOKEN : ${{ secrets.DO_TOKEN }}
-        GANDI_V5_APIKEY : ${{ secrets.GANDI_V5_APIKEY }}
         GANDI_V5_DOMAIN : dnscontroltest-gandilivedns.com
+        GANDI_V5_APIKEY : ${{ secrets.GANDI_V5_APIKEY }}
         GCLOUD_DOMAIN: dnscontroltest-gcloud.com
-        GCLOUD_EMAIL: dnscontrol@dnscontrol-dev.iam.gserviceaccount.com
-        GCLOUD_PRIVATEKEY: ${{ secrets.GCLOUD_PRIVATEKEY }}
-        GCLOUD_PROJECT: dnscontrol-dev
         GCLOUD_TYPE: service_account
+        GCLOUD_EMAIL: dnscontrol@dnscontrol-dev.iam.gserviceaccount.com
+        GCLOUD_PROJECT: dnscontrol-dev
+        GCLOUD_PRIVATEKEY: ${{ secrets.GCLOUD_PRIVATEKEY }}
         HEXONET_DOMAIN : a-b-c-movies.com
         HEXONET_ENTITY : OTE
         HEXONET_PW : test.passw0rd
         HEXONET_UID : test.user
         NAMEDOTCOM_DOMAIN: dnscontrol-ndc.com
-        NAMEDOTCOM_KEY: ${{ secrets.NAMEDOTCOM_KEY }}
         NAMEDOTCOM_URL: api.name.com
         NAMEDOTCOM_USER: dnscontroltest
+        NAMEDOTCOM_KEY: ${{ secrets.NAMEDOTCOM_KEY }}
         R53_DOMAIN: dnscontroltest-r53.com
-        R53_KEY: ${{ secrets.R53_KEY }}
         R53_KEY_ID: ${{ secrets.R53_KEY_ID }}
+        R53_KEY: ${{ secrets.R53_KEY }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,7 @@ jobs:
         go-version: ^1.15
     - name: Run integration tests for ${{ matrix.provider }} provider
       working-directory: integrationTest
-      run: if [ -n "$${{ matrix.provider }}__CAN_SECRET" ] ; then  go test -v -verbose -provider ${{ matrix.provider }} ; else echo SKIPPING ; fi
+      run: if [ "$${{ matrix.provider }}__CAN_SECRET" = "true" ] ; then  go test -v -verbose -provider ${{ matrix.provider }} ; else echo SKIPPING ; fi
       env:
 # Keep these sorted lexically: (i.e. ascii sorted)
         BIND__CAN_SECRET: ${{ secrets.BIND__CAN_SECRET }}


### PR DESCRIPTION
Secrets are not propagated to an Action if the PR is from a forked repo.  The good news is that this prevents an outside from logging secrets.  The bad news it that outsiders always see their tests as failing.

With this change, every provider is tested but the tests abort early if the action doesn't have access to the secrets.  More specifically, the value "true" must be found in an env named `${PROVIDER}__CAN_SECRET` (for example `BIND__CAN_SECRET` or `HEXONET__CAN_SECRET`)

Sadly the `if` clause can not access secrets, so we must run every test just to see it fail.

In this PR we:

* List the matrix of providers one-per-line to make it easier to add/remove provider names; as well as add comments.
* For each provider in the matrix, set an env named `${PROVIDER}__CAN_SECRET` to true if tests are to run.

You can see that TomOnTime/dnscontrol (a fork) was able to "bring my own secrets" here: https://github.com/TomOnTime/dnscontrol/pull/1/checks?check_run_id=1468101735