### PR TITLE
Gracefully skip tests if the secrets are not available

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,13 +52,13 @@ jobs:
       uses: actions/setup-go@v2
       with:
         go-version: ^1.15
-    - name: Run integration tests for ${{ matrix.provider }} provider
-      working-directory: integrationTest
-      run: if [ "$${{ matrix.provider }}__CAN_SECRET" = "true" ] ; then  go test -v -verbose -provider ${{ matrix.provider }} ; else echo SKIPPING ; fi
+    - name: Examining creds for ${{ matrix.provider }} provider
+      run: if [ "$${{ matrix.provider }}__CAN_SECRET" = "true" ] ; then echo "CAN_CONTINUE=true" >> $GITHUB_ENV ; fi
       env:
 # These are used to determine if secrets are available to the runner.
 # "true" means no secrets are required for these tests.
-        AZURE_DNS__CAN_SECRET: ${{ secrets.AZURE_DNS__CAN_SECRET }}
+#        AZURE_DNS__CAN_SECRET: ${{ secrets.AZURE_DNS__CAN_SECRET }}
+        AZURE_DNS__CAN_SECRET: false
         BIND__CAN_SECRET: true
         CLOUDFLAREAPI__CAN_SECRET: ${{ secrets.CLOUDFLAREAPI__CAN_SECRET }}
         DIGITALOCEAN__CAN_SECRET: ${{ secrets.DIGITALOCEAN__CAN_SECRET }}
@@ -67,6 +67,11 @@ jobs:
         HEXONET__CAN_SECRET: true
         NAMEDOTCOM__CAN_SECRET: ${{ secrets.NAMEDOTCOM__CAN_SECRET }}
         ROUTE53__CAN_SECRET: ${{ secrets.ROUTE53__CAN_SECRET }}
+    - name: Run integration tests for ${{ matrix.provider }} provider
+      working-directory: integrationTest
+      run: go test -v -verbose -provider ${{ matrix.provider }}
+      if: ${{ env.CAN_CONTINUE == 'true' }}
+      env:
 # These extract the secrets that are used by the tests. (alphabetical)
         AZURE_RESOURCE_GROUP: DNSControl
         AZURE_DOMAIN: dnscontrol-azure.com

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,7 +69,7 @@ jobs:
         GANDI_V5__CAN_SECRET: ${{ secrets.GANDI_V5__CAN_SECRET }}
         GCLOUD__CAN_SECRET: ${{ secrets.GCLOUD__CAN_SECRET }}
         HEXONET__CAN_SECRET: true
-        INWX__CAN_SECRET: ${{ secrets.ROUTE53__CAN_SECRET }}
+        INWX__CAN_SECRET: ${{ secrets.INWX__CAN_SECRET }}
         NAMEDOTCOM__CAN_SECRET: ${{ secrets.NAMEDOTCOM__CAN_SECRET }}
         ROUTE53__CAN_SECRET: ${{ secrets.ROUTE53__CAN_SECRET }}
     - name: Run integration tests for ${{ matrix.provider }} provider

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,6 +43,7 @@ jobs:
 # All others: (alphabetical)
         - DIGITALOCEAN
         - GANDI_V5
+        - INWX
     steps:
     - name: Checkout repo
       uses: actions/checkout@v2
@@ -68,6 +69,7 @@ jobs:
         GANDI_V5__CAN_SECRET: ${{ secrets.GANDI_V5__CAN_SECRET }}
         GCLOUD__CAN_SECRET: ${{ secrets.GCLOUD__CAN_SECRET }}
         HEXONET__CAN_SECRET: true
+        INWX__CAN_SECRET: ${{ secrets.ROUTE53__CAN_SECRET }}
         NAMEDOTCOM__CAN_SECRET: ${{ secrets.NAMEDOTCOM__CAN_SECRET }}
         ROUTE53__CAN_SECRET: ${{ secrets.ROUTE53__CAN_SECRET }}
     - name: Run integration tests for ${{ matrix.provider }} provider
@@ -76,33 +78,36 @@ jobs:
       if: ${{ env.CAN_CONTINUE == 'yes' }}
 # Extract the secrets that are used by the tests. (Please keep this list sorted)
       env:
-        AZURE_RESOURCE_GROUP: DNSControl
-        AZURE_DOMAIN: dnscontrol-azure.com
-        AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-        AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
         AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
         AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
+        AZURE_DOMAIN: dnscontrol-azure.com
+        AZURE_RESOURCE_GROUP: DNSControl
+        AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+        AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
         CF_DOMAIN: ${{ secrets.CF_DOMAIN }}
+        CF_KEY: ${{ secrets.CF_KEY }}
         CF_TOKEN: ${{ secrets.CF_TOKEN }}
         CF_USER: ${{ secrets.CF_USER }}
-        CF_KEY: ${{ secrets.CF_KEY }}
-        DO_DOMAIN : dnscontrol-do.com
-        DO_TOKEN : ${{ secrets.DO_TOKEN }}
-        GANDI_V5_DOMAIN : dnscontroltest-gandilivedns.com
-        GANDI_V5_APIKEY : ${{ secrets.GANDI_V5_APIKEY }}
+        DO_DOMAIN: dnscontrol-do.com
+        DO_TOKEN: ${{ secrets.DO_TOKEN }}
+        GANDI_V5_APIKEY: ${{ secrets.GANDI_V5_APIKEY }}
+        GANDI_V5_DOMAIN: dnscontroltest-gandilivedns.com
         GCLOUD_DOMAIN: dnscontroltest-gcloud.com
-        GCLOUD_TYPE: service_account
         GCLOUD_EMAIL: dnscontrol@dnscontrol-dev.iam.gserviceaccount.com
-        GCLOUD_PROJECT: dnscontrol-dev
         GCLOUD_PRIVATEKEY: ${{ secrets.GCLOUD_PRIVATEKEY }}
-        HEXONET_DOMAIN : a-b-c-movies.com
-        HEXONET_ENTITY : OTE
-        HEXONET_PW : test.passw0rd
-        HEXONET_UID : test.user
+        GCLOUD_PROJECT: dnscontrol-dev
+        GCLOUD_TYPE: service_account
+        HEXONET_DOMAIN: a-b-c-movies.com
+        HEXONET_ENTITY: OTE
+        HEXONET_PW: test.passw0rd
+        HEXONET_UID: test.user
+        INWX_DOMAIN: ${{ secrets.INWX_DOMAIN }}
+        INWX_PASSWORD: ${{ secrets.INWX_PASSWORD }}
+        INWX_USER: ${{ secrets.INWX_USER }}
         NAMEDOTCOM_DOMAIN: dnscontrol-ndc.com
+        NAMEDOTCOM_KEY: ${{ secrets.NAMEDOTCOM_KEY }}
         NAMEDOTCOM_URL: api.name.com
         NAMEDOTCOM_USER: dnscontroltest
-        NAMEDOTCOM_KEY: ${{ secrets.NAMEDOTCOM_KEY }}
         R53_DOMAIN: dnscontroltest-r53.com
-        R53_KEY_ID: ${{ secrets.R53_KEY_ID }}
         R53_KEY: ${{ secrets.R53_KEY }}
+        R53_KEY_ID: ${{ secrets.R53_KEY_ID }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,7 @@ jobs:
         go-version: ^1.15
     - name: Run integration tests for ${{ matrix.provider }} provider
       working-directory: integrationTest
-      run: if [ x"${{ matrix.provider }}__CAN_SECRET" == x"true" ] ; then  go test -v -verbose -provider ${{ matrix.provider }} ; else echo 'SKIPPING: ${{ matrix.provider }} (Secrets not available to Actions)' ; fi
+      run: if [ "x$${{ matrix.provider }}__CAN_SECRET" = "xtrue" ] ; then  go test -v -verbose -provider ${{ matrix.provider }} ; else echo SKIPPING ; fi
       env:
 # Keep these sorted lexically: (i.e. ascii sorted)
         AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,6 +55,7 @@ jobs:
     - name: Run integration tests for ${{ matrix.provider }} provider
       working-directory: integrationTest
       run: go test -v -verbose -provider ${{ matrix.provider }}
+      if: ${{ secrets.I_CAN_SEE_SECRETS == 'true' }}
       env:
 # Keep these sorted lexically: (i.e. ascii sorted)
         AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,8 +53,8 @@ jobs:
       uses: actions/setup-go@v2
       with:
         go-version: ^1.15
-    - name: Examining creds for ${{ matrix.provider }} provider
-      run: echo "${{ matrix.provider }}__CAN_SECRET" ; echo "$${{ matrix.provider }}__CAN_SECRET" | wc -c ; if [ "$${{ matrix.provider }}__CAN_SECRET" = "true" ] ; then echo "CAN_CONTINUE=yes" >> $GITHUB_ENV ; echo "CAN_CONTINUE=yes" ; else echo '***SKIPPING***' ; fi
+    - name: Determining test viability for ${{ matrix.provider }} provider
+      run: if [ "$${{ matrix.provider }}__CAN_SECRET" = "true" ] ; then echo "CAN_CONTINUE=yes" >> $GITHUB_ENV ; echo "Decision: CONTINUE" ; else echo 'Decision: SKIP' ; fi
 # Does the provider's tests require secrets?
 # Yes?  Set a secret called ${PROVIDER}__CAN_SECRET with value "true" (no quotes).
 # No?   Set it to "true" like you see for BIND__CAN_SECRET.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,9 +54,18 @@ jobs:
         go-version: ^1.15
     - name: Run integration tests for ${{ matrix.provider }} provider
       working-directory: integrationTest
-      run: if [ "x$${{ matrix.provider }}__CAN_SECRET" = "xtrue" ] ; then  go test -v -verbose -provider ${{ matrix.provider }} ; else echo SKIPPING ; fi
+      run: if [ -n "$${{ matrix.provider }}__CAN_SECRET" ] ; then  go test -v -verbose -provider ${{ matrix.provider }} ; else echo SKIPPING ; fi
       env:
 # Keep these sorted lexically: (i.e. ascii sorted)
+        BIND__CAN_SECRET: ${{ secrets.BIND__CAN_SECRET }}
+        HEXONET__CAN_SECRET: "true"
+        AZURE_DNS__CAN_SECRET: "false"
+        CLOUDFLAREAPI__CAN_SECRET: ${{ secrets.CLOUDFLAREAPI__CAN_SECRET }}
+        GCLOUD__CAN_SECRET: ${{ secrets.GCLOUD__CAN_SECRET }}
+        NAMEDOTCOM__CAN_SECRET: ${{ secrets.NAMEDOTCOM__CAN_SECRET }}
+        ROUTE53__CAN_SECRET: ${{ secrets.ROUTE53__CAN_SECRET }}
+        DIGITALOCEAN__CAN_SECRET: ${{ secrets.DIGITALOCEAN__CAN_SECRET }}
+        GANDI_V5__CAN_SECRET: ${{ secrets.GANDI_V5__CAN_SECRET }}
         AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
         AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
         AZURE_DOMAIN: dnscontrol-azure.com

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,8 +55,9 @@ jobs:
     - name: Run integration tests for ${{ matrix.provider }} provider
       working-directory: integrationTest
       run: go test -v -verbose -provider ${{ matrix.provider }}
-      if: ${{ secrets.I_CAN_SEE_SECRETS == 'true' }}
+      if: ${{ env.I_CAN_SEE_SECRETS == 'true' }}
       env:
+        I_CAN_SEE_SECRETS: ${{ secrets.I_CAN_SEE_SECRETS }}
 # Keep these sorted lexically: (i.e. ascii sorted)
         AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
         AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,10 +54,8 @@ jobs:
         go-version: ^1.15
     - name: Run integration tests for ${{ matrix.provider }} provider
       working-directory: integrationTest
-      run: go test -v -verbose -provider ${{ matrix.provider }}
-      if: ${{ env.I_CAN_SEE_SECRETS == 'true' }}
+      run: if [ x"${{ matrix.provider }}__CAN_SECRET" == x"true" ] ; then  go test -v -verbose -provider ${{ matrix.provider }} ; else echo 'SKIPPING: ${{ matrix.provider }} (Secrets not available to Actions)' ; fi
       env:
-        I_CAN_SEE_SECRETS: ${{ secrets.I_CAN_SEE_SECRETS }}
 # Keep these sorted lexically: (i.e. ascii sorted)
         AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
         AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,16 +31,16 @@ jobs:
       fail-fast: false
       matrix:
         provider:
-# Providers that don't require secrets:
+# Providers that don't require secrets: (alphabetical)
         - BIND
         - HEXONET
-# Providers designated "officially supported":
+# Providers designated "officially supported": (alphabetical)
         - AZURE_DNS
         - CLOUDFLAREAPI
         - GCLOUD
         - NAMEDOTCOM
         - ROUTE53
-# All others:
+# All others: (alphabetical)
         - DIGITALOCEAN
         - GANDI_V5
     steps:
@@ -56,7 +56,7 @@ jobs:
       working-directory: integrationTest
       run: go test -v -verbose -provider ${{ matrix.provider }}
       env:
-# Keep these sorted lexically: (unix "sort" command order")
+# Keep these sorted lexically: (i.e. ascii sorted)
         AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
         AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
         AZURE_DOMAIN: dnscontrol-azure.com

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,12 +53,15 @@ jobs:
       with:
         go-version: ^1.15
     - name: Examining creds for ${{ matrix.provider }} provider
-      run: if [ "$${{ matrix.provider }}__CAN_SECRET" = "true" ] ; then echo "CAN_CONTINUE=true" >> $GITHUB_ENV ; fi
+      run: if [ "$${{ matrix.provider }}__CAN_SECRET" = "true" ] ; then echo "CAN_CONTINUE=yes" >> $GITHUB_ENV ; fi
+# Does the provider's tests require secrets?
+# Yes?  Set a secret called ${PROVIDER}__CAN_SECRET with value # "true" (no quotes).
+# No?   Set it to "true" like you see for BIND__CAN_SECRET.
+# This way tests only run if the secrets are available to the runner.
+# A fork can "bring your own secrets" for locally-defined tests.
+# Please keep the list sorted.
       env:
-# These are used to determine if secrets are available to the runner.
-# "true" means no secrets are required for these tests.
-#        AZURE_DNS__CAN_SECRET: ${{ secrets.AZURE_DNS__CAN_SECRET }}
-        AZURE_DNS__CAN_SECRET: false
+        AZURE_DNS__CAN_SECRET: ${{ secrets.AZURE_DNS__CAN_SECRET }}
         BIND__CAN_SECRET: true
         CLOUDFLAREAPI__CAN_SECRET: ${{ secrets.CLOUDFLAREAPI__CAN_SECRET }}
         DIGITALOCEAN__CAN_SECRET: ${{ secrets.DIGITALOCEAN__CAN_SECRET }}
@@ -70,17 +73,19 @@ jobs:
     - name: Run integration tests for ${{ matrix.provider }} provider
       working-directory: integrationTest
       run: go test -v -verbose -provider ${{ matrix.provider }}
-      if: ${{ env.CAN_CONTINUE == 'true' }}
+      if: ${{ env.CAN_CONTINUE == 'yes' }}
+# Extract the secrets that are used by the tests. (Please keep this list sorted)
       env:
-# These extract the secrets that are used by the tests. (alphabetical)
         AZURE_RESOURCE_GROUP: DNSControl
         AZURE_DOMAIN: dnscontrol-azure.com
         AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
         AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
         AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
         AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
-        CF_DOMAIN: dnscontroltest-cf.com
+        CF_DOMAIN: ${{ secrets.CF_DOMAIN }}
         CF_TOKEN: ${{ secrets.CF_TOKEN }}
+        CF_USER: ${{ secrets.CF_USER }}
+        CF_KEY: ${{ secrets.CF_KEY }}
         DO_DOMAIN : dnscontrol-do.com
         DO_TOKEN : ${{ secrets.DO_TOKEN }}
         GANDI_V5_DOMAIN : dnscontroltest-gandilivedns.com

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        provider: [AZURE_DNS, BIND, CLOUDFLAREAPI, DIGITALOCEAN, GANDI_V5, GCLOUD, HEXONET, NAMEDOTCOM, ROUTE53]
+        provider:
+# Providers that don't require secrets:
+        - BIND
+        - HEXONET
+# Providers designated "officially supported":
+        - AZURE_DNS
+        - CLOUDFLAREAPI
+        - GCLOUD
+        - NAMEDOTCOM
+        - ROUTE53
+# All others:
+        - DIGITALOCEAN
+        - GANDI_V5
     steps:
     - name: Checkout repo
       uses: actions/checkout@v2
@@ -44,31 +56,32 @@ jobs:
       working-directory: integrationTest
       run: go test -v -verbose -provider ${{ matrix.provider }}
       env:
-        AZURE_RESOURCE_GROUP: DNSControl
-        AZURE_DOMAIN: dnscontrol-azure.com
-        AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-        AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+# Keep these sorted lexically: (unix "sort" command order")
         AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
         AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
+        AZURE_DOMAIN: dnscontrol-azure.com
+        AZURE_RESOURCE_GROUP: DNSControl
+        AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+        AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
         CF_DOMAIN: dnscontroltest-cf.com
         CF_TOKEN: ${{ secrets.CF_TOKEN }}
         DO_DOMAIN : dnscontrol-do.com
         DO_TOKEN : ${{ secrets.DO_TOKEN }}
-        GANDI_V5_DOMAIN : dnscontroltest-gandilivedns.com
         GANDI_V5_APIKEY : ${{ secrets.GANDI_V5_APIKEY }}
+        GANDI_V5_DOMAIN : dnscontroltest-gandilivedns.com
         GCLOUD_DOMAIN: dnscontroltest-gcloud.com
-        GCLOUD_TYPE: service_account
         GCLOUD_EMAIL: dnscontrol@dnscontrol-dev.iam.gserviceaccount.com
-        GCLOUD_PROJECT: dnscontrol-dev
         GCLOUD_PRIVATEKEY: ${{ secrets.GCLOUD_PRIVATEKEY }}
+        GCLOUD_PROJECT: dnscontrol-dev
+        GCLOUD_TYPE: service_account
         HEXONET_DOMAIN : a-b-c-movies.com
         HEXONET_ENTITY : OTE
         HEXONET_PW : test.passw0rd
         HEXONET_UID : test.user
         NAMEDOTCOM_DOMAIN: dnscontrol-ndc.com
+        NAMEDOTCOM_KEY: ${{ secrets.NAMEDOTCOM_KEY }}
         NAMEDOTCOM_URL: api.name.com
         NAMEDOTCOM_USER: dnscontroltest
-        NAMEDOTCOM_KEY: ${{ secrets.NAMEDOTCOM_KEY }}
         R53_DOMAIN: dnscontroltest-r53.com
-        R53_KEY_ID: ${{ secrets.R53_KEY_ID }}
         R53_KEY: ${{ secrets.R53_KEY }}
+        R53_KEY_ID: ${{ secrets.R53_KEY_ID }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,9 +54,9 @@ jobs:
       with:
         go-version: ^1.15
     - name: Examining creds for ${{ matrix.provider }} provider
-      run: if [ "$${{ matrix.provider }}__CAN_SECRET" = "true" ] ; then echo "CAN_CONTINUE=yes" >> $GITHUB_ENV ; echo "CAN_CONTINUE=yes" ; else echo '***SKIPPING***' ; fi
+      run: echo "${{ matrix.provider }}__CAN_SECRET" ; echo "$${{ matrix.provider }}__CAN_SECRET" | wc -c ; if [ "$${{ matrix.provider }}__CAN_SECRET" = "true" ] ; then echo "CAN_CONTINUE=yes" >> $GITHUB_ENV ; echo "CAN_CONTINUE=yes" ; else echo '***SKIPPING***' ; fi
 # Does the provider's tests require secrets?
-# Yes?  Set a secret called ${PROVIDER}__CAN_SECRET with value # "true" (no quotes).
+# Yes?  Set a secret called ${PROVIDER}__CAN_SECRET with value "true" (no quotes).
 # No?   Set it to "true" like you see for BIND__CAN_SECRET.
 # This way tests only run if the secrets are available to the runner.
 # A fork can "bring your own secrets" for locally-defined tests.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,41 +56,43 @@ jobs:
       working-directory: integrationTest
       run: if [ "$${{ matrix.provider }}__CAN_SECRET" = "true" ] ; then  go test -v -verbose -provider ${{ matrix.provider }} ; else echo SKIPPING ; fi
       env:
-# Keep these sorted lexically: (i.e. ascii sorted)
-        BIND__CAN_SECRET: ${{ secrets.BIND__CAN_SECRET }}
-        HEXONET__CAN_SECRET: "true"
-        AZURE_DNS__CAN_SECRET: "false"
+# These are used to determine if secrets are available to the runner.
+# "true" means no secrets are required for these tests.
+        AZURE_DNS__CAN_SECRET: ${{ secrets.AZURE_DNS__CAN_SECRET }}
+        BIND__CAN_SECRET: true
         CLOUDFLAREAPI__CAN_SECRET: ${{ secrets.CLOUDFLAREAPI__CAN_SECRET }}
-        GCLOUD__CAN_SECRET: ${{ secrets.GCLOUD__CAN_SECRET }}
-        NAMEDOTCOM__CAN_SECRET: ${{ secrets.NAMEDOTCOM__CAN_SECRET }}
-        ROUTE53__CAN_SECRET: ${{ secrets.ROUTE53__CAN_SECRET }}
         DIGITALOCEAN__CAN_SECRET: ${{ secrets.DIGITALOCEAN__CAN_SECRET }}
         GANDI_V5__CAN_SECRET: ${{ secrets.GANDI_V5__CAN_SECRET }}
-        AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
-        AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
-        AZURE_DOMAIN: dnscontrol-azure.com
+        GCLOUD__CAN_SECRET: ${{ secrets.GCLOUD__CAN_SECRET }}
+        HEXONET__CAN_SECRET: true
+        NAMEDOTCOM__CAN_SECRET: ${{ secrets.NAMEDOTCOM__CAN_SECRET }}
+        ROUTE53__CAN_SECRET: ${{ secrets.ROUTE53__CAN_SECRET }}
+# These extract the secrets that are used by the tests. (alphabetical)
         AZURE_RESOURCE_GROUP: DNSControl
+        AZURE_DOMAIN: dnscontrol-azure.com
         AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
         AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+        AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+        AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
         CF_DOMAIN: dnscontroltest-cf.com
         CF_TOKEN: ${{ secrets.CF_TOKEN }}
         DO_DOMAIN : dnscontrol-do.com
         DO_TOKEN : ${{ secrets.DO_TOKEN }}
-        GANDI_V5_APIKEY : ${{ secrets.GANDI_V5_APIKEY }}
         GANDI_V5_DOMAIN : dnscontroltest-gandilivedns.com
+        GANDI_V5_APIKEY : ${{ secrets.GANDI_V5_APIKEY }}
         GCLOUD_DOMAIN: dnscontroltest-gcloud.com
-        GCLOUD_EMAIL: dnscontrol@dnscontrol-dev.iam.gserviceaccount.com
-        GCLOUD_PRIVATEKEY: ${{ secrets.GCLOUD_PRIVATEKEY }}
-        GCLOUD_PROJECT: dnscontrol-dev
         GCLOUD_TYPE: service_account
+        GCLOUD_EMAIL: dnscontrol@dnscontrol-dev.iam.gserviceaccount.com
+        GCLOUD_PROJECT: dnscontrol-dev
+        GCLOUD_PRIVATEKEY: ${{ secrets.GCLOUD_PRIVATEKEY }}
         HEXONET_DOMAIN : a-b-c-movies.com
         HEXONET_ENTITY : OTE
         HEXONET_PW : test.passw0rd
         HEXONET_UID : test.user
         NAMEDOTCOM_DOMAIN: dnscontrol-ndc.com
-        NAMEDOTCOM_KEY: ${{ secrets.NAMEDOTCOM_KEY }}
         NAMEDOTCOM_URL: api.name.com
         NAMEDOTCOM_USER: dnscontroltest
+        NAMEDOTCOM_KEY: ${{ secrets.NAMEDOTCOM_KEY }}
         R53_DOMAIN: dnscontroltest-r53.com
-        R53_KEY: ${{ secrets.R53_KEY }}
         R53_KEY_ID: ${{ secrets.R53_KEY_ID }}
+        R53_KEY: ${{ secrets.R53_KEY }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,7 @@ jobs:
       with:
         go-version: ^1.15
     - name: Determining test viability for ${{ matrix.provider }} provider
-      run: if [ "$${{ matrix.provider }}__CAN_SECRET" = "true" ] ; then echo "CAN_CONTINUE=yes" >> $GITHUB_ENV ; echo "Decision: CONTINUE" ; else echo 'Decision: SKIP' ; fi
+      run: if [ "$${{ matrix.provider }}__CAN_SECRET" = "true" ] ; then echo "CAN_CONTINUE=yes" >> "$GITHUB_ENV" ; fi
 # Does the provider's tests require secrets?
 # Yes?  Set a secret called ${PROVIDER}__CAN_SECRET with value "true" (no quotes).
 # No?   Set it to "true" like you see for BIND__CAN_SECRET.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,7 @@ jobs:
         go-version: ^1.15
     - name: Run integration tests for ${{ matrix.provider }} provider
       working-directory: integrationTest
-      run: if [ -n "$${{ matrix.provider }}__CAN_SECRET" ] ; then  go test -v -verbose -provider ${{ matrix.provider }} ; else echo SKIPPING ; fi
+      run: if [ "$${{ matrix.provider }}__CAN_SECRET" = "true" ] ; then  go test -v -verbose -provider ${{ matrix.provider }} ; else echo SKIPPING ; fi
       env:
 # Keep these sorted lexically: (i.e. ascii sorted)
         BIND__CAN_SECRET: ${{ secrets.BIND__CAN_SECRET }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,7 @@ jobs:
       with:
         go-version: ^1.15
     - name: Examining creds for ${{ matrix.provider }} provider
-      run: if [ "$${{ matrix.provider }}__CAN_SECRET" = "true" ] ; then echo "CAN_CONTINUE=yes" >> $GITHUB_ENV ; fi
+      run: if [ "$${{ matrix.provider }}__CAN_SECRET" = "true" ] ; then echo "CAN_CONTINUE=yes" >> $GITHUB_ENV ; echo "CAN_CONTINUE=yes" ; else echo '***SKIPPING***' ; fi
 # Does the provider's tests require secrets?
 # Yes?  Set a secret called ${PROVIDER}__CAN_SECRET with value # "true" (no quotes).
 # No?   Set it to "true" like you see for BIND__CAN_SECRET.

--- a/integrationTest/providers.json
+++ b/integrationTest/providers.json
@@ -22,7 +22,9 @@
     "domain": "example.com"
   },
   "CLOUDFLAREAPI": {
+    "apikey": "$CF_KEY",
     "apitoken": "$CF_TOKEN",
+    "apiuser": "$CF_USER",
     "domain": "$CF_DOMAIN"
   },
   "CLOUDFLAREAPI_OLD": {


### PR DESCRIPTION
Secrets are not propagated to an Action if the PR is from a forked repo.  The good news is that this prevents an outsiders from logging secrets.  The bad news it that outsiders always see their tests as failing.

With this change, every provider is tested but the tests abort early if the action doesn't have access to the secrets.  More specifically, the value "true" must be found in an env named `${PROVIDER}__CAN_SECRET` (for example `BIND__CAN_SECRET` or `HEXONET__CAN_SECRET`)

In this PR we:

* List the matrix of providers one-per-line to make it easier to add/remove provider names; as well as add comments.
* For each provider in the matrix, set an env named `${PROVIDER}__CAN_SECRET` to true if tests are to run.
* Add a step that determines if future steps should be skipped

You can see that TomOnTime/dnscontrol (a fork) was able to "bring my own secrets" here: https://github.com/TomOnTime/dnscontrol/pull/1/checks?check_run_id=1468101735