### PR TITLE
update cloudns to support request from subuser (sub-auth-id)

### DIFF
--- a/providers/cloudns/api.go
+++ b/providers/cloudns/api.go
@@ -235,4 +235,5 @@ func fixTTL(ttl uint32) uint32 {
 		}
 	}
 
-	return allowedTTLValues[0]}
+	return allowedTTLValues[0]
+}

--- a/providers/cloudns/api.go
+++ b/providers/cloudns/api.go
@@ -15,6 +15,7 @@ type cloudnsProvider struct {
 	creds            struct {
 		id       string
 		password string
+		subid    string
 	}
 }
 
@@ -195,6 +196,7 @@ func (c *cloudnsProvider) get(endpoint string, params requestParams) ([]byte, er
 	// Add auth params
 	q.Add("auth-id", c.creds.id)
 	q.Add("auth-password", c.creds.password)
+	q.Add("sub-auth-id", c.creds.subid)
 
 	for pName, pValue := range params {
 		q.Add(pName, pValue)
@@ -233,5 +235,4 @@ func fixTTL(ttl uint32) uint32 {
 		}
 	}
 
-	return allowedTTLValues[0]
-}
+	return allowedTTLValues[0]}

--- a/providers/cloudns/cloudnsProvider.go
+++ b/providers/cloudns/cloudnsProvider.go
@@ -23,14 +23,12 @@ Info required in `creds.json`:
 func NewCloudns(m map[string]string, metadata json.RawMessage) (providers.DNSServiceProvider, error) {
 	c := &cloudnsProvider{}
 
-	c.creds.id, c.creds.password, c.creds.subid = m["auth-id"], m["auth-password"],m["sub-auth-id"]
-	
-	if ((c.creds.id == "" && c.creds.subid == "") || c.creds.password == "" ) {
+	c.creds.id, c.creds.password, c.creds.subid = m["auth-id"], m["auth-password"], m["sub-auth-id"]
+
+	if (c.creds.id == "" && c.creds.subid == "") || c.creds.password == "" {
 		return nil, fmt.Errorf("missing ClouDNS auth-id and auth-password")
 	}
 
-	
-	
 	// Get a domain to validate authentication
 	if err := c.fetchDomainList(); err != nil {
 		return nil, err

--- a/providers/cloudns/cloudnsProvider.go
+++ b/providers/cloudns/cloudnsProvider.go
@@ -13,24 +13,24 @@ import (
 )
 
 /*
-
 CloDNS API DNS provider:
-
 Info required in `creds.json`:
    - auth-id
    - auth-password
-
 */
 
 // NewCloudns creates the provider.
 func NewCloudns(m map[string]string, metadata json.RawMessage) (providers.DNSServiceProvider, error) {
 	c := &cloudnsProvider{}
 
-	c.creds.id, c.creds.password = m["auth-id"], m["auth-password"]
-	if c.creds.id == "" || c.creds.password == "" {
+	c.creds.id, c.creds.password, c.creds.subid = m["auth-id"], m["auth-password"],m["sub-auth-id"]
+	
+	if ((c.creds.id == "" && c.creds.subid == "") || c.creds.password == "" ) {
 		return nil, fmt.Errorf("missing ClouDNS auth-id and auth-password")
 	}
 
+	
+	
 	// Get a domain to validate authentication
 	if err := c.fetchDomainList(); err != nil {
 		return nil, err


### PR DESCRIPTION
I updated the Provider Cloudns to supprt auhtentification with "sub-auth-id". for security reason it is good to work just with subuser in order to avoid the contrl of DNS-management. I modified the files : cloudnssudo Provider.go and api.go