### PR TITLE
(#1003) Make OVH TXTMulti capable

### DIFF
--- a/integrationTest/integration_test.go
+++ b/integrationTest/integration_test.go
@@ -652,7 +652,7 @@ func makeTests(t *testing.T) []*TestGroup {
 		),
 
 		testgroup("Null MX",
-			not("AZURE_DNS", "GANDI_V5", "INWX", "NAMEDOTCOM", "DIGITALOCEAN", "NETCUP", "DNSIMPLE", "HEDNS", "VULTR"), // These providers don't support RFC 7505
+			not("AZURE_DNS", "GANDI_V5", "INWX", "NAMEDOTCOM", "DIGITALOCEAN", "NETCUP", "DNSIMPLE", "HEDNS", "VULTR", "OVH"), // These providers don't support RFC 7505
 			tc("Null MX", mx("@", 0, ".")),
 		),
 

--- a/providers/ovh/ovhProvider.go
+++ b/providers/ovh/ovhProvider.go
@@ -28,6 +28,7 @@ var features = providers.DocumentationNotes{
 	providers.DocDualHost:            providers.Can(),
 	providers.DocOfficiallySupported: providers.Cannot(),
 	providers.CanGetZones:            providers.Can(),
+	providers.CanUseTXTMulti:         providers.Can(),
 }
 
 func newOVH(m map[string]string, metadata json.RawMessage) (*ovhProvider, error) {


### PR DESCRIPTION
In fact OVH natively supports multi TXT, so there's really nothing to do here :)
I also excluded OVH from the Null MX integration test, because this provider doesn't yet support this RFC.