### PR TITLE
Revert "CLOUDFLARE: Now supports PunyCode/IDNA"

### DIFF
--- a/integrationTest/integration_test.go
+++ b/integrationTest/integration_test.go
@@ -799,8 +799,9 @@ func makeTests(t *testing.T) []*TestGroup {
 		),
 
 		testgroup("IDNA",
-			not("SOFTLAYER"),
+			not("SOFTLAYER", "CLOUDFLAREAPI"),
 			// SOFTLAYER: fails at direct internationalization, punycode works, of course.
+			// CLOUDFLAREAPI: fails. Needs to be debugged.
 			tc("Internationalized name", a("ööö", "1.2.3.4")),
 			tc("Change IDN", a("ööö", "2.2.2.2")),
 			tc("Internationalized CNAME Target", cname("a", "ööö.com.")),

--- a/providers/cloudflare/cloudflareProvider.go
+++ b/providers/cloudflare/cloudflareProvider.go
@@ -149,11 +149,6 @@ func (c *cloudflareProvider) getDomainID(name string) (string, error) {
 
 // GetDomainCorrections returns a list of corrections to update a domain.
 func (c *cloudflareProvider) GetDomainCorrections(dc *models.DomainConfig) ([]*models.Correction, error) {
-	err := dc.Punycode()
-	if err != nil {
-		return nil, err
-	}
-
 	id, err := c.getDomainID(dc.Name)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Reverts StackExchange/dnscontrol#1019