### PR TITLE
BUG: Packetframe always include default nameservers

### DIFF
--- a/providers/packetframe/api.go
+++ b/providers/packetframe/api.go
@@ -14,6 +14,11 @@ const (
 	defaultBaseURL = "https://packetframe.com/api/"
 )
 
+var defaultNameServerNames = []string{
+	"ns1.packetframe.com",
+	"ns2.packetframe.com",
+}
+
 type zone struct {
 	ID         string   `json:"id"`
 	Zone       string   `json:"zone"`
@@ -74,6 +79,16 @@ func (c *packetframeProvider) getRecords(zoneID string) ([]domainRecord, error) 
 		return records, fmt.Errorf("failed fetching domain list (Packetframe): %w", err)
 	}
 	records = append(records, dr.Data.Records...)
+
+	for i := range defaultNameServerNames {
+		records = append(records, domainRecord{
+			Type:  "NS",
+			TTL:   86400,
+			Value: defaultNameServerNames[i] + ".",
+			Zone:  zoneID,
+			ID:    "0",
+		})
+	}
 
 	return records, nil
 }


### PR DESCRIPTION
This change is in response to the issue presented by @natesales here https://github.com/StackExchange/dnscontrol/pull/1347#issuecomment-1005250670, and following the practices done in the linodeProvider as a way to avoid the issue. It also changes the messages given from corrections to be the DNSControl supplied correction messages. Attached below is the integration test, go vet, and golint results.

```
➜  packetframe git:(packetframe-nameservers) ✗ go vet ./...
➜  packetframe git:(packetframe-nameservers) ✗ golint ./...
```

```
=== RUN   TestDNSProviders
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/Clean_Slate:Empty
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/00:GeneralACD:Create_an_A_record
    integration_test.go:220: CREATE A packetframe-dnscontrol.hammy.network 1.1.1.1 ttl=300
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/00:GeneralACD:Change_it
    integration_test.go:220: MODIFY A packetframe-dnscontrol.hammy.network: (1.1.1.1 ttl=300) -> (1.2.3.4 ttl=300)
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/00:GeneralACD:Add_another
    integration_test.go:220: CREATE A www.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/00:GeneralACD:Add_another(same_name)
    integration_test.go:220: CREATE A www.packetframe-dnscontrol.hammy.network 5.6.7.8 ttl=300
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/00:GeneralACD:Change_a_ttl
    integration_test.go:220: MODIFY A packetframe-dnscontrol.hammy.network: (1.2.3.4 ttl=300) -> (1.2.3.4 ttl=1000)
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/00:GeneralACD:Change_single_target_from_set
    integration_test.go:220: MODIFY A www.packetframe-dnscontrol.hammy.network: (1.2.3.4 ttl=300) -> (2.2.2.2 ttl=300)
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/00:GeneralACD:Change_all_ttls
    integration_test.go:220: MODIFY A packetframe-dnscontrol.hammy.network: (1.2.3.4 ttl=1000) -> (1.2.3.4 ttl=500)
    integration_test.go:220: MODIFY A www.packetframe-dnscontrol.hammy.network: (5.6.7.8 ttl=300) -> (5.6.7.8 ttl=400)
    integration_test.go:220: MODIFY A www.packetframe-dnscontrol.hammy.network: (2.2.2.2 ttl=300) -> (2.2.2.2 ttl=400)
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/00:GeneralACD:Delete_one
    integration_test.go:220: DELETE A www.packetframe-dnscontrol.hammy.network 2.2.2.2 ttl=400
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/00:GeneralACD:Add_back_and_change_ttl
    integration_test.go:220: CREATE A www.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=700
    integration_test.go:220: DELETE A packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=500
    integration_test.go:220: MODIFY A www.packetframe-dnscontrol.hammy.network: (5.6.7.8 ttl=400) -> (5.6.7.8 ttl=700)
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/00:GeneralACD:Change_targets_and_ttls
    integration_test.go:220: MODIFY A www.packetframe-dnscontrol.hammy.network: (1.2.3.4 ttl=700) -> (1.1.1.1 ttl=300)
    integration_test.go:220: MODIFY A www.packetframe-dnscontrol.hammy.network: (5.6.7.8 ttl=700) -> (2.2.2.2 ttl=300)
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/Post_cleanup:Empty
    integration_test.go:220: DELETE A www.packetframe-dnscontrol.hammy.network 1.1.1.1 ttl=300
    integration_test.go:220: DELETE A www.packetframe-dnscontrol.hammy.network 2.2.2.2 ttl=300
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/01:WildcardACD:Create_wildcard
    integration_test.go:220: CREATE A *.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: CREATE A www.packetframe-dnscontrol.hammy.network 1.1.1.1 ttl=300
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/01:WildcardACD:Delete_wildcard
    integration_test.go:220: DELETE A *.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/Post_cleanup:Empty#01
    integration_test.go:220: DELETE A www.packetframe-dnscontrol.hammy.network 1.1.1.1 ttl=300
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/02:CNAME:Create_a_CNAME
    integration_test.go:220: CREATE CNAME foo.packetframe-dnscontrol.hammy.network google.com. ttl=300
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/02:CNAME:Change_CNAME_target
    integration_test.go:220: MODIFY CNAME foo.packetframe-dnscontrol.hammy.network: (google.com. ttl=300) -> (google2.com. ttl=300)
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/02:CNAME:Empty
    integration_test.go:220: DELETE CNAME foo.packetframe-dnscontrol.hammy.network google2.com. ttl=300
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/02:CNAME:Record_pointing_to_@
    integration_test.go:220: CREATE CNAME foo.packetframe-dnscontrol.hammy.network packetframe-dnscontrol.hammy.network. ttl=300
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/Post_cleanup:Empty#02
    integration_test.go:220: DELETE CNAME foo.packetframe-dnscontrol.hammy.network packetframe-dnscontrol.hammy.network. ttl=300
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/03:MX:MX_record
    integration_test.go:220: CREATE MX packetframe-dnscontrol.hammy.network 5 foo.com. ttl=300
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/03:MX:Second_MX_record,_same_prio
    integration_test.go:220: CREATE MX packetframe-dnscontrol.hammy.network 5 foo2.com. ttl=300
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/03:MX:3_MX
    integration_test.go:220: CREATE MX packetframe-dnscontrol.hammy.network 15 foo3.com. ttl=300
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/03:MX:Delete_one
    integration_test.go:220: DELETE MX packetframe-dnscontrol.hammy.network 5 foo.com. ttl=300
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/03:MX:Change_to_other_name
    integration_test.go:220: CREATE MX mail.packetframe-dnscontrol.hammy.network 15 foo3.com. ttl=300
    integration_test.go:220: DELETE MX packetframe-dnscontrol.hammy.network 15 foo3.com. ttl=300
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/03:MX:Change_Preference
    integration_test.go:220: MODIFY MX packetframe-dnscontrol.hammy.network: (5 foo2.com. ttl=300) -> (7 foo2.com. ttl=300)
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/03:MX:Record_pointing_to_@
    integration_test.go:220: CREATE MX foo.packetframe-dnscontrol.hammy.network 8 packetframe-dnscontrol.hammy.network. ttl=300
    integration_test.go:220: DELETE MX mail.packetframe-dnscontrol.hammy.network 15 foo3.com. ttl=300
    integration_test.go:220: DELETE MX packetframe-dnscontrol.hammy.network 7 foo2.com. ttl=300
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/Post_cleanup:Empty#03
    integration_test.go:220: DELETE MX foo.packetframe-dnscontrol.hammy.network 8 packetframe-dnscontrol.hammy.network. ttl=300
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/04:Null_MX:Null_MX
    integration_test.go:220: CREATE MX packetframe-dnscontrol.hammy.network 0 . ttl=300
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/Post_cleanup:Empty#04
    integration_test.go:220: DELETE MX packetframe-dnscontrol.hammy.network 0 . ttl=300
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/05:NS:NS_for_subdomain
    integration_test.go:220: CREATE NS xyz.packetframe-dnscontrol.hammy.network ns2.foo.com. ttl=300
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/05:NS:Dual_NS_for_subdomain
    integration_test.go:220: CREATE NS xyz.packetframe-dnscontrol.hammy.network ns1.foo.com. ttl=300
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/05:NS:NS_Record_pointing_to_@
    integration_test.go:220: CREATE NS foo.packetframe-dnscontrol.hammy.network packetframe-dnscontrol.hammy.network. ttl=300
    integration_test.go:220: CREATE A packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: DELETE NS xyz.packetframe-dnscontrol.hammy.network ns1.foo.com. ttl=300
    integration_test.go:220: DELETE NS xyz.packetframe-dnscontrol.hammy.network ns2.foo.com. ttl=300
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/Post_cleanup:Empty#05
    integration_test.go:220: DELETE NS foo.packetframe-dnscontrol.hammy.network packetframe-dnscontrol.hammy.network. ttl=300
    integration_test.go:220: DELETE A packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/06:IGNORE_NAME_function:Create_some_records
    integration_test.go:220: CREATE A foo.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: CREATE TXT foo.packetframe-dnscontrol.hammy.network "simple" ttl=300
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/06:IGNORE_NAME_function:Add_a_new_record_-_ignoring_foo
    integration_test.go:220: CREATE A bar.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/06:IGNORE_NAME_function:Empty
    integration_test.go:220: DELETE A bar.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: DELETE TXT foo.packetframe-dnscontrol.hammy.network "simple" ttl=300
    integration_test.go:220: DELETE A foo.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/06:IGNORE_NAME_function:Create_some_records#01
    integration_test.go:220: CREATE TXT bar.foo.packetframe-dnscontrol.hammy.network "simple" ttl=300
    integration_test.go:220: CREATE A bar.foo.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/06:IGNORE_NAME_function:Add_a_new_record_-_ignoring_*.foo
    integration_test.go:220: CREATE A bar.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/Post_cleanup:Empty#06
    integration_test.go:220: DELETE TXT bar.foo.packetframe-dnscontrol.hammy.network "simple" ttl=300
    integration_test.go:220: DELETE A bar.foo.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: DELETE A bar.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/07:IGNORE_NAME_apex:Create_some_records
    integration_test.go:220: CREATE TXT bar.packetframe-dnscontrol.hammy.network "stringbar" ttl=300
    integration_test.go:220: CREATE A bar.packetframe-dnscontrol.hammy.network 2.4.6.8 ttl=300
    integration_test.go:220: CREATE TXT packetframe-dnscontrol.hammy.network "simple" ttl=300
    integration_test.go:220: CREATE A packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/07:IGNORE_NAME_apex:Add_a_new_record_-_ignoring_apex
    integration_test.go:220: CREATE A added.packetframe-dnscontrol.hammy.network 4.6.8.9 ttl=300
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/Post_cleanup:Empty#07
    integration_test.go:220: DELETE A added.packetframe-dnscontrol.hammy.network 4.6.8.9 ttl=300
    integration_test.go:220: DELETE A bar.packetframe-dnscontrol.hammy.network 2.4.6.8 ttl=300
    integration_test.go:220: DELETE TXT bar.packetframe-dnscontrol.hammy.network "stringbar" ttl=300
    integration_test.go:220: DELETE TXT packetframe-dnscontrol.hammy.network "simple" ttl=300
    integration_test.go:220: DELETE A packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/08:IGNORE_TARGET_function:Create_some_records
    integration_test.go:220: CREATE CNAME bar.packetframe-dnscontrol.hammy.network test.bar.com. ttl=300
    integration_test.go:220: CREATE CNAME foo.packetframe-dnscontrol.hammy.network test.foo.com. ttl=300
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/08:IGNORE_TARGET_function:Add_a_new_record_-_ignoring_test.foo.com.
    integration_test.go:220: MODIFY CNAME bar.packetframe-dnscontrol.hammy.network: (test.bar.com. ttl=300) -> (bar.foo.com. ttl=300)
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/08:IGNORE_TARGET_function:Empty
    integration_test.go:220: DELETE CNAME bar.packetframe-dnscontrol.hammy.network bar.foo.com. ttl=300
    integration_test.go:220: DELETE CNAME foo.packetframe-dnscontrol.hammy.network test.foo.com. ttl=300
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/08:IGNORE_TARGET_function:Create_some_records#01
    integration_test.go:220: CREATE CNAME bar.foo.packetframe-dnscontrol.hammy.network a.b.foo.com. ttl=300
    integration_test.go:220: CREATE A test.foo.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/08:IGNORE_TARGET_function:Add_a_new_record_-_ignoring_**.foo.com._targets
    integration_test.go:220: CREATE A bar.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: DELETE A test.foo.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/Post_cleanup:Empty#08
    integration_test.go:220: DELETE CNAME bar.foo.packetframe-dnscontrol.hammy.network a.b.foo.com. ttl=300
    integration_test.go:220: DELETE A bar.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/09:simple_TXT:Create_a_TXT
    integration_test.go:220: CREATE TXT foo.packetframe-dnscontrol.hammy.network "simple" ttl=300
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/09:simple_TXT:Change_a_TXT
    integration_test.go:220: MODIFY TXT foo.packetframe-dnscontrol.hammy.network: ("simple" ttl=300) -> ("changed" ttl=300)
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/09:simple_TXT:Create_a_TXT_with_spaces
    integration_test.go:220: MODIFY TXT foo.packetframe-dnscontrol.hammy.network: ("changed" ttl=300) -> ("with spaces" ttl=300)
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/Post_cleanup:Empty#09
    integration_test.go:220: DELETE TXT foo.packetframe-dnscontrol.hammy.network "with spaces" ttl=300
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/10:simple_TXT-spf1:Create_a_TXT/SPF
    integration_test.go:220: CREATE TXT foo.packetframe-dnscontrol.hammy.network "v=spf1 ip4:99.99.99.99 -all" ttl=300
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/Post_cleanup:Empty#10
    integration_test.go:220: DELETE TXT foo.packetframe-dnscontrol.hammy.network "v=spf1 ip4:99.99.99.99 -all" ttl=300
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/11:long_TXT:Create_long_TXT
    integration_test.go:220: CREATE TXT foo.packetframe-dnscontrol.hammy.network "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA" ttl=300
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/11:long_TXT:Change_long_TXT
    integration_test.go:220: MODIFY TXT foo.packetframe-dnscontrol.hammy.network: ("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA" ttl=300) -> ("BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB" ttl=300)
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/11:long_TXT:Create_long_TXT_with_spaces
    integration_test.go:220: MODIFY TXT foo.packetframe-dnscontrol.hammy.network: ("BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB" ttl=300) -> ("XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY" ttl=300)
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/Post_cleanup:Empty#11
    integration_test.go:220: DELETE TXT foo.packetframe-dnscontrol.hammy.network "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY" ttl=300
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/12:complex_TXT:TXT_with_0-octel_string
    integration_test.go:220: CREATE TXT foo1.packetframe-dnscontrol.hammy.network "" ttl=300
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/12:complex_TXT:Empty
    integration_test.go:220: DELETE TXT foo1.packetframe-dnscontrol.hammy.network "" ttl=300
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/12:complex_TXT:Create_a_254-byte_TXT
    integration_test.go:220: CREATE TXT foo254.packetframe-dnscontrol.hammy.network "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB" ttl=300
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/12:complex_TXT:Empty#01
    integration_test.go:220: DELETE TXT foo254.packetframe-dnscontrol.hammy.network "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB" ttl=300
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/12:complex_TXT:Create_a_255-byte_TXT
    integration_test.go:220: CREATE TXT foo255.packetframe-dnscontrol.hammy.network "CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC" ttl=300
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/12:complex_TXT:Empty#02
    integration_test.go:220: DELETE TXT foo255.packetframe-dnscontrol.hammy.network "CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC" ttl=300
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/12:complex_TXT:Create_a_256-byte_TXT
    integration_test.go:220: CREATE TXT foo256.packetframe-dnscontrol.hammy.network "DDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD" ttl=300
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/12:complex_TXT:Empty#03
    integration_test.go:220: DELETE TXT foo256.packetframe-dnscontrol.hammy.network "DDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD" ttl=300
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/12:complex_TXT:Create_TXT_with_single-quote
    integration_test.go:220: CREATE TXT foosq.packetframe-dnscontrol.hammy.network "quo'te" ttl=300
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/12:complex_TXT:Empty#04
    integration_test.go:220: DELETE TXT foosq.packetframe-dnscontrol.hammy.network "quo'te" ttl=300
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/12:complex_TXT:Create_TXT_with_backtick
    integration_test.go:220: CREATE TXT foobt.packetframe-dnscontrol.hammy.network "blah`blah" ttl=300
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/12:complex_TXT:Empty#05
    integration_test.go:220: DELETE TXT foobt.packetframe-dnscontrol.hammy.network "blah`blah" ttl=300
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/12:complex_TXT:Create_TXT_with_double-quote
    integration_test.go:220: CREATE TXT foodq.packetframe-dnscontrol.hammy.network "quo\"te" ttl=300
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/12:complex_TXT:Empty#06
    integration_test.go:220: DELETE TXT foodq.packetframe-dnscontrol.hammy.network "quo\"te" ttl=300
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/12:complex_TXT:Create_TXT_with_ws_at_end
    integration_test.go:220: CREATE TXT foows1.packetframe-dnscontrol.hammy.network "with space at end " ttl=300
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/12:complex_TXT:Empty#07
    integration_test.go:220: DELETE TXT foows1.packetframe-dnscontrol.hammy.network "with space at end " ttl=300
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/12:complex_TXT:Create_TXT_0
    integration_test.go:220: CREATE TXT foo1s.packetframe-dnscontrol.hammy.network "short" ttl=300
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/12:complex_TXT:Create_TXT_1
    integration_test.go:220: CREATE TXT foo1l.packetframe-dnscontrol.hammy.network "ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ" ttl=300
    integration_test.go:220: DELETE TXT foo1s.packetframe-dnscontrol.hammy.network "short" ttl=300
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/12:complex_TXT:Create_TXT_10
    integration_test.go:220: CREATE TXT foo2ls.packetframe-dnscontrol.hammy.network "ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ" "short" ttl=300
    integration_test.go:220: DELETE TXT foo1l.packetframe-dnscontrol.hammy.network "ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ" ttl=300
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/12:complex_TXT:Create_TXT_11
    integration_test.go:220: CREATE TXT foo2ll.packetframe-dnscontrol.hammy.network "ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ" "ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ" ttl=300
    integration_test.go:220: DELETE TXT foo2ls.packetframe-dnscontrol.hammy.network "ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ" "short" ttl=300
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/12:complex_TXT:Create_TXT_100
    integration_test.go:220: CREATE TXT foo3lss.packetframe-dnscontrol.hammy.network "ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ" "short" "short" ttl=300
    integration_test.go:220: DELETE TXT foo2ll.packetframe-dnscontrol.hammy.network "ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ" "ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ" ttl=300
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/12:complex_TXT:Create_TXT_101
    integration_test.go:220: CREATE TXT foo3lsl.packetframe-dnscontrol.hammy.network "ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ" "short" "ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ" ttl=300
    integration_test.go:220: DELETE TXT foo3lss.packetframe-dnscontrol.hammy.network "ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ" "short" "short" ttl=300
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/12:complex_TXT:Create_TXT_110
    integration_test.go:220: CREATE TXT foo3lls.packetframe-dnscontrol.hammy.network "ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ" "ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ" "short" ttl=300
    integration_test.go:220: DELETE TXT foo3lsl.packetframe-dnscontrol.hammy.network "ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ" "short" "ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ" ttl=300
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/12:complex_TXT:Create_TXT_111
    integration_test.go:220: CREATE TXT foo3lll.packetframe-dnscontrol.hammy.network "ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ" "ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ" "ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ" ttl=300
    integration_test.go:220: DELETE TXT foo3lls.packetframe-dnscontrol.hammy.network "ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ" "ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ" "short" ttl=300
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/12:complex_TXT:Create_TXT_1hh
    integration_test.go:220: CREATE TXT foo3lhh.packetframe-dnscontrol.hammy.network "ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ" "HHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHH" "HHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHH" ttl=300
    integration_test.go:220: DELETE TXT foo3lll.packetframe-dnscontrol.hammy.network "ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ" "ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ" "ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ" ttl=300
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/12:complex_TXT:Create_TXT_1hh0
    integration_test.go:220: CREATE TXT foo4lhhs.packetframe-dnscontrol.hammy.network "ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ" "HHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHH" "HHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHH" "short" ttl=300
    integration_test.go:220: DELETE TXT foo3lhh.packetframe-dnscontrol.hammy.network "ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ" "HHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHH" "HHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHH" ttl=300
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/Post_cleanup:Empty#12
    integration_test.go:220: DELETE TXT foo4lhhs.packetframe-dnscontrol.hammy.network "ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ" "HHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHH" "HHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHH" "short" ttl=300
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/13:long_TXT:Create_a_505_TXT
    integration_test.go:220: CREATE TXT foo257.packetframe-dnscontrol.hammy.network "EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE" ttl=300
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/13:long_TXT:Create_a_506_TXT
    integration_test.go:220: MODIFY TXT foo257.packetframe-dnscontrol.hammy.network: ("EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE" ttl=300) -> ("EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE" ttl=300)
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/13:long_TXT:Create_a_507_TXT
    integration_test.go:220: MODIFY TXT foo257.packetframe-dnscontrol.hammy.network: ("EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE" ttl=300) -> ("EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE" ttl=300)
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/13:long_TXT:Create_a_508_TXT
    integration_test.go:220: MODIFY TXT foo257.packetframe-dnscontrol.hammy.network: ("EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE" ttl=300) -> ("EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE" ttl=300)
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/13:long_TXT:Create_a_509_TXT
    integration_test.go:220: MODIFY TXT foo257.packetframe-dnscontrol.hammy.network: ("EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE" ttl=300) -> ("EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE" ttl=300)
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/13:long_TXT:Create_a_510_TXT
    integration_test.go:220: MODIFY TXT foo257.packetframe-dnscontrol.hammy.network: ("EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE" ttl=300) -> ("EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE" ttl=300)
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/13:long_TXT:Create_a_511_TXT
    integration_test.go:220: MODIFY TXT foo257.packetframe-dnscontrol.hammy.network: ("EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE" ttl=300) -> ("EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE" ttl=300)
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/13:long_TXT:Create_a_512_TXT
    integration_test.go:220: MODIFY TXT foo257.packetframe-dnscontrol.hammy.network: ("EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE" ttl=300) -> ("EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE" ttl=300)
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/13:long_TXT:Create_a_513_TXT
    integration_test.go:220: MODIFY TXT foo257.packetframe-dnscontrol.hammy.network: ("EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE" ttl=300) -> ("EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE" ttl=300)
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/13:long_TXT:Create_a_514_TXT
    integration_test.go:220: MODIFY TXT foo257.packetframe-dnscontrol.hammy.network: ("EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE" ttl=300) -> ("EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE" ttl=300)
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/13:long_TXT:Create_a_515_TXT
    integration_test.go:220: MODIFY TXT foo257.packetframe-dnscontrol.hammy.network: ("EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE" ttl=300) -> ("EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE" ttl=300)
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/13:long_TXT:Create_a_516_TXT
    integration_test.go:220: MODIFY TXT foo257.packetframe-dnscontrol.hammy.network: ("EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE" ttl=300) -> ("EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE" ttl=300)
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/Post_cleanup:Empty#13
    integration_test.go:220: DELETE TXT foo257.packetframe-dnscontrol.hammy.network "EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE" ttl=300
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/14:TXTMulti:Create_TXTMulti_1
    integration_test.go:220: CREATE TXT foo1.packetframe-dnscontrol.hammy.network "simple" ttl=300
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/14:TXTMulti:Add_TXTMulti_2
    integration_test.go:220: CREATE TXT foo2.packetframe-dnscontrol.hammy.network "one" "two" ttl=300
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/14:TXTMulti:Add_TXTMulti_3
    integration_test.go:220: CREATE TXT foo3.packetframe-dnscontrol.hammy.network "eh" "bee" "cee" ttl=300
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/14:TXTMulti:Change_TXTMultii-0
    integration_test.go:220: MODIFY TXT foo1.packetframe-dnscontrol.hammy.network: ("simple" ttl=300) -> ("dimple" ttl=300)
    integration_test.go:220: MODIFY TXT foo2.packetframe-dnscontrol.hammy.network: ("one" "two" ttl=300) -> ("fun" "two" ttl=300)
    integration_test.go:220: MODIFY TXT foo3.packetframe-dnscontrol.hammy.network: ("eh" "bee" "cee" ttl=300) -> ("eh" "bzz" "cee" ttl=300)
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/14:TXTMulti:Change_TXTMulti-1[0]
    integration_test.go:220: MODIFY TXT foo2.packetframe-dnscontrol.hammy.network: ("fun" "two" ttl=300) -> ("moja" "two" ttl=300)
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/14:TXTMulti:Change_TXTMulti-1[1]
    integration_test.go:220: MODIFY TXT foo2.packetframe-dnscontrol.hammy.network: ("moja" "two" ttl=300) -> ("moja" "mbili" ttl=300)
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/Post_cleanup:Empty#14
    integration_test.go:220: DELETE TXT foo1.packetframe-dnscontrol.hammy.network "dimple" ttl=300
    integration_test.go:220: DELETE TXT foo2.packetframe-dnscontrol.hammy.network "moja" "mbili" ttl=300
    integration_test.go:220: DELETE TXT foo3.packetframe-dnscontrol.hammy.network "eh" "bzz" "cee" ttl=300
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/15:TXTMulti-same:Create_TXTMulti_1
    integration_test.go:220: CREATE TXT foo.packetframe-dnscontrol.hammy.network "simple" ttl=300
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/15:TXTMulti-same:Add_TXTMulti_2
    integration_test.go:220: CREATE TXT foo.packetframe-dnscontrol.hammy.network "one" "two" ttl=300
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/15:TXTMulti-same:Add_TXTMulti_3
    integration_test.go:220: CREATE TXT foo.packetframe-dnscontrol.hammy.network "eh" "bee" "cee" ttl=300
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/15:TXTMulti-same:Change_TXTMultii-0
    integration_test.go:220: MODIFY TXT foo.packetframe-dnscontrol.hammy.network: ("eh" "bee" "cee" ttl=300) -> ("dimple" ttl=300)
    integration_test.go:220: MODIFY TXT foo.packetframe-dnscontrol.hammy.network: ("one" "two" ttl=300) -> ("eh" "bzz" "cee" ttl=300)
    integration_test.go:220: MODIFY TXT foo.packetframe-dnscontrol.hammy.network: ("simple" ttl=300) -> ("fun" "two" ttl=300)
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/15:TXTMulti-same:Change_TXTMulti-1[0]
    integration_test.go:220: MODIFY TXT foo.packetframe-dnscontrol.hammy.network: ("fun" "two" ttl=300) -> ("moja" "two" ttl=300)
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/15:TXTMulti-same:Change_TXTMulti-1[1]
    integration_test.go:220: MODIFY TXT foo.packetframe-dnscontrol.hammy.network: ("moja" "two" ttl=300) -> ("moja" "mbili" ttl=300)
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/Post_cleanup:Empty#15
    integration_test.go:220: DELETE TXT foo.packetframe-dnscontrol.hammy.network "dimple" ttl=300
    integration_test.go:220: DELETE TXT foo.packetframe-dnscontrol.hammy.network "eh" "bzz" "cee" ttl=300
    integration_test.go:220: DELETE TXT foo.packetframe-dnscontrol.hammy.network "moja" "mbili" ttl=300
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/16:TypeChange:Create_a_CNAME
    integration_test.go:220: CREATE CNAME foo.packetframe-dnscontrol.hammy.network google.com. ttl=300
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/16:TypeChange:Change_to_A_record
    integration_test.go:220: CREATE A foo.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: DELETE CNAME foo.packetframe-dnscontrol.hammy.network google.com. ttl=300
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/16:TypeChange:Change_back_to_CNAME
    integration_test.go:220: CREATE CNAME foo.packetframe-dnscontrol.hammy.network google2.com. ttl=300
    integration_test.go:220: DELETE A foo.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/Post_cleanup:Empty#16
    integration_test.go:220: DELETE CNAME foo.packetframe-dnscontrol.hammy.network google2.com. ttl=300
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/17:Case_Sensitivity:Create_CAPS
    integration_test.go:220: CREATE MX bar.packetframe-dnscontrol.hammy.network 5 bar.com. ttl=300
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/17:Case_Sensitivity:Downcase_label
    integration_test.go:220: CREATE A decoy.packetframe-dnscontrol.hammy.network 1.1.1.1 ttl=300
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/17:Case_Sensitivity:Downcase_target
    integration_test.go:220: MODIFY A decoy.packetframe-dnscontrol.hammy.network: (1.1.1.1 ttl=300) -> (2.2.2.2 ttl=300)
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/17:Case_Sensitivity:Upcase_both
    integration_test.go:220: MODIFY A decoy.packetframe-dnscontrol.hammy.network: (2.2.2.2 ttl=300) -> (3.3.3.3 ttl=300)
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/Post_cleanup:Empty#17
    integration_test.go:220: DELETE MX bar.packetframe-dnscontrol.hammy.network 5 bar.com. ttl=300
    integration_test.go:220: DELETE A decoy.packetframe-dnscontrol.hammy.network 3.3.3.3 ttl=300
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/18:IDNA:Internationalized_name
    integration_test.go:220: CREATE A xn--ndaaa.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/18:IDNA:Change_IDN
    integration_test.go:220: MODIFY A xn--ndaaa.packetframe-dnscontrol.hammy.network: (1.2.3.4 ttl=300) -> (2.2.2.2 ttl=300)
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/18:IDNA:Internationalized_CNAME_Target
    integration_test.go:220: CREATE CNAME a.packetframe-dnscontrol.hammy.network xn--ndaaa.com. ttl=300
    integration_test.go:220: DELETE A xn--ndaaa.packetframe-dnscontrol.hammy.network 2.2.2.2 ttl=300
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/Post_cleanup:Empty#18
    integration_test.go:220: DELETE CNAME a.packetframe-dnscontrol.hammy.network xn--ndaaa.com. ttl=300
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/19:IDNAs_in_CNAME_targets:IDN_CNAME_AND_Target
    integration_test.go:220: CREATE CNAME xn--o-0gab.packetframe-dnscontrol.hammy.network xn--ndaaa.xn--vhquv. ttl=300
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/Post_cleanup:Empty#19
    integration_test.go:220: DELETE CNAME xn--o-0gab.packetframe-dnscontrol.hammy.network xn--ndaaa.xn--vhquv. ttl=300
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/20:pager101:99_records
    integration_test.go:220: CREATE A rec0000.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: CREATE A rec0001.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: CREATE A rec0002.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: CREATE A rec0003.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: CREATE A rec0004.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: CREATE A rec0005.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: CREATE A rec0006.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: CREATE A rec0007.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: CREATE A rec0008.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: CREATE A rec0009.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: CREATE A rec0010.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: CREATE A rec0011.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: CREATE A rec0012.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: CREATE A rec0013.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: CREATE A rec0014.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: CREATE A rec0015.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: CREATE A rec0016.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: CREATE A rec0017.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: CREATE A rec0018.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: CREATE A rec0019.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: CREATE A rec0020.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: CREATE A rec0021.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: CREATE A rec0022.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: CREATE A rec0023.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: CREATE A rec0024.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: CREATE A rec0025.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: CREATE A rec0026.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: CREATE A rec0027.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: CREATE A rec0028.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: CREATE A rec0029.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: CREATE A rec0030.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: CREATE A rec0031.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: CREATE A rec0032.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: CREATE A rec0033.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: CREATE A rec0034.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: CREATE A rec0035.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: CREATE A rec0036.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: CREATE A rec0037.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: CREATE A rec0038.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: CREATE A rec0039.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: CREATE A rec0040.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: CREATE A rec0041.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: CREATE A rec0042.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: CREATE A rec0043.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: CREATE A rec0044.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: CREATE A rec0045.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: CREATE A rec0046.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: CREATE A rec0047.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: CREATE A rec0048.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: CREATE A rec0049.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: CREATE A rec0050.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: CREATE A rec0051.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: CREATE A rec0052.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: CREATE A rec0053.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: CREATE A rec0054.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: CREATE A rec0055.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: CREATE A rec0056.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: CREATE A rec0057.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: CREATE A rec0058.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: CREATE A rec0059.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: CREATE A rec0060.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: CREATE A rec0061.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: CREATE A rec0062.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: CREATE A rec0063.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: CREATE A rec0064.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: CREATE A rec0065.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: CREATE A rec0066.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: CREATE A rec0067.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: CREATE A rec0068.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: CREATE A rec0069.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: CREATE A rec0070.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: CREATE A rec0071.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: CREATE A rec0072.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: CREATE A rec0073.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: CREATE A rec0074.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: CREATE A rec0075.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: CREATE A rec0076.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: CREATE A rec0077.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: CREATE A rec0078.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: CREATE A rec0079.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: CREATE A rec0080.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: CREATE A rec0081.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: CREATE A rec0082.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: CREATE A rec0083.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: CREATE A rec0084.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: CREATE A rec0085.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: CREATE A rec0086.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: CREATE A rec0087.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: CREATE A rec0088.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: CREATE A rec0089.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: CREATE A rec0090.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: CREATE A rec0091.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: CREATE A rec0092.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: CREATE A rec0093.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: CREATE A rec0094.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: CREATE A rec0095.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: CREATE A rec0096.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: CREATE A rec0097.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: CREATE A rec0098.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/20:pager101:100_records
    integration_test.go:220: CREATE A rec0099.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/20:pager101:101_records
    integration_test.go:220: CREATE A rec0100.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/Post_cleanup:Empty#20
    integration_test.go:220: DELETE A rec0000.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: DELETE A rec0001.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: DELETE A rec0002.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: DELETE A rec0003.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: DELETE A rec0004.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: DELETE A rec0005.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: DELETE A rec0006.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: DELETE A rec0007.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: DELETE A rec0008.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: DELETE A rec0009.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: DELETE A rec0010.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: DELETE A rec0011.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: DELETE A rec0012.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: DELETE A rec0013.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: DELETE A rec0014.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: DELETE A rec0015.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: DELETE A rec0016.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: DELETE A rec0017.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: DELETE A rec0018.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: DELETE A rec0019.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: DELETE A rec0020.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: DELETE A rec0021.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: DELETE A rec0022.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: DELETE A rec0023.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: DELETE A rec0024.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: DELETE A rec0025.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: DELETE A rec0026.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: DELETE A rec0027.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: DELETE A rec0028.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: DELETE A rec0029.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: DELETE A rec0030.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: DELETE A rec0031.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: DELETE A rec0032.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: DELETE A rec0033.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: DELETE A rec0034.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: DELETE A rec0035.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: DELETE A rec0036.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: DELETE A rec0037.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: DELETE A rec0038.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: DELETE A rec0039.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: DELETE A rec0040.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: DELETE A rec0041.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: DELETE A rec0042.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: DELETE A rec0043.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: DELETE A rec0044.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: DELETE A rec0045.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: DELETE A rec0046.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: DELETE A rec0047.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: DELETE A rec0048.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: DELETE A rec0049.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: DELETE A rec0050.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: DELETE A rec0051.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: DELETE A rec0052.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: DELETE A rec0053.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: DELETE A rec0054.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: DELETE A rec0055.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: DELETE A rec0056.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: DELETE A rec0057.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: DELETE A rec0058.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: DELETE A rec0059.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: DELETE A rec0060.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: DELETE A rec0061.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: DELETE A rec0062.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: DELETE A rec0063.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: DELETE A rec0064.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: DELETE A rec0065.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: DELETE A rec0066.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: DELETE A rec0067.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: DELETE A rec0068.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: DELETE A rec0069.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: DELETE A rec0070.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: DELETE A rec0071.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: DELETE A rec0072.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: DELETE A rec0073.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: DELETE A rec0074.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: DELETE A rec0075.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: DELETE A rec0076.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: DELETE A rec0077.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: DELETE A rec0078.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: DELETE A rec0079.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: DELETE A rec0080.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: DELETE A rec0081.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: DELETE A rec0082.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: DELETE A rec0083.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: DELETE A rec0084.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: DELETE A rec0085.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: DELETE A rec0086.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: DELETE A rec0087.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: DELETE A rec0088.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: DELETE A rec0089.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: DELETE A rec0090.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: DELETE A rec0091.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: DELETE A rec0092.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: DELETE A rec0093.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: DELETE A rec0094.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: DELETE A rec0095.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: DELETE A rec0096.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: DELETE A rec0097.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: DELETE A rec0098.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: DELETE A rec0099.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
    integration_test.go:220: DELETE A rec0100.packetframe-dnscontrol.hammy.network 1.2.3.4 ttl=300
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/21:pager601_***SKIPPED(disabled_by_only)***:Empty
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/22:pager1201_***SKIPPED(disabled_by_only)***:Empty
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/23:CAA_***SKIPPED(CanUseCAA_not_supported)***:Empty
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/24:CAA_with_;_***SKIPPED(CanUseCAA_not_supported)***:Empty
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/25:NAPTR_***SKIPPED(CanUseNAPTR_not_supported)***:Empty
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/26:PTR:Create_PTR_record
    integration_test.go:220: CREATE PTR 4.packetframe-dnscontrol.hammy.network foo.com. ttl=300
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/26:PTR:Modify_PTR_record
    integration_test.go:220: MODIFY PTR 4.packetframe-dnscontrol.hammy.network: (foo.com. ttl=300) -> (bar.com. ttl=300)
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/Post_cleanup:Empty#21
    integration_test.go:220: DELETE PTR 4.packetframe-dnscontrol.hammy.network bar.com. ttl=300
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/27:SOA_***SKIPPED(CanUseSOA_not_supported)***:Empty
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/28:SRV:SRV_record
    integration_test.go:220: CREATE SRV _sip._tcp.packetframe-dnscontrol.hammy.network 5 6 7 foo.com. ttl=300
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/28:SRV:Second_SRV_record,_same_prio
    integration_test.go:220: CREATE SRV _sip._tcp.packetframe-dnscontrol.hammy.network 5 60 70 foo2.com. ttl=300
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/28:SRV:3_SRV
    integration_test.go:220: CREATE SRV _sip._tcp.packetframe-dnscontrol.hammy.network 15 65 75 foo3.com. ttl=300
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/28:SRV:Delete_one
    integration_test.go:220: DELETE SRV _sip._tcp.packetframe-dnscontrol.hammy.network 5 60 70 foo2.com. ttl=300
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/28:SRV:Change_Target
    integration_test.go:220: MODIFY SRV _sip._tcp.packetframe-dnscontrol.hammy.network: (15 65 75 foo3.com. ttl=300) -> (15 65 75 foo4.com. ttl=300)
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/28:SRV:Change_Priority
    integration_test.go:220: MODIFY SRV _sip._tcp.packetframe-dnscontrol.hammy.network: (5 6 7 foo.com. ttl=300) -> (52 6 7 foo.com. ttl=300)
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/28:SRV:Change_Weight
    integration_test.go:220: MODIFY SRV _sip._tcp.packetframe-dnscontrol.hammy.network: (52 6 7 foo.com. ttl=300) -> (52 62 7 foo.com. ttl=300)
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/28:SRV:Change_Port
    integration_test.go:220: MODIFY SRV _sip._tcp.packetframe-dnscontrol.hammy.network: (52 62 7 foo.com. ttl=300) -> (52 62 72 foo.com. ttl=300)
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/Post_cleanup:Empty#22
    integration_test.go:220: DELETE SRV _sip._tcp.packetframe-dnscontrol.hammy.network 15 65 75 foo4.com. ttl=300
    integration_test.go:220: DELETE SRV _sip._tcp.packetframe-dnscontrol.hammy.network 52 62 72 foo.com. ttl=300
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/29:SRV_w/_null_target:Null_Target
    integration_test.go:220: CREATE SRV _sip._tcp.packetframe-dnscontrol.hammy.network 52 62 72 foo.com. ttl=300
    integration_test.go:220: CREATE SRV _sip._tcp.packetframe-dnscontrol.hammy.network 15 65 75 . ttl=300
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/Post_cleanup:Empty#23
    integration_test.go:220: DELETE SRV _sip._tcp.packetframe-dnscontrol.hammy.network 15 65 75 . ttl=300
    integration_test.go:220: DELETE SRV _sip._tcp.packetframe-dnscontrol.hammy.network 52 62 72 foo.com. ttl=300
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/30:SSHFP_***SKIPPED(CanUseSSHFP_not_supported)***:Empty
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/31:TLSA_***SKIPPED(CanUseTLSA_not_supported)***:Empty
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/32:DS_***SKIPPED(CanUseDS_not_supported)***:Empty
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/33:DS_(children_only)_***SKIPPED(CanUseDSForChildren_not_supported)***:Empty
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/34:DS_(children_only)_CLOUDNS_***SKIPPED(CanUseDSForChildren_not_supported)***:Empty
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/35:ALIAS_***SKIPPED(CanUseAlias_not_supported)***:Empty
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/36:AZURE_ALIAS_***SKIPPED(CanUseAzureAlias_not_supported)***:Empty
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/37:R53_ALIAS2_***SKIPPED(CanUseRoute53Alias_not_supported)***:Empty
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/38:R53_ALIAS_ORDER_***SKIPPED(CanUseRoute53Alias_not_supported)***:Empty
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/39:CF_REDIRECT_***SKIPPED(disabled_by_only)***:Empty
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/40:CF_PROXY_***SKIPPED(disabled_by_only)***:Empty
=== RUN   TestDNSProviders/packetframe-dnscontrol.hammy.network/41:CF_WORKER_ROUTE_***SKIPPED(disabled_by_only)***:Empty
--- PASS: TestDNSProviders (84.39s)
    --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network (84.39s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/Clean_Slate:Empty (0.46s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/00:GeneralACD:Create_an_A_record (0.31s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/00:GeneralACD:Change_it (0.31s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/00:GeneralACD:Add_another (0.33s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/00:GeneralACD:Add_another(same_name) (0.28s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/00:GeneralACD:Change_a_ttl (0.34s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/00:GeneralACD:Change_single_target_from_set (0.28s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/00:GeneralACD:Change_all_ttls (0.78s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/00:GeneralACD:Delete_one (0.28s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/00:GeneralACD:Add_back_and_change_ttl (0.65s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/00:GeneralACD:Change_targets_and_ttls (0.53s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/Post_cleanup:Empty (0.39s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/01:WildcardACD:Create_wildcard (0.40s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/01:WildcardACD:Delete_wildcard (0.40s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/Post_cleanup:Empty#01 (0.30s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/02:CNAME:Create_a_CNAME (0.47s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/02:CNAME:Change_CNAME_target (0.42s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/02:CNAME:Empty (0.19s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/02:CNAME:Record_pointing_to_@ (0.32s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/Post_cleanup:Empty#02 (0.20s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/03:MX:MX_record (0.31s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/03:MX:Second_MX_record,_same_prio (0.31s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/03:MX:3_MX (0.32s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/03:MX:Delete_one (0.41s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/03:MX:Change_to_other_name (0.43s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/03:MX:Change_Preference (0.34s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/03:MX:Record_pointing_to_@ (0.61s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/Post_cleanup:Empty#03 (0.25s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/04:Null_MX:Null_MX (0.31s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/Post_cleanup:Empty#04 (0.20s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/05:NS:NS_for_subdomain (0.29s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/05:NS:Dual_NS_for_subdomain (0.31s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/05:NS:NS_Record_pointing_to_@ (0.82s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/Post_cleanup:Empty#05 (0.37s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/06:IGNORE_NAME_function:Create_some_records (0.41s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/06:IGNORE_NAME_function:Add_a_new_record_-_ignoring_foo (0.32s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/06:IGNORE_NAME_function:Empty (0.48s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/06:IGNORE_NAME_function:Create_some_records#01 (0.61s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/06:IGNORE_NAME_function:Add_a_new_record_-_ignoring_*.foo (0.28s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/Post_cleanup:Empty#06 (0.45s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/07:IGNORE_NAME_apex:Create_some_records (0.62s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/07:IGNORE_NAME_apex:Add_a_new_record_-_ignoring_apex (0.40s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/Post_cleanup:Empty#07 (0.63s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/08:IGNORE_TARGET_function:Create_some_records (0.39s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/08:IGNORE_TARGET_function:Add_a_new_record_-_ignoring_test.foo.com. (0.33s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/08:IGNORE_TARGET_function:Empty (0.50s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/08:IGNORE_TARGET_function:Create_some_records#01 (0.61s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/08:IGNORE_TARGET_function:Add_a_new_record_-_ignoring_**.foo.com._targets (0.46s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/Post_cleanup:Empty#08 (0.34s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/09:simple_TXT:Create_a_TXT (0.56s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/09:simple_TXT:Change_a_TXT (0.30s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/09:simple_TXT:Create_a_TXT_with_spaces (0.36s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/Post_cleanup:Empty#09 (0.21s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/10:simple_TXT-spf1:Create_a_TXT/SPF (0.31s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/Post_cleanup:Empty#10 (0.20s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/11:long_TXT:Create_long_TXT (0.29s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/11:long_TXT:Change_long_TXT (0.44s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/11:long_TXT:Create_long_TXT_with_spaces (0.29s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/Post_cleanup:Empty#11 (0.20s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/12:complex_TXT:TXT_with_0-octel_string (0.34s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/12:complex_TXT:Empty (0.20s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/12:complex_TXT:Create_a_254-byte_TXT (0.35s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/12:complex_TXT:Empty#01 (0.39s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/12:complex_TXT:Create_a_255-byte_TXT (0.36s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/12:complex_TXT:Empty#02 (0.25s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/12:complex_TXT:Create_a_256-byte_TXT (0.35s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/12:complex_TXT:Empty#03 (0.22s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/12:complex_TXT:Create_TXT_with_single-quote (0.30s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/12:complex_TXT:Empty#04 (0.20s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/12:complex_TXT:Create_TXT_with_backtick (0.54s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/12:complex_TXT:Empty#05 (0.21s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/12:complex_TXT:Create_TXT_with_double-quote (0.28s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/12:complex_TXT:Empty#06 (0.19s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/12:complex_TXT:Create_TXT_with_ws_at_end (0.28s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/12:complex_TXT:Empty#07 (0.25s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/12:complex_TXT:Create_TXT_0 (0.47s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/12:complex_TXT:Create_TXT_1 (0.41s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/12:complex_TXT:Create_TXT_10 (0.42s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/12:complex_TXT:Create_TXT_11 (0.59s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/12:complex_TXT:Create_TXT_100 (0.62s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/12:complex_TXT:Create_TXT_101 (0.39s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/12:complex_TXT:Create_TXT_110 (0.45s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/12:complex_TXT:Create_TXT_111 (0.47s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/12:complex_TXT:Create_TXT_1hh (0.43s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/12:complex_TXT:Create_TXT_1hh0 (0.45s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/Post_cleanup:Empty#12 (0.21s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/13:long_TXT:Create_a_505_TXT (0.40s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/13:long_TXT:Create_a_506_TXT (0.28s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/13:long_TXT:Create_a_507_TXT (0.33s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/13:long_TXT:Create_a_508_TXT (0.32s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/13:long_TXT:Create_a_509_TXT (0.32s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/13:long_TXT:Create_a_510_TXT (0.40s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/13:long_TXT:Create_a_511_TXT (0.34s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/13:long_TXT:Create_a_512_TXT (0.30s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/13:long_TXT:Create_a_513_TXT (0.28s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/13:long_TXT:Create_a_514_TXT (0.33s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/13:long_TXT:Create_a_515_TXT (0.29s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/13:long_TXT:Create_a_516_TXT (0.29s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/Post_cleanup:Empty#13 (0.21s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/14:TXTMulti:Create_TXTMulti_1 (0.45s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/14:TXTMulti:Add_TXTMulti_2 (0.29s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/14:TXTMulti:Add_TXTMulti_3 (0.29s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/14:TXTMulti:Change_TXTMultii-0 (0.59s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/14:TXTMulti:Change_TXTMulti-1[0] (0.28s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/14:TXTMulti:Change_TXTMulti-1[1] (0.41s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/Post_cleanup:Empty#14 (0.60s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/15:TXTMulti-same:Create_TXTMulti_1 (0.34s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/15:TXTMulti-same:Add_TXTMulti_2 (0.28s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/15:TXTMulti-same:Add_TXTMulti_3 (0.32s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/15:TXTMulti-same:Change_TXTMultii-0 (0.63s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/15:TXTMulti-same:Change_TXTMulti-1[0] (0.31s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/15:TXTMulti-same:Change_TXTMulti-1[1] (0.28s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/Post_cleanup:Empty#15 (0.44s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/16:TypeChange:Create_a_CNAME (0.28s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/16:TypeChange:Change_to_A_record (0.46s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/16:TypeChange:Change_back_to_CNAME (0.50s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/Post_cleanup:Empty#16 (0.27s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/17:Case_Sensitivity:Create_CAPS (0.31s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/17:Case_Sensitivity:Downcase_label (0.36s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/17:Case_Sensitivity:Downcase_target (0.52s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/17:Case_Sensitivity:Upcase_both (0.29s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/Post_cleanup:Empty#17 (0.32s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/18:IDNA:Internationalized_name (0.28s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/18:IDNA:Change_IDN (0.29s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/18:IDNA:Internationalized_CNAME_Target (0.53s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/Post_cleanup:Empty#18 (0.21s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/19:IDNAs_in_CNAME_targets:IDN_CNAME_AND_Target (0.31s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/Post_cleanup:Empty#19 (0.21s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/20:pager101:99_records (14.92s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/20:pager101:100_records (0.31s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/20:pager101:101_records (0.35s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/Post_cleanup:Empty#20 (14.81s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/21:pager601_***SKIPPED(disabled_by_only)***:Empty (0.08s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/22:pager1201_***SKIPPED(disabled_by_only)***:Empty (0.09s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/23:CAA_***SKIPPED(CanUseCAA_not_supported)***:Empty (0.14s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/24:CAA_with_;_***SKIPPED(CanUseCAA_not_supported)***:Empty (0.09s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/25:NAPTR_***SKIPPED(CanUseNAPTR_not_supported)***:Empty (0.09s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/26:PTR:Create_PTR_record (0.30s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/26:PTR:Modify_PTR_record (0.50s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/Post_cleanup:Empty#21 (0.22s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/27:SOA_***SKIPPED(CanUseSOA_not_supported)***:Empty (0.09s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/28:SRV:SRV_record (0.31s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/28:SRV:Second_SRV_record,_same_prio (0.30s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/28:SRV:3_SRV (0.38s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/28:SRV:Delete_one (0.45s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/28:SRV:Change_Target (0.35s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/28:SRV:Change_Priority (0.28s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/28:SRV:Change_Weight (0.37s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/28:SRV:Change_Port (0.28s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/Post_cleanup:Empty#22 (0.41s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/29:SRV_w/_null_target:Null_Target (0.55s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/Post_cleanup:Empty#23 (0.31s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/30:SSHFP_***SKIPPED(CanUseSSHFP_not_supported)***:Empty (0.09s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/31:TLSA_***SKIPPED(CanUseTLSA_not_supported)***:Empty (0.14s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/32:DS_***SKIPPED(CanUseDS_not_supported)***:Empty (0.08s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/33:DS_(children_only)_***SKIPPED(CanUseDSForChildren_not_supported)***:Empty (0.08s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/34:DS_(children_only)_CLOUDNS_***SKIPPED(CanUseDSForChildren_not_supported)***:Empty (0.09s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/35:ALIAS_***SKIPPED(CanUseAlias_not_supported)***:Empty (0.09s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/36:AZURE_ALIAS_***SKIPPED(CanUseAzureAlias_not_supported)***:Empty (0.08s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/37:R53_ALIAS2_***SKIPPED(CanUseRoute53Alias_not_supported)***:Empty (0.09s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/38:R53_ALIAS_ORDER_***SKIPPED(CanUseRoute53Alias_not_supported)***:Empty (0.08s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/39:CF_REDIRECT_***SKIPPED(disabled_by_only)***:Empty (0.09s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/40:CF_PROXY_***SKIPPED(disabled_by_only)***:Empty (0.15s)
        --- PASS: TestDNSProviders/packetframe-dnscontrol.hammy.network/41:CF_WORKER_ROUTE_***SKIPPED(disabled_by_only)***:Empty (0.09s)
=== RUN   TestDualProviders
    integration_test.go:312: Skipping.  DocDualHost == Cannot
--- SKIP: TestDualProviders (0.00s)
PASS
ok  	github.com/StackExchange/dnscontrol/v3/integrationTest	84.407s
```