### PR TITLE
Add PrivateKey authentication for TransIP

### DIFF
--- a/docs/_providers/transip.md
+++ b/docs/_providers/transip.md
@@ -9,7 +9,21 @@ jsId: TRANSIP
 
 ## Configuration
 
-In your providers config json file you must include a TransIP personal access token:
+In your providers config json file you must include your TransIP credentials
+
+You can login with your AccountName and a PrivateKey which can be generated in the TransIP control panel. The PrivateKey is a stringified version of the private key given by the API, see the example below , each newline is replaced by "\n".
+
+{% highlight json %}
+{
+  "transip":{
+    "AccountName": "your-account-name"
+    "PrivateKey": "-----BEGIN RSA PRIVATE KEY-----\nMIICXAIBAAKBgQCqGKukO1De7zhZj6+H0qtjTkVxwTCpvKe4eCZ0FPqri0cb2JZfXJ/DgYSF6vUp\nwmJG8wVQZKjeGcjDOL5UlsuusFncCzWBQ7RKNUSesmQRMSGkVb1/3j+skZ6UtW+5u09lHNsj6tQ5\n1s1SPrCBkedbNf0Tp0GbMJDyR4e9T04ZZwIDAQABAoGAFijko56+qGyN8M0RVyaRAXz++xTqHBLh\n3tx4VgMtrQ+WEgCjhoTwo23KMBAuJGSYnRmoBZM3lMfTKevIkAidPExvYCdm5dYq3XToLkkLv5L2\npIIVOFMDG+KESnAFV7l2c+cnzRMW0+b6f8mR1CJzZuxVLL6Q02fvLi55/mbSYxECQQDeAw6fiIQX\nGukBI4eMZZt4nscy2o12KyYner3VpoeE+Np2q+Z3pvAMd/aNzQ/W9WaI+NRfcxUJrmfPwIGm63il\nAkEAxCL5HQb2bQr4ByorcMWm/hEP2MZzROV73yF41hPsRC9m66KrheO9HPTJuo3/9s5p+sqGxOlF\nL0NDt4SkosjgGwJAFklyR1uZ/wPJjj611cdBcztlPdqoxssQGnh85BzCj/u3WqBpE2vjvyyvyI5k\nX6zk7S0ljKtt2jny2+00VsBerQJBAJGC1Mg5Oydo5NwD6BiROrPxGo2bpTbu/fhrT8ebHkTz2epl\nU9VQQSQzY1oZMVX8i1m5WUTLPz2yLJIBQVdXqhMCQBGoiuSoSjafUhV7i1cEGpb88h5NBYZzWXGZ\n37sJ5QsW+sJyoNde3xH8vdXhzU7eT82D6X/scw9RZz+/6rCJ4p0=\n-----END RSA PRIVATE KEY-----"
+  }
+}
+{% endhighlight %}
+
+Or you can choose to have an AccessToken as credential. These can be generated in the TransIP control panel and have a limited lifetime
+
 
 {% highlight json %}
 {
@@ -18,6 +32,8 @@ In your providers config json file you must include a TransIP personal access to
   }
 }
 {% endhighlight %}
+
+
 
 ## Metadata
 

--- a/docs/_providers/transip.md
+++ b/docs/_providers/transip.md
@@ -11,7 +11,7 @@ jsId: TRANSIP
 
 In your providers config json file you must include your TransIP credentials
 
-You can login with your AccountName and a PrivateKey which can be generated in the TransIP control panel. The PrivateKey is a stringified version of the private key given by the API, see the example below , each newline is replaced by "\n".
+You can login with your AccountName and a PrivateKey which can be generated in the TransIP control panel. The PrivateKey is a stringified version of the private key given by the API, see the example below, each newline is replaced by "\n".
 
 {% highlight json %}
 {

--- a/providers/transip/transipProvider.go
+++ b/providers/transip/transipProvider.go
@@ -43,12 +43,19 @@ var features = providers.DocumentationNotes{
 }
 
 func NewTransip(m map[string]string, metadata json.RawMessage) (providers.DNSServiceProvider, error) {
-	if m["AccessToken"] == "" {
-		return nil, fmt.Errorf("no TransIP token provided")
+
+	if m["AccessToken"] == "" && m["PrivateKey"] == "" {
+		return nil, fmt.Errorf("no TransIP AccessToken or PrivateKey provided")
+	}
+
+	if m["PrivateKey"] != "" && m["AccountName"] == "" {
+		return nil, fmt.Errorf("no AccountName given, required for authenticating with PrivateKey")
 	}
 
 	client, err := gotransip.NewClient(gotransip.ClientConfiguration{
-		Token: m["AccessToken"],
+		Token:            m["AccessToken"],
+		AccountName:      m["AccountName"],
+		PrivateKeyReader: strings.NewReader(m["PrivateKey"]),
 	})
 
 	if err != nil {


### PR DESCRIPTION
Add PrivateKey authentication for TransIP.

Appearently the AccessTokens have limited lifetime. TransIP has a separate authentication method for it: with your AccountName and a PrivateKey.
This PR adds that capability while still providing the AccessToken authentication method as well.