### PR TITLE
VULTR: Fix TXT quoting issue

### DIFF
--- a/integrationTest/integration_test.go
+++ b/integrationTest/integration_test.go
@@ -790,8 +790,8 @@ func makeTests(t *testing.T) []*TestGroup {
 		),
 
 		testgroup("simple TXT-spf1",
-			// This was added because Vultr syntax-checks TXT records that
-			// with SPF contents.
+			// This was added because Vultr syntax-checks TXT records with
+			// SPF contents.
 			tc("Create a TXT/SPF", txt("foo", "v=spf1 ip4:99.99.99.99 -all")),
 		),
 

--- a/integrationTest/integration_test.go
+++ b/integrationTest/integration_test.go
@@ -789,6 +789,12 @@ func makeTests(t *testing.T) []*TestGroup {
 			tc("Create a TXT with spaces", txt("foo", "with spaces")),
 		),
 
+		testgroup("simple TXT-spf1",
+			// This was added because Vultr syntax-checks TXT records that
+			// with SPF contents.
+			tc("Create a TXT/SPF", txt("foo", "v=spf1 ip4:99.99.99.99 -all")),
+		),
+
 		testgroup("long TXT",
 			tc("Create long TXT", txt("foo", strings.Repeat("A", 300))),
 			tc("Change long TXT", txt("foo", strings.Repeat("B", 310))),

--- a/providers/vultr/auditrecords.go
+++ b/providers/vultr/auditrecords.go
@@ -16,5 +16,9 @@ func AuditRecords(records []*models.RecordConfig) error {
 	}
 	// Still needed as of 2021-03-02
 
+	if err := recordaudit.TxtNoMultipleStrings(records); err != nil {
+		return err
+	}
+
 	return nil
 }

--- a/providers/vultr/vultrProvider.go
+++ b/providers/vultr/vultrProvider.go
@@ -251,6 +251,10 @@ func toVultrRecord(dc *models.DomainConfig, rc *models.RecordConfig, vultrID int
 		r.Data = fmt.Sprintf(`%v %s "%s"`, rc.CaaFlag, rc.CaaTag, rc.GetTargetField())
 	case "SSHFP":
 		r.Data = fmt.Sprintf("%d %d %s", rc.SshfpAlgorithm, rc.SshfpFingerprint, rc.GetTargetField())
+	case "TXT":
+		// Adds quotes if a TXT record. Without this, it fails to add TXT records with
+		//    "FAILURE! Unable to update record: Record data must be enclosed in quotes"
+		r.Data = fmt.Sprintf(`"%s"`, r.Data)
 	default:
 	}
 

--- a/providers/vultr/vultrProvider.go
+++ b/providers/vultr/vultrProvider.go
@@ -252,9 +252,13 @@ func toVultrRecord(dc *models.DomainConfig, rc *models.RecordConfig, vultrID int
 	case "SSHFP":
 		r.Data = fmt.Sprintf("%d %d %s", rc.SshfpAlgorithm, rc.SshfpFingerprint, rc.GetTargetField())
 	case "TXT":
-		// Adds quotes if a TXT record. Without this, it fails to add TXT records with
-		//    "FAILURE! Unable to update record: Record data must be enclosed in quotes"
-		r.Data = fmt.Sprintf(`"%s"`, r.Data)
+		if !(strings.Contains(r.Data, "spf")) {
+			// Adds quotes if a TXT record and not an spf record. Without this, it fails to add TXT records with
+			//    "FAILURE! Unable to update record: Record data must be enclosed in quotes"
+			// There must be a better way to detect a record built using SPF Builder as currently these records will fail
+			//    with "FAILURE! Unable to add record: Quotes may only appear at the beginning and end of the data"
+			r.Data = fmt.Sprintf(`"%s"`, r.Data)
+		}
 	default:
 	}
 

--- a/providers/vultr/vultrProvider.go
+++ b/providers/vultr/vultrProvider.go
@@ -256,6 +256,9 @@ func toVultrRecord(dc *models.DomainConfig, rc *models.RecordConfig, vultrID int
 	case "SSHFP":
 		r.Data = fmt.Sprintf("%d %d %s", rc.SshfpAlgorithm, rc.SshfpFingerprint, rc.GetTargetField())
 	case "TXT":
+		// Vultr doesn't permit TXT strings to include double-quotes
+		// therefore, we don't have to escape interior double-quotes.
+		// Vultr's API requires the string to begin and end with double-quotes.
 		r.Data = `"` + strings.Join(rc.TxtStrings, "") + `"`
 	default:
 	}


### PR DESCRIPTION
* VULTR TXT records must be a single string
* VULTR TXT records may not include the double-quote char
* VULTR's API's line protocol requires TXT strings to be surrounded by double-quotes
* VULTR's API syntax-checks TXT records that start with v=spf1