### PR TITLE
Add TLSA Support for gcloud Provider

### DIFF
--- a/providers/gcloud/gcloudProvider.go
+++ b/providers/gcloud/gcloudProvider.go
@@ -20,16 +20,16 @@ import (
 
 var features = providers.DocumentationNotes{
 	providers.CanGetZones:            providers.Can(),
-	providers.CanUseDSForChildren:    providers.Can(),
 	providers.CanUseCAA:              providers.Can(),
+	providers.CanUseDSForChildren:    providers.Can(),
 	providers.CanUsePTR:              providers.Can(),
 	providers.CanUseSRV:              providers.Can(),
 	providers.CanUseSSHFP:            providers.Can(),
+	providers.CanUseTLSA:             providers.Can(),
 	providers.CanUseTXTMulti:         providers.Can(),
 	providers.DocCreateDomains:       providers.Can(),
 	providers.DocDualHost:            providers.Can(),
 	providers.DocOfficiallySupported: providers.Can(),
-	providers.CanUseTLSA:		  providers.Can(),
 }
 
 func sPtr(s string) *string {

--- a/providers/gcloud/gcloudProvider.go
+++ b/providers/gcloud/gcloudProvider.go
@@ -29,6 +29,7 @@ var features = providers.DocumentationNotes{
 	providers.DocCreateDomains:       providers.Can(),
 	providers.DocDualHost:            providers.Can(),
 	providers.DocOfficiallySupported: providers.Can(),
+	providers.CanUseTLSA:		  providers.Can(),
 }
 
 func sPtr(s string) *string {


### PR DESCRIPTION
@Knight1 noticed that TLSA support wasn't enabled, but should be. Fixing.