### PR TITLE
HETZNER: fix edge cases in TXT handling

### DIFF
--- a/providers/hetzner/auditrecords.go
+++ b/providers/hetzner/auditrecords.go
@@ -2,12 +2,10 @@ package hetzner
 
 import (
 	"github.com/StackExchange/dnscontrol/v3/models"
-	"github.com/StackExchange/dnscontrol/v3/pkg/recordaudit"
 )
 
 // AuditRecords returns an error if any records are not
 // supportable by this provider.
 func AuditRecords(records []*models.RecordConfig) error {
-	return recordaudit.TxtNotEmpty(records)
-	// Still needed as of 2021-03-01
+	return nil
 }

--- a/providers/hetzner/types.go
+++ b/providers/hetzner/types.go
@@ -2,6 +2,7 @@ package hetzner
 
 import (
 	"github.com/StackExchange/dnscontrol/v3/models"
+	"strings"
 )
 
 type bulkCreateRecordsRequest struct {
@@ -63,20 +64,22 @@ func fromRecordConfig(in *models.RecordConfig, zone *zone) *record {
 	record := &record{
 		Name:   in.GetLabel(),
 		Type:   in.Type,
-		Value:  in.GetTargetField(),
+		Value:  in.GetTargetCombined(),
 		TTL:    &ttl,
 		ZoneID: zone.ID,
 	}
 
-	switch record.Type {
-	case "TXT":
-		// Cannot use `in.GetTargetCombined()` for TXTs:
-		// Their validation would complain about a missing `;`.
-		// Test case: single_TXT:Create_a_255-byte_TXT
+	if record.Type == "TXT" && len(in.TxtStrings) == 1 {
+		// HACK: HETZNER rejects values that fit into 255 bytes w/o quotes,
+		//  but do not fit w/ added quotes (via GetTargetCombined()).
+		// Sending the raw, non-quoted value works for the comprehensive
+		//  suite of integrations tests.
+		// The HETZNER validation does not provide helpful error messages.
 		// {"error":{"message":"422 Unprocessable Entity: missing: ; ","code":422}}
-		record.Value = in.GetTargetField()
-	default:
-		record.Value = in.GetTargetCombined()
+		valueNotQuoted := in.TxtStrings[0]
+		if len(valueNotQuoted) == 254 || len(valueNotQuoted) == 255 {
+			record.Value = valueNotQuoted
+		}
 	}
 
 	return record
@@ -90,7 +93,15 @@ func toRecordConfig(domain string, record *record) *models.RecordConfig {
 	}
 	rc.SetLabel(record.Name, domain)
 
-	_ = rc.PopulateFromString(record.Type, record.Value, domain)
+	value := record.Value
+	// HACK: Hetzner is inserting a trailing space after multiple, quoted values.
+	// NOTE: The actual DNS answer does not contain the space.
+	if record.Type == "TXT" && len(value) > 0 && value[len(value)-1] == ' ' {
+		// Per RFC 1035 spaces outside quoted values are irrelevant.
+		value = strings.TrimRight(value, " ")
+	}
+
+	_ = rc.PopulateFromString(record.Type, value, domain)
 
 	return rc
 }


### PR DESCRIPTION
The TXT handling of HETZNER seems to buggy, server-side.
I came up with workarounds client-side, but IMHO they should be fixed upstream. I will email them and see how that goes before marking this as read-for-review.

I do not think that a rewrite of the TXT handling will have an impact for these bugs as they seem to be server-side.

Bugs and workarounds:
- send empty string as `""` instead of sending an empty string as value
- send `strings.Repeat("A", 254)` as `AA...A` instead of `"AA..A"`
- send `strings.Repeat("A", 255)` as `AA...A` instead of `"AA..A"`
- receive `"AA...A" "BB...B" "CC...C" ` (trailing space), trim the space

Actions:
- Make use of new default handling of TXTs for de-serializing.
- Empty value is represented as quoted empty string now, which the
   HETZNER validation happily accepts -- drop audit record.
- Work around validation error for 254/255 bytes long values.
- Work around added whitespace in API response with multiple values.

Signed-off-by: Jakob Ackermann <das7pad@outlook.com>