### PR TITLE
GANDI_V5 & OVH: Implement ZoneLister

### DIFF
--- a/providers/gandiv5/gandi_v5Provider.go
+++ b/providers/gandiv5/gandi_v5Provider.go
@@ -98,6 +98,22 @@ func newHelper(m map[string]string, metadata json.RawMessage) (*gandiv5Provider,
 
 // Section 3: Domain Service Provider (DSP) related functions
 
+// ListZones lists the zones on this account.
+func (client *gandiv5Provider) ListZones() ([]string, error) {
+	g := gandi.NewLiveDNSClient(client.apikey, gandi.Config{SharingID: client.sharingid, Debug: client.debug})
+
+	listResp, err := g.ListDomains()
+	if err != nil {
+		return nil, err
+	}
+
+	zones := make([]string, len(listResp))
+	for i, zone := range listResp {
+		zones[i] = zone.FQDN
+	}
+	return zones, nil
+}
+
 // NB(tal): To future-proof your code, all new providers should
 // implement GetDomainCorrections exactly as you see here
 // (byte-for-byte the same). In 3.0

--- a/providers/ovh/ovhProvider.go
+++ b/providers/ovh/ovhProvider.go
@@ -85,6 +85,14 @@ func (e errNoExist) Error() string {
 	return fmt.Sprintf("Domain %s not found in your ovh account", e.domain)
 }
 
+// ListZones lists the zones on this account.
+func (c *ovhProvider) ListZones() (zones []string, err error) {
+	for zone := range c.zones {
+		zones = append(zones, zone)
+	}
+	return
+}
+
 // GetZoneRecords gets the records of a zone and returns them in RecordConfig format.
 func (c *ovhProvider) GetZoneRecords(domain string) (models.Records, error) {
 	if !c.zones[domain] {


### PR DESCRIPTION
Hi!

It appears that those two providers I use, can implement the `ZoneLister` interface.

For OVH, as it already fetches the zones when creating the `DNSServiceProvider`, I choose to return them instead of doing the request again (as the code already makes the assumption this list doesn't change).