### PR TITLE
MSDNS: Improve reliability of zone dump

### DIFF
--- a/providers/msdns/powershell_test.go
+++ b/providers/msdns/powershell_test.go
@@ -49,17 +49,17 @@ func Test_generatePSZoneDump(t *testing.T) {
 		{
 			name: "local",
 			args: args{domainname: "example.com"},
-			want: `Get-DnsServerResourceRecord -ZoneName "example.com" | ConvertTo-Json -depth 4`,
+			want: `$OutputEncoding = [Text.UTF8Encoding]::UTF8 ; Get-DnsServerResourceRecord -ZoneName "example.com" | Select-Object -Property * -ExcludeProperty Cim* | ConvertTo-Json -depth 4 | Out-File "foo" -Encoding utf8`,
 		},
 		{
 			name: "remote",
 			args: args{domainname: "example.com", dnsserver: "mydnsserver"},
-			want: `Get-DnsServerResourceRecord -ComputerName "mydnsserver" -ZoneName "example.com" | ConvertTo-Json -depth 4`,
+			want: `$OutputEncoding = [Text.UTF8Encoding]::UTF8 ; Get-DnsServerResourceRecord -ComputerName "mydnsserver" -ZoneName "example.com" | Select-Object -Property * -ExcludeProperty Cim* | ConvertTo-Json -depth 4 | Out-File "foo" -Encoding utf8`,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := generatePSZoneDump(tt.args.dnsserver, tt.args.domainname); got != tt.want {
+			if got := generatePSZoneDump(tt.args.dnsserver, tt.args.domainname, "foo"); got != tt.want {
 				t.Errorf("generatePSZoneDump() = got=(\n%s\n) want=(\n%s\n)", got, tt.want)
 			}
 		})


### PR DESCRIPTION
* Zone dump was 90M.  By moving from UTF16 to UTF8 we saved 50%
* Zone dump was capturing stdout, which is slow for big files. Now we write to a tmp file.
* Zone dump was outputting a lot of `Cim*` crap which we didn't need. File size now reduced 90%