### PR TITLE
DESEC: clarify supported capabilities

### DIFF
--- a/integrationTest/providers.json
+++ b/integrationTest/providers.json
@@ -39,6 +39,10 @@
     "auth-password": "$CLOUDNS_AUTH_PASSWORD",
     "domain": "$CLOUDNS_DOMAIN"
   },
+  "DESEC": {
+    "auth-token": "$DESEC_TOKEN",
+    "domain": "$DESEC_DOMAIN"
+  },
   "DIGITALOCEAN": {
     "domain": "$DIGITALOCEAN_DOMAIN",
     "token": "$DIGITALOCEAN_TOKEN"

--- a/providers/desec/desecProvider.go
+++ b/providers/desec/desecProvider.go
@@ -47,7 +47,7 @@ var features = providers.DocumentationNotes{
 	providers.CanUseTLSA:             providers.Can(),
 	providers.CanUsePTR:              providers.Can(),
 	providers.CanGetZones:            providers.Can(),
-	providers.CanAutoDNSSEC:          providers.Cannot(),
+	providers.CanAutoDNSSEC:          providers.Can("deSEC always signs all records. When trying to disable, a notice is printed."),
 }
 
 var defaultNameServerNames = []string{
@@ -69,6 +69,10 @@ func (c *desecProvider) GetNameservers(domain string) ([]*models.Nameserver, err
 }
 
 func (c *desecProvider) GetDomainCorrections(dc *models.DomainConfig) ([]*models.Correction, error) {
+	if dc.AutoDNSSEC == "off" {
+		fmt.Printf("Notice: DNSSEC signing was not requested, but cannot be turned off. (deSEC always signs all records.)\n")
+	}
+
 	existing, err := c.GetZoneRecords(dc.Name)
 	if err != nil {
 		return nil, err

--- a/providers/desec/desecProvider.go
+++ b/providers/desec/desecProvider.go
@@ -46,6 +46,7 @@ var features = providers.DocumentationNotes{
 	providers.CanUseCAA:              providers.Can(),
 	providers.CanUseTLSA:             providers.Can(),
 	providers.CanUsePTR:              providers.Can(),
+	providers.CanUseNAPTR:            providers.Can(),
 	providers.CanGetZones:            providers.Can(),
 	providers.CanAutoDNSSEC:          providers.Can("deSEC always signs all records. When trying to disable, a notice is printed."),
 }

--- a/providers/desec/desecProvider.go
+++ b/providers/desec/desecProvider.go
@@ -39,7 +39,7 @@ var features = providers.DocumentationNotes{
 	providers.DocDualHost:            providers.Unimplemented(),
 	providers.DocOfficiallySupported: providers.Cannot(),
 	providers.DocCreateDomains:       providers.Can(),
-	providers.CanUseAlias:            providers.Cannot(),
+	providers.CanUseAlias:            providers.Unimplemented("Apex aliasing is supported via new SVCB and HTTPS record types. For details, check the deSEC docs."),
 	providers.CanUseSRV:              providers.Can(),
 	providers.CanUseDS:               providers.Can(),
 	providers.CanUseSSHFP:            providers.Can(),
@@ -141,7 +141,7 @@ func PrepDesiredRecords(dc *models.DomainConfig, minTTL uint32) {
 		}
 		if rec.TTL < minTTL {
 			if rec.Type != "NS" {
-				printer.Warnf("Please contact support@desec.io if you need ttls < %d. Setting ttl of %s type %s from %d to %d\n", minTTL, rec.GetLabelFQDN(), rec.Type, rec.TTL, minTTL)
+				printer.Warnf("Please contact support@desec.io if you need TTLs < %d. Setting TTL of %s type %s from %d to %d\n", minTTL, rec.GetLabelFQDN(), rec.Type, rec.TTL, minTTL)
 			}
 			rec.TTL = minTTL
 		}

--- a/providers/desec/protocol.go
+++ b/providers/desec/protocol.go
@@ -65,7 +65,7 @@ func (c *desecProvider) fetchDomainList() error {
 	endpoint := "/domains/"
 	var bodyString, err = c.get(endpoint, "GET")
 	if err != nil {
-		return fmt.Errorf("failed fetching domain list (deSEC): %s", err)
+		return fmt.Errorf("Failed fetching domain list (deSEC): %s", err)
 	}
 	err = json.Unmarshal(bodyString, &dr)
 	if err != nil {
@@ -85,7 +85,7 @@ func (c *desecProvider) getRecords(domain string) ([]resourceRecord, error) {
 	var rrsNew []resourceRecord
 	var bodyString, err = c.get(fmt.Sprintf(endpoint, domain), "GET")
 	if err != nil {
-		return rrsNew, fmt.Errorf("failed fetching records for domain %s (deSEC): %s", domain, err)
+		return rrsNew, fmt.Errorf("Failed fetching records for domain %s (deSEC): %s", domain, err)
 	}
 	err = json.Unmarshal(bodyString, &rrs)
 	if err != nil {
@@ -112,14 +112,14 @@ func (c *desecProvider) createDomain(domain string) error {
 	var resp []byte
 	var err error
 	if resp, err = c.post(endpoint, "POST", byt); err != nil {
-		return fmt.Errorf("failed domain create (deSEC): %v", err)
+		return fmt.Errorf("Failed domain create (deSEC): %v", err)
 	}
 	dm := domainObject{}
 	err = json.Unmarshal(resp, &dm)
 	if err != nil {
 		return err
 	}
-	printer.Printf("If you want to use DNSSec please add the DS record at your registrar using one of the keys:\n")
+	printer.Printf("To enable DNSSEC validation for your domain, make sure to convey the DS record(s) to your registrar:\n")
 	printer.Printf("%+q", dm.Keys)
 	return nil
 }
@@ -129,7 +129,7 @@ func (c *desecProvider) upsertRR(rr []resourceRecord, domain string) error {
 	endpoint := fmt.Sprintf("/domains/%s/rrsets/", domain)
 	byt, _ := json.Marshal(rr)
 	if _, err := c.post(endpoint, "PUT", byt); err != nil {
-		return fmt.Errorf("failed create rrset (deSEC): %v", err)
+		return fmt.Errorf("Failed create RRset (deSEC): %v", err)
 	}
 	return nil
 }
@@ -137,7 +137,7 @@ func (c *desecProvider) upsertRR(rr []resourceRecord, domain string) error {
 func (c *desecProvider) deleteRR(domain, shortname, t string) error {
 	endpoint := fmt.Sprintf("/domains/%s/rrsets/%s/%s/", domain, shortname, t)
 	if _, err := c.get(endpoint, "DELETE"); err != nil {
-		return fmt.Errorf("failed delete rrset (deSEC): %v", err)
+		return fmt.Errorf("Failed delete RRset (deSEC): %v", err)
 	}
 	return nil
 }
@@ -170,7 +170,7 @@ retry:
 		if err == nil {
 			return bodyString, fmt.Errorf("%s", errResp.Detail)
 		}
-		return bodyString, fmt.Errorf("http status %d %s, the api does not provide more information", resp.StatusCode, resp.Status)
+		return bodyString, fmt.Errorf("HTTP status %d %s, the API does not provide more information", resp.StatusCode, resp.Status)
 	}
 	return bodyString, nil
 }
@@ -208,9 +208,9 @@ retry:
 		var errResp errorResponse
 		err = json.Unmarshal(bodyString, &errResp)
 		if err == nil {
-			return bodyString, fmt.Errorf("http status %d %s details: %s", resp.StatusCode, resp.Status, errResp.Detail)
+			return bodyString, fmt.Errorf("HTTP status %d %s details: %s", resp.StatusCode, resp.Status, errResp.Detail)
 		}
-		return bodyString, fmt.Errorf("http status %d %s, the api does not provide more information", resp.StatusCode, resp.Status)
+		return bodyString, fmt.Errorf("HTTP status %d %s, the API does not provide more information", resp.StatusCode, resp.Status)
 	}
 	//time.Sleep(334 * time.Millisecond)
 	return bodyString, nil


### PR DESCRIPTION
According to [AUTODNSSEC_ON.md](https://github.com/StackExchange/dnscontrol/blob/ce6006cce7b6877bc56dfb6c9df969e47e7cbb86/docs/_functions/domain/AUTODNSSEC_ON.md), AutoDNSSEC means that the provider automatically signs records, taking care of all of the signing configuration.

deSEC automatically signs all domains, so the AutoDNSSEC flag should be `"on"`. This PR makes this change. Also, when trying to turn off DNSSEC, we now tell the user that deSEC domains are always signed.

(The PR also improves the phrasing of some other messages shown to the user.)

If this is merged, will the AutoDNSSEC field in the provider matrix update automatically (https://stackexchange.github.io/dnscontrol/provider-list)? If not, please let me know what else I should be changing.