### PR TITLE
CLOUDFLAREAPI: Initial support for CF_WORKER_ROUTE (without tests).

### DIFF
--- a/docs/_functions/domain/CF_WORKER_ROUTE.md
+++ b/docs/_functions/domain/CF_WORKER_ROUTE.md
@@ -1,0 +1,29 @@
+---
+name: CF_WORKER_ROUTE
+parameters:
+  - pattern
+  - script
+---
+
+`CF_WORKER_ROUTE` uses [Cloudflare Workers](https://developers.cloudflare.com/workers/) 
+API to setup [routes](https://developers.cloudflare.com/workers/platform/routes)
+for a given domain.
+
+If _any_ `CF_WORKER_ROUTE` function is used then `dnscontrol` will manage _all_ 
+Worker Routes for the domain.
+
+WARNING: This interface is not extensively tested. Take precautions such as making
+backups and manually verifying `dnscontrol preview` output before running
+`dnscontrol push`. This is especially true when mixing Worker Routes that are
+managed by DNSControl and those that aren't.
+
+This example assigns the patterns `api.foo.com/*` and `foo.com/api/*` to a `my-worker` script:
+
+{% include startExample.html %}
+{% highlight js %}
+D("foo.com", .... ,
+    CF_WORKER_ROUTE("api.foo.com/*", "my-worker"),
+    CF_WORKER_ROUTE("foo.com/api/*", "my-worker"),
+);
+{%endhighlight%}
+{% include endExample.html %}

--- a/docs/_providers/cloudflare.md
+++ b/docs/_providers/cloudflare.md
@@ -170,3 +170,20 @@ Notice a few details:
 2. The IP address in those A records may be mostly irrelevant, as cloudflare should handle all requests (assuming some page rule matches).
 3. Ordering matters for priority. CF_REDIRECT records will be added in the order they appear in your js. So put catch-alls at the bottom.
 4. if _any_ `CF_REDIRECT` or `CF_TEMP_REDIRECT` functions are used then `dnscontrol` will manage _all_ "Forwarding URL" type Page Rules for the domain. Page Rule types other than "Forwarding URL” will be left alone.
+
+## Worker routes
+The Cloudflare provider can manage Worker Routes for your domains. Simply use the `CF_WORKER_ROUTE` function passing the route pattern and the worker name:
+
+{% highlight js %}
+
+var CLOUDFLARE = NewDnsProvider('cloudflare','CLOUDFLAREAPI');
+
+D("foo.com", REG_NONE, DnsProvider(CLOUDFLARE),
+    // Assign the patterns `api.foo.com/*` and `foo.com/api/*` to `my-worker` script.
+    CF_WORKER_ROUTE("api.foo.com/*", "my-worker"),
+    CF_WORKER_ROUTE("foo.com/api/*", "my-worker"),
+);
+
+{%endhighlight%}
+
+Please notice that if _any_ `CF_WORKER_ROUTE` function is used then `dnscontrol` will manage _all_ Worker Routes for the domain.

--- a/models/domain.go
+++ b/models/domain.go
@@ -84,7 +84,7 @@ func (dc *DomainConfig) Punycode() error {
 				return err
 			}
 			rec.SetTarget(t)
-		case "CF_REDIRECT", "CF_TEMP_REDIRECT":
+		case "CF_REDIRECT", "CF_TEMP_REDIRECT", "CF_WORKER_ROUTE":
 			rec.SetTarget(rec.GetTargetField())
 		case "A", "AAAA", "CAA", "DS", "NAPTR", "SOA", "SSHFP", "TXT", "TLSA", "AZURE_ALIAS":
 			// Nothing to do.

--- a/models/record.go
+++ b/models/record.go
@@ -34,12 +34,14 @@ import (
 //     ALIAS
 //     CF_REDIRECT
 //     CF_TEMP_REDIRECT
+//     CF_WORKER_ROUTE
 //     FRAME
 //     IMPORT_TRANSFORM
 //     NAMESERVER
 //     NO_PURGE
 //     NS1_URLFWD
 //     PAGE_RULE
+//     WORKER_ROUTE
 //     PURGE
 //     URL
 //     URL301
@@ -512,7 +514,7 @@ func downcase(recs []*RecordConfig) {
 		case "ANAME", "CNAME", "DS", "MX", "NS", "PTR", "NAPTR", "SRV", "TLSA", "AKAMAICDN":
 			// These record types have a target that is case insensitive, so we downcase it.
 			r.target = strings.ToLower(r.target)
-		case "A", "AAAA", "ALIAS", "CAA", "IMPORT_TRANSFORM", "TXT", "SSHFP", "CF_REDIRECT", "CF_TEMP_REDIRECT":
+		case "A", "AAAA", "ALIAS", "CAA", "IMPORT_TRANSFORM", "TXT", "SSHFP", "CF_REDIRECT", "CF_TEMP_REDIRECT", "CF_WORKER_ROUTE":
 			// These record types have a target that is case sensitive, or is an IP address. We leave them alone.
 			// Do nothing.
 		case "SOA":

--- a/pkg/js/helpers.js
+++ b/pkg/js/helpers.js
@@ -716,7 +716,8 @@ function recordBuilder(type, opts) {
             // Handle D_EXTEND() with subdomains.
             if (d.subdomain &&
                 record.type != 'CF_REDIRECT' &&
-                record.type != 'CF_TEMP_REDIRECT') {
+                record.type != 'CF_TEMP_REDIRECT' &&
+                record.type != 'CF_WORKER_ROUTE') {
                 fqdn = [d.subdomain, d.name].join(".")
 
                 record.subdomain = d.subdomain;
@@ -849,6 +850,18 @@ var CF_TEMP_REDIRECT = recordBuilder('CF_TEMP_REDIRECT', {
         record.target = args.source + ',' + args.destination;
     },
 });
+
+var CF_WORKER_ROUTE = recordBuilder('CF_WORKER_ROUTE', {
+    args: [
+        ['pattern', _validateCloudflareRedirect],
+        ['script', _validateCloudflareRedirect],
+    ],
+    transform: function(record, args, modifiers) {
+        record.name = '@';
+        record.target = args.pattern + ',' + args.script;
+    },
+});
+
 
 var URL = recordBuilder('URL');
 var URL301 = recordBuilder('URL301');


### PR DESCRIPTION
Initial implementation of CF_WORKER_ROUTE.

Adds [Cloudflare Worker routes](https://developers.cloudflare.com/workers/platform/routes) support via new `CF_WORKER_ROUTE` function.

No tests, as I have yet to understand the tests infrastructure. But the code is working as I did some manual tests with a personal CF account (Create, Modify and Delete routes are working as expected).

Thanks to @tlimoncelli for guidance and incentive.