### PR TITLE
Correct hard coded DNS Made Easy system nameserver TTL

### DIFF
--- a/providers/dnsmadeeasy/types.go
+++ b/providers/dnsmadeeasy/types.go
@@ -188,6 +188,9 @@ func fromRecordConfig(rc *models.RecordConfig) *recordRequestData {
 }
 
 func systemNameServerToRecordConfig(domain string, nameServer string) *models.RecordConfig {
+	// DNS Made Easy does not allow the system name servers to be edited, and said records appear to always have a fixed TTL of 86400.
+	const fixedNameServerRecordTTL = 86400;
+
 	target := nameServer + "."
-	return toRecordConfig(domain, &recordResponseDataEntry{Type: "NS", Value: target, TTL: int(models.DefaultTTL)})
+	return toRecordConfig(domain, &recordResponseDataEntry{Type: "NS", Value: target, TTL: fixedNameServerRecordTTL})
 }


### PR DESCRIPTION
In my (very limited) experience with DNS Made Easy, the system nameserver
TTL is always 86400 and is not able to be altered.

Without this change, if you specify any TTL (other than 300) via
NAMESERVER_TTL() dnscontrol detects a difference and attempts to update
DNS Made Easy with the new value, which fails because the system
nameservers cannot be altered.

With this change in place the same thing will obviously still happen, if
you use NAMESERVER_TTL() with any TTL other than 86400, but that will be
a bit less confusing since the 86400 value appears in the DNS Made Easy
UI at least.