### PR TITLE
[ClouDNS] Fix for TXT records. 

### DIFF
--- a/providers/cloudns/auditrecords.go
+++ b/providers/cloudns/auditrecords.go
@@ -1,6 +1,7 @@
 package cloudns
 
 import (
+	"fmt"
 	"github.com/StackExchange/dnscontrol/v3/models"
 	"github.com/StackExchange/dnscontrol/v3/pkg/recordaudit"
 )
@@ -29,5 +30,22 @@ func AuditRecords(records []*models.RecordConfig) error {
 	}
 	// Still needed as of 2021-03-11
 
+	if err := txtNoMultipleStrings(records); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ClouDNS NOT allow multiple TXT records with same name
+// But allow values longer the 255
+func txtNoMultipleStrings(records []*models.RecordConfig) error {
+	for _, rc := range records {
+		if rc.HasFormatIdenticalToTXT() { // TXT and similar:
+			if len(rc.TxtStrings) > 1 {
+				return fmt.Errorf("multiple strings in one txt")
+			}
+		}
+	}
 	return nil
 }

--- a/providers/cloudns/cloudnsProvider.go
+++ b/providers/cloudns/cloudnsProvider.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/StackExchange/dnscontrol/v3/models"
 	"github.com/StackExchange/dnscontrol/v3/pkg/diff"
-	"github.com/StackExchange/dnscontrol/v3/pkg/txtutil"
 	"github.com/StackExchange/dnscontrol/v3/providers"
 )
 
@@ -55,7 +54,7 @@ var features = providers.DocumentationNotes{
 
 func init() {
 	fns := providers.DspFuncs{
-		Initializer:    NewCloudns,
+		Initializer:   NewCloudns,
 		RecordAuditor: AuditRecords,
 	}
 	providers.RegisterDomainServiceProviderType("CLOUDNS", fns, features)
@@ -94,7 +93,6 @@ func (c *cloudnsProvider) GetDomainCorrections(dc *models.DomainConfig) ([]*mode
 	}
 	// Normalize
 	models.PostProcessRecords(existingRecords)
-	txtutil.SplitSingleLongTxt(dc.Records) // Autosplit long TXT records
 
 	// ClouDNS doesn't allow selecting an arbitrary TTL, only a set of predefined values https://asia.cloudns.net/wiki/article/188/
 	// We need to make sure we don't change it every time if it is as close as it's going to get


### PR DESCRIPTION
Better handling of TXT records. ClouDNS NOT allow multiple TXT records with same name but allow values longer the 255

Now TXT tests - pass

> go test -v -verbose -provider CLOUDNS -start 9 -end 13
> ...
>PASS