### PR TITLE
Fix #1338 - OVH provider should work when domain is not registered 

### DIFF
--- a/docs/_providers/ovh.md
+++ b/docs/_providers/ovh.md
@@ -119,14 +119,13 @@ control panel manually.
 
 ## Dual providers scenario
 
-Since OVH doesn't allow to host DNS for a domain that is not registered in their registrar, some dual providers
-scenario are not possible:
+OVH now allows to host DNS zone for a domain that is not registered in their registrar (see: https://www.ovh.com/manager/web/#/zone). The following dual providers scenario are supported:
 
 | registrar | zone        | working? |
 |:---------:|:-----------:|:--------:|
 |  OVH      | other       |    √     |
 |  OVH      | OVH + other |    √     |
-|  other    | OVH         |    X     |
+|  other    | OVH         |    √     |
 
 ## Caveat
 

--- a/providers/ovh/ovhProvider.go
+++ b/providers/ovh/ovhProvider.go
@@ -68,7 +68,7 @@ func (c *ovhProvider) GetNameservers(domain string) ([]*models.Nameserver, error
 		return nil, fmt.Errorf("'%s' not a zone in ovh account", domain)
 	}
 
-	ns, err := c.fetchRegistrarNS(domain)
+	ns, err := c.fetchNS(domain)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
OVH now supports managing/creating only a zone (provided this one has been created in the control panel beforehand).
The provider was relying on the registrar NS instead of the zone NS preventing to manage the zone if the domain wasn't
registered to OVH.
These changes fix this behavior by getting the zone NS if the domain is not registered at OVH.
This also allows now to use OVH in all dual providers scenario.