### PR TITLE
DMARC_BUILDER: specify version, use values when specified

### DIFF
--- a/docs/_functions/record/DMARC_BUILDER.md
+++ b/docs/_functions/record/DMARC_BUILDER.md
@@ -71,6 +71,7 @@ insecure    IN  TXT "v=DMARC1; p=none; ruf=mailto:mailauth-reports@example.com; 
 ### Parameters
 
 * `label:` The DNS label for the DMARC record (`_dmarc` prefix is added, default: `'@'`)
+* `version:` The DMARC version to be used (default: `DMARC1`)
 * `policy:` The DMARC policy (`p=`), must be one of `'none'`, `'quarantine'`, `'reject'`
 * `subdomainPolicy:` The DMARC policy for subdomains (`sp=`), must be one of `'none'`, `'quarantine'`, `'reject'` (optional)
 * `alignmentSPF:` `'strict'`/`'s'` or `'relaxed'`/`'r'` alignment for SPF (`aspf=`, default: `'r'`)

--- a/pkg/js/helpers.js
+++ b/pkg/js/helpers.js
@@ -965,6 +965,7 @@ function CAA_BUILDER(value) {
 
 // DMARC_BUILDER takes an object:
 // label: The DNS label for the DMARC record (_dmarc prefix is added; default: '@')
+// version: The DMARC version, by default DMARC1 (optional)
 // policy: The DMARC policy (p=), must be one of 'none', 'quarantine', 'reject'
 // subdomainPolicy: The DMARC policy for subdomains (sp=), must be one of 'none', 'quarantine', 'reject' (optional)
 // alignmentSPF: 'strict'/'s' or 'relaxed'/'r' alignment for SPF (aspf=, default: 'r')
@@ -984,6 +985,10 @@ function DMARC_BUILDER(value) {
         value.label = '@';
     }
 
+    if (!value.version) {
+        value.version = 'DMARC1';
+    }
+
     var label = '_dmarc';
     if (value.label !== '@') {
         label += '.' + value.label;
@@ -997,7 +1002,8 @@ function DMARC_BUILDER(value) {
         throw 'Invalid DMARC policy';
     }
 
-    var record = ['v=DMARC1'];
+    var record = [];
+    record.push('v=' + value.version);
     record.push('p=' + value.policy);
 
     // Subdomain policy
@@ -1045,7 +1051,7 @@ function DMARC_BUILDER(value) {
     }
 
     // Percentage
-    if (value.percent && value.percent != 100) {
+    if (value.percent) {
         record.push('pct=' + value.percent);
     }
 
@@ -1082,7 +1088,7 @@ function DMARC_BUILDER(value) {
     }
 
     // Failure report format
-    if (value.ruf && value.failureFormat && value.failureFormat !== 'afrf') {
+    if (value.ruf && value.failureFormat) {
         record.push('rf=' + value.failureFormat);
     }
 


### PR DESCRIPTION
This makes two tiny changes, which makes sense in my opinion:

1. It allows specifying a DMARC version, if required in the future. The only option, and the default, is `DMARC1`. If a new version is ever introduced, it allows specifying without needing to update dnscontrol.
2. When `percent`=100 or `failureFormat`=afrf, the option are not added to the TXT record at all. While they might be indeed the default in RFCs, the default might change in the future. When those values are clearly specified when using `DMARC_BUILDER()`, they should be added to the TXT record - being default or not.