### PR TITLE
INWX: fix apex domains

### DIFF
--- a/providers/inwx/inwxProvider.go
+++ b/providers/inwx/inwxProvider.go
@@ -161,11 +161,16 @@ func newInwxDsp(m map[string]string, metadata json.RawMessage) (providers.DNSSer
 func makeNameserverRecordRequest(domain string, rec *models.RecordConfig) *goinwx.NameserverRecordRequest {
 	content := rec.GetTargetField()
 
+	name := rec.GetLabel()
+	if name == "@" {
+		name = ""
+	}
+
 	req := &goinwx.NameserverRecordRequest{
 		Domain:  domain,
 		Type:    rec.Type,
 		Content: content,
-		Name:    rec.GetLabel(),
+		Name:    name,
 		TTL:     int(rec.TTL),
 	}
 
@@ -299,6 +304,9 @@ func (api *inwxAPI) GetZoneRecords(domain string) (models.Records, error) {
 	var records = []*models.RecordConfig{}
 
 	for _, record := range info.Records {
+		if record.Name == "" {
+			record.Name = "@"
+		}
 		if record.Type == "SOA" {
 			continue
 		}


### PR DESCRIPTION
INWX has changed their API to use an empty string () instead of
the common @. Fix that by converting between the two.

Fixes #1218 