### PR TITLE
Documentation: Customizing nameservers for hosting.de provider

### DIFF
--- a/docs/_providers/hostingde.md
+++ b/docs/_providers/hostingde.md
@@ -7,6 +7,7 @@ jsId: hostingde
 # hosting.de Provider
 
 ## Configuration
+
 In your credentials file, you must provide your [`authToken` and optionally an `ownerAccountId`](https://www.hosting.de/api/#requests-and-authentication).
 
 **If you want to use this provider with http.net or a demo system you need to provide a custom `baseURL`.**
@@ -28,6 +29,7 @@ In your credentials file, you must provide your [`authToken` and optionally an `
 {% endhighlight %}
 
 ## Usage
+
 Example JavaScript:
 
 {% highlight js %}

--- a/docs/_providers/hostingde.md
+++ b/docs/_providers/hostingde.md
@@ -4,33 +4,26 @@ title: hosting.de Provider
 layout: default
 jsId: hostingde
 ---
+
 # hosting.de Provider
 
 ## Configuration
 
 In your credentials file, you must provide your [`authToken` and optionally an `ownerAccountId`](https://www.hosting.de/api/#requests-and-authentication).
 
-**If you want to use this provider with http.net or a demo system you need to provide a custom `baseURL`.**
-
-* hosting.de (default): `https://secure.hosting.de`
-* http.net: `https://partner.http.net`
-* Demo: `https://demo.routing.net`
+### Example `creds.json`
 
 ```json
 {
   "hosting.de": {
     "authToken": "YOUR_API_KEY"
-  },
-  "http.net": {
-    "authToken": "YOUR_API_KEY",
-    "baseURL": "https://partner.http.net"
   }
 }
 ```
 
 ## Usage
 
-Example JavaScript:
+### Example `dnsconfig.js`
 
 ```js
 var REG_HOSTINGDE = NewRegistrar('hosting.de', 'HOSTINGDE')
@@ -41,15 +34,29 @@ D('example.tld', REG_HOSTINGDE, DnsProvider(DNS_HOSTINGDE),
 );
 ```
 
-## Customize nameservers
+## Using this provider with http.net and others
 
-hosting.de has the concept of *nameserver sets* but this provider does not implement it.
-The `HOSTINGDE` provider **ignores the default nameserver set** defined in your account!
-Instead, it uses hosting.de's nameservers (`ns1.hosting.de.`, `ns2.hosting.de.`, and `ns3.hosting.de.`) by default, regardless of your account settings.
+http.net and other DNS service providers use an API that is compatible with hosting.de's API.
+Using them requires setting the `baseURL` and (optionally) overriding the default nameservers.
 
-If you want to change this behaviour to, for example, use http.net's nameservers, you can do this by setting an array of strings called `default_ns` in the provider metadata:
+### Example http.net configuration
+
+#### Example `creds.json`
+
+```json
+{
+  "http.net": {
+    "authToken": "YOUR_API_KEY",
+    "baseURL": "https://partner.http.net"
+  }
+}
+```
+
+#### Example `dnsconfig.js`
 
 ```js
+var REG_HTTPNET = NewRegistrar('http.net', 'HOSTINGDE');
+
 var DNS_HTTPNET = NewDnsProvider('http.net', 'HOSTINGDE', {
   default_ns: [
     'ns1.routing.net.',
@@ -58,3 +65,10 @@ var DNS_HTTPNET = NewDnsProvider('http.net', 'HOSTINGDE', {
   ],
 });
 ```
+
+#### Why this works
+
+hosting.de has the concept of _nameserver sets_ but this provider does not implement it.
+The `HOSTINGDE` provider **ignores the default nameserver set** defined in your account to avoid unintentional changes and consolidate the full configuration in DNSControl.
+Instead, it uses hosting.de's nameservers (`ns1.hosting.de.`, `ns2.hosting.de.`, and `ns3.hosting.de.`) by default, regardless of your account settings.
+Using the `default_ns` metadata, the default nameserver set can be overwritten.

--- a/docs/_providers/hostingde.md
+++ b/docs/_providers/hostingde.md
@@ -40,3 +40,21 @@ D('example.tld', REG_HOSTINGDE, DnsProvider(DNS_HOSTINGDE),
     A('test', '1.2.3.4')
 );
 {% endhighlight %}
+
+## Customize nameservers
+
+hosting.de has the concept of *nameserver sets* but this provider does not implement it.
+The `HOSTINGDE` provider **ignores the default nameserver set** defined in your account!
+Instead, it uses hosting.de's nameservers (`ns1.hosting.de.`, `ns2.hosting.de.`, and `ns3.hosting.de.`) by default, regardless of your account settings.
+
+If you want to change this behaviour to, for example, use http.net's nameservers, you can do this by setting an array of strings called `default_ns` in the provider metadata:
+
+```js
+var DNS_HTTPNET = NewDnsProvider('http.net', 'HOSTINGDE', {
+  default_ns: [
+    'ns1.routing.net.',
+    'ns2.routing.net.',
+    'ns3.routing.net.',
+  ],
+});
+```

--- a/providers/hostingde/api.go
+++ b/providers/hostingde/api.go
@@ -17,6 +17,7 @@ type hostingdeProvider struct {
 	authToken      string
 	ownerAccountID string
 	baseURL        string
+	nameservers    []string
 }
 
 func (hp *hostingdeProvider) getDomainConfig(domain string) (*domainConfig, error) {
@@ -51,7 +52,7 @@ func (hp *hostingdeProvider) createZone(domain string) error {
 	}
 
 	records := []*record{}
-	for _, ns := range defaultNameservers {
+	for _, ns := range hp.nameservers {
 		records = append(records, &record{
 			Name:    domain,
 			Type:    "NS",


### PR DESCRIPTION
The hosting.de provider can be used with http.net's offerings too, but http.net uses different nameservers.

This PR adds documentation on how to change the nameservers used and on how to simplify using them, including an example.

Note: Furthermore, it switches to  `fenced_code_blocks` in an effort to improve the legibility when using Markdown preview. If this poses problems, feel free to remove the commit.