### PR TITLE
Add test cases for IDN domains

### DIFF
--- a/pkg/js/parse_tests/029-dextendsub.js
+++ b/pkg/js/parse_tests/029-dextendsub.js
@@ -3,6 +3,7 @@ var CF = NewDnsProvider("Cloudflare", "CLOUDFLAREAPI");
 
 // Zone that gets extended by subdomain
 D("foo.net", REG, DnsProvider(CF),
+  DefaultTTL(300),
   A("@", "10.1.1.1"),
   A("www", "10.2.2.2")
 );
@@ -13,10 +14,12 @@ D_EXTEND("bar.foo.net",
 
 // Zone and subdomain zone, each get extended.
 D("foo.tld", REG, DnsProvider(CF),
+  DefaultTTL(300),
   A("@", "20.5.5.5"),
   A("www", "20.6.6.6")
 );
 D("bar.foo.tld", REG, DnsProvider(CF),
+  DefaultTTL(300),
   A("@", "30.7.7.7"),
   A("www", "30.8.8.8")
 );
@@ -29,10 +32,12 @@ D_EXTEND("foo.tld",
 
 // Zone and subdomain zone, each get extended by a subdomain.
 D("foo.help", REG, DnsProvider(CF),
+  DefaultTTL(300),
   A("@", "40.12.12.12"),
   A("www", "40.12.12.12")
 );
 D("bar.foo.help", REG, DnsProvider(CF),
+  DefaultTTL(300),
   A("@", "50.13.13.13"),
   A("www", "50.14.14.14")
 );
@@ -47,6 +52,7 @@ D_EXTEND("morty.foo.help",
 
 // Zone extended by a subdomain and sub-subdomain.
 D("foo.here", REG, DnsProvider(CF),
+  DefaultTTL(300),
   A("@", "60.19.19.19"),
   A("www", "60.20.20.20")
 );
@@ -65,8 +71,69 @@ D_EXTEND("a.long.path.of.sub.domains.foo.net",
   A("www", "10.26.26.26")
 );
 
+// ASCII zone
+D("example.com", REG, DnsProvider(CF),
+  DefaultTTL(300),
+  A("@", "10.0.0.1"),
+  A("www", "10.0.0.2")
+);
+// … extended by an IDN subdomain
+D_EXTEND("düsseldorf.example.com",
+  A("@", "10.0.0.3"),
+  A("www", "10.0.0.4")
+);
+// … extended by a one-character IDN subdomain
+D_EXTEND("ü.example.com",
+  A("@", "10.0.0.5"),
+  A("www", "10.0.0.6")
+);
+
+// IDN zone
+D("düsseldorf.example.net", REG, DnsProvider(CF),
+  DefaultTTL(300),
+  A("@", "10.0.0.7"),
+  A("www", "10.0.0.8")
+);
+// … extended by an ASCII subdomain
+D_EXTEND("subdomain.düsseldorf.example.net",
+  A("@", "10.0.0.9"),
+  A("www", "10.0.0.10")
+);
+// … extended by an IDN subdomain
+D_EXTEND("düsseltal.düsseldorf.example.net",
+  A("@", "10.0.0.11"),
+  A("www", "10.0.0.12")
+);
+// … extended by a one-character IDN subdomain
+D_EXTEND("ü.düsseldorf.example.net",
+  A("@", "10.0.0.13"),
+  A("www", "10.0.0.14")
+);
+
+// One-character IDN zone
+D("ü.example.net", REG, DnsProvider(CF),
+  DefaultTTL(300),
+  A("@", "10.0.0.15"),
+  A("www", "10.0.0.16")
+);
+// … extended by an ASCII subdomain
+D_EXTEND("subdomain.ü.example.net",
+  A("@", "10.0.0.17"),
+  A("www", "10.0.0.18")
+);
+// … extended by an IDN subdomain
+D_EXTEND("düsseldorf.ü.example.net",
+  A("@", "10.0.0.19"),
+  A("www", "10.0.0.20")
+);
+// … extended by a one-character IDN subdomain
+D_EXTEND("ü.ü.example.net",
+  A("@", "10.0.0.21"),
+  A("www", "10.0.0.22")
+);
+
 // Zone extended by a subdomain, with absolute and relative CNAME targets
-D("example.tld", REG, DnsProvider(CF));
+D("example.tld", REG, DnsProvider(CF), DefaultTTL(300));
 D_EXTEND("sub.example.tld",
     CNAME("a", "b"), // a.sub.example.tld -> b.sub.example.tld
     CNAME("b", "@"), // a.sub.example.tld -> sub.example.tld

--- a/pkg/js/parse_tests/029-dextendsub.json
+++ b/pkg/js/parse_tests/029-dextendsub.json
@@ -1,85 +1,450 @@
 {
-  "dns_providers": [ { "name": "Cloudflare", "type": "CLOUDFLAREAPI" } ],
+  "registrars": [
+    {
+      "name": "Third-Party",
+      "type": "NONE"
+    }
+  ],
+  "dns_providers": [
+    {
+      "name": "Cloudflare",
+      "type": "CLOUDFLAREAPI"
+    }
+  ],
   "domains": [
     {
       "name": "foo.net",
-      "dnsProviders": { "Cloudflare": -1 },
+      "registrar": "Third-Party",
+      "dnsProviders": {
+        "Cloudflare": -1
+      },
       "records": [
-        { "name": "@", "target": "10.1.1.1", "type": "A" },
-        { "name": "www", "target": "10.2.2.2", "type": "A" },
-        { "name": "bar", "subdomain": "bar", "target": "10.3.3.3", "type": "A" },
-        { "name": "www.bar", "subdomain": "bar", "target": "10.4.4.4", "type": "A" },
-        { "name": "a.long.path.of.sub.domains", "subdomain": "a.long.path.of.sub.domains", "target": "10.25.25.25", "type": "A" },
-        { "name": "www.a.long.path.of.sub.domains", "subdomain": "a.long.path.of.sub.domains", "target": "10.26.26.26", "type": "A" }
-      ],
-      "registrar": "Third-Party"
+        {
+          "type": "A",
+          "name": "@",
+          "ttl": 300,
+          "target": "10.1.1.1"
+        },
+        {
+          "type": "A",
+          "name": "www",
+          "ttl": 300,
+          "target": "10.2.2.2"
+        },
+        {
+          "type": "A",
+          "name": "bar",
+          "subdomain": "bar",
+          "ttl": 300,
+          "target": "10.3.3.3"
+        },
+        {
+          "type": "A",
+          "name": "www.bar",
+          "subdomain": "bar",
+          "ttl": 300,
+          "target": "10.4.4.4"
+        },
+        {
+          "type": "A",
+          "name": "a.long.path.of.sub.domains",
+          "subdomain": "a.long.path.of.sub.domains",
+          "ttl": 300,
+          "target": "10.25.25.25"
+        },
+        {
+          "type": "A",
+          "name": "www.a.long.path.of.sub.domains",
+          "subdomain": "a.long.path.of.sub.domains",
+          "ttl": 300,
+          "target": "10.26.26.26"
+        }
+      ]
     },
     {
       "name": "foo.tld",
-      "dnsProviders": { "Cloudflare": -1 },
+      "registrar": "Third-Party",
+      "dnsProviders": {
+        "Cloudflare": -1
+      },
       "records": [
-        { "name": "@", "target": "20.5.5.5", "type": "A" },
-        { "name": "www", "target": "20.6.6.6", "type": "A" },
-        { "name": "a", "target": "20.10.10.10", "type": "A" }
-      ],
-      "registrar": "Third-Party"
+        {
+          "type": "A",
+          "name": "@",
+          "ttl": 300,
+          "target": "20.5.5.5"
+        },
+        {
+          "type": "A",
+          "name": "www",
+          "ttl": 300,
+          "target": "20.6.6.6"
+        },
+        {
+          "type": "A",
+          "name": "a",
+          "ttl": 300,
+          "target": "20.10.10.10"
+        }
+      ]
     },
     {
       "name": "bar.foo.tld",
-      "dnsProviders": { "Cloudflare": -1 },
+      "registrar": "Third-Party",
+      "dnsProviders": {
+        "Cloudflare": -1
+      },
       "records": [
-        { "name": "@", "target": "30.7.7.7", "type": "A" },
-        { "name": "www", "target": "30.8.8.8", "type": "A" },
-        { "name": "a", "target": "30.9.9.9", "type": "A" }
-      ],
-      "registrar": "Third-Party"
+        {
+          "type": "A",
+          "name": "@",
+          "ttl": 300,
+          "target": "30.7.7.7"
+        },
+        {
+          "type": "A",
+          "name": "www",
+          "ttl": 300,
+          "target": "30.8.8.8"
+        },
+        {
+          "type": "A",
+          "name": "a",
+          "ttl": 300,
+          "target": "30.9.9.9"
+        }
+      ]
     },
     {
       "name": "foo.help",
-      "dnsProviders": { "Cloudflare": -1 },
+      "registrar": "Third-Party",
+      "dnsProviders": {
+        "Cloudflare": -1
+      },
       "records": [
-        { "name": "@", "target": "40.12.12.12", "type": "A" },
-        { "name": "www", "target": "40.12.12.12", "type": "A" },
-        { "name": "morty", "subdomain": "morty", "target": "40.17.17.17", "type": "A" },
-        { "name": "www.morty", "subdomain": "morty", "target": "40.18.18.18", "type": "A" }
-      ],
-      "registrar": "Third-Party"
+        {
+          "type": "A",
+          "name": "@",
+          "ttl": 300,
+          "target": "40.12.12.12"
+        },
+        {
+          "type": "A",
+          "name": "www",
+          "ttl": 300,
+          "target": "40.12.12.12"
+        },
+        {
+          "type": "A",
+          "name": "morty",
+          "subdomain": "morty",
+          "ttl": 300,
+          "target": "40.17.17.17"
+        },
+        {
+          "type": "A",
+          "name": "www.morty",
+          "subdomain": "morty",
+          "ttl": 300,
+          "target": "40.18.18.18"
+        }
+      ]
     },
     {
       "name": "bar.foo.help",
-      "dnsProviders": { "Cloudflare": -1 },
+      "registrar": "Third-Party",
+      "dnsProviders": {
+        "Cloudflare": -1
+      },
       "records": [
-        { "name": "@", "target": "50.13.13.13", "type": "A" },
-        { "name": "www", "target": "50.14.14.14", "type": "A" },
-        { "name": "zip", "subdomain": "zip", "target": "50.15.15.15", "type": "A" },
-        { "name": "www.zip", "subdomain": "zip", "target": "50.16.16.16", "type": "A" }
-      ],
-      "registrar": "Third-Party"
+        {
+          "type": "A",
+          "name": "@",
+          "ttl": 300,
+          "target": "50.13.13.13"
+        },
+        {
+          "type": "A",
+          "name": "www",
+          "ttl": 300,
+          "target": "50.14.14.14"
+        },
+        {
+          "type": "A",
+          "name": "zip",
+          "subdomain": "zip",
+          "ttl": 300,
+          "target": "50.15.15.15"
+        },
+        {
+          "type": "A",
+          "name": "www.zip",
+          "subdomain": "zip",
+          "ttl": 300,
+          "target": "50.16.16.16"
+        }
+      ]
     },
     {
       "name": "foo.here",
-      "dnsProviders": { "Cloudflare": -1 },
+      "registrar": "Third-Party",
+      "dnsProviders": {
+        "Cloudflare": -1
+      },
       "records": [
-        { "name": "@", "target": "60.19.19.19", "type": "A" },
-        { "name": "www", "target": "60.20.20.20", "type": "A" },
-        { "name": "bar", "subdomain": "bar", "target": "60.21.21.21", "type": "A" },
-        { "name": "www.bar", "subdomain": "bar", "target": "60.22.22.22", "type": "A" },
-        { "name": "baz.bar", "subdomain": "baz.bar", "target": "60.23.23.23", "type": "A" },
-        { "name": "www.baz.bar", "subdomain": "baz.bar", "target": "60.24.24.24", "type": "A" }
-      ],
-      "registrar": "Third-Party"
+        {
+          "type": "A",
+          "name": "@",
+          "ttl": 300,
+          "target": "60.19.19.19"
+        },
+        {
+          "type": "A",
+          "name": "www",
+          "ttl": 300,
+          "target": "60.20.20.20"
+        },
+        {
+          "type": "A",
+          "name": "bar",
+          "subdomain": "bar",
+          "ttl": 300,
+          "target": "60.21.21.21"
+        },
+        {
+          "type": "A",
+          "name": "www.bar",
+          "subdomain": "bar",
+          "ttl": 300,
+          "target": "60.22.22.22"
+        },
+        {
+          "type": "A",
+          "name": "baz.bar",
+          "subdomain": "baz.bar",
+          "ttl": 300,
+          "target": "60.23.23.23"
+        },
+        {
+          "type": "A",
+          "name": "www.baz.bar",
+          "subdomain": "baz.bar",
+          "ttl": 300,
+          "target": "60.24.24.24"
+        }
+      ]
+    },
+    {
+      "name": "example.com",
+      "registrar": "Third-Party",
+      "dnsProviders": {
+        "Cloudflare": -1
+      },
+      "records": [
+        {
+          "type": "A",
+          "name": "@",
+          "ttl": 300,
+          "target": "10.0.0.1"
+        },
+        {
+          "type": "A",
+          "name": "www",
+          "ttl": 300,
+          "target": "10.0.0.2"
+        },
+        {
+          "type": "A",
+          "name": "düsseldorf",
+          "subdomain": "düsseldorf",
+          "ttl": 300,
+          "target": "10.0.0.3"
+        },
+        {
+          "type": "A",
+          "name": "www.düsseldorf",
+          "subdomain": "düsseldorf",
+          "ttl": 300,
+          "target": "10.0.0.4"
+        },
+        {
+          "type": "A",
+          "name": "ü",
+          "subdomain": "ü",
+          "ttl": 300,
+          "target": "10.0.0.5"
+        },
+        {
+          "type": "A",
+          "name": "www.ü",
+          "subdomain": "ü",
+          "ttl": 300,
+          "target": "10.0.0.6"
+        }
+      ]
+    },
+    {
+      "name": "düsseldorf.example.net",
+      "registrar": "Third-Party",
+      "dnsProviders": {
+        "Cloudflare": -1
+      },
+      "records": [
+        {
+          "type": "A",
+          "name": "@",
+          "ttl": 300,
+          "target": "10.0.0.7"
+        },
+        {
+          "type": "A",
+          "name": "www",
+          "ttl": 300,
+          "target": "10.0.0.8"
+        },
+        {
+          "type": "A",
+          "name": "subdomain",
+          "subdomain": "subdomain",
+          "ttl": 300,
+          "target": "10.0.0.9"
+        },
+        {
+          "type": "A",
+          "name": "www.subdomain",
+          "subdomain": "subdomain",
+          "ttl": 300,
+          "target": "10.0.0.10"
+        },
+        {
+          "type": "A",
+          "name": "düsseltal",
+          "subdomain": "düsseltal",
+          "ttl": 300,
+          "target": "10.0.0.11"
+        },
+        {
+          "type": "A",
+          "name": "www.düsseltal",
+          "subdomain": "düsseltal",
+          "ttl": 300,
+          "target": "10.0.0.12"
+        },
+        {
+          "type": "A",
+          "name": "ü",
+          "subdomain": "ü",
+          "ttl": 300,
+          "target": "10.0.0.13"
+        },
+        {
+          "type": "A",
+          "name": "www.ü",
+          "subdomain": "ü",
+          "ttl": 300,
+          "target": "10.0.0.14"
+        }
+      ]
+    },
+    {
+      "name": "ü.example.net",
+      "registrar": "Third-Party",
+      "dnsProviders": {
+        "Cloudflare": -1
+      },
+      "records": [
+        {
+          "type": "A",
+          "name": "@",
+          "ttl": 300,
+          "target": "10.0.0.15"
+        },
+        {
+          "type": "A",
+          "name": "www",
+          "ttl": 300,
+          "target": "10.0.0.16"
+        },
+        {
+          "type": "A",
+          "name": "subdomain",
+          "subdomain": "subdomain",
+          "ttl": 300,
+          "target": "10.0.0.17"
+        },
+        {
+          "type": "A",
+          "name": "www.subdomain",
+          "subdomain": "subdomain",
+          "ttl": 300,
+          "target": "10.0.0.18"
+        },
+        {
+          "type": "A",
+          "name": "düsseldorf",
+          "subdomain": "düsseldorf",
+          "ttl": 300,
+          "target": "10.0.0.19"
+        },
+        {
+          "type": "A",
+          "name": "www.düsseldorf",
+          "subdomain": "düsseldorf",
+          "ttl": 300,
+          "target": "10.0.0.20"
+        },
+        {
+          "type": "A",
+          "name": "ü",
+          "subdomain": "ü",
+          "ttl": 300,
+          "target": "10.0.0.21"
+        },
+        {
+          "type": "A",
+          "name": "www.ü",
+          "subdomain": "ü",
+          "ttl": 300,
+          "target": "10.0.0.22"
+        }
+      ]
     },
     {
       "name": "example.tld",
-      "dnsProviders": { "Cloudflare": -1 },
+      "registrar": "Third-Party",
+      "dnsProviders": {
+        "Cloudflare": -1
+      },
       "records": [
-        { "name": "a.sub", "subdomain": "sub", "target": "b", "type": "CNAME" },
-        { "name": "b.sub", "subdomain": "sub", "target": "@", "type": "CNAME" },
-        { "name": "c.sub", "subdomain": "sub", "target": "sub.example.tld.", "type": "CNAME" },
-        { "name": "e.sub", "subdomain": "sub", "target": "otherdomain.tld.", "type": "CNAME" }
-      ],
-      "registrar": "Third-Party"
+        {
+          "type": "CNAME",
+          "name": "a.sub",
+          "subdomain": "sub",
+          "ttl": 300,
+          "target": "b"
+        },
+        {
+          "type": "CNAME",
+          "name": "b.sub",
+          "subdomain": "sub",
+          "ttl": 300,
+          "target": "@"
+        },
+        {
+          "type": "CNAME",
+          "name": "c.sub",
+          "subdomain": "sub",
+          "ttl": 300,
+          "target": "sub.example.tld."
+        },
+        {
+          "type": "CNAME",
+          "name": "e.sub",
+          "subdomain": "sub",
+          "ttl": 300,
+          "target": "otherdomain.tld."
+        }
+      ]
     }
-  ],
-  "registrars": [ { "name": "Third-Party", "type": "NONE" } ]
+  ]
 }

--- a/pkg/js/parse_tests/029-dextendsub/düsseldorf.example.net.zone
+++ b/pkg/js/parse_tests/029-dextendsub/düsseldorf.example.net.zone
@@ -1,0 +1,9 @@
+$TTL 300
+@                IN A     10.0.0.7
+düsseltal       IN A     10.0.0.11
+www.düsseltal   IN A     10.0.0.12
+subdomain        IN A     10.0.0.9
+www.subdomain    IN A     10.0.0.10
+www              IN A     10.0.0.8
+ü               IN A     10.0.0.13
+www.ü           IN A     10.0.0.14

--- a/pkg/js/parse_tests/029-dextendsub/example.com.zone
+++ b/pkg/js/parse_tests/029-dextendsub/example.com.zone
@@ -1,0 +1,7 @@
+$TTL 300
+@                IN A     10.0.0.1
+düsseldorf      IN A     10.0.0.3
+www.düsseldorf  IN A     10.0.0.4
+www              IN A     10.0.0.2
+ü               IN A     10.0.0.5
+www.ü           IN A     10.0.0.6

--- a/pkg/js/parse_tests/029-dextendsub/ü.example.net.zone
+++ b/pkg/js/parse_tests/029-dextendsub/ü.example.net.zone
@@ -1,0 +1,9 @@
+$TTL 300
+@                IN A     10.0.0.15
+düsseldorf      IN A     10.0.0.19
+www.düsseldorf  IN A     10.0.0.20
+subdomain        IN A     10.0.0.17
+www.subdomain    IN A     10.0.0.18
+www              IN A     10.0.0.16
+ü               IN A     10.0.0.21
+www.ü           IN A     10.0.0.22


### PR DESCRIPTION
Added test cases for every permutation of IDN domains I could think of.

Tests pass with current master (866aa798e2a3acbb3b595afdbbe20ee74b0604c5) but fail with `v3.12.0`.

P.S. Recreated IR JSON file, had to set the `CNAME` tests (760ee8dc46f74f48e216bcaeb82f87f133ca4e16 `029-extendsub.js` lines 138 and 139) to be relative manually to get the tests to pass.