### PR TITLE
Add R53_ZONE as an domain identifier

### DIFF
--- a/docs/_functions/record/R53_ZONE.md
+++ b/docs/_functions/record/R53_ZONE.md
@@ -4,8 +4,12 @@ parameters:
   - zone_id
 ---
 
-R53_ZONE sets the required Route53 hosted zone id in a R53_ALIAS record.
+R53_ZONE lets you specify the AWS Zone ID for an entire domain (D()) or a specific R53_ALIAS() record.
 
-This directive has no impact when used in anything else than a R53_ALIAS.
+When used with D(), it sets the zone id of the domain. This can be used to differentiate between split horizon domains in public and private zones.
 
-Please refer to the R53_ALIAS directive for usage.
+When used with R53_ALIAS() it sets the required Route53 hosted zone id in a R53_ALIAS record. See [https://stackexchange.github.io/dnscontrol/js#R53_ALIAS](R53_ALIAS's documentation) for details.
+
+
+
+

--- a/pkg/js/helpers.js
+++ b/pkg/js/helpers.js
@@ -26,6 +26,10 @@ function initialize() {
     defaultArgs = [];
 }
 
+function _isDomain(d) {
+  return _.isArray(d.nameservers) && _.isArray(d.records) && _.isString(d.name);
+}
+
 // Returns an array of domains which were registered so far during runtime
 // Own function for compatibility reasons or if some day special processing would be required.
 function getConfiguredDomains() {
@@ -276,8 +280,10 @@ var R53_ALIAS = recordBuilder('R53_ALIAS', {
 
 // R53_ZONE(zone_id)
 function R53_ZONE(zone_id) {
-    return function(r) {
-        if (_.isObject(r.r53_alias)) {
+    return function (r) {
+        if (_isDomain(r)) {
+            r.meta.zone_id = zone_id;
+        } else if (_.isObject(r.r53_alias)) {
             r.r53_alias['zone_id'] = zone_id;
         } else {
             r.r53_alias = { zone_id: zone_id };

--- a/pkg/js/parse_tests/040-r53-zone.js
+++ b/pkg/js/parse_tests/040-r53-zone.js
@@ -1,0 +1,7 @@
+D('foo.com', 'none', R53_ZONE('Z2FTEDLFRTZ'));
+D(
+    'foo.com!internal',
+    'none',
+    R53_ZONE('Z2FTEDLFRTF'),
+    R53_ALIAS('atest', 'A', 'foo.com.', R53_ZONE('Z2FTEDLFRTZ'))
+);

--- a/pkg/js/parse_tests/040-r53-zone.json
+++ b/pkg/js/parse_tests/040-r53-zone.json
@@ -1,0 +1,34 @@
+{
+  "registrars": [],
+  "dns_providers": [],
+  "domains": [
+    {
+      "name": "foo.com",
+      "registrar": "none",
+      "dnsProviders": {},
+      "records": [],
+      "meta": {
+        "zone_id": "Z2FTEDLFRTZ"
+      }
+    },
+    {
+      "name": "foo.com!internal",
+      "registrar": "none",
+      "dnsProviders": {},
+      "records": [
+        {
+          "type": "R53_ALIAS",
+          "name": "atest",
+          "r53_alias": {
+            "type": "A",
+            "zone_id": "Z2FTEDLFRTZ"
+          },
+          "target": "foo.com."
+        }
+      ],
+      "meta": {
+        "zone_id": "Z2FTEDLFRTF"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Using R53_ZONE allows you to differentiate between split horizon domains across zones.

## But why?
Well, imagine you have a hosted public zone called enrise.com and a private zone for enrise.com specific to a VPC. different enrise.com zones across different VPCs. In these examples DNSControl doesn't allow you to specify the zone by ID. This MR addresses this by using the `R53_ZONE` directive inside the `D` directive