### PR TITLE
ns1: fix multivalue CAA handling

### DIFF
--- a/providers/ns1/ns1Provider.go
+++ b/providers/ns1/ns1Provider.go
@@ -170,7 +170,12 @@ func buildRecord(recs models.Records, domain string, id string) *dns.Record {
 		} else if r.Type == "TXT" {
 			rec.AddAnswer(&dns.Answer{Rdata: r.TxtStrings})
 		} else if r.Type == "CAA" {
-			rec.AddAnswer(&dns.Answer{Rdata: strings.Split(fmt.Sprintf("%v %s %s", r.CaaFlag, r.CaaTag, r.GetTargetField()), " ")})
+			rec.AddAnswer(&dns.Answer{
+				Rdata: []string{
+					fmt.Sprintf("%v", r.CaaFlag),
+					r.CaaTag,
+					fmt.Sprintf("%s", r.GetTargetField()),
+			}})
 		} else if r.Type == "SRV" {
 			rec.AddAnswer(&dns.Answer{Rdata: strings.Split(fmt.Sprintf("%d %d %d %v", r.SrvPriority, r.SrvWeight, r.SrvPort, r.GetTargetField()), " ")})
 		} else {
@@ -198,6 +203,13 @@ func convert(zr *dns.ZoneRecord, domain string) ([]*models.RecordConfig, error) 
 			rec.Type = rtype
 			if err := rec.SetTarget(ans); err != nil {
 				panic(fmt.Errorf("unparsable %s record received from ns1: %w", rtype, err))
+			}
+		case "CAA":
+			//dnscontrol expects quotes around multivalue CAA entries, API doesn't add them, so let's force them
+			x_ans := strings.SplitN(ans, " ", 3)
+			answer := fmt.Sprintf(`%s %s "%s"`, x_ans[0],x_ans[1],x_ans[2])
+			if err := rec.PopulateFromString(rtype, answer, domain); err != nil {
+				panic(fmt.Errorf("unparsable %s record received from ns1: %w", err))
 			}
 		default:
 			if err := rec.PopulateFromString(rtype, ans, domain); err != nil {

--- a/providers/ns1/ns1Provider.go
+++ b/providers/ns1/ns1Provider.go
@@ -205,10 +205,9 @@ func convert(zr *dns.ZoneRecord, domain string) ([]*models.RecordConfig, error) 
 				panic(fmt.Errorf("unparsable %s record received from ns1: %w", rtype, err))
 			}
 		case "CAA":
-			//dnscontrol expects quotes around multivalue CAA entries, API doesn't add them, so let's force them
+			//dnscontrol expects quotes around multivalue CAA entries, API doesn't add them
 			x_ans := strings.SplitN(ans, " ", 3)
-			answer := fmt.Sprintf(`%s %s "%s"`, x_ans[0],x_ans[1],x_ans[2])
-			if err := rec.PopulateFromString(rtype, answer, domain); err != nil {
+			if err := rec.SetTargetCAAStrings(x_ans[0], x_ans[1], x_ans[2]); err != nil {
 				panic(fmt.Errorf("unparsable %s record received from ns1: %w", err))
 			}
 		default:

--- a/providers/ns1/ns1Provider.go
+++ b/providers/ns1/ns1Provider.go
@@ -197,22 +197,22 @@ func convert(zr *dns.ZoneRecord, domain string) ([]*models.RecordConfig, error) 
 		case "ALIAS":
 			rec.Type = rtype
 			if err := rec.SetTarget(ans); err != nil {
-				panic(fmt.Errorf("unparsable %s record received from ns1: %w", rtype, err))
+				return found, fmt.Errorf("unparsable %s record received from ns1: %w", rtype, err)
 			}
 		case "URLFWD":
 			rec.Type = rtype
 			if err := rec.SetTarget(ans); err != nil {
-				panic(fmt.Errorf("unparsable %s record received from ns1: %w", rtype, err))
+				return found, fmt.Errorf("unparsable %s record received from ns1: %w", rtype, err)
 			}
 		case "CAA":
 			//dnscontrol expects quotes around multivalue CAA entries, API doesn't add them
 			x_ans := strings.SplitN(ans, " ", 3)
 			if err := rec.SetTargetCAAStrings(x_ans[0], x_ans[1], x_ans[2]); err != nil {
-				panic(fmt.Errorf("unparsable %s record received from ns1: %w", err))
+				return found, fmt.Errorf("unparsable %s record received from ns1: %w", rtype, err)
 			}
 		default:
 			if err := rec.PopulateFromString(rtype, ans, domain); err != nil {
-				panic(fmt.Errorf("unparsable record received from ns1: %w", err))
+				return found, fmt.Errorf("unparsable record received from ns1: %w", err)
 			}
 		}
 		found = append(found, rec)

--- a/providers/ns1/ns1Provider.go
+++ b/providers/ns1/ns1Provider.go
@@ -197,22 +197,22 @@ func convert(zr *dns.ZoneRecord, domain string) ([]*models.RecordConfig, error) 
 		case "ALIAS":
 			rec.Type = rtype
 			if err := rec.SetTarget(ans); err != nil {
-				return found, fmt.Errorf("unparsable %s record received from ns1: %w", rtype, err)
+				return nil, fmt.Errorf("unparsable %s record received from ns1: %w", rtype, err)
 			}
 		case "URLFWD":
 			rec.Type = rtype
 			if err := rec.SetTarget(ans); err != nil {
-				return found, fmt.Errorf("unparsable %s record received from ns1: %w", rtype, err)
+				return nil, fmt.Errorf("unparsable %s record received from ns1: %w", rtype, err)
 			}
 		case "CAA":
 			//dnscontrol expects quotes around multivalue CAA entries, API doesn't add them
 			x_ans := strings.SplitN(ans, " ", 3)
 			if err := rec.SetTargetCAAStrings(x_ans[0], x_ans[1], x_ans[2]); err != nil {
-				return found, fmt.Errorf("unparsable %s record received from ns1: %w", rtype, err)
+				return nil, fmt.Errorf("unparsable %s record received from ns1: %w", rtype, err)
 			}
 		default:
 			if err := rec.PopulateFromString(rtype, ans, domain); err != nil {
-				return found, fmt.Errorf("unparsable record received from ns1: %w", err)
+				return nil, fmt.Errorf("unparsable record received from ns1: %w", err)
 			}
 		}
 		found = append(found, rec)


### PR DESCRIPTION
Introducing better multivalue support for the CAA entry broke CAA support for ns1, failing the relevant test.

Failing case:
```
=== RUN   TestDNSProviders/example.com/25:Issue_1374:CAA_spaces
```

This is was happening because provider's CAA handling was splitting fields on spaces, which trashed answers containing  spaces in the 3rd field (ie. splitting the 3rd field into multiple fields)

While dnscontrol has support to handle such cases of fields containing spaces via `ParseQuotedFields`, ns1's client isn't enclosing such fields in quotes and `ParseQuotedFields()` can't work its magic.

So to fix this issue, rework ns1's CAA handling a bit to not use `string.Split(str, " ")` anymore.

While there, clear up panics in the provider and surface errors to be picked and handled as needed.