### PR TITLE
typo fix and Audit Records update for ClouDNS

### DIFF
--- a/providers/cloudns/api.go
+++ b/providers/cloudns/api.go
@@ -9,7 +9,7 @@ import (
 	"time"
 )
 
-// Api layer for CloDNS
+// Api layer for ClouDNS
 type cloudnsProvider struct {
 	domainIndex      map[string]string
 	nameserversNames []string

--- a/providers/cloudns/auditrecords.go
+++ b/providers/cloudns/auditrecords.go
@@ -24,5 +24,10 @@ func AuditRecords(records []*models.RecordConfig) error {
 	}
 	// Still needed as of 2021-03-01
 
+	if err := recordaudit.TxtNoDoubleQuotes(records); err != nil {
+		return err
+	}
+	// Still needed as of 2021-03-11
+
 	return nil
 }

--- a/providers/cloudns/cloudnsProvider.go
+++ b/providers/cloudns/cloudnsProvider.go
@@ -14,7 +14,7 @@ import (
 )
 
 /*
-CloDNS API DNS provider:
+ClouDNS API DNS provider:
 Info required in `creds.json`:
    - auth-id or sub-auth-id
    - auth-password


### PR DESCRIPTION
The following two points have been fixed.

- Fixed that "ClouDNS" was changed to "CloDNS" in the source code.
- Added a description to Audit Records that does not allow double quotes in TXT records.

I am new to Go language.
Therefore, there may be something strange.
