### PR TITLE
CLOUDNS: More accurate TXT record checking (remove length check)

### DIFF
--- a/pkg/recordaudit/txt.go
+++ b/pkg/recordaudit/txt.go
@@ -97,8 +97,6 @@ func TxtNoMultipleStrings(records []*models.RecordConfig) error {
 		if rc.HasFormatIdenticalToTXT() { // TXT and similar:
 			if len(rc.TxtStrings) > 1 {
 				return fmt.Errorf("multiple strings in one txt")
-			} else if len(rc.TxtStrings) == 1 && len(rc.TxtStrings[0]) > 255 {
-				return fmt.Errorf("strings >255 octets")
 			}
 		}
 

--- a/providers/cloudns/auditrecords.go
+++ b/providers/cloudns/auditrecords.go
@@ -1,7 +1,6 @@
 package cloudns
 
 import (
-	"fmt"
 	"github.com/StackExchange/dnscontrol/v3/models"
 	"github.com/StackExchange/dnscontrol/v3/pkg/recordaudit"
 )
@@ -30,22 +29,9 @@ func AuditRecords(records []*models.RecordConfig) error {
 	}
 	// Still needed as of 2021-03-11
 
-	if err := txtNoMultipleStrings(records); err != nil {
+	if err := recordaudit.TxtNoMultipleStrings(records); err != nil {
 		return err
 	}
 
-	return nil
-}
-
-// ClouDNS NOT allow multiple TXT records with same name
-// But allow values longer the 255
-func txtNoMultipleStrings(records []*models.RecordConfig) error {
-	for _, rc := range records {
-		if rc.HasFormatIdenticalToTXT() { // TXT and similar:
-			if len(rc.TxtStrings) > 1 {
-				return fmt.Errorf("multiple strings in one txt")
-			}
-		}
-	}
 	return nil
 }

--- a/providers/msdns/auditrecords.go
+++ b/providers/msdns/auditrecords.go
@@ -14,6 +14,10 @@ func AuditRecords(records []*models.RecordConfig) error {
 	}
 	// Still needed as of 2021-03-01
 
+	if err := recordaudit.TxtNoLongStrings(records); err != nil {
+		return err
+	}
+
 	if err := recordaudit.TxtNotEmpty(records); err != nil {
 		return err
 	}

--- a/providers/vultr/auditrecords.go
+++ b/providers/vultr/auditrecords.go
@@ -20,5 +20,9 @@ func AuditRecords(records []*models.RecordConfig) error {
 		return err
 	}
 
+	if err := recordaudit.TxtNoLongStrings(records); err != nil {
+		return err
+	}
+
 	return nil
 }


### PR DESCRIPTION
Fix issue [#1139].
All functions in should test for only one condition. There already is a
function that tests for long TXT records: `TxtNoLongStrings`.
Add calls to `TxtNoLongStrings` in all providers that use
`TxtNoMultipleStrings`, to keep functionality, except for NS1 and ClouDNS,
which allow for any TXT record length, but not for multiple strings per
TXT.