### PR TITLE
Hosting.de: Allow using as registrar only

### DIFF
--- a/providers/hostingde/api.go
+++ b/providers/hostingde/api.go
@@ -20,15 +20,10 @@ type hostingdeProvider struct {
 }
 
 func (hp *hostingdeProvider) getDomainConfig(domain string) (*domainConfig, error) {
-	zc, err := hp.getZoneConfig(domain)
-	if err != nil {
-		return nil, fmt.Errorf("error getting zone config: %w", err)
-	}
-
 	params := request{
 		Filter: filter{
 			Field: "domainName",
-			Value: zc.Name,
+			Value: domain,
 		},
 	}
 


### PR DESCRIPTION
Currently, it is not possible to use the Hosting.de provider as a registrar only and use something else for DNS. It fails with the following error message:

```
******************** Domain: <some_domain>
----- DNS Provider: <some_other_provider>...
0 corrections
----- Registrar: hosting.de...
ERROR
Error getting corrections: error getting nameservers: error getting domain config: error getting zone config: zone not found
```

I'm pretty sure the problem is here:

https://github.com/StackExchange/dnscontrol/blob/3405757271b66c7e679b78af74810bedd3e7b50b/providers/hostingde/api.go#L23-L26

For getting the domain config, this always does a `getZoneConfig()` call. However, the [corresponding API call](https://www.hosting.de/api/#list-zoneconfigs) is part of the DNS section of the API. It only works if the domain is set up as a DNS zone with Hosting.de, which is likely not going to be the case if the user manages the domain's DNS elsewhere.

The zone config is only used to filter for the correct domain for the `domainsFind` API call:

https://github.com/StackExchange/dnscontrol/blob/3405757271b66c7e679b78af74810bedd3e7b50b/providers/hostingde/api.go#L31

As far as I can tell, this should be the same as the `domain` parameter that is passed to the function anyway. Thus, this PR removes the `getZoneConfig()` call and instead filters directly on `domain` without re-fetching it from the zone config.

With this change, I'm able to use Hosting.de just as a registrar:

```
******************** Domain: <some_domain>
----- DNS Provider: <some_other_provider>...
0 corrections
----- Registrar: hosting.de...
0 corrections
```

However, I'm neither familiar with dnscontrol nor with Hosting.de's API. There may well be a reason for the `getZoneConfig()` call that I'm just not aware of. My apologies if I've missed something.