### PR TITLE
GANDI_V5 & DESEC: correctly handle multiple RR in a RRset

### DIFF
--- a/providers/desec/convert.go
+++ b/providers/desec/convert.go
@@ -57,10 +57,7 @@ func recordsToNative(rcs []*models.RecordConfig, origin string) []resourceRecord
 				Subname: label,
 				Records: []string{r.GetTargetCombined()},
 			}
-			zrs = append(zrs, zr)
-			//keys[key] = &zr   // This didn't work.
-			keys[key] = &zrs[len(zrs)-1] // This does work. I don't know why.
-
+			keys[key] = &zr
 		} else {
 			zr.Records = append(zr.Records, r.GetTargetCombined())
 
@@ -74,5 +71,8 @@ func recordsToNative(rcs []*models.RecordConfig, origin string) []resourceRecord
 		}
 	}
 
+	for _, zr := range keys {
+		zrs = append(zrs, *zr)
+	}
 	return zrs
 }

--- a/providers/gandiv5/convert.go
+++ b/providers/gandiv5/convert.go
@@ -63,10 +63,7 @@ func recordsToNative(rcs []*models.RecordConfig, origin string) []livedns.Domain
 				RrsetName:   label,
 				RrsetValues: []string{r.GetTargetCombined()},
 			}
-			zrs = append(zrs, zr)
-			//keys[key] = &zr   // This didn't work.
-			keys[key] = &zrs[len(zrs)-1] // This does work. I don't know why.
-
+			keys[key] = &zr
 		} else {
 			zr.RrsetValues = append(zr.RrsetValues, r.GetTargetCombined())
 
@@ -80,5 +77,8 @@ func recordsToNative(rcs []*models.RecordConfig, origin string) []livedns.Domain
 		}
 	}
 
+	for _, zr := range keys {
+		zrs = append(zrs, *zr)
+	}
 	return zrs
 }


### PR DESCRIPTION
When having multiple RR in a RRset, only a few of them may be applied.
In my case, when I have two A records, only one of them makes its way
to Gandi.

In `convert.go`, we had:

```go
var zrs []livedns.DomainRecord
// [...]
zrs = append(zrs, zr)
keys[key] = &zrs[len(zrs)-1]
```

If the slice needs to be extended when appending, the reference we got
in `keys[key]` may be outdated because the new slice contains a copy
of the old one. We either need to store references to domain records
in the slice or we need to stop keeping reference of items in the
slice.

I have fixed this with the second solution as I think the order of the
RRsets is not important.