### PR TITLE
CLOUDFLARE: Stop requiring accountname

### DIFF
--- a/docs/_providers/cloudflare.md
+++ b/docs/_providers/cloudflare.md
@@ -43,7 +43,6 @@ If your Cloudflare account has access to multiple Cloudflare accounts, you can s
   "cloudflare": {
     "apitoken": "...",
     "accountid": "your-cloudflare-account-id",
-    "accountname": "your-cloudflare-account-name"
   }
 }
 {% endhighlight %}

--- a/providers/cloudflare/rest.go
+++ b/providers/cloudflare/rest.go
@@ -56,7 +56,7 @@ func (c *cloudflareProvider) deleteRec(rec cloudflare.DNSRecord, domainID string
 }
 
 func (c *cloudflareProvider) createZone(domainName string) (string, error) {
-	zone, err := c.cfClient.CreateZone(context.Background(), domainName, false, cloudflare.Account{Name: c.AccountName, ID: c.AccountID}, "full")
+	zone, err := c.cfClient.CreateZone(context.Background(), domainName, false, cloudflare.Account{ID: c.cfClient.AccountID}, "full")
 	return zone.ID, err
 }
 


### PR DESCRIPTION
There is no API call I've found that requires it, only the accountID.  Also, we now set the cfClient.AccountID similar to b55278140f63e0f95a3418bcd61b810c731ae08f (h/t @fdcastel) and no longer store duplicate information in the cfClient and api objects.

Fixes #1275