### PR TITLE
Fetch ClouDNS allowed TTL values from API. #1078

### DIFF
--- a/providers/cloudns/api.go
+++ b/providers/cloudns/api.go
@@ -71,21 +71,7 @@ type domainRecord struct {
 
 type recordResponse map[string]domainRecord
 
-var allowedTTLValues = []uint32{
-	60,      // 1 minute
-	300,     // 5 minutes
-	900,     // 15 minutes
-	1800,    // 30 minutes
-	3600,    // 1 hour
-	21600,   // 6 hours
-	43200,   // 12 hours
-	86400,   // 1 day
-	172800,  // 2 days
-	259200,  // 3 days
-	604800,  // 1 week
-	1209600, // 2 weeks
-	2419200, // 4 weeks
-}
+var allowedTTLValues = []uint32{}
 
 func (c *cloudnsProvider) fetchAvailableNameservers() error {
 	c.nameserversNames = nil
@@ -104,6 +90,21 @@ func (c *cloudnsProvider) fetchAvailableNameservers() error {
 		}
 
 	}
+	return nil
+}
+
+func (c *cloudnsProvider) fetchAvailableTTLValues(domain string) error {
+	allowedTTLValues = nil
+	params := requestParams{
+		"domain-name": domain,
+	}
+
+	var bodyString, err = c.get("/dns/get-available-ttl.json", params)
+	if err != nil {
+		return fmt.Errorf("failed fetching available TTL values list from ClouDNS: %s", err)
+	}
+
+	json.Unmarshal(bodyString, &allowedTTLValues)
 	return nil
 }
 

--- a/providers/cloudns/cloudnsProvider.go
+++ b/providers/cloudns/cloudnsProvider.go
@@ -96,6 +96,7 @@ func (c *cloudnsProvider) GetDomainCorrections(dc *models.DomainConfig) ([]*mode
 
 	// ClouDNS doesn't allow selecting an arbitrary TTL, only a set of predefined values https://asia.cloudns.net/wiki/article/188/
 	// We need to make sure we don't change it every time if it is as close as it's going to get
+	c.fetchAvailableTTLValues(dc.Name)
 	for _, record := range dc.Records {
 		record.TTL = fixTTL(record.TTL)
 	}

--- a/providers/cloudns/cloudnsProvider.go
+++ b/providers/cloudns/cloudnsProvider.go
@@ -94,9 +94,10 @@ func (c *cloudnsProvider) GetDomainCorrections(dc *models.DomainConfig) ([]*mode
 	// Normalize
 	models.PostProcessRecords(existingRecords)
 
-	// ClouDNS doesn't allow selecting an arbitrary TTL, only a set of predefined values https://asia.cloudns.net/wiki/article/188/
-	// We need to make sure we don't change it every time if it is as close as it's going to get
+	// Get a list of available TTL values.
+	// The TTL list needs to be obtained for each domain, so get it first here.
 	c.fetchAvailableTTLValues(dc.Name)
+	// ClouDNS can only be specified from a specific TTL list, so change the TTL in advance.
 	for _, record := range dc.Records {
 		record.TTL = fixTTL(record.TTL)
 	}


### PR DESCRIPTION
Fetch ClouDNS allowed TTL values from API.
Fix the problem of # 1078.
