### PR TITLE
AXFRDDNS: fix doc: false advertisement of Get-Zones capability

### DIFF
--- a/providers/axfrddns/axfrddnsProvider.go
+++ b/providers/axfrddns/axfrddnsProvider.go
@@ -49,7 +49,7 @@ var features = providers.DocumentationNotes{
 	providers.DocCreateDomains:       providers.Cannot(),
 	providers.DocDualHost:            providers.Cannot(),
 	providers.DocOfficiallySupported: providers.Cannot(),
-	providers.CanGetZones:            providers.Can(),
+	providers.CanGetZones:            providers.Cannot(),
 }
 
 // axfrddnsProvider stores the client info for the provider.


### PR DESCRIPTION
Hi!

The AXFRDDNS doesn't implement the `ListZones` function, but advertises `providers.CanGetZones: providers.Can()`.

If I understand correctly the `providers.CanGetZones` capability, it relies only on `ListZones` function/`ZoneLister` interface, so this PR just indicates in the doc that this provider doesn't support it.

AFAIK, you can't ask authoritative servers for domains they serve: so it can't be implemented.