### PR TITLE
HEDNS: Fix CNAME, NS and PTR record handling of trailing .

### DIFF
--- a/providers/hedns/hednsProvider.go
+++ b/providers/hedns/hednsProvider.go
@@ -313,8 +313,8 @@ func (c *hednsProvider) GetZoneRecords(domain string) (models.Records, error) {
 
 		rc.SetLabelFromFQDN(rc.Original.(Record).RecordName, domain)
 
-		// dns.he.net omits the trailing "." on the hostnames for certain record types
-		if rc.Type == "CNAME" || rc.Type == "MX" || rc.Type == "NS" || rc.Type == "PTR" {
+		// dns.he.net omits the trailing "." on the hostnames for certain MX records
+		if rc.Type == "MX" {
 			rc.Target += "."
 		}
 


### PR DESCRIPTION
Fixed handling of CNAME, NS and PTR record targets where HE.net DNS now automatically appends these.