### PR TITLE
Less frequently Dependabot runs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,13 +9,13 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
 
   # Maintain dependencies for Go
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "monthly"
     ignore:
       - dependency-name: "github.com/billputer/go-namecheap"
       - dependency-name: "github.com/dnsimple/dnsimple-go"
@@ -23,4 +23,4 @@ updates:
       - dependency-name: "github.com/ovh/go-ovh"
       - dependency-name: "github.com/vultr/govultr"
       - dependency-name: "gopkg.in/ns1/ns1-go.v2"
-      
+


### PR DESCRIPTION
AWS and Azure dependencies seem to have daily updates that usually don't affect this project.  Changing the dependabot settings so that security issues are reported immediately but other changes are reported monthly or weekly.