### PR TITLE
ROUTE53: Docs should specify FQDN with dot.

### DIFF
--- a/docs/_functions/domain/R53_ALIAS.md
+++ b/docs/_functions/domain/R53_ALIAS.md
@@ -38,9 +38,9 @@ The zone id can be found depending on the target type:
 D('example.com', REGISTRAR, DnsProvider('ROUTE53'),
   R53_ALIAS('foo', 'A', 'bar'),                              // record in same zone
   R53_ALIAS('foo', 'A', 'bar', R53_ZONE('Z35SXDOTRQ7X7K')),  // record in same zone, zone specified
-  R53_ALIAS('foo', 'A', 'blahblah.elasticloadbalancing.us-west-1.amazonaws.com', R53_ZONE('Z368ELLRRE2KJ0')),     // a classic ELB in us-west-1
-  R53_ALIAS('foo', 'A', 'blahblah.elasticbeanstalk.us-west-2.amazonaws.com', R53_ZONE('Z38NKT9BP95V3O')),     // an Elastic Beanstalk environment in us-west-2
-  R53_ALIAS('foo', 'A', 'blahblah-bucket.s3-website-us-west-1.amazonaws.com', R53_ZONE('Z2F56UZL2M1ACD')),     // a website S3 Bucket in us-west-1
+  R53_ALIAS('foo', 'A', 'blahblah.elasticloadbalancing.us-west-1.amazonaws.com.', R53_ZONE('Z368ELLRRE2KJ0')),     // a classic ELB in us-west-1
+  R53_ALIAS('foo', 'A', 'blahblah.elasticbeanstalk.us-west-2.amazonaws.com.', R53_ZONE('Z38NKT9BP95V3O')),     // an Elastic Beanstalk environment in us-west-2
+  R53_ALIAS('foo', 'A', 'blahblah-bucket.s3-website-us-west-1.amazonaws.com.', R53_ZONE('Z2F56UZL2M1ACD')),     // a website S3 Bucket in us-west-1
 );
 
 {%endhighlight%}


### PR DESCRIPTION
After helping with https://github.com/StackExchange/dnscontrol/issues/1128 I noticed that the examples don't include a "." at the end of FQDNs.  I think that lead to the confusion.

Here's a PR with corrected (I hope) examples.  Are they more correct?

CC @masterzen 