### PR TITLE
docs: add clarity around named profiles

### DIFF
--- a/docs/_providers/route53.md
+++ b/docs/_providers/route53.md
@@ -43,6 +43,20 @@ $ export AWS_SDK_LOAD_CONFIG=1
 $ export AWS_PROFILE=ZZZZZZZZ
 ```
 
+Ensure you have a minimal creds.json file with the DNS Provider specified, otherwise versions above 3.8.0 will fail. So, for:
+
+```
+var R53_MAIN = NewDnsProvider('r53_main', 'ROUTE53');
+```
+
+You will need a creds.json file with the following content:
+
+```json
+{
+  "R53_MAIN": {}
+}
+```
+
 You can find some other ways to authenticate to Route53 in the [go sdk configuration](https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html).
 
 ## Metadata


### PR DESCRIPTION
Specifically that creds.json is now required for versions >3.8.0 when using named profiles, as well as the environment variables.

fixes #1261 