### PR TITLE
Fixes Oracle provider code leaves trailing dot on nameserver

### DIFF
--- a/providers/oracle/oracleProvider.go
+++ b/providers/oracle/oracleProvider.go
@@ -146,7 +146,7 @@ func (o *oracleProvider) GetNameservers(domain string) ([]*models.Nameserver, er
 		nss[i] = *ns.Hostname
 	}
 
-	return models.ToNameservers(nss)
+	return models.ToNameserversStripTD(nss)
 }
 
 func (o *oracleProvider) GetZoneRecords(domain string) (models.Records, error) {


### PR DESCRIPTION
Fixes #1305 Am not 100% sure if changing ToNameserver to ToNameserversStripTD is the correct way to fix the issue but seem to resolved the issue I was having.