### PR TITLE
Implement job concurrency on build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,6 +35,7 @@ jobs:
   integration-tests:
     runs-on: ubuntu-latest
     needs: build
+    concurrency: ${{ matrix.provider }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
This should prevent builds from interacting with each other thereby keeping builds from failing when 2 provider tests happen at the same time.

@tlimoncelli I think this should do the trick, but having some problems getting it to work on my fork.