### PR TITLE
Make creds file executable

### DIFF
--- a/providers/config/providerConfig.go
+++ b/providers/config/providerConfig.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 
 	"github.com/DisposaBoy/JsonConfigReader"
@@ -75,7 +76,7 @@ func executeCredsFile(filename string) ([]byte, error) {
 	cmd := filename
 	if !strings.HasPrefix(filename, "/") {
 		// if the path doesn't start with `/` make sure we aren't relying on $PATH.
-		cmd = "./" + filename
+		cmd = strings.Join([]string{".", filename}, string(filepath.Separator))
 	}
 	out, err := exec.Command(cmd).Output()
 	return out, err

--- a/providers/config/providerConfig.go
+++ b/providers/config/providerConfig.go
@@ -34,15 +34,7 @@ func LoadProviderConfigs(fname string) (map[string]map[string]string, error) {
 		}
 	} else {
 		// no executable bit found nor marked as executable so read it in
-		dat, err = utfutil.ReadFile(fname, utfutil.POSIX)
-		if err != nil {
-			// no creds file is ok. Bind requires nothing for example. Individual providers will error if things not found.
-			if os.IsNotExist(err) {
-				fmt.Printf("INFO: Config file %q does not exist. Skipping.\n", fname)
-				return results, nil
-			}
-			return nil, fmt.Errorf("failed reading provider credentials file %v: %v", fname, err)
-		}
+		dat, err = readCredsFile(fname)
 	}
 
 	s := string(dat)
@@ -64,6 +56,19 @@ func isExecutable(filename string) bool {
 		}
 	}
 	return false
+}
+
+func readCredsFile(filename string) ([]byte, error) {
+	dat, err := utfutil.ReadFile(filename, utfutil.POSIX)
+	if err != nil {
+		// no creds file is ok. Bind requires nothing for example. Individual providers will error if things not found.
+		if os.IsNotExist(err) {
+			fmt.Printf("INFO: Config file %q does not exist. Skipping.\n", filename)
+			return []byte{}, nil
+		}
+		return nil, fmt.Errorf("failed reading provider credentials file %v: %v", filename, err)
+	}
+	return dat, nil
 }
 
 func executeCredsFile(filename string) ([]byte, error) {


### PR DESCRIPTION
Makes the creds file executable as requested in #1116. It checks the unix file permissions for the executable bit or it can be marked as executable with a "!" as in front of the file name.