### PR TITLE
SPF Flatten for non apex domains

### DIFF
--- a/models/record.go
+++ b/models/record.go
@@ -452,6 +452,16 @@ func (recs Records) FQDNMap() (m map[string]bool) {
 	return m
 }
 
+func (recs Records) GetByType(typeName string) Records {
+	results := Records{}
+	for _, rec := range recs {
+		if rec.Type == typeName {
+			results = append(results, rec)
+		}
+	}
+	return results
+}
+
 // GroupedByKey returns a map of keys to records.
 func (recs Records) GroupedByKey() map[RecordKey]Records {
 	groups := map[RecordKey]Records{}

--- a/pkg/normalize/flatten.go
+++ b/pkg/normalize/flatten.go
@@ -15,9 +15,9 @@ func flattenSPFs(cfg *models.DNSConfig) []error {
 	var errs []error
 	var err error
 	for _, domain := range cfg.Domains {
-		apexTXTs := domain.Records.GroupedByKey()[models.RecordKey{Type: "TXT", NameFQDN: domain.Name}]
+		txtRecords := domain.Records.GetByType("TXT")
 		// flatten all spf records that have the "flatten" metadata
-		for _, txt := range apexTXTs {
+		for _, txt := range txtRecords {
 			var rec *spflib.SPFRecord
 			txtTarget := strings.Join(txt.TxtStrings, "")
 			if txt.Metadata["flatten"] != "" || txt.Metadata["split"] != "" {


### PR DESCRIPTION
SPF Flatten for non apex domains. Fixes #785.

The fix was relatively easy. Instead of only considering the TXT of the Apex, let's consider all TXT records in a domain.
