### PR TITLE
HEDNS: Fix usage of target field to resolve TXT handling

### DIFF
--- a/providers/hedns/hednsProvider.go
+++ b/providers/hedns/hednsProvider.go
@@ -298,7 +298,10 @@ func (c *hednsProvider) GetZoneRecords(domain string) (models.Records, error) {
 				RecordID:   parser.parseIntAttr(element, "id"),
 			},
 		}
-		rc.SetTarget(parser.parseStringAttr(element.Find("td:nth-child(7)"), "data"))
+		data := parser.parseStringAttr(element.Find("td:nth-child(7)"), "data")
+		if err != nil {
+			return false
+		}
 
 		priority := parser.parseIntElement(element.Find("td:nth-child(6)"))
 		if parser.err != nil {
@@ -313,24 +316,20 @@ func (c *hednsProvider) GetZoneRecords(domain string) (models.Records, error) {
 
 		rc.SetLabelFromFQDN(rc.Original.(Record).RecordName, domain)
 
-		// dns.he.net omits the trailing "." on the hostnames for certain record types
-		if rc.Type == "CNAME" || rc.Type == "MX" || rc.Type == "NS" || rc.Type == "PTR" {
-			rc.SetTarget(rc.GetTargetField() + ".")
-		}
-
 		switch rc.Type {
 		case "ALIAS":
-			err = rc.SetTarget(rc.GetTargetField())
+			err = rc.SetTarget(data)
 		case "MX":
-			err = rc.SetTargetMX(uint16(priority), rc.GetTargetField())
+			// dns.he.net omits the trailing "." on the hostnames for MX records
+			err = rc.SetTargetMX(uint16(priority), data + ".")
 		case "SRV":
-			err = rc.SetTargetSRVPriorityString(uint16(priority), rc.GetTargetField())
+			err = rc.SetTargetSRVPriorityString(uint16(priority), data)
 		case "SPF":
 			// Convert to TXT record as SPF is deprecated
 			rc.Type = "TXT"
 			fallthrough
 		default:
-			err = rc.PopulateFromString(rc.Type, rc.GetTargetField(), domain)
+			err = rc.PopulateFromString(rc.Type, data, domain)
 		}
 
 		if err != nil {


### PR DESCRIPTION
Fixes handling of TXT records that were failing with the use of the `.target` field as an intermediate location before `.PopulateFromString`. This was failing due to the behaviour of `.GetTargetFields` for TXT records, where the data was being stored in `.target`.