### PR TITLE
Disable ClouDNS NAPTR support

### DIFF
--- a/providers/cloudns/cloudnsProvider.go
+++ b/providers/cloudns/cloudnsProvider.go
@@ -46,7 +46,6 @@ var features = providers.DocumentationNotes{
 	providers.CanUseSSHFP:            providers.Can(),
 	providers.CanUseCAA:              providers.Can(),
 	providers.CanUseTLSA:             providers.Can(),
-	providers.CanUseNAPTR:            providers.Can(),
 	providers.CanUsePTR:              providers.Can(),
 	providers.CanGetZones:            providers.Can(),
 	providers.CanUseDSForChildren:    providers.Can(),


### PR DESCRIPTION
This change removes part of commit 9949cba.
ClouDNS does not support changing the NAPTR in the API, so I need to disable this change.
I apologize for any inconvenience caused.
