### PR TITLE
Replace Jekyll highlight tags with fenced code blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,13 +163,13 @@ Alternatively, on Mac you can install it using homebrew:
 
 ## Via [docker](https://hub.docker.com/r/stackexchange/dnscontrol/)
 
-```
+```bash
 docker run --rm -it -v $(pwd)/dnsconfig.js:/dns/dnsconfig.js -v $(pwd)/creds.json:/dns/creds.json stackexchange/dnscontrol dnscontrol preview
 ```
 
 The documentation can be viewed via Docker:
 
-```
+```bash
 cd docs
 docker run --rm -it --volume="$PWD:/srv/jekyll" --volume="$PWD/vendor/bundle:/usr/local/bundle" --env JEKYLL_ENV=production jekyll/jekyll:3.8 jekyll build -V
 # Open docs/_site/index.html in your web browser to see the results.

--- a/cmd/convertzone/README.md
+++ b/cmd/convertzone/README.md
@@ -23,12 +23,11 @@ the OctoDNS provider), so why not use it?
 
 Build the software and install in your personal bin:
 
-```cmd
-$ cd cmd/convertzone
-$ go build
-$ cp convertzone ~/bin/.
+```bash
+cd cmd/convertzone
+go build
+cp convertzone ~/bin/.
 ```
-
 
 ## Usage Overview
 

--- a/docs/_functions/domain/A.md
+++ b/docs/_functions/domain/A.md
@@ -13,14 +13,14 @@ The address should be an ip address, either a string, or a numeric value obtaine
 Modifiers can be any number of [record modifiers](#record-modifiers) or json objects, which will be merged into the record's metadata.
 
 {% include startExample.html %}
-{% highlight js %}
 
+```js
 D("example.com", REGISTRAR, DnsProvider("R53"),
   A("@", "1.2.3.4"),
   A("foo", "2.3.4.5"),
   A("test.foo", IP("1.2.3.4"), TTL(5000)),
   A("*", "1.2.3.4", {foo: 42})
 );
+```
 
-{%endhighlight%}
 {% include endExample.html %}

--- a/docs/_functions/domain/AAAA.md
+++ b/docs/_functions/domain/AAAA.md
@@ -13,8 +13,8 @@ The address should be an IPv6 address as a string.
 Modifiers can be any number of [record modifiers](#record-modifiers) or json objects, which will be merged into the record's metadata.
 
 {% include startExample.html %}
-{% highlight js %}
 
+```js
 var addrV6 = "2001:0db8:85a3:0000:0000:8a2e:0370:7334"
 
 D("example.com", REGISTRAR, DnsProvider("R53"),
@@ -23,6 +23,6 @@ D("example.com", REGISTRAR, DnsProvider("R53"),
   AAAA("test.foo", addrV6, TTL(5000)),
   AAAA("*", addrV6, {foo: 42})
 );
+```
 
-{%endhighlight%}
 {% include endExample.html %}

--- a/docs/_functions/domain/ALIAS.md
+++ b/docs/_functions/domain/ALIAS.md
@@ -15,11 +15,11 @@ The name should be the relative label for the domain.
 Target should be a string representing the target. If it is a single label we will assume it is a relative name on the current domain. If it contains *any* dots, it should be a fully qualified domain name, ending with a `.`.
 
 {% include startExample.html %}
-{% highlight js %}
 
+```js
 D("example.com", REGISTRAR, DnsProvider("CLOUDFLARE"),
   ALIAS("@", "google.com."), // example.com -> google.com
 );
+```
 
-{%endhighlight%}
 {% include endExample.html %}

--- a/docs/_functions/domain/AUTODNSSEC_ON.md
+++ b/docs/_functions/domain/AUTODNSSEC_ON.md
@@ -18,7 +18,8 @@ NOTE: No parenthesis should follow these keywords.  That is, the
 correct syntax is `AUTODNSSEC_ON` not `AUTODNSSEC_ON()`
 
 {% include startExample.html %}
-{% highlight js %}
+
+```js
 D("example.com", .... ,
   AUTODNSSEC_ON,  // Enable AutoDNSSEC.
   A("@", "10.1.1.1")
@@ -28,7 +29,8 @@ D("insecure.com", .... ,
   AUTODNSSEC_OFF,  // Disable AutoDNSSEC.
   A("@", "10.2.2.2")
 );
-{%endhighlight%}
+```
+
 {% include endExample.html %}
 
 If neither `AUTODNSSEC_ON` or `AUTODNSSEC_OFF` is specified for a

--- a/docs/_functions/domain/AZURE_ALIAS.md
+++ b/docs/_functions/domain/AZURE_ALIAS.md
@@ -16,7 +16,7 @@ Attempting to use AZURE_ALIAS on another provider than Azure will result in an e
 
 The name should be the relative label for the domain.
 
-The type can be any of the following: 
+The type can be any of the following:
 * A
 * AAAA
 * CNAME
@@ -27,7 +27,7 @@ The Target can :
 
 * Point to a public IP resource from a DNS `A/AAAA` record set.
 You can create an A/AAAA record set and make it an alias record set to point to a public IP resource (standard or basic).
-The DNS record set changes automatically if the public IP address changes or is deleted. 
+The DNS record set changes automatically if the public IP address changes or is deleted.
 Dangling DNS records that point to incorrect IP addresses are avoided.
 There is a current limit of 20 alias records sets per resource.
 * Point to a Traffic Manager profile from a DNS `A/AAAA/CNAME` record set.
@@ -39,16 +39,16 @@ You can create an alias record set of type A/AAAA for contoso.com (the zone apex
 This is useful when you create static websites using Azure storage and Azure CDN.
 * Point to another DNS record set within the same zone.
 Alias records can reference other record sets of the same type.
-For example, a DNS CNAME record set can be an alias to another CNAME record set. 
+For example, a DNS CNAME record set can be an alias to another CNAME record set.
 This arrangement is useful if you want some record sets to be aliases and some non-aliases.
 
 {% include startExample.html %}
-{% highlight js %}
 
+```js
 D("example.com", REGISTRAR, DnsProvider("AZURE_DNS"),
   AZURE_ALIAS("foo", "A", "/subscriptions/726f8cd6-6459-4db4-8e6d-2cd2716904e2/resourceGroups/test/providers/Microsoft.Network/trafficManagerProfiles/testpp2"), // record for traffic manager
   AZURE_ALIAS("foo", "CNAME", "/subscriptions/726f8cd6-6459-4db4-8e6d-2cd2716904e2/resourceGroups/test/providers/Microsoft.Network/dnszones/example.com/A/quux."), // record in the same zone
 );
+```
 
-{%endhighlight%}
 {% include endExample.html %}

--- a/docs/_functions/domain/CAA.md
+++ b/docs/_functions/domain/CAA.md
@@ -20,8 +20,8 @@ Flags are controlled by modifier:
 CAA record is supported only by BIND, Google Cloud DNS, Amazon Route 53 and OVH. Some certificate authorities may not support this record until the mandatory date of September 2017.
 
 {% include startExample.html %}
-{% highlight js %}
 
+```js
 D("example.com", REGISTRAR, DnsProvider("GCLOUD"),
   // Allow letsencrypt to issue certificate for this domain
   CAA("@", "issue", "letsencrypt.org"),
@@ -31,6 +31,6 @@ D("example.com", REGISTRAR, DnsProvider("GCLOUD"),
   // this record then refuse to issue any certificate
   CAA("@", "iodef", "mailto:test@example.com", CAA_CRITICAL)
 );
+```
 
-{%endhighlight%}
 {% include endExample.html %}

--- a/docs/_functions/domain/CF_REDIRECT.md
+++ b/docs/_functions/domain/CF_REDIRECT.md
@@ -26,9 +26,11 @@ only after sufficient time has elapsed to prove this is what you really want.
 This example redirects the bare (aka apex, or naked) domain to www:
 
 {% include startExample.html %}
-{% highlight js %}
+
+```js
 D("foo.com", .... ,
   CF_REDIRECT("mydomain.com/*", "https://www.mydomain.com/$1"),
 );
-{%endhighlight%}
+```
+
 {% include endExample.html %}

--- a/docs/_functions/domain/CF_TEMP_REDIRECT.md
+++ b/docs/_functions/domain/CF_TEMP_REDIRECT.md
@@ -19,9 +19,11 @@ backups and manually verifying `dnscontrol preview` output before running
 managed by DNSControl and those that aren't.
 
 {% include startExample.html %}
-{% highlight js %}
+
+```js
 D("foo.com", .... ,
   CF_TEMP_REDIRECT("example.mydomain.com/*", "https://otherplace.yourdomain.com/$1"),
 );
-{%endhighlight%}
+```
+
 {% include endExample.html %}

--- a/docs/_functions/domain/CF_WORKER_ROUTE.md
+++ b/docs/_functions/domain/CF_WORKER_ROUTE.md
@@ -5,11 +5,11 @@ parameters:
   - script
 ---
 
-`CF_WORKER_ROUTE` uses the [Cloudflare Workers](https://developers.cloudflare.com/workers/) 
+`CF_WORKER_ROUTE` uses the [Cloudflare Workers](https://developers.cloudflare.com/workers/)
 API to manage [worker routes](https://developers.cloudflare.com/workers/platform/routes)
 for a given domain.
 
-If _any_ `CF_WORKER_ROUTE` function is used then `dnscontrol` will manage _all_ 
+If _any_ `CF_WORKER_ROUTE` function is used then `dnscontrol` will manage _all_
 Worker Routes for the domain. To be clear: this means it will delete existing routes that
 were created outside of DNSControl.
 
@@ -20,10 +20,12 @@ backups and manually verifying `dnscontrol preview` output before running
 This example assigns the patterns `api.foo.com/*` and `foo.com/api/*` to a `my-worker` script:
 
 {% include startExample.html %}
-{% highlight js %}
+
+```js
 D("foo.com", .... ,
     CF_WORKER_ROUTE("api.foo.com/*", "my-worker"),
     CF_WORKER_ROUTE("foo.com/api/*", "my-worker"),
 );
-{%endhighlight%}
+```
+
 {% include endExample.html %}

--- a/docs/_functions/domain/CNAME.md
+++ b/docs/_functions/domain/CNAME.md
@@ -12,13 +12,13 @@ Using `@` or `*` for CNAME records is not recommended, as different providers su
 Target should be a string representing the CNAME target. If it is a single label we will assume it is a relative name on the current domain. If it contains *any* dots, it should be a fully qualified domain name, ending with a `.`.
 
 {% include startExample.html %}
-{% highlight js %}
 
+```js
 D("example.com", REGISTRAR, DnsProvider("R53"),
   CNAME("foo", "google.com."), // foo.example.com -> google.com
   CNAME("abc", "@"), // abc.example.com -> example.com
   CNAME("def", "test"), // def.example.com -> test.example.com
 );
+```
 
-{%endhighlight%}
 {% include endExample.html %}

--- a/docs/_functions/domain/DS.md
+++ b/docs/_functions/domain/DS.md
@@ -20,11 +20,11 @@ Digest Type must be a number.
 Digest must be a string.
 
 {% include startExample.html %}
-{% highlight js %}
 
+```js
 D("example.com", REGISTRAR, DnsProvider(R53),
   DS("example.com", 2371, 13, 2, "ABCDEF")
 );
+```
 
-{%endhighlight%}
 {% include endExample.html %}

--- a/docs/_functions/domain/DefaultTTL.md
+++ b/docs/_functions/domain/DefaultTTL.md
@@ -8,14 +8,14 @@ DefaultTTL sets the TTL for all records in a domain that do not explicitly set o
 it will use the DNSControl global default of 300 seconds.
 
 {% include startExample.html %}
-{% highlight js %}
 
+```js
 D('example.com', REGISTRAR, DnsProvider('R53'),
   DefaultTTL("4h"),
   A('@','1.2.3.4'), // uses default
   A('foo', '2.3.4.5', TTL(600)) // overrides default
 );
-{%endhighlight%}
+```
 
 The DefaultTTL duration is the same format as [TTL](#TTL), an integer number of seconds
 or a string with a unit such as `'4d'`.

--- a/docs/_functions/domain/IGNORE_NAME.md
+++ b/docs/_functions/domain/IGNORE_NAME.md
@@ -23,13 +23,15 @@ Technically `IGNORE_NAME` is a promise that DNSControl will not add, change, or 
 In this example, DNSControl will insert/update the "baz.example.com" record but will leave unchanged the "foo.example.com" and "bar.example.com" ones.
 
 {% include startExample.html %}
-{% highlight js %}
+
+```js
 D("example.com",
   `IGNORE_NAME`("foo"),
   `IGNORE_NAME`("bar"),
   A("baz", "1.2.3.4")
 );
-{%endhighlight%}
+```
+
 {% include endExample.html %}
 
 `IGNORE_NAME` also supports glob patterns in the style of the [gobwas/glob](https://github.com/gobwas/glob) library. All of

--- a/docs/_functions/domain/IGNORE_TARGET.md
+++ b/docs/_functions/domain/IGNORE_TARGET.md
@@ -20,12 +20,14 @@ IGNORE_TARGET is generally used in very specific situations:
 In this example, DNSControl will insert/update the "baz.example.com" record but will leave unchanged a CNAME to "foo.acm-validations.aws" record.
 
 {% include startExample.html %}
-{% highlight js %}
+
+```js
 D("example.com",
   IGNORE_TARGET('**.acm-validations.aws.', 'CNAME'),
   A("baz", "1.2.3.4")
 );
-{%endhighlight%}
+```
+
 {% include endExample.html %}
 
 IGNORE_TARGET also supports glob patterns in the style of the [gobwas/glob](https://github.com/gobwas/glob#example) library. Some example patterns:

--- a/docs/_functions/domain/IMPORT_TRANSFORM.md
+++ b/docs/_functions/domain/IMPORT_TRANSFORM.md
@@ -24,8 +24,8 @@ be very error prone. Therefore instead you maintain foo.com and
 let `IMPORT_TRANSFORM` automatically generate bar.com.
 
 {% include startExample.html %}
-{% highlight html %}
 
+```html
 foo.com:
     one.foo.com.    IN A 1.2.3.1
     two.foo.com.    IN A 1.2.3.2
@@ -38,15 +38,15 @@ bar.com:
     two.foo.com.bar.com.    IN A 1.2.3.2
     three.foo.com.bar.com.  IN A 123.123.123.113
     four.foo.com.bar.com.   IN A 123.123.123.114
+```
 
-{%endhighlight%}
 {% include endExample.html %}
 
 Here's how you'd implement this in DNSControl:
 
 {% include startExample.html %}
-{% highlight js %}
 
+```js
 var TRANSFORM_INT = [
     // RANGE_START, RANGE_END, NEW_BASE
     { low: "1.2.3.10", high: "1.2.3.20", newBase: "123.123.123.100" },  //   .10 to .20 rewritten as 123.123.123.100+IP
@@ -64,8 +64,8 @@ D("bar.com", .... ,
   A("www","123.123.123.123")
   IMPORT_TRANSFORM(TRANSFORM_INT, 'foo.com', 300),
 );
+```
 
-{%endhighlight%}
 {% include endExample.html %}
 
 Transform rules are: RANGE_START, RANGE_END, NEW_BASE.  NEW_BASE may be:

--- a/docs/_functions/domain/IMPORT_TRANSFORM.md
+++ b/docs/_functions/domain/IMPORT_TRANSFORM.md
@@ -25,7 +25,7 @@ let `IMPORT_TRANSFORM` automatically generate bar.com.
 
 {% include startExample.html %}
 
-```html
+```text
 foo.com:
     one.foo.com.    IN A 1.2.3.1
     two.foo.com.    IN A 1.2.3.2

--- a/docs/_functions/domain/INCLUDE.md
+++ b/docs/_functions/domain/INCLUDE.md
@@ -8,8 +8,8 @@ Includes all records from a given domain
 
 
 {% include startExample.html %}
-{% highlight js %}
 
+```js
 D("example.com!external", REGISTRAR, DnsProvider(R53),
   A("test", "8.8.8.8")
 );
@@ -18,6 +18,6 @@ D("example.com!internal", REGISTRAR, DnsProvider(R53),
   INCLUDE("example.com!external"),
   A("home", "127.0.0.1")
 );
+```
 
-{%endhighlight%}
 {% include endExample.html %}

--- a/docs/_functions/domain/MX.md
+++ b/docs/_functions/domain/MX.md
@@ -14,12 +14,12 @@ Priority should be a number.
 Target should be a string representing the MX target. If it is a single label we will assume it is a relative name on the current domain. If it contains *any* dots, it should be a fully qualified domain name, ending with a `.`.
 
 {% include startExample.html %}
-{% highlight js %}
 
+```js
 D("example.com", REGISTRAR, DnsProvider(R53),
   MX("@", 5, "mail"), // mx example.com -> mail.example.com
   MX("sub", 10, "mail.foo.com.")
 );
+```
 
-{%endhighlight%}
 {% include endExample.html %}

--- a/docs/_functions/domain/NAMESERVER.md
+++ b/docs/_functions/domain/NAMESERVER.md
@@ -18,8 +18,8 @@ delegations. `NAMESERVER()` is for informing upstream delegations.
 For more information, refer to [this page]({{site.github.url}}/nameservers).
 
 {% include startExample.html %}
-{% highlight js %}
 
+```js
 D("example.com", REGISTRAR, .... ,
   DnsProvider(route53, 0),
   // Replace the nameservers:
@@ -32,8 +32,8 @@ D("example2.com", REGISTRAR, .... ,
   NAMESERVER("ns1.myserver.com."),
   NAMESERVER("ns2.myserver.com."),
 );
+```
 
-{%endhighlight%}
 {% include endExample.html %}
 
 
@@ -79,7 +79,7 @@ special Registrar called "NONE". It makes no changes.
 
 It looks like this:
 
-```
+```js
 var REG_THIRDPARTY = NewRegistrar('ThirdParty', 'NONE')
 D("mydomain.com", REG_THIRDPARTY,
   ...

--- a/docs/_functions/domain/NAMESERVER_TTL.md
+++ b/docs/_functions/domain/NAMESERVER_TTL.md
@@ -9,11 +9,12 @@ TTL sets the TTL on the domain apex NS RRs defined by [NAMESERVER](#NAMESERVER).
 The value can be an integer or a string. See [TTL](#TTL) for examples.
 
 {% include startExample.html %}
-{% highlight js %}
 
+```js
 D('example.com', REGISTRAR, DnsProvider('R53'),
   NAMESERVER_TTL('2d'),
   NAMESERVER('ns')
 );
-{%endhighlight%}
+```
+
 {% include endExample.html %}

--- a/docs/_functions/domain/NO_PURGE.md
+++ b/docs/_functions/domain/NO_PURGE.md
@@ -16,11 +16,13 @@ address will update the record. Removing the A("foo", ...) record
 from dnscontrol will leave the record in place.
 
 {% include startExample.html %}
-{% highlight js %}
+
+```js
 D("example.com", .... , NO_PURGE,
   A("foo","1.2.3.4")
 );
-{%endhighlight%}
+```
+
 {% include endExample.html %}
 
 The main caveat of NO_PURGE is that intentionally deleting records

--- a/docs/_functions/domain/NS.md
+++ b/docs/_functions/domain/NS.md
@@ -15,14 +15,14 @@ The difference between `NS()` and `NAMESERVER()` is explained in the `NAMESERVER
 Target should be a string representing the NS target. If it is a single label we will assume it is a relative name on the current domain. If it contains *any* dots, it should be a fully qualified domain name, ending with a `.`.
 
 {% include startExample.html %}
-{% highlight js %}
 
+```js
 D("example.com", REGISTRAR, DnsProvider("R53"),
   NS("foo", "ns1.example2.com."), // Delegate ".foo.example.com" zone to another server.
   NS("foo", "ns2.example2.com."), // Delegate ".foo.example.com" zone to another server.
   A("ns1.example2.com", "10.10.10.10"), // Glue records
   A("ns2.example2.com", "10.10.10.20"), // Glue records
 );
+```
 
-{%endhighlight%}
 {% include endExample.html %}

--- a/docs/_functions/domain/PTR.md
+++ b/docs/_functions/domain/PTR.md
@@ -57,7 +57,8 @@ and A, B, C are the first 3 octets of the IP address. For example
 `128/27.18.20.172.in-addr.arpa`
 
 {% include startExample.html %}
-{% highlight js %}
+
+```js
 D(REV('1.2.3.0/24'), REGISTRAR, DnsProvider(BIND),
   PTR('1', 'foo.example.com.'),
   PTR('2', 'bar.example.com.'),
@@ -76,8 +77,8 @@ D(REV('2001:db8:302::/48'), REGISTRAR, DnsProvider(BIND),
   PTR('2001:db8:302::2', 'two.example.com.'),                          // '2.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0'
   PTR('2001:db8:302::3', 'three.example.com.'),                        // '3.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0'
 );
+```
 
-{%endhighlight%}
 {% include endExample.html %}
 
 In the future we plan on adding a flag to `A()` which will insert

--- a/docs/_functions/domain/PURGE.md
+++ b/docs/_functions/domain/PURGE.md
@@ -13,26 +13,31 @@ These three examples all are equivalent.
 PURGE is the default:
 
 {% include startExample.html %}
-{% highlight js %}
+
+```js
 D("example.com", .... ,
 );
-{%endhighlight%}
+```
+
 {% include endExample.html %}
 
 Purge is the default, but we set it anyway:
 
 {% include startExample.html %}
-{% highlight js %}
+
+```js
 D("example.com", .... ,
   PURGE,
 );
-{%endhighlight%}
+```
+
 {% include endExample.html %}
 
 Since the "last command wins", this is the same as `PURGE`:
 
 {% include startExample.html %}
-{% highlight js %}
+
+```js
 D("example.com", .... ,
   PURGE,
   NO_PURGE,
@@ -40,5 +45,6 @@ D("example.com", .... ,
   NO_PURGE,
   PURGE,
 );
-{%endhighlight%}
+```
+
 {% include endExample.html %}

--- a/docs/_functions/domain/R53_ALIAS.md
+++ b/docs/_functions/domain/R53_ALIAS.md
@@ -33,8 +33,8 @@ The zone id can be found depending on the target type:
 * _Another Route 53 record_: you can either specify the correct zone id or do not specify anything and dnscontrol will figure out the right zone id. (Note: Route53 alias can't reference a record in a different zone).
 
 {% include startExample.html %}
-{% highlight js %}
 
+```js
 D('example.com', REGISTRAR, DnsProvider('ROUTE53'),
   R53_ALIAS('foo', 'A', 'bar'),                              // record in same zone
   R53_ALIAS('foo', 'A', 'bar', R53_ZONE('Z35SXDOTRQ7X7K')),  // record in same zone, zone specified
@@ -42,6 +42,6 @@ D('example.com', REGISTRAR, DnsProvider('ROUTE53'),
   R53_ALIAS('foo', 'A', 'blahblah.elasticbeanstalk.us-west-2.amazonaws.com.', R53_ZONE('Z38NKT9BP95V3O')),     // an Elastic Beanstalk environment in us-west-2
   R53_ALIAS('foo', 'A', 'blahblah-bucket.s3-website-us-west-1.amazonaws.com.', R53_ZONE('Z2F56UZL2M1ACD')),     // a website S3 Bucket in us-west-1
 );
+```
 
-{%endhighlight%}
 {% include endExample.html %}

--- a/docs/_functions/domain/SOA.md
+++ b/docs/_functions/domain/SOA.md
@@ -14,13 +14,13 @@ parameters:
 `SOA` adds an `SOA` record to a domain. The name should be `@`.  ns and mbox are strings. The other fields are unsigned 32-bit ints.
 
 {% include startExample.html %}
-{% highlight js %}
 
+```js
 D("example.com", REG_THIRDPARTY, DnsProvider("DNS_BIND"),
   SOA("@", "ns3.example.org.", "hostmaster.example.org.", 3600, 600, 604800, 1440),
 );
+```
 
-{%endhighlight%}
 {% include endExample.html %}
 
 ## Notes:

--- a/docs/_functions/domain/SRV.md
+++ b/docs/_functions/domain/SRV.md
@@ -14,14 +14,14 @@ parameters:
 Priority, weight, and port are ints.
 
 {% include startExample.html %}
-{% highlight js %}
 
+```js
 D("example.com", REGISTRAR, DnsProvider("GCLOUD"),
   // Create SRV records for a a SIP service:
   //               pr  w   port, target
   SRV('_sip._tcp', 10, 60, 5060, 'bigbox.example.tld.'),
   SRV('_sip._tcp', 10, 20, 5060, 'smallbox1.example.tld.'),
 );
+```
 
-{%endhighlight%}
 {% include endExample.html %}

--- a/docs/_functions/domain/SSHFP.md
+++ b/docs/_functions/domain/SSHFP.md
@@ -29,9 +29,9 @@ SSHFP contains a fingerprint of a SSH server which can be validated before SSH c
 `value` is the fingerprint as a string.
 
 {% include startExample.html %}
-{% highlight js %}
 
+```js
 SSHFP('@', 1, 1, '00yourAmazingFingerprint00'),
+```
 
-{%endhighlight%}
 {% include endExample.html %}

--- a/docs/_functions/domain/TLSA.md
+++ b/docs/_functions/domain/TLSA.md
@@ -16,12 +16,12 @@ Usage, selector, and type are ints.
 Certificate is a hex string.
 
 {% include startExample.html %}
-{% highlight js %}
 
+```js
 D("example.com", REGISTRAR, DnsProvider("GCLOUD"),
   // Create TLSA record for certificate used on TCP port 443
   TLSA("_443._tcp", 3, 1, 1, "abcdef0"),
 );
+```
 
-{%endhighlight%}
 {% include endExample.html %}

--- a/docs/_functions/domain/TXT.md
+++ b/docs/_functions/domain/TXT.md
@@ -19,7 +19,8 @@ will be done for you.
 Modifiers can be any number of [record modifiers](#record-modifiers) or json objects, which will be merged into the record's metadata.
 
 {% include startExample.html %}
-{% highlight js %}
+
+```js
     D("example.com", REGISTRAR, ....,
       TXT('@', '598611146-3338560'),
       TXT('listserve', 'google-site-verification=12345'),
@@ -28,7 +29,8 @@ Modifiers can be any number of [record modifiers](#record-modifiers) or json obj
       TXT('_domainkey', 't=y; o=-;'), // Escapes are done for you automatically.
       TXT('long', 'X'.repeat(300)) // Long strings are split automatically.
     );
-{%endhighlight%}
+```
+
 {% include endExample.html %}
 
 NOTE: In the past, long strings had to be annotated with the keyword

--- a/docs/_functions/global/D.md
+++ b/docs/_functions/global/D.md
@@ -18,7 +18,8 @@ Modifier arguments are processed according to type as follows:
    be used like a macro in multiple domains.
 
 {% include startExample.html %}
-{% highlight js %}
+
+```js
 var REGISTRAR = NewRegistrar("name.com", "NAMEDOTCOM");
 var r53 = NewDnsProvider("R53","ROUTE53");
 
@@ -42,7 +43,8 @@ D("example.com", REGISTRAR, DnsProvider(r53),
   CNAME("test", "foo.example2.com."),
   GOOGLE_APPS_DOMAIN_MX
 );
-{%endhighlight%}
+```
+
 {% include endExample.html %}
 
 
@@ -57,7 +59,8 @@ To differentiate the different domains, specify the domains as
 `example.com!outside`.
 
 {% include startExample.html %}
-{% highlight js %}
+
+```js
 var REG = NewRegistrar("Third-Party", "NONE");
 var DNS_INSIDE = NewDnsProvider("Cloudflare", "CLOUDFLAREAPI");
 var DNS_OUTSIDE = NewDnsProvider("bind", "BIND");
@@ -73,7 +76,8 @@ D("example.com!outside", REG, DnsProvider(DNS_OUTSIDE),
 D_EXTEND("example.com!inside",
   A("internal", "10.99.99.99")
 );
-{%endhighlight%}
+```
+
 {% include endExample.html %}
 
 A domain name without a `!` is assigned a tag that is the empty

--- a/docs/_functions/global/DEFAULTS.md
+++ b/docs/_functions/global/DEFAULTS.md
@@ -8,7 +8,8 @@ parameters:
 arguments passed as if they were the first modifiers in the argument list.
 
 {% include startExample.html %}
-{% highlight js %}
+
+```js
 var COMMON = NewDnsProvider("foo","BIND");
 // we want to create backup zone files for all domains, but not actually register them.
 // also create a default TTL
@@ -19,5 +20,6 @@ D("example.com", REGISTRAR, DnsProvider("R53"), A("@","1.2.3.4")); // this domai
 // clear defaults
 DEFAULTS();
 D("example2.com", REGISTRAR, DnsProvider("R53"), A("@","1.2.3.4")); // this domain will not have the previous defaults.
-{%endhighlight%}
+```
+
 {% include endExample.html %}

--- a/docs/_functions/global/DOMAIN_ELSEWHERE.md
+++ b/docs/_functions/global/DOMAIN_ELSEWHERE.md
@@ -18,10 +18,10 @@ point (delegate) the domain at a specific list of DNS servers.
 
 For example these two statements are equivalent:
 
-```
+```js
 DOMAIN_ELSEWHERE("example.com", REG_NAMEDOTCOM, ["ns1.foo.com", "ns2.foo.com"]);
 
-# ...is equivalent to...
+// ...is equivalent to...
 
 D("example.com", REG_NAMEDOTCOM,
     NO_PURGE,

--- a/docs/_functions/global/DOMAIN_ELSEWHERE_AUTO.md
+++ b/docs/_functions/global/DOMAIN_ELSEWHERE_AUTO.md
@@ -21,10 +21,10 @@ hard-code them in your dnsconfig.js file.
 
 For example these two statements are equivalent:
 
-```
+```js
 DOMAIN_ELSEWHERE_AUTO("example.com", REG_NAMEDOTCOM, DSP_AZURE);
 
-# ...is equivalent to...
+// ...is equivalent to...
 
 D("example.com", REG_NAMEDOTCOM,
     NO_PURGE,

--- a/docs/_functions/global/D_EXTEND.md
+++ b/docs/_functions/global/D_EXTEND.md
@@ -26,13 +26,14 @@ defined as separate domains via separate `D()` statements, then
 not `domain.tld`.
 
 Some operators only act on an apex domain (e.g.
-`CF_REDIRECT` and `CF_TEMP_REDIRECT`). Using them 
+`CF_REDIRECT` and `CF_TEMP_REDIRECT`). Using them
 in a `D_EXTEND` subdomain may not be what you expect.
 
 Example:
 
 {% include startExample.html %}
-{% highlight js %}
+
+```js
 D("domain.tld", REG, DnsProvider(DNS),
   A("@", "127.0.0.1"), // domain.tld
   A("www", "127.0.0.2"), // www.domain.tld
@@ -55,11 +56,11 @@ D_EXTEND("sub.domain.tld",
   A("@", "127.0.0.7"), // sub.domain.tld
   CNAME("i", "j") // i.sub.domain.tld -> j.sub.domain.tld
 );
-{%endhighlight%}
+```
 
 This will end up in the following modifications:
 
-```
+```text
 ******************** Domain: domain.tld
 ----- Getting nameservers from: cloudflare
 ----- DNS Provider: cloudflare...7 corrections
@@ -76,6 +77,7 @@ This will end up in the following modifications:
 #11: CREATE CNAME g.sub.sub.domain.tld h.sub.sub.domain.tld.
 #12: CREATE CNAME i.sub.domain.tld j.sub.domain.tld.
 ```
+
 {% include endExample.html %}
 
 ProTips: `D_EXTEND()` permits you to create very complex and

--- a/docs/_functions/global/FETCH.md
+++ b/docs/_functions/global/FETCH.md
@@ -19,7 +19,8 @@ Otherwise the syntax of `FETCH` is the same as `fetch`.
 > 2. Make sure DnsControl only uses verified configuration if you want to use `FETCH`. For example, an attacker can send Pull Requests to your config repo, and have your CI test malicious configurations and make arbitrary HTTP requests. Therefore, `FETCH` must be explicitly enabled with flag `--allow-fetch` on DnsControl invocation.
 
 {% include startExample.html %}
-{% highlight js %}
+
+```js
 var REG_NONE = NewRegistrar('none', 'NONE');
 var DNS_BIND = NewDnsProvider('bind', 'BIND');
 
@@ -40,5 +41,6 @@ FETCH('https://example.com', {
     TXT('@', t.slice(0, 100)),
   ]);
 });
-{%endhighlight%}
+```
+
 {% include endExample.html %}

--- a/docs/_functions/global/IP.md
+++ b/docs/_functions/global/IP.md
@@ -9,11 +9,11 @@ Converts an IPv4 address from string to an integer. This allows performing mathe
 This does not accept IPv6 addresses. (PRs gladly accepted.)
 
 {% include startExample.html %}
-{% highlight js %}
 
+```js
 var addrA = IP('1.2.3.4')
 var addrB = addrA + 1
 // addrB = 1.2.3.5
+```
 
-{%endhighlight%}
 {% include endExample.html %}

--- a/docs/_functions/global/NewDnsProvider.md
+++ b/docs/_functions/global/NewDnsProvider.md
@@ -15,10 +15,12 @@ Metadata is an optional object, that will only be used by certain providers. See
 This function will return the name as a string so that you may assign it to a variable to use inside [D](#D) directives.
 
 {% include startExample.html %}
-{% highlight js %}
+
+```js
 var REGISTRAR = NewRegistrar("name.com", "NAMEDOTCOM");
 var R53 = NewDnsProvider("r53", "ROUTE53");
 
 D("example.com", REGISTRAR, DnsProvider(R53), A("@","1.2.3.4"));
-{%endhighlight%}
+```
+
 {% include endExample.html %}

--- a/docs/_functions/global/NewRegistrar.md
+++ b/docs/_functions/global/NewRegistrar.md
@@ -15,10 +15,12 @@ Metadata is an optional object, that will only be used by certain providers. See
 This function will return the name as a string so that you may assign it to a variable to use inside [D](#D) directives.
 
 {% include startExample.html %}
-{% highlight js %}
+
+```js
 var REGISTRAR = NewRegistrar("name.com", "NAMEDOTCOM");
 var r53 = NewDnsProvider("R53","ROUTE53");
 
 D("example.com", REGISTRAR, DnsProvider(r53), A("@","1.2.3.4"));
-{%endhighlight%}
+```
+
 {% include endExample.html %}

--- a/docs/_functions/global/PANIC.md
+++ b/docs/_functions/global/PANIC.md
@@ -7,7 +7,9 @@ parameters:
 `PANIC` terminates the script and therefore DnsControl with an exit code of 1. This should be used if your script cannot gather enough information to generate records, for example when a HTTP request failed.
 
 {% include startExample.html %}
-{% highlight js %}
+
+```js
 PANIC("Something really bad has happened");
-{%endhighlight%}
+```
+
 {% include endExample.html %}

--- a/docs/_functions/global/REV.md
+++ b/docs/_functions/global/REV.md
@@ -30,7 +30,8 @@ zeroed out automatically. Thus, `REV('1.2.3.4/24') is an error.  This is done
 to catch typos.
 
 {% include startExample.html %}
-{% highlight js %}
+
+```js
 D(REV('1.2.3.0/24'), REGISTRAR, DnsProvider(BIND),
   PTR("1", 'foo.example.com.'),
   PTR("2", 'bar.example.com.'),
@@ -45,9 +46,8 @@ D(REV('2001:db8:302::/48'), REGISTRAR, DnsProvider(BIND),
   PTR("2001:db8:302::2", 'two.example.com.'),                          // 2.0.0...
   PTR("2001:db8:302::3", 'three.example.com.'),                        // 3.0.0...
 );
+```
 
-
-{%endhighlight%}
 {% include endExample.html %}
 
 In the future we plan on adding a flag to `A()` which will insert

--- a/docs/_functions/global/getConfiguredDomains.md
+++ b/docs/_functions/global/getConfiguredDomains.md
@@ -12,17 +12,19 @@ domains at the end of your configuration file.
 
 Example for adding records to all configured domains:
 {% include startExample.html %}
-{% highlight js %}
+
+```js
 var domains = getConfiguredDomains();
 for(i = 0; i < domains.length; i++) {
   D_EXTEND(domains[i],
     TXT('_important', 'BLA') // I know, not really creative.
   )
 }
-{%endhighlight%}
+```
 
 This will end up in following modifications:
-```
+
+```text
 ******************** Domain: domain1.tld
 ----- Getting nameservers from: registrar
 ----- DNS Provider: registrar...2 corrections
@@ -35,23 +37,25 @@ This will end up in following modifications:
 #1: CREATE TXT _important.domain2.tld "BLA" ttl=43200
 #2: REFRESH zone domain2.tld
 ```
+
 {% include endExample.html %}
 
 Example for adding DMARC report records:
 {% include startExample.html %}
 This example might be more useful, specially for configuring the DMARC report records. According to DMARC RFC you need to specify `domain2.tld._report.dmarc.domain1.tld` to allow `domain2.tld` to send aggregate/forensic email reports to `domain1.tld`. This can be used to do this in an easy way, without using the wildcard from the RFC.
 
-{% highlight js %}
+```js
 var domains = getConfiguredDomains();
 for(i = 0; i < domains.length; i++) {
 	D_EXTEND("domain1.tld",
 		TXT(domains[i] + '._report._dmarc', 'v=DMARC1')
 	);
 }
-{%endhighlight%}
+```
 
 This will end up in following modifications:
-```
+
+```text
 ******************** Domain: domain2.tld
 ----- Getting nameservers from: registrar
 ----- DNS Provider: registrar...4 corrections
@@ -60,4 +64,5 @@ This will end up in following modifications:
 #3: CREATE TXT domain4.tld._report._dmarc.domain2.tld "v=DMARC1" ttl=43200
 #4: REFRESH zone domain2.tld
 ```
+
 {% include endExample.html %}

--- a/docs/_functions/global/require.md
+++ b/docs/_functions/global/require.md
@@ -19,19 +19,17 @@ is interpreted relative to the program's working directory at the time
 of the call.
 
 {% include startExample.html %}
-{% highlight js %}
 
+```js
 // dnsconfig.js
 require('kubernetes/clusters.js');
 
 D("mydomain.net", REG, PROVIDER,
     IncludeKubernetes()
 );
+```
 
-{%endhighlight%}
-
-{% highlight js %}
-
+```js
 // kubernetes/clusters.js
 require('./clusters/prod.js');
 require('./clusters/dev.js');
@@ -39,34 +37,30 @@ require('./clusters/dev.js');
 function IncludeKubernetes() {
     return [includeK8Sprod(), includeK8Sdev()];
 }
+```
 
-{%endhighlight%}
-
-{% highlight js %}
-
+```js
 // kubernetes/clusters/prod.js
 function includeK8Sprod() {
     return [ /* ... */ ];
 }
+```
 
-{%endhighlight%}
-
-{% highlight js %}
-
+```js
 // kubernetes/clusters/dev.js
 function includeK8Sdev() {
     return [ /* ... */ ];
 }
+```
 
-{%endhighlight%}
 {% include endExample.html %}
 
 You can also use it to require json files and initialize variables with it:
 For Example:
 
 {% include startExample.html %}
-{% highlight js %}
 
+```js
 // dnsconfig.js
 var domains = require('./domain-ip-map.json')
 
@@ -75,16 +69,16 @@ for (var domain in domains) {
         A("@", domains[domain])
     );
 }
+```
 
-{%endhighlight%}
-
-{%highlight js %}
+```js
 // domain-ip-map.json
 {
     "mydomain.net": "1.1.1.1",
     "myotherdomain.org": "5.5.5.5"
 }
-{%endhighlight}
+```
+
 {% include endExample.html %}
 
 # Future

--- a/docs/_functions/global/require_glob.md
+++ b/docs/_functions/global/require_glob.md
@@ -13,12 +13,14 @@ Possible parameters are:
 - If being recursive. This is a boolean if the search should be recursive or not. Define either `true` or `false`. Default is `true`.
 
 Example to load `.js` files recursively:
-```
+
+```js
 require_glob("./domains/");
 ```
 
 Example to load `.js` files only in `domains/`:
-```
+
+```js
 require_glob("./domains/", false);
 ```
 
@@ -26,12 +28,14 @@ One more important thing to note: `require_glob()` is as smart as `require()` is
 file where it's being executed in. Let's go with an example, as it describes it better:
 
 dnscontrol.js:
-```
+
+```js
 require("domains/index.js");
 ```
 
 domains/index.js:
-```
+
+```js
 require_glob("./user1/");
 ```
 

--- a/docs/_functions/record/DMARC_BUILDER.md
+++ b/docs/_functions/record/DMARC_BUILDER.md
@@ -23,7 +23,8 @@ DMARC_BUILDER({
 ```
 
 This yield the following record:
-```
+
+```text
 @   IN  TXT "v=DMARC1; p=reject; ruf=mailto:mailauth-reports@example.com"
 ```
 
@@ -62,7 +63,7 @@ DMARC_BUILDER({
 
 This yields the following records:
 
-```
+```text
 @           IN  TXT "v=DMARC1; p=reject; sp=quarantine; adkim=s; aspf=r; pct=50; rua=mailto:mailauth-reports@example.com,https://dmarc.example.com/submit; ruf=mailto:mailauth-reports@example.com; fo=1; ri=3600"
 insecure    IN  TXT "v=DMARC1; p=none; ruf=mailto:mailauth-reports@example.com; fo=d"
 ```

--- a/docs/_functions/record/TTL.md
+++ b/docs/_functions/record/TTL.md
@@ -23,8 +23,8 @@ The value can be:
   * We highly recommend using units instead of the number of seconds. Would your coworkers understand your intention better if you wrote `14400` or `'4h'`?
 
 {% include startExample.html %}
-{% highlight js %}
 
+```js
 D('example.com', REGISTRAR, DnsProvider('R53'),
   DefaultTTL(2000),
   A('@','1.2.3.4'), // uses default
@@ -32,5 +32,6 @@ D('example.com', REGISTRAR, DnsProvider('R53'),
   A('demo1', '3.4.5.11', TTL('5d')),  // 5 days
   A('demo2', '3.4.5.12', TTL('5w')),  // 5 weeks
 );
-{%endhighlight%}
+```
+
 {% include endExample.html %}

--- a/docs/_providers/activedir.md
+++ b/docs/_providers/activedir.md
@@ -27,18 +27,18 @@ To activate this mode, set `"fakeps":"true"` inside your credentials file for th
 
 The `ActiveDirectory_PS` provider reads an `ADServer` setting from `creds.json` to know the name of the ActiveDirectory DNS Server to update.
 
-{% highlight javascript %}
+```js
 {
   "activedir": {
     "ADServer": "ny-dc01"
   }
 }
-{% endhighlight %}
+```
 
 
 If you want to modify the "fake powershell" mode details, you can set them in the credentials file:
 
-{% highlight javascript %}
+```js
 {
   "activedir": {
     "ADServer": "ny-dc01",
@@ -47,19 +47,19 @@ If you want to modify the "fake powershell" mode details, you can set them in th
     "psout": "commandsToRun.ps1"
   }
 }
-{% endhighlight %}
+```
 
 
 An example DNS configuration:
 
-{% highlight javascript %}
+```js
 var REG_NONE = NewRegistrar('none', 'NONE')
 var ACTIVEDIRECTORY = NewDnsProvider("activedir", "ACTIVEDIRECTORY_PS");
 
 D('example.tld', REG_NONE, DnsProvider(ACTIVEDIRECTORY),
       A("test","1.2.3.4")
 )
-{% endhighlight %}
+```
 
 To generate a `adzonedump.ZONE.json` file, run `dnscontrol preview` on a Windows system then copy the appropriate file to the system you'll use in "fake powershell" mode.
 

--- a/docs/_providers/akamaiedgedns.md
+++ b/docs/_providers/akamaiedgedns.md
@@ -25,22 +25,23 @@ the required credentials.
 ## Configuration
 
 In the credentials file (creds.json), you must provide the following:
-{% highlight json %}  
-"akamaiedgedns": {  
-    "client_secret": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",  
-    "host": "akaa-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.xxxx.akamaiapis.net",  
-    "access_token": "akaa-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",  
-    "client_token": "akaa-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",  
-    "contract_id": "X-XXXX",  
-    "group_id": "NNNNNN"  
-}  
-{% endhighlight %}  
+
+```json
+"akamaiedgedns": {
+    "client_secret": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+    "host": "akaa-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.xxxx.akamaiapis.net",
+    "access_token": "akaa-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+    "client_token": "akaa-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+    "contract_id": "X-XXXX",
+    "group_id": "NNNNNN"
+}
+```
 
 ## Usage
 
 A new zone created by DNSControl:
 
-```
+```bash
 dnscontrol create-domains
 ```
 
@@ -53,24 +54,25 @@ The NS records for these authorities have a TTL of 86400.
 
 Add:
 
-```
+```js
 NAMESERVER_TTL(86400)
 ```
 
 modifier to the dnscontrol.js D() function so that DNSControl does not change the TTL of the authoritative NS records.
 
-Example 'dnsconfig.js':  
-{% highlight js %}  
-var REG_NONE = NewRegistrar('none', 'NONE');  
-var DNS_AKAMAIEDGEDNS = NewDnsProvider('akamaiedgedns', 'AKAMAIEDGEDNS');  
+Example 'dnsconfig.js':
 
-D('example.com', REG_NONE, DnsProvider(DNS_AKAMAIEDGEDNS),  
-  NAMESERVER_TTL(86400),  
-  AUTODNSSEC_ON,  
-  AKAMAICDN("@", "www.preconfigured.edgesuite.net", TTL(20)),  
-  A('foo','1.2.3.4')  
-);  
-{% endhighlight %}  
+```js
+var REG_NONE = NewRegistrar('none', 'NONE');
+var DNS_AKAMAIEDGEDNS = NewDnsProvider('akamaiedgedns', 'AKAMAIEDGEDNS');
+
+D('example.com', REG_NONE, DnsProvider(DNS_AKAMAIEDGEDNS),
+  NAMESERVER_TTL(86400),
+  AUTODNSSEC_ON,
+  AKAMAICDN("@", "www.preconfigured.edgesuite.net", TTL(20)),
+  A('foo','1.2.3.4')
+);
+```
 
 AKAMAICDN is a proprietary record type that is used to configure [Zone Apex Mapping](https://blogs.akamai.com/2019/08/fast-dns-zone-apex-mapping-dnssec.html).
 The AKAMAICDN target must be preconfigured in the Akamai network.

--- a/docs/_providers/axfrddns.md
+++ b/docs/_providers/axfrddns.md
@@ -39,14 +39,14 @@ the provider:
 
 For instance, your `creds.json` might looks like:
 
-{% highlight json %}
+```json
 {
     "axfrddns": {
         "transfer-key": "hmac-sha256:transfer-key-id:Base64EncodedSecret=",
         "update-key": "hmac-sha256:update-key-id:AnotherSecret="
     }
 }
-{% endhighlight %}
+```
 
 If either key is missing, DNSControl defaults to IP-based ACL
 authentication for that function. Including both keys is the most
@@ -56,14 +56,14 @@ operations, which is the least secure option.
 If distinct zones require distinct keys, you will need to instantiate the
 provider once for each key:
 
-{% highlight javascript %}
+```js
 var AXFRDDNS_A = NewDnsProvider('axfrddns-a', 'AXFRDDNS'}
 var AXFRDDNS_B = NewDnsProvider('axfrddns-b', 'AXFRDDNS'}
-{% endhighlight %}
+```
 
 And update `creds.json` accordingly:
 
-{% highlight json %}
+```json
 {
     "axfrddns-a": {
         "transfer-key": "hmac-sha256:transfer-key-id:Base64EncodedSecret=",
@@ -74,7 +74,7 @@ And update `creds.json` accordingly:
         "update-key": "hmac-sha512:update-key-id-B:YetAnotherSecret="
     }
 }
-{% endhighlight %}
+```
 
 ### Default nameservers
 
@@ -85,7 +85,7 @@ provider.
 This list can be provided either as metadata or in `creds.json`. Only
 the later allows `get-zones` to work properly.
 
-{% highlight javascript %}
+```js
 var AXFRDDNS = NewDnsProvider('axfrddns', 'AXFRDDNS',
     'default_ns': [
         'ns1.example.tld.',
@@ -94,13 +94,13 @@ var AXFRDDNS = NewDnsProvider('axfrddns', 'AXFRDDNS',
         'ns4.example.tld.'
     ]
 }
-{% endhighlight %}
+```
 
-{% highlight json %}
+```json
 {
    nameservers = "ns1.example.tld,ns2.example.tld,ns3.example.tld,ns4.example.tld"
 }
-{% endhighlight %}
+```
 
 ### Primary master
 
@@ -113,20 +113,20 @@ of the zone. In that case, the IP or the name of the primary server
 must be provided in `creds.json`. With this option, a non-standard
 port might be used.
 
-{% highlight json %}
+```json
 {
    master = "10.20.30.40:5353"
 }
-{% endhighlight %}
+```
 
 When no nameserver appears in the zone, and no default nameservers nor
 custom master are configured, the AXFR+DDNS provider will fail with
 the following error message:
 
-{% highlight text %}
+```text
 [Error] AXFRDDNS: the nameservers list cannot be empty.
 Please consider adding default `nameservers` or an explicit `master` in `creds.json`.
-{% endhighlight %}
+```
 
 
 ## Server configuration examples
@@ -137,7 +137,7 @@ Here is a sample `named.conf` example for an authauritative server on
 zone `example.tld`. It uses a simple IP-based ACL for the AXFR
 transfer and a conjunction of TSIG and IP-based ACL for the updates.
 
-{% highlight javascript %}
+```js
 options {
 
 	listen-on { any; };
@@ -179,7 +179,7 @@ key update-key-id {
   algorithm HMAC-SHA256;
   secret "AnotherSecret=";
 };
-{% endhighlight %}
+```
 
 ## FYI: get-zones
 
@@ -190,9 +190,9 @@ THe AXFR+DDNS provider does not display DNSSec records. But, if any
 DNSSec records is found in the zone, it will replace all of them with
 a single placeholder record:
 
-{% highlight text %}
+```text
     __dnssec         IN TXT   "Domain has DNSSec records, not displayed here."
-{% endhighlight %}
+```
 
 ## FYI: create-domain
 

--- a/docs/_providers/azuredns.md
+++ b/docs/_providers/azuredns.md
@@ -8,7 +8,7 @@
 
 You can specify the API credentials in the credentials json file:
 
-{% highlight json %}
+```json
 {
  "azuredns_main":{
       "SubscriptionID": "AZURE_SUBSCRIPTION_ID",
@@ -18,19 +18,19 @@ You can specify the API credentials in the credentials json file:
       "ClientSecret": "AZURE_CLIENT_SECRET",
  }
 }
-{% endhighlight %}
+```
 
 You can also use environment variables, but this is discouraged, unless your environment provides them already.
 
-```
-$ export AZURE_SUBSCRIPTION_ID=XXXXXXXXX
-$ export AZURE_RESOURCE_GROUP=YYYYYYYYY
-$ export AZURE_TENANT_ID=ZZZZZZZZ
-$ export AZURE_CLIENT_ID=AAAAAAAAA
-$ export AZURE_CLIENT_SECRET=BBBBBBBBB
+```bash
+export AZURE_SUBSCRIPTION_ID=XXXXXXXXX
+export AZURE_RESOURCE_GROUP=YYYYYYYYY
+export AZURE_TENANT_ID=ZZZZZZZZ
+export AZURE_CLIENT_ID=AAAAAAAAA
+export AZURE_CLIENT_SECRET=BBBBBBBBB
 ```
 
-{% highlight json %}
+```json
 {
  "azuredns_main":{
       "SubscriptionID": "$AZURE_SUBSCRIPTION_ID",
@@ -40,7 +40,7 @@ $ export AZURE_CLIENT_SECRET=BBBBBBBBB
       "ClientSecret": "$AZURE_CLIENT_SECRET",
  }
 }
-{% endhighlight %}
+```
 
 ## Metadata
 This provider does not recognize any special metadata fields unique to Azure DNS.
@@ -48,14 +48,14 @@ This provider does not recognize any special metadata fields unique to Azure DNS
 ## Usage
 Example Javascript:
 
-{% highlight js %}
+```js
 var REG_NONE = NewRegistrar('none','NONE');
 var ADNS = NewDnsProvider('azuredns_main', 'AZURE_DNS');
 
 D('example.tld', REG_NONE, DnsProvider(ADNS),
     A('test','1.2.3.4')
 );
-{%endhighlight%}
+```
 
 ## Activation
 DNSControl depends on a standard [Client credentials Authentication](https://docs.microsoft.com/en-us/cli/azure/create-an-azure-service-principal-azure-cli?view=azure-cli-latest) with permission to list, create and update hosted zones.

--- a/docs/_providers/bind.md
+++ b/docs/_providers/bind.md
@@ -15,21 +15,21 @@ Both of those tasks are different at each site, so they are best done by a local
 The BIND provider does not require anything in `creds.json`. However
 you can specify a `directory` where the provider will look for and create zone files. The default is the `zones` directory (in the current directory).
 
-{% highlight json %}
+```json
 {
   "bind": {
     "directory": "myzones",
     "filenameformat": "%U.zone"      << The default
   }
 }
-{% endhighlight %}
+```
 
 
 The BIND accepts some optional metadata via your DNS config when you create the provider:
 
 In this example we set the default SOA settings and NS records.
 
-{% highlight javascript %}
+```js
 var BIND = NewDnsProvider('bind', 'BIND', {
         'default_soa': {
         'master': 'ns1.example.tld.',
@@ -46,7 +46,7 @@ var BIND = NewDnsProvider('bind', 'BIND', {
         'ns4.example.tld.'
     ]
 })
-{% endhighlight %}
+```
 
 # FYI: SOA Records
 
@@ -111,7 +111,7 @@ forth.
 The dnscontrol `get-zones all` subcommand scans the directory for
 any files named `*.zone` and assumes they are zone files.
 
-```
+```bash
 dnscontrol get-zones --format=nameonly - BIND all
 ```
 

--- a/docs/_providers/cloudflare.md
+++ b/docs/_providers/cloudflare.md
@@ -21,14 +21,14 @@ provide a [Cloudflare API token](https://dash.cloudflare.com/profile/api-tokens)
 
 This method is enabled by setting the "apitoken" value in `creds.json`:
 
-{% highlight json %}
+```json
 {
   "cloudflare": {
     "apitoken": "your-cloudflare-api-token",
     "accountid": "your-cloudflare-account-id"
   }
 }
-{% endhighlight %}
+```
 
 See [Cloudflare's documentation](https://support.cloudflare.com/hc/en-us/articles/200167836-Managing-API-Tokens-and-Keys) for instructions on how to generate and configure permissions on API tokens.
 
@@ -51,7 +51,7 @@ This method is not recommended because these credentials give DNSControl access 
 
 This method is enabled by setting the "apikey" and "apiuser" values in `creds.json`:
 
-{% highlight json %}
+```json
 {
   "cloudflare": {
     "apikey": "your-cloudflare-api-key",
@@ -59,7 +59,7 @@ This method is enabled by setting the "apikey" and "apiuser" values in `creds.js
     "accountid": "your-cloudflare-account-id"
   }
 }
-{% endhighlight %}
+```
 
 You can not mix `apikey`/`apiuser` and `apitoken`.  If all three values are set, you will receive an error.
 
@@ -68,14 +68,14 @@ The Account ID is used to disambiguate when API key has access to multiple Cloud
 
 The "accountid" is found in the Cloudflare portal ("Account ID") on the DNS page. Set it in `creds.json`:
 
-{% highlight json %}
+```json
 {
   "cloudflare": {
     "apitoken": "...",
     "accountid": "your-cloudflare-account-id",
   }
 }
-{% endhighlight %}
+```
 
 Older `creds.json` files that do not have accountid set may work for now, but not in the future.
 
@@ -101,20 +101,18 @@ What does on/off/full mean?
 
 You can also set the default proxy mode using `DEFAULTS()` function. For example:
 
-{% highlight js %}
-
+```js
 DEFAULTS(
   CF_PROXY_DEFAULT_OFF // turn proxy off when not specified otherwise
 );
-
-{% endhighlight %}
+```
 
 **Aliases:**
 
 To make configuration files more readable and less prone to errors,
 the following aliases are *pre-defined*:
 
-{% highlight js %}
+```js
 // Meta settings for individual records.
 var CF_PROXY_OFF = {'cloudflare_proxy': 'off'};     // Proxy disabled.
 var CF_PROXY_ON = {'cloudflare_proxy': 'on'};       // Proxy enabled.
@@ -128,22 +126,22 @@ var CF_PROXY_DEFAULT_ON = {'cloudflare_proxy_default': 'on'};
 var CF_UNIVERSALSSL_OFF = { cloudflare_universalssl: 'off' };
 // UniversalSSL on for entire domain:
 var CF_UNIVERSALSSL_ON = { cloudflare_universalssl: 'on' };
-{% endhighlight %}
+```
 
 The following example shows how to set meta variables with and without aliases:
 
-{% highlight js %}
+```js
 D('example.tld', REG_NONE, DnsProvider(CLOUDFLARE),
     A('www1','1.2.3.11', CF_PROXY_ON),        // turn proxy ON.
     A('www2','1.2.3.12', CF_PROXY_OFF),       // default is OFF, this is a no-op.
     A('www3','1.2.3.13', {'cloudflare_proxy': 'on'}) // Old format.
 );
-{% endhighlight %}
+```
 
 ## Usage
 Example Javascript:
 
-{% highlight js %}
+```js
 var REG_NONE = NewRegistrar('none', 'NONE')
 var CLOUDFLARE = NewDnsProvider('cloudflare','CLOUDFLAREAPI');
 
@@ -165,7 +163,7 @@ D('example2.tld', REG_NONE, DnsProvider(CLOUDFLARE),
     ALIAS('@','www.example2.tld.'),
     CNAME('myalias','www.example2.tld.')
 );
-{%endhighlight%}
+```
 
 
 ## New domains
@@ -177,8 +175,7 @@ control panel manually or via the `dnscontrol create-domains` command.
 ## Redirects
 The Cloudflare provider can manage "Forwarding URL" Page Rules (redirects) for your domains. Simply use the `CF_REDIRECT` and `CF_TEMP_REDIRECT` functions to make redirects:
 
-{% highlight js %}
-
+```js
 // chiphacker.com should redirect to electronics.stackexchange.com
 
 var CLOUDFLARE = NewDnsProvider('cloudflare','CLOUDFLAREAPI', {"manage_redirects": true}); // enable manage_redirects
@@ -197,7 +194,7 @@ D("chiphacker.com", REG_NONE, DnsProvider(CLOUDFLARE),
 
     // ...
 );
-{%endhighlight%}
+```
 
 Notice a few details:
 
@@ -209,8 +206,7 @@ Notice a few details:
 ## Worker routes
 The Cloudflare provider can manage Worker Routes for your domains. Simply use the `CF_WORKER_ROUTE` function passing the route pattern and the worker name:
 
-{% highlight js %}
-
+```js
 var CLOUDFLARE = NewDnsProvider('cloudflare','CLOUDFLAREAPI', {"manage_workers": true}); // enable managing worker routes
 
 D("foo.com", REG_NONE, DnsProvider(CLOUDFLARE),
@@ -218,8 +214,7 @@ D("foo.com", REG_NONE, DnsProvider(CLOUDFLARE),
     CF_WORKER_ROUTE("api.foo.com/*", "my-worker"),
     CF_WORKER_ROUTE("foo.com/api/*", "my-worker"),
 );
-
-{%endhighlight%}
+```
 
 The API key you use must be enabled to edit workers.  In the portal, edit the API key,
 under "Permissions" add "Account", "Workers Scripts", "Edit". Without this permission you may see errors that mention "failed fetching worker route list from cloudflare: bad status code from cloudflare: 403 not 200"
@@ -235,10 +230,8 @@ have the required permissions listed above.  The flag `-cfworkers=false` will di
 This flag is intended for use with legacy domains where the integration test credentials do not
 have access to read/edit Workers. This flag will eventually go away.
 
-{% highlight bash %}
-
+```bash
 go test -v -verbose -provider CLOUDFLAREAPI -cfworkers=false
-
-{%endhighlight%}
+```
 
 When `-cfworkers=false` is set, tests related to Workers are skipped.  The Account ID is not required.

--- a/docs/_providers/cloudns.md
+++ b/docs/_providers/cloudns.md
@@ -7,11 +7,11 @@ jsId: CLOUDNS
 # ClouDNS Provider
 
 ## Configuration
-In your credentials file, you must provide your [Api user ID and password](https://www.cloudns.net/wiki/article/42/). 
+In your credentials file, you must provide your [Api user ID and password](https://www.cloudns.net/wiki/article/42/).
 
-Current version of provider doesn't support `sub-auth-user`. 
+Current version of provider doesn't support `sub-auth-user`.
 
-{% highlight json %}
+```json
 {
   "cloudns": {
     "auth-id": "12345",
@@ -19,7 +19,7 @@ Current version of provider doesn't support `sub-auth-user`.
     "auth-password": "your-password"
   }
 }
-{% endhighlight %}
+```
 
 ## Records
 
@@ -35,14 +35,14 @@ This provider does not recognize any special metadata fields unique to ClouDNS.
 ## Usage
 Example Javascript:
 
-{% highlight js %}
+```js
 var REG_NONE = NewRegistrar('none', 'NONE')
 var CLOUDNS = NewDnsProvider("cloudns", "CLOUDNS");
 
 D("example.tld", REG_NONE, DnsProvider(CLOUDNS),
     A("test","1.2.3.4")
 );
-{%endhighlight%}
+```
 
 ## Activation
 [Create Auth ID](https://www.cloudns.net/api-settings/).  Only paid account can use API
@@ -64,4 +64,4 @@ ClouDNS does not allow all TTLs, only a specific subset of TTLs. By default, the
 - 2419200 (4 weeks)
 
 The provider will automatically round up your TTL to one of these values. For example, 350 seconds would become 900
-seconds, but 300 seconds would stay 300 seconds. 
+seconds, but 300 seconds would stay 300 seconds.

--- a/docs/_providers/cscglobal.md
+++ b/docs/_providers/cscglobal.md
@@ -11,7 +11,7 @@ DNSControl's CSC Global provider supports being a Registrar. Support for being a
 ## Configuration
 In your `creds.json` file, you must provide your API key and user/client token. You can optionally provide an comma separated list of email addresses to have CSC Global send updates to.
 
-{% highlight json %}
+```json
 {
   "cscglobal": {
     "api-key": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
@@ -19,19 +19,19 @@ In your `creds.json` file, you must provide your API key and user/client token. 
     "notification_emails": "test@exmaple.tld,hostmaster@example.tld"
   }
 }
-{% endhighlight %}
+```
 
 ## Usage
 Example Javascript for `example.tld` and delegated to Route53:
 
-{% highlight js %}
+```js
 var REG_CSCGLOBAL = NewRegistrar('cscglobal', 'CSCGLOBAL');
 var R53 = NewDnsProvider('r53_main', 'ROUTE53');
 
 D("example.tld", REG_CSCGLOBAL, DnsProvider(R53),
   A('test','1.2.3.4')
 );
-{% endhighlight %}
+```
 
 ## Activation
 To get access to the [CSC Global API](https://www.cscglobal.com/cscglobal/docs/dbs/domainmanager/api-v2/) contact your account manager.

--- a/docs/_providers/desec.md
+++ b/docs/_providers/desec.md
@@ -8,13 +8,13 @@ jsId: DESEC
 ## Configuration
 In your providers credentials file you must provide a deSEC account auth token:
 
-{% highlight json %}
+```json
 {
   "desec": {
     "auth-token": "your-deSEC-auth-token"
   }
 }
-{% endhighlight %}
+```
 
 ## Metadata
 This provider does not recognize any special metadata fields unique to deSEC.
@@ -22,14 +22,14 @@ This provider does not recognize any special metadata fields unique to deSEC.
 ## Usage
 Example Javascript:
 
-{% highlight js %}
+```js
 var REG_NONE = NewRegistrar('none', 'NONE');    // No registrar.
 var deSEC = NewDnsProvider('desec', 'DESEC');  // deSEC
 
 D('example.tld', REG_NONE, DnsProvider(deSEC),
     A('test','1.2.3.4')
 );
-{% endhighlight %}
+```
 
 ## Activation
 DNSControl depends on a deSEC account auth token.

--- a/docs/_providers/digitalocean.md
+++ b/docs/_providers/digitalocean.md
@@ -10,13 +10,13 @@ jsId: DIGITALOCEAN
 In your credentials file, you must provide your
 [DigitalOcean OAuth Token](https://cloud.digitalocean.com/settings/applications)
 
-{% highlight json %}
+```json
 {
   "digitalocean": {
     "token": "your-digitalocean-ouath-token"
   }
 }
-{% endhighlight %}
+```
 
 ## Metadata
 This provider does not recognize any special metadata fields unique to DigitalOcean.
@@ -24,14 +24,14 @@ This provider does not recognize any special metadata fields unique to DigitalOc
 ## Usage
 Example Javascript:
 
-{% highlight js %}
+```js
 var REG_NONE = NewRegistrar('none', 'NONE')
 var DIGITALOCEAN = NewDnsProvider("digitalocean", "DIGITALOCEAN");
 
 D("example.tld", REG_NONE, DnsProvider(DIGITALOCEAN),
     A("test","1.2.3.4")
 );
-{%endhighlight%}
+```
 
 ## Activation
 [Create OAuth Token](https://cloud.digitalocean.com/settings/applications)

--- a/docs/_providers/dnsimple.md
+++ b/docs/_providers/dnsimple.md
@@ -8,13 +8,13 @@ jsId: DNSIMPLE
 ## Configuration
 In your providers credentials file you must provide a DNSimple account access token:
 
-{% highlight json %}
+```json
 {
   "dnsimple": {
     "token": "your-dnsimple-account-access-token"
   }
 }
-{% endhighlight %}
+```
 
 ## Metadata
 This provider does not recognize any special metadata fields unique to DNSimple.
@@ -22,14 +22,14 @@ This provider does not recognize any special metadata fields unique to DNSimple.
 ## Usage
 Example Javascript:
 
-{% highlight js %}
+```js
 var REG_DNSIMPLE = NewRegistrar("dnsimple", "DNSIMPLE");
 var DNSIMPLE = NewDnsProvider("dnsimple", "DNSIMPLE");
 
 D("example.tld", REG_DNSIMPLE, DnsProvider(DNSIMPLE),
     A("test","1.2.3.4")
 );
-{% endhighlight %}
+```
 
 ## Activation
 DNSControl depends on a DNSimple account access token.

--- a/docs/_providers/dnsmadeeasy.md
+++ b/docs/_providers/dnsmadeeasy.md
@@ -9,14 +9,14 @@ jsId: DNSMADEEASY
 ## Configuration
 In your credentials file, you must provide your `api_key` and `secret_key`. More info about authentication can be found in [DNS Made Easy API docs](https://api-docs.dnsmadeeasy.com/).
 
-{% highlight json %}
+```json
 {
   "dnsmadeeasy": {
     "api_key": "1c1a3c91-4770-4ce7-96f4-54c0eb0e457a",
     "secret_key": "e2268cde-2ccd-4668-a518-8aa8757a65a0"
   }
 }
-{% endhighlight %}
+```
 
 ## Records
 
@@ -32,14 +32,14 @@ This provider does not recognize any special metadata fields unique to DNS Made 
 ## Usage
 Example Javascript:
 
-{% highlight js %}
+```js
 var REG_NONE = NewRegistrar('none', 'NONE')
 var DNSMADEEASY = NewDnsProvider("dnsmadeeasy", "DNSMADEEASY");
 
 D("example.tld", REG_NONE, DnsProvider(DNSMADEEASY),
     A("test","1.2.3.4")
 );
-{%endhighlight%}
+```
 
 ## Activation
 You can generate your `api_key` and `secret_key` in [Control Panel](https://cp.dnsmadeeasy.com/) in Account Information in Config menu.

--- a/docs/_providers/doh.md
+++ b/docs/_providers/doh.md
@@ -11,13 +11,13 @@ This is a read-only/monitoring "registrar". It does a DNS NS lookup to confirm t
 ## Configuration
 The DNS-over-HTTPS provider does not require anything in `creds.json`. By default, it uses Google Public DNS however you may configure an alternative RFC 8484 DoH provider.
 
-{% highlight json %}
+```json
 {
   "DNS-over-HTTPS": {
     "host": "cloudflare-dns.com"
   }
 }
-{% endhighlight %}
+```
 
 Some common DoH providers are `cloudflare-dns.com` ([Cloudflare](https://developers.cloudflare.com/1.1.1.1/dns-over-https)), `9.9.9.9` ([Quad9](https://www.quad9.net/about/)), and `dns.google` ([Google Public DNS](https://developers.google.com/speed/public-dns/docs/doh)).
 
@@ -27,11 +27,11 @@ This provider does not recognize any special metadata fields unique to DOH.
 ## Usage
 Example Javascript:
 
-{% highlight js %}
+```js
 var REG_MONITOR = NewRegistrar('DNS-over-HTTPS', 'DNSOVERHTTPS');
 
 D("example.com", REG_MONITOR,
   NAMESERVER("ns1.example.com."),
   NAMESERVER("ns2.example.com."),
 );
-{% endhighlight %}
+```

--- a/docs/_providers/easyname.md
+++ b/docs/_providers/easyname.md
@@ -11,7 +11,7 @@ DNSControl's easyname provider supports being a Registrar. Support for being a D
 ## Configuration
 In your credentials file, you must provide your [API-Access](https://my.easyname.com/en/account/api) information
 
-{% highlight json %}
+```json
 {
   "easyname": {
     "userid": 12345,
@@ -21,7 +21,7 @@ In your credentials file, you must provide your [API-Access](https://my.easyname
     "signsalt": "API Signing Salt"
   }
 }
-{% endhighlight %}
+```
 
 ## Metadata
 This provider does not recognize any special metadata fields unique to easyname.
@@ -29,14 +29,14 @@ This provider does not recognize any special metadata fields unique to easyname.
 ## Usage
 Example Javascript:
 
-{% highlight js %}
+```js
 var REG_EASYNAME = NewRegistrar('easyname', 'EASYNAME');
 
 D("example.com", REG_EASYNAME,
   NAMESERVER("ns1.example.com."),
   NAMESERVER("ns2.example.com."),
 );
-{% endhighlight %}
+```
 
 ## Activation
 

--- a/docs/_providers/gandi_v5.md
+++ b/docs/_providers/gandi_v5.md
@@ -28,14 +28,14 @@ same backend `"GANDI_V5"` provider.
 (NB: in practice, this doesn't appear to be necessary and `sharing_id` is not
 enforced?)
 
-{% highlight json %}
+```json
 {
   "gandi": {
     "apikey": "your-gandi-key",
     "sharing_id": "your-sharing_id"
   }
 }
-{% endhighlight %}
+```
 
 ## Metadata
 This provider does not recognize any special metadata fields unique to Gandi.
@@ -50,14 +50,14 @@ names.
 ## Usage
 Example Javascript:
 
-{% highlight js %}
+```js
 var GANDI = NewDnsProvider("gandi", "GANDI_V5");
 var REG_GANDI = NewRegistrar("gandi", "GANDI_V5");
 
 D("example.tld", REG_GANDI, DnsProvider(GANDI),
     A("test","1.2.3.4")
 );
-{% endhighlight %}
+```
 
 If you are converting from the old "GANDI" provider,
 simply change "GANDI" to "GANDI_V5" in `dnsconfig.js`.
@@ -71,6 +71,6 @@ If a domain does not exist in your Gandi account, DNSControl will *not* automati
 
 This is the error you'll see if your API key is invalid.
 
-```
+```text
 Error getting corrections: 401: The server could not verify that you authorized to access the document you requested. Either you supplied the wrong credentials (e.g., bad api key), or your access token has expired
 ```

--- a/docs/_providers/gcloud.md
+++ b/docs/_providers/gcloud.md
@@ -1,6 +1,6 @@
 ---
 name: Google Cloud DNS
-title: Google Cloud DNS Provider 
+title: Google Cloud DNS Provider
 layout: default
 jsId: GCLOUD
 ---
@@ -11,7 +11,7 @@ jsId: GCLOUD
 
 For Google cloud authentication, DNSControl requires a JSON 'Service Account Key' for your project. Newlines in the private key need to be replaced with `\n`.Copy the full JSON object into your `creds.json` like so:
 
-{% highlight json %}
+```json
 {
     "gcloud": {
         "type": "service_account",
@@ -27,7 +27,7 @@ For Google cloud authentication, DNSControl requires a JSON 'Service Account Key
         "name_server_set" : "optional_name_server_set_name (contact your TAM)"
     }
 }
-{% endhighlight %}
+```
 
 **Note**: The `project_id`, `private_key`, and `client_email`, are the only fields that are strictly required, but it is sometimes easier to just paste the entire json object in. Either way is fine.  `name_server_set` is optional and requires special permission from your TAM at Google in order to setup (See [Name server sets](#name_server_sets) below)
 
@@ -39,14 +39,14 @@ This provider does not recognize any special metadata fields unique to google cl
 ## Usage
 Use this provider like any other DNS Provider:
 
-{% highlight js %}
+```js
 var REG_NAMECOM = NewRegistrar("name.com","NAMEDOTCOM");
 var GCLOUD = NewDnsProvider("gcloud", "GCLOUD");
 
 D("example.tld", REG_NAMECOM, DnsProvider(GCLOUD),
     A("test","1.2.3.4")
 );
-{%endhighlight%}
+```
 
 ## Activation
 1. Go to your app-engine console and select the appropriate project.
@@ -65,7 +65,7 @@ control panel manually or via the `create-domains` command.
 ## Name server sets
 
 This optional feature lets you pin domains to a set of GCLOUD name servers.  The `nameServerSet` field is exposed in their API but there is
-currently no facility for creating a name server set.  You need special permission from your technical account manager at Google and they 
+currently no facility for creating a name server set.  You need special permission from your technical account manager at Google and they
 will enable it on your account, responding with a list of names to use in the `name_server_set` field above.
 
 > `name_server_set` only applies on `create-domains` at the moment. Additional work needs to be done to support it during `push`

--- a/docs/_providers/hedns.md
+++ b/docs/_providers/hedns.md
@@ -15,21 +15,21 @@ Electric changes their interface, and you should be willing to accept this possi
 In your `creds.json` file you must provide your `dns.he.net` account username and password. These are the same username
 and password used to login to the [web interface]([https://dns.he.net]).
 
-{% highlight json %}
+```json
 {
   "hedns":{
     "username": "yourUsername",
     "password": "yourPassword"
   }
 }
-{% endhighlight %}
+```
 
 ### Two factor authentication
 
 If two-factor authentication has been enabled on your account you will also need to provide a valid TOTP code.
 This can also be done via an environment variable:
 
-{% highlight json %}
+```json
 {
   "hedns":{
     "username": "yourUsername",
@@ -37,24 +37,24 @@ This can also be done via an environment variable:
     "totp": "$HEDNS_TOTP"
   }
 }
-{% endhighlight %}
+```
 
 and then you can run
 
-{% highlight bash %}
-$ HEDNS_TOTP=12345 dnscontrol preview
-{% endhighlight %}
+```bash
+HEDNS_TOTP=12345 dnscontrol preview
+```
 
 It is also possible to directly provide the shared TOTP secret using the key "totp-key" in `creds.json`. This secret is
 only available when first enabling two-factor authentication.
 
 **Security Warning**:
-* Anyone with access to this `creds.json` file will have *full* access to your Hurricane Electric account and will be 
+* Anyone with access to this `creds.json` file will have *full* access to your Hurricane Electric account and will be
   able to modify and delete your DNS entries
 * Storing the shared secret together with the password weakens two factor authentication because both factors are stored
   in a single place.
 
-{% highlight json %}
+```json
 {
   "hedns":{
     "username": "yourUsername",
@@ -62,7 +62,7 @@ only available when first enabling two-factor authentication.
     "totp-key": "yourTOTPSharedSecret"
   }
 }
-{% endhighlight %}
+```
 
 ### Persistent Sessions
 
@@ -74,14 +74,14 @@ To work around this limitation, if multiple requests need to be made, the option
 `creds.json`, which is the directory where a `.hedns-session` file will be created. This can be used to allow reuse of an
 existing session between runs, without the need to re-authenticate.
 
-This option is disabled by default when this key is not present, 
+This option is disabled by default when this key is not present,
 
 **Security Warning**:
 * Anyone with access to this `.hedns-session` file will be able to use the existing session (until it expires) and have
   *full* access to your Hurrican Electric account and will be able to modify and delete your DNS entries.
 * It should be stored in a location only trusted users can access.
 
-{% highlight json %}
+```json
 {
   "hedns":{
     "username": "yourUsername",
@@ -90,7 +90,7 @@ This option is disabled by default when this key is not present,
     "session-file-path": "."
   }
 }
-{% endhighlight %}
+```
 
 
 ## Metadata
@@ -99,10 +99,10 @@ This provider does not recognize any special metadata fields unique to Hurricane
 ## Usage
 Example Javascript:
 
-{% highlight js %}
+```js
 var DNSIMPLE = NewDnsProvider("hedns", "HEDNS");
 
 D("example.tld", REG_DNSIMPLE, DnsProvider(HEDNS),
     A("test","1.2.3.4")
 );
-{% endhighlight %}
+```

--- a/docs/_providers/hetzner.md
+++ b/docs/_providers/hetzner.md
@@ -12,13 +12,13 @@ jsId: HETZNER
 In your credentials file, you must provide a
 [Hetzner API Key](https://dns.hetzner.com/settings/api-token).
 
-{% highlight json %}
+```json
 {
   "hetzner": {
     "api_key": "your-api-key"
   }
 }
-{% endhighlight %}
+```
 
 ## Metadata
 
@@ -29,14 +29,14 @@ This provider does not recognize any special metadata fields unique to Hetzner
 
 Example Javascript:
 
-{% highlight js %}
+```js
 var REG_NONE = NewRegistrar('none', 'NONE');
 var HETZNER = NewDnsProvider("hetzner", "HETZNER");
 
 D("example.tld", REG_NONE, DnsProvider(HETZNER),
     A("test","1.2.3.4")
 );
-{%endhighlight%}
+```
 
 ## Activation
 
@@ -73,26 +73,27 @@ Example: Your per minute quota is 60 requests and in your settings you
  DNSControl will emit a warning in case it breaches the next quota.
 
 In your `creds.json` for all `HETZNER` provider entries:
-{% highlight json %}
+
+```json
 {
   "hetzner": {
     "optimize_for_rate_limit_quota": "Minute",
     "api_key": "your-api-key"
   }
 }
-{% endhighlight %}
+```
 
 Every response from the Hetzner DNS Console API includes your limits:
 
-{% highlight txt %}
-$ curl --silent --include \
+```bash
+curl --silent --include \
     --header 'Auth-API-Token: ...' \
     https://dns.hetzner.com/api/v1/zones \
   | grep x-ratelimit-limit
 x-ratelimit-limit-second: 3
 x-ratelimit-limit-minute: 42
 x-ratelimit-limit-hour: 1337
-{% endhighlight %}
+```
 
 Every DNSControl invocation starts from scratch in regard to rate-limiting.
 In case you are frequently invoking DNSControl, you will likely hit a limit for
@@ -104,11 +105,12 @@ With `start_with_default_rate_limit` DNSControl uses a quota equivalent to
  API response.
 
 In your `creds.json` for all `HETZNER` provider entries:
-{% highlight json %}
+
+```json
 {
   "hetzner": {
     "start_with_default_rate_limit": "true",
     "api_key": "your-api-key"
   }
 }
-{% endhighlight %}
+```

--- a/docs/_providers/hexonet.md
+++ b/docs/_providers/hexonet.md
@@ -19,7 +19,7 @@ This is based on API documents found at [https://wiki.hexonet.net/wiki/DNS_API](
 
 Please provide your HEXONET login data in your credentials file `creds.json` as follows:
 
-{% highlight json %}
+```json
 {
   "hexonet": {
     "apilogin": "your-hexonet-account-id",
@@ -29,11 +29,11 @@ Please provide your HEXONET login data in your credentials file `creds.json` as 
     "debugmode": "0", // set it to "1" to get debug output of the communication with our Backend System API
   }
 }
-{% endhighlight %}
+```
 
 Here a working example for our OT&E System:
 
-{% highlight json %}
+```json
 {
   "hexonet": {
     "apilogin": "test.user",
@@ -42,7 +42,7 @@ Here a working example for our OT&E System:
     "debugmode": "0",
   }
 }
-{% endhighlight %}
+```
 
 NOTE: The above credentials are known to the public.
 
@@ -64,7 +64,7 @@ Here's an example DNS Configuration `dnsconfig.js` using our provider module.
 Even though it shows how you use us as Domain Registrar AND DNS Provider, we don't force you to do that.
 You are free to decide if you want to use both of our provider technology or just one of them.
 
-{% highlight javascript %}
+```js
 // Providers:
 var REG_HX = NewRegistrar('hexonet', 'HEXONET');
 var DNS_HX = NewDnsProvider('hexonet', 'HEXONET');
@@ -87,7 +87,7 @@ D('abhoster.com', REG_HX, DnsProvider(DNS_HX),
     A('elk1', '10.190.234.178'),
     A('test', '56.123.54.12')
 );
-{% endhighlight %}
+```
 
 ## Metadata
 

--- a/docs/_providers/hostingde.md
+++ b/docs/_providers/hostingde.md
@@ -7,6 +7,7 @@ jsId: hostingde
 # hosting.de Provider
 
 ## Configuration
+
 In your credentials file, you must provide your [`authToken` and optionally an `ownerAccountId`](https://www.hosting.de/api/#requests-and-authentication).
 
 **If you want to use this provider with http.net or a demo system you need to provide a custom `baseURL`.**
@@ -15,7 +16,7 @@ In your credentials file, you must provide your [`authToken` and optionally an `
 * http.net: `https://partner.http.net`
 * Demo: `https://demo.routing.net`
 
-{% highlight json %}
+```json
 {
   "hosting.de": {
     "authToken": "YOUR_API_KEY"
@@ -25,16 +26,35 @@ In your credentials file, you must provide your [`authToken` and optionally an `
     "baseURL": "https://partner.http.net"
   }
 }
-{% endhighlight %}
+```
 
 ## Usage
+
 Example JavaScript:
 
-{% highlight js %}
+```js
 var REG_HOSTINGDE = NewRegistrar('hosting.de', 'HOSTINGDE')
 var DNS_HOSTINGDE = NewDnsProvider('hosting.de' 'HOSTINGDE');
 
 D('example.tld', REG_HOSTINGDE, DnsProvider(DNS_HOSTINGDE),
     A('test', '1.2.3.4')
 );
-{% endhighlight %}
+```
+
+## Customize nameservers
+
+hosting.de has the concept of *nameserver sets* but this provider does not implement it.
+The `HOSTINGDE` provider **ignores the default nameserver set** defined in your account!
+Instead, it uses hosting.de's nameservers (`ns1.hosting.de.`, `ns2.hosting.de.`, and `ns3.hosting.de.`) by default, regardless of your account settings.
+
+If you want to change this behaviour to, for example, use http.net's nameservers, you can do this by setting an array of strings called `default_ns` in the provider metadata:
+
+```js
+var DNS_HTTPNET = NewDnsProvider('http.net', 'HOSTINGDE', {
+  default_ns: [
+    'ns1.routing.net.',
+    'ns2.routing.net.',
+    'ns3.routing.net.',
+  ],
+});
+```

--- a/docs/_providers/internetbs.md
+++ b/docs/_providers/internetbs.md
@@ -11,14 +11,14 @@ DNSControl's Internet.bs provider supports being a Registrar. Support for being 
 ## Configuration
 In your credentials file, you must provide your API key and account password
 
-{% highlight json %}
+```json
 {
   "internetbs": {
     "api-key": "your-api-key",
     "password": "account-password"
   }
 }
-{% endhighlight %}
+```
 
 ## Metadata
 This provider does not recognize any special metadata fields unique to Internet.bs.
@@ -26,14 +26,14 @@ This provider does not recognize any special metadata fields unique to Internet.
 ## Usage
 Example Javascript:
 
-{% highlight js %}
+```js
 var REG_INTERNETBS = NewRegistrar('internetbs', 'INTERNETBS');
 
 D("example.com", REG_INTERNETBS,
   NAMESERVER("ns1.example.com."),
   NAMESERVER("ns2.example.com."),
 );
-{% endhighlight %}
+```
 
 ## Activation
 

--- a/docs/_providers/inwx.md
+++ b/docs/_providers/inwx.md
@@ -12,14 +12,14 @@ INWX.de is a Berlin-based domain registrar.
 In your `creds.json` file you must provide your INWX
 username and password:
 
-{% highlight json %}
+```json
 {
   "inwx":{
     "username": "yourUsername",
     "password": "yourPassword"
   }
 }
-{% endhighlight %}
+```
 
 ### Two factor authentication
 
@@ -35,7 +35,7 @@ See issue [issue 848](https://github.com/StackExchange/dnscontrol/issues/848#iss
 If two factor authentication has been enabled you will also need to provide a valid TOTP number.
 This can also be done via an environment variable:
 
-{% highlight json %}
+```json
 {
   "inwx":{
     "username": "yourUsername",
@@ -43,22 +43,22 @@ This can also be done via an environment variable:
     "totp": "$INWX_TOTP"
   }
 }
-{% endhighlight %}
+```
 
 and then you can run
 
-{% highlight bash %}
-$ INWX_TOTP=12345 dnscontrol preview
-{% endhighlight %}
+```bash
+INWX_TOTP=12345 dnscontrol preview
+```
 
 It is also possible to directly provide the shared TOTP secret using the key "totp-key" in `creds.json`.
-This secret is only shown once when two factor authentication is enabled and you'll have to make sure to write it down then. 
+This secret is only shown once when two factor authentication is enabled and you'll have to make sure to write it down then.
 
 **Important Notes**:
 * Anyone with access to this `creds.json` file will have *full* access to your INWX account and will be able to transfer and/or delete your domains
 * Storing the shared secret together with the password weakens two factor authentication because both factors are stored in a single place.
 
-{% highlight json %}
+```json
 {
   "inwx":{
     "username": "yourUsername",
@@ -66,13 +66,14 @@ This secret is only shown once when two factor authentication is enabled and you
     "totp-key": "yourTOTPSharedSecret"
   }
 }
-{% endhighlight %}
+```
 
 
 ### Sandbox
 You can optionally also specify sandbox with a value of 1 to
 redirect all requests to the sandbox API instead:
-{% highlight json %}
+
+```json
 {
   "inwx":{
     "username": "yourUsername",
@@ -80,7 +81,7 @@ redirect all requests to the sandbox API instead:
     "sandbox": "1"
   }
 }
-{% endhighlight %}
+```
 
 If sandbox is omitted or set to any other value the production
 API will be used.
@@ -94,15 +95,14 @@ INWX.
 Example Javascript for `example.tld` registered with INWX
 and delegated to CloudFlare:
 
-{% highlight js %}
+```js
 var regInwx = NewRegistrar('inwx', 'INWX')
 var dnsCF = NewDnsProvider('cloudflare', 'CLOUDFLAREAPI')
 
 D("example.tld", regInwx, DnsProvider(dnsCF),
     A("test","1.2.3.4")
 );
-
-{%endhighlight%}
+```
 
 
 

--- a/docs/_providers/linode.md
+++ b/docs/_providers/linode.md
@@ -10,13 +10,13 @@ jsId: LINODE
 In your credentials file, you must provide your
 [Linode Personal Access Token](https://cloud.linode.com/profile/tokens)
 
-{% highlight json %}
+```json
 {
   "linode": {
     "token": "your-linode-personal-access-token"
   }
 }
-{% endhighlight %}
+```
 
 ## Metadata
 This provider does not recognize any special metadata fields unique to Linode.
@@ -24,14 +24,14 @@ This provider does not recognize any special metadata fields unique to Linode.
 ## Usage
 Example Javascript:
 
-{% highlight js %}
+```js
 var REG_NONE = NewRegistrar('none', 'NONE')
 var LINODE = NewDnsProvider("linode", "LINODE");
 
 D("example.tld", REG_NONE, DnsProvider(LINODE),
     A("test","1.2.3.4")
 );
-{%endhighlight%}
+```
 
 ## Activation
 [Create Personal Access Token](https://cloud.linode.com/profile/tokens)
@@ -54,4 +54,4 @@ Linode does not allow all TTLs, but only a specific subset of TTLs. The followin
 - 2419200
 
 The provider will automatically round up your TTL to one of these values. For example, 600 seconds would become 3600
-seconds, but 300 seconds would stay 300 seconds. 
+seconds, but 300 seconds would stay 300 seconds.

--- a/docs/_providers/msdns.md
+++ b/docs/_providers/msdns.md
@@ -41,25 +41,25 @@ The `ActiveDirectory_PS` provider reads an `computername` setting from
 `creds.json` to know the name of the ActiveDirectory DNS Server to run the commands on.
 Otherwise
 
-{% highlight javascript %}
+```js
 {
   "msdns": {
     "dnsserver": "ny-dc01",
     "pssession": "mywindowshost"
   }
 }
-{% endhighlight %}
+```
 
 An example DNS configuration:
 
-{% highlight javascript %}
+```js
 var REG_NONE = NewRegistrar('none', 'NONE')
 var MSDNS = NewDnsProvider("msdns", "MSDNS");
 
 D('example.tld', REG_NONE, DnsProvider(MSDNS),
       A("test","1.2.3.4")
 )
-{% endhighlight %}
+```
 
 
 # Converting from `ACTIVEDIRECTORY_PS`
@@ -76,7 +76,7 @@ If you were using the `ACTIVEDIRECTORY_PS` provider and are switching to `MSDNS`
 
 During the transition your `creds.json` file might look like:
 
-{% highlight javascript %}
+```js
 {
   "msdns": {
     "ADServer": "ny-dc01",         << Delete these after you have
@@ -87,7 +87,7 @@ During the transition your `creds.json` file might look like:
     "pssession": "mywindowshost"
   }
 }
-{% endhighlight %}
+```
 
 3. Run `dnscontrol preview` to make sure the provider works as expected.
 

--- a/docs/_providers/msdns.md
+++ b/docs/_providers/msdns.md
@@ -41,7 +41,7 @@ The `ActiveDirectory_PS` provider reads an `computername` setting from
 `creds.json` to know the name of the ActiveDirectory DNS Server to run the commands on.
 Otherwise
 
-```js
+```json
 {
   "msdns": {
     "dnsserver": "ny-dc01",
@@ -76,7 +76,7 @@ If you were using the `ACTIVEDIRECTORY_PS` provider and are switching to `MSDNS`
 
 During the transition your `creds.json` file might look like:
 
-```js
+```json
 {
   "msdns": {
     "ADServer": "ny-dc01",         << Delete these after you have

--- a/docs/_providers/name.com.md
+++ b/docs/_providers/name.com.md
@@ -10,14 +10,14 @@ jsId: NAMEDOTCOM
 ## Configuration
 In your credentials file you must provide your name.com api username and access token:
 
-{% highlight json %}
+```json
 {
   "name.com":{
     "apikey": "yourApiKeyFromName.com",
     "apiuser": "yourUsername"
   }
 }
-{% endhighlight %}
+```
 
 There is another key name `apiurl` but it is optional and defaults to the correct value. If you want to use the test environment ("OT&E"), then add this:
 
@@ -32,26 +32,26 @@ This provider does not recognize any special metadata fields unique to name.com.
 ## Usage
 **Example Javascript (DNS hosted with name.com):**
 
-{% highlight js %}
+```js
 var REG_NAMECOM = NewRegistrar("name.com","NAMEDOTCOM");
 var NAMECOM = NewDnsProvider("name.com","NAMEDOTCOM");
 
 D("example.tld", REG_NAMECOM, DnsProvider(NAMECOM),
     A("test","1.2.3.4")
 );
-{%endhighlight%}
+```
 
 
 **Example Javascript (Registrar only. DNS hosted elsewhere):**
 
-{% highlight js %}
+```js
 var REG_NAMECOM = NewRegistrar("name.com","NAMEDOTCOM");
 var R53 = NewDnsProvider("r53", "ROUTE53");
 
 D("example.tld", REG_NAMECOM, DnsProvider(R53),
     A("test","1.2.3.4")
 );
-{%endhighlight%}
+```
 
 {% include alert.html text="Note: name.com does not allow control over the NS records of your zones via the api. It is not recommended to use name.com's dns provider unless it is your only dns host." %}
 
@@ -62,7 +62,7 @@ In order to activate API functionality on your Name.com account, you must apply 
 
 ### invalid character '<'
 
-```
+```text
 integration_test.go:140: api returned unexpected response: invalid character '<' looking for beginning of value
 ```
 
@@ -83,7 +83,7 @@ TODO(tlim): Improve the error message. (Volunteer needed!)
 
 ### dial tcp: lookup https: no such host
 
-```
+```text
 integration_test.go:81: Failed getting nameservers Get https://https//api.name.com/api/v4/domains/stackosphere.com?: dial tcp: lookup https: no such host
 ```
 

--- a/docs/_providers/namecheap.md
+++ b/docs/_providers/namecheap.md
@@ -12,19 +12,19 @@ Namecheap only provides a registrar provider implementation.
 In your providers config json file you must provide your Namecheap api
 username and key:
 
-{% highlight json %}
+```json
 {
   "namecheap":{
     "apikey": "yourApiKeyFromNameCheap",
     "apiuser": "yourUsername"
   }
 }
-{% endhighlight %}
+```
 
 You can optionally specify BaseURL to use a different endpoint - typically the
 sandbox:
 
-{% highlight json %}
+```json
 {
   "namecheap.com":{
     "apikey": "yourApiKeyFromNameCheap",
@@ -32,7 +32,7 @@ sandbox:
     "BaseURL": "https://api.sandbox.namecheap.com/xml.response"
   }
 }
-{% endhighlight %}
+```
 
 if BaseURL is omitted, the production namecheap url is used.
 
@@ -44,19 +44,19 @@ Namecheap.
 ## Usage
 Example Javascript:
 
-{% highlight js %}
+```js
 var REG_NAMECHEAP = NewRegistrar("namecheap","NAMECHEAP");
 var R53 = NewDnsProvider("r53", "ROUTE53");
 
 D("example.tld", REG_NAMECHEAP, DnsProvider(R53),
     A("test","1.2.3.4")
 );
-{%endhighlight%}
+```
 
 Namecheap provides custom redirect records URL, URL301, and FRAME.  These
 records can be used like any other record:
 
-{% highlight js %}
+```js
 var REG_NAMECHEAP = NewRegistrar("namecheap","NAMECHEAP");
 var NAMECHEAP = NewDnsProvider("namecheap","NAMECHEAP");
 
@@ -65,7 +65,7 @@ D("example.tld", REG_NAMECHEAP, DnsProvider(NAMECHEAP),
   URL('www', 'http://example.com/'),
   URL301('backup', 'http://backup.example.com/')
 )
-{% endhighlight %}
+```
 
 ## Activation
 In order to activate API functionality on your Namecheap account, you must

--- a/docs/_providers/netcup.md
+++ b/docs/_providers/netcup.md
@@ -9,7 +9,7 @@ jsId: NETCUP
 ## Configuration
 In your credentials file, you must provide your [api key, password and your customer number](https://www.netcup-wiki.de/wiki/CCP_API#Authentifizierung).
 
-{% highlight json %}
+```json
 {
   "netcup": {
     "api-key": "abc12345",
@@ -17,19 +17,19 @@ In your credentials file, you must provide your [api key, password and your cust
     "customer-number": "123456"
   }
 }
-{% endhighlight %}
+```
 
 ## Usage
 Example Javascript:
 
-{% highlight js %}
+```js
 var REG_NONE = NewRegistrar('none', 'NONE')
 var NETCUP = NewDnsProvider('netcup' 'NETCUP');
 
 D('example.tld', REG_NONE, DnsProvider(NETCUP),
     A('test','1.2.3.4')
 );
-{%endhighlight%}
+```
 
 
 ## Caveats

--- a/docs/_providers/ns1.md
+++ b/docs/_providers/ns1.md
@@ -10,13 +10,13 @@ jsId: NS1
 
 In your credentials json file you must provide your NS1 api key:
 
-{% highlight json %}
+```json
 {
   "ns1":{
     "api_token": "your-ns1-token"
   }
 }
-{% endhighlight %}
+```
 
 ## Metadata
 This provider does not recognize any special metadata fields unique to NS1.
@@ -24,12 +24,12 @@ This provider does not recognize any special metadata fields unique to NS1.
 ## Usage
 Example Javascript:
 
-{% highlight js %}
+```js
 var REG_NONE = NewRegistrar('none', 'NONE')
 var NS1 = NewDnsProvider("ns1", "NS1");
 
 D("example.tld", REG_NONE, DnsProvider(NS1),
     A("test","1.2.3.4")
 );
-{% endhighlight %}
+```
 

--- a/docs/_providers/oracle.md
+++ b/docs/_providers/oracle.md
@@ -11,7 +11,7 @@ jsId: ORACLE
 Create an API key through the Oracle Cloud portal, and provide the user OCID, tenancy OCID, key fingerprint, region, and the contents of the private key.
 The OCID of the compartment DNS resources should be put in can also optionally be provided.
 
-{% highlight json %}
+```json
 {
   "oracle": {
     "user_ocid": "$ORACLE_USER_OCID",
@@ -22,7 +22,7 @@ The OCID of the compartment DNS resources should be put in can also optionally b
     "compartment": "$ORACLE_COMPARTMENT"
   },
 }
-{% endhighlight %}
+```
 
 ## Metadata
 This provider does not recognize any special metadata fields unique to Oracle Cloud.
@@ -30,7 +30,7 @@ This provider does not recognize any special metadata fields unique to Oracle Cl
 ## Usage
 Example Javascript:
 
-{% highlight js %}
+```js
 var REG_NONE = NewRegistrar('none', 'NONE')
 var ORACLE = NewDnsProvider("oracle", "ORACLE");
 
@@ -39,5 +39,5 @@ D("example.tld", REG_NONE, DnsProvider(ORACLE),
 
     A("test","1.2.3.4")
 );
-{% endhighlight %}
+```
 

--- a/docs/_providers/ovh.md
+++ b/docs/_providers/ovh.md
@@ -9,7 +9,7 @@ jsId: OVH
 
 In your providers config json file you must provide a OVH app-key, app-secret-key and consumer-key:
 
-{% highlight json %}
+```json
 {
   "ovh":{
     "app-key": "your app key",
@@ -17,7 +17,7 @@ In your providers config json file you must provide a OVH app-key, app-secret-ke
     "consumer-key": "your consumer key"
   }
 }
-{% endhighlight %}
+```
 
 See [the Activation section](#activation) for details on obtaining these credentials.
 
@@ -30,25 +30,26 @@ This provider does not recognize any special metadata fields unique to OVH.
 Example javascript:
 
 Example javascript (DNS hosted with OVH):
-{% highlight js %}
+
+```js
 var REG_OVH = NewRegistrar("ovh", "OVH");
 var OVH = NewDnsProvider("ovh", "OVH");
 
 D("example.tld", REG_OVH, DnsProvider(OVH),
     A("test","1.2.3.4")
 );
-{% endhighlight %}
+```
 
 Example javascript (Registrar only. DNS hosted elsewhere):
 
-{% highlight js %}
+```js
 var REG_OVH = NewRegistrar("ovh", "OVH");
 var R53 = NewDnsProvider("r53", "ROUTE53");
 
 D("example.tld", REG_OVH, DnsProvider(R53),
     A("test","1.2.3.4")
 );
-{%endhighlight%}
+```
 
 
 ## Activation
@@ -62,7 +63,7 @@ which gives the `app-key` and `app-secret-key`.
 Once done, to obtain the `consumer-key` it is necessary to authorize the just created app
 to access the data in a specific account:
 
-{% highlight bash %}
+```bash
 curl -XPOST -H"X-Ovh-Application: <you-app-key>" -H "Content-type: application/json" https://eu.api.ovh.com/1.0/auth/credential -d'{
   "accessRules": [
     {
@@ -95,16 +96,17 @@ curl -XPOST -H"X-Ovh-Application: <you-app-key>" -H "Content-type: application/j
     }
   ]
 }'
-{% endhighlight %}
+```
 
 It should return something akin to:
-{% highlight json %}
+
+```json
 {
   "validationUrl": "https://eu.api.ovh.com/auth/?credentialToken=<long-token>",
   "consumerKey": "<your-consumer-key>",
   "state": "pendingValidation"
 }
-{% endhighlight %}
+```
 
 Open the "validationUrl" in a browser and log in with your OVH account. This will link the app with your account,
 authorizing it to access your zones and domains.

--- a/docs/_providers/packetframe.md
+++ b/docs/_providers/packetframe.md
@@ -1,5 +1,5 @@
 ---
-name: Packetframe 
+name: Packetframe
 title: Packetframe Provider
 layout: default
 jsId: PACKETFRAME
@@ -9,13 +9,13 @@ jsId: PACKETFRAME
 ## Configuration
 In your credentials file, you must provide your Packetframe Token which can be extracted from the `token` cookie on packetframe.com
 
-{% highlight json %}
+```json
 {
   "packetframe": {
     "token": "your-packetframe-token"
   }
 }
-{% endhighlight %}
+```
 
 ## Metadata
 This provider does not recognize any special metadata fields unique to Packetframe.
@@ -23,11 +23,11 @@ This provider does not recognize any special metadata fields unique to Packetfra
 ## Usage
 Example Javascript:
 
-{% highlight js %}
+```js
 var REG_NONE = NewRegistrar('none', 'NONE')
 var PACKETFRAME = NewDnsProvider("packetframe", "PACKETFRAME");
 
 D("example.tld", REG_NONE, DnsProvider(PACKETFRAME),
     A("test","1.2.3.4")
 );
-{%endhighlight%}
+```

--- a/docs/_providers/powerdns.md
+++ b/docs/_providers/powerdns.md
@@ -7,11 +7,11 @@ jsId: POWERDNS
 # PowerDNS Provider
 
 ## Configuration
-In your credentials file, you must provide your [API URL, API Key and Server ID](https://doc.powerdns.com/authoritative/http-api/index.html). 
+In your credentials file, you must provide your [API URL, API Key and Server ID](https://doc.powerdns.com/authoritative/http-api/index.html).
 
 In most cases the Server id is `localhost`
 
-{% highlight json %}
+```json
 {
   "powerdns": {
     "apiUrl": "http://localhost",
@@ -19,12 +19,12 @@ In most cases the Server id is `localhost`
     "serverName": "localhost"
   }
 }
-{% endhighlight %}
+```
 
 ## Metadata
 Following metadata are available:
 
-{% highlight js %}
+```js
 {
     'default_ns': [
         'a.example.com.',
@@ -32,7 +32,7 @@ Following metadata are available:
     ],
     'dnssec_on_create': false
 }
-{% endhighlight %}
+```
 
 - `default_ns` sets the nameserver which are used
 - `dnssec_on_create` specifies if DNSSEC should be enabled when creating zones
@@ -40,14 +40,14 @@ Following metadata are available:
 ## Usage
 Example Javascript:
 
-{% highlight js %}
+```js
 var REG_NONE = NewRegistrar('none', 'NONE')
 var POWERDNS = NewDnsProvider("powerdns", "POWERDNS");
 
 D("example.tld", REG_NONE, DnsProvider(POWERDNS),
     A("test","1.2.3.4")
 );
-{%endhighlight%}
+```
 
 ## Activation
 See the [PowerDNS documentation](https://doc.powerdns.com/authoritative/http-api/index.html) how the API can be enabled.

--- a/docs/_providers/route53.md
+++ b/docs/_providers/route53.md
@@ -8,7 +8,7 @@ jsId: ROUTE53
 ## Configuration
 You can specify the API credentials in the credentials json file:
 
-{% highlight json %}
+```json
 {
     "r53_main": {
         "KeyId": "your-aws-key",
@@ -17,34 +17,34 @@ You can specify the API credentials in the credentials json file:
         "DelegationSet" : "optional-delegation-set-id"
     }
 }
-{% endhighlight %}
+```
 
 You can also use environment variables, but this is discouraged, unless your environment provides them already.
 
-```
-$ export AWS_ACCESS_KEY_ID=XXXXXXXXX
-$ export AWS_SECRET_ACCESS_KEY=YYYYYYYYY
-$ export AWS_SESSION_TOKEN=ZZZZZZZZ
+```bash
+export AWS_ACCESS_KEY_ID=XXXXXXXXX
+export AWS_SECRET_ACCESS_KEY=YYYYYYYYY
+export AWS_SESSION_TOKEN=ZZZZZZZZ
 ```
 
-{% highlight json %}
+```json
 {
     "r53_main": {
         "KeyId": "$AWS_ACCESS_KEY_ID",
         "SecretKey": "$AWS_SECRET_ACCESS_KEY"
     }
 }
-{% endhighlight %}
+```
 
 Alternatively if you want to used [named profiles](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html) you need to export the following variable
 
-```
-$ export AWS_PROFILE=ZZZZZZZZ
+```bash
+export AWS_PROFILE=ZZZZZZZZ
 ```
 
 Ensure you have a minimal creds.json file with the DNS Provider specified, otherwise versions above 3.8.0 will fail. So, for:
 
-```
+```js
 var R53_MAIN = NewDnsProvider('r53_main', 'ROUTE53');
 ```
 
@@ -64,21 +64,21 @@ This provider does not recognize any special metadata fields unique to route 53.
 ## Usage
 Example Javascript:
 
-{% highlight js %}
+```js
 var REG_NONE = NewRegistrar('none', 'NONE');
 var R53 = NewDnsProvider('r53_main', 'ROUTE53');
 
 D('example.tld', REG_NONE, DnsProvider(R53),
     A('test','1.2.3.4')
 );
-{% endhighlight %}
+```
 
 ## Activation
 DNSControl depends on a standard [AWS access key](https://aws.amazon.com/developers/access-keys/) with permission to list, create and update hosted zones. If you do not have the permissions required you will receive the following error message `Check your credentials, your not authorized to perform actions on Route 53 AWS Service`.
 
 You can apply the `AmazonRoute53FullAccess` policy however this includes access to many other areas of AWS. The minimum permissions required are as follows:
 
-{% highlight json %}
+```json
 {
     "Version": "2012-10-17",
     "Statement": [
@@ -96,7 +96,7 @@ You can apply the `AmazonRoute53FullAccess` policy however this includes access 
         }
     ]
 }
-{% endhighlight %}
+```
 
 If Route53 is also your registrar, you will need `route53domains:UpdateDomainNameservers` and `route53domains:GetDomainDetail` as well and possibly others.
 
@@ -106,8 +106,8 @@ If a domain does not exist in your Route53 account, DNSControl will *not* automa
 ## Delegation Sets
 Creation of new delegation sets are not supported by this code. However, if you have a delegation set already created, ala:
 
-```
-$ aws route53 create-reusable-delegation-set --caller-reference "foo"
+```bash
+aws route53 create-reusable-delegation-set --caller-reference "foo"
 {
     "Location": "https://route53.amazonaws.com/2013-04-01/delegationset/12312312123",
     "DelegationSet": {
@@ -138,7 +138,7 @@ but not as a DnsProvider.  The situation is described in
 
 In this situation you will see a message like:
 
-```
+```text
 ----- Registrar: r53_main
 Error getting corrections: AccessDeniedException: User: arn:aws:iam::868399730840:user/dnscontrol is not authorized to perform: route53domains:GetDomainDetail
   status code: 400, request id: 48b534a1-7902-11e7-afa6-a3fffd2ce139
@@ -181,8 +181,8 @@ More info is available in
 
 ### Creds key mismatch
 
-```
-$ dnscontrol preview
+```bash
+dnscontrol preview
 Creating r53 dns provider: NoCredentialProviders: no valid providers in chain. Deprecated.
 	For verbose messaging see aws.Config.CredentialsChainVerboseErrors
 ```
@@ -192,8 +192,8 @@ that the string `r53_main` is specified in `NewDnsProvider('r53_main', 'ROUTE53'
 
 ### Invalid KeyId
 
-```
-$ dnscontrol preview
+```bash
+dnscontrol preview
 Creating r53_main dns provider: InvalidClientTokenId: The security token included in the request is invalid.
 	status code: 403, request id: 8c006a24-e7df-11e7-9162-01963394e1df
 ```
@@ -202,8 +202,8 @@ This means the KeyId is unknown to AWS.
 
 ### Invalid SecretKey
 
-```
-$ dnscontrol preview
+```bash
+dnscontrol preview
 Creating r53_main dns provider: SignatureDoesNotMatch: The request signature we calculated does not match the signature you provided. Check your AWS Secret Access Key and signing method. Consult the service documentation for details.
 	status code: 403, request id: 9171d89a-e7df-11e7-8586-cbea3ea4e710
 ```
@@ -212,8 +212,8 @@ This means the SecretKey is incorrect. It may be a quoting issue.
 
 ### Incomplete Signature
 
-```
-$  ./dnscontrol preview
+```bash
+dnscontrol preview
 IncompleteSignature: 'ABCDEFGHIJKLMNOPQRST/20200118/us-east-1/route53/aws4_request' not a valid key=value pair (missing equal-sign) in Authorization header: 'AWS4-HMAC-SHA256 Credential= ABCDEFGHIJKLMNOPQRST/20200118/us-east-1/route53/aws4_request, SignedHeaders=host;x-amz-date, Signature=571c0b13205669a338f0fb9f351dc03c7016c8737c738081bc885c68378ad877'.
         status code: 403, request id: 12a34b5c-d678-9e01-f2gh-3456i7jk89lm
 ```

--- a/docs/_providers/softlayer.md
+++ b/docs/_providers/softlayer.md
@@ -15,37 +15,38 @@ it can not be easily fixed.
 To authenticate with SoftLayer requires at least a `username` and `api_key` for authentication. It can also optionally take a `timeout` and `endpoint_url` parameter however these are optional and will use standard defaults if not provided.
 
 These can be supplied in the `creds.json` file:
-{% highlight json %}
+
+```json
 {
   "softlayer": {
     "username": "myusername",
     "api_key": "mysecretapikey"
   }
 }
-{% endhighlight %}
+```
 
 To maintain compatibility with existing softlayer CLI services these can also be provided by the `SL_USERNAME` and `SL_API_KEY` environment variables or specified in the `~/.softlayer`, but this is discouraged. More information about these methods can be found at [the softlayer-go library documentation](https://github.com/softlayer/softlayer-go#sessions).
 
 ## Usage
 Use this provider like any other DNS Provider:
 
-{% highlight js %}
+```js
 var REG_NONE = NewRegistrar("none","NONE"); // no registrar
 var SOFTLAYER = NewDnsProvider("softlayer", "SOFTLAYER");
 
 D("example.tld", registrary, DnsProvider(SOFTLAYER),
     A("test","1.2.3.4")
 );
-{%endhighlight%}
+```
 
 ## Metadata
 This provider does not recognize any special metadata fields unique to SoftLayer dns.
 For compatibility with the pre-generated NAMESERVER fields it's recommended to set the NS TTL to 86400 such as:
 
-{% highlight js %}
+```js
 D("example.tld", REG_NONE, DnsProvider(SOFTLAYER),
     NAMESERVER_TTL(86400),
 
     A("test","1.2.3.4")
 );
-{%endhighlight%}
+```

--- a/docs/_providers/transip.md
+++ b/docs/_providers/transip.md
@@ -13,25 +13,25 @@ In your providers config json file you must include your TransIP credentials
 
 You can login with your AccountName and a PrivateKey which can be generated in the TransIP control panel. The PrivateKey is a stringified version of the private key given by the API, see the example below, each newline is replaced by "\n".
 
-{% highlight json %}
+```json
 {
   "transip":{
     "AccountName": "your-account-name"
     "PrivateKey": "-----BEGIN RSA PRIVATE KEY-----\nMIICXAIBAAKBgQCqGKukO1De7zhZj6+H0qtjTkVxwTCpvKe4eCZ0FPqri0cb2JZfXJ/DgYSF6vUp\nwmJG8wVQZKjeGcjDOL5UlsuusFncCzWBQ7RKNUSesmQRMSGkVb1/3j+skZ6UtW+5u09lHNsj6tQ5\n1s1SPrCBkedbNf0Tp0GbMJDyR4e9T04ZZwIDAQABAoGAFijko56+qGyN8M0RVyaRAXz++xTqHBLh\n3tx4VgMtrQ+WEgCjhoTwo23KMBAuJGSYnRmoBZM3lMfTKevIkAidPExvYCdm5dYq3XToLkkLv5L2\npIIVOFMDG+KESnAFV7l2c+cnzRMW0+b6f8mR1CJzZuxVLL6Q02fvLi55/mbSYxECQQDeAw6fiIQX\nGukBI4eMZZt4nscy2o12KyYner3VpoeE+Np2q+Z3pvAMd/aNzQ/W9WaI+NRfcxUJrmfPwIGm63il\nAkEAxCL5HQb2bQr4ByorcMWm/hEP2MZzROV73yF41hPsRC9m66KrheO9HPTJuo3/9s5p+sqGxOlF\nL0NDt4SkosjgGwJAFklyR1uZ/wPJjj611cdBcztlPdqoxssQGnh85BzCj/u3WqBpE2vjvyyvyI5k\nX6zk7S0ljKtt2jny2+00VsBerQJBAJGC1Mg5Oydo5NwD6BiROrPxGo2bpTbu/fhrT8ebHkTz2epl\nU9VQQSQzY1oZMVX8i1m5WUTLPz2yLJIBQVdXqhMCQBGoiuSoSjafUhV7i1cEGpb88h5NBYZzWXGZ\n37sJ5QsW+sJyoNde3xH8vdXhzU7eT82D6X/scw9RZz+/6rCJ4p0=\n-----END RSA PRIVATE KEY-----"
   }
 }
-{% endhighlight %}
+```
 
 Or you can choose to have an AccessToken as credential. These can be generated in the TransIP control panel and have a limited lifetime
 
 
-{% highlight json %}
+```json
 {
   "transip":{
     "AccessToken": "your-transip-personal-access-token"
   }
 }
-{% endhighlight %}
+```
 
 
 
@@ -43,13 +43,13 @@ This provider does not recognize any special metadata fields unique to TransIP.
 
 Example javascript:
 
-{% highlight js %}
+```js
 var TRANSIP = NewDnsProvider("transip", "TRANSIP");
 
 D("example.tld", REG_DNSIMPLE, DnsProvider(TRANSIP),
     A("test","1.2.3.4")
 );
-{% endhighlight %}
+```
 
 ## Activation
 

--- a/docs/_providers/vultr.md
+++ b/docs/_providers/vultr.md
@@ -10,13 +10,13 @@ jsId: VULTR
 
 In your providers config json file you must include a Vultr personal access token:
 
-{% highlight json %}
+```json
 {
   "vultr":{
     "token": "your-vultr-personal-access-token"
   }
 }
-{% endhighlight %}
+```
 
 ## Metadata
 
@@ -26,13 +26,13 @@ This provider does not recognize any special metadata fields unique to Vultr.
 
 Example javascript:
 
-{% highlight js %}
+```js
 var VULTR = NewDnsProvider("vultr", "VULTR");
 
 D("example.tld", REG_DNSIMPLE, DnsProvider(VULTR),
     A("test","1.2.3.4")
 );
-{% endhighlight %}
+```
 
 ## Activation
 

--- a/docs/adding-new-rtypes.md
+++ b/docs/adding-new-rtypes.md
@@ -31,7 +31,7 @@ record has a field called `Flag`, therefore the field name in
 
 Here are some examples:
 
-```
+```go
 type RecordConfig struct {
   ...
   MxPreference uint16            `json:"mxpreference,omitempty"`
@@ -75,7 +75,7 @@ will report something like the `MISSING` message below. In this
 example we removed `providers.CanUseCAA` from the
 `providerCapabilityChecks` list.
 
-```
+```text
 --- FAIL: TestCapabilitiesAreFiltered (0.00s)
     capabilities_test.go:66: ok: providers.CanUseAlias (0) is checked for with "ALIAS"
     capabilities_test.go:68: MISSING: providers.CanUseCAA (1) is not checked by checkProviderCapabilities
@@ -141,7 +141,7 @@ list.
 
 Each `testgroup()` is a named list of tests.
 
-```
+```js
 testgroup("MX",                                   <<< 1
   tc("MX record", mx("@", 5, "foo.com.")),        <<< 2
   tc("Change MX pref", mx("@", 10, "foo.com.")),  <<< 3

--- a/docs/alias.md
+++ b/docs/alias.md
@@ -14,7 +14,7 @@ A few notes:
 1. A provider must "opt-in" to supporting ALIAS records. When registering a provider, you specify which capabilities you support. Here is an example of how the
   cloudflare provider declares its support for aliases:
 
-```
+```go
 func init() {
 	providers.RegisterDomainServiceProviderType("CLOUDFLAREAPI", newCloudflare, providers.CanUseAlias)
 }

--- a/docs/bug-triage.md
+++ b/docs/bug-triage.md
@@ -41,7 +41,7 @@ automatically from all the issues tagged `provider-request`:
 
 Message to requester:
 
-```
+```text
 Thank you for requesting this provider!
 
 I've tagged this issue as a provider-request.  It will (soon) be listed as a "requested provider" on the provider list web page:

--- a/docs/byo-secrets.md
+++ b/docs/byo-secrets.md
@@ -79,7 +79,7 @@ In this branch, edit `.github/workflows/build.yml`:
    to the matrix of providers.  Technically you are adding to the list
    at `jobs.integration-tests.strategy.matrix.provider`.
 
-```
+```yaml
       matrix:
         provider:
 ...
@@ -102,7 +102,7 @@ Please replicate the formatting of the existing entries:
 * The `*_DOMAIN` variable is first.
 * The remaining variables are sorted lexicographically (what nerds call alphabetical order).
 
-```
+```yaml
       FANCYDNS_DOMAIN: ${{ secrets.FANCYDNS_DOMAIN }}
       FANCYDNS_KEY: ${{ secrets.FANCYDNS_KEY }}
       FANCYDNS_USER: ${{ secrets.FANCYDNS_USER }}
@@ -117,7 +117,7 @@ Let's look at three examples:
 The `BIND` integration tests do not require any secrets because it
 simply generates files locally.
 
-```
+```yaml
       BIND_DOMAIN: example.com
 ```
 
@@ -139,7 +139,7 @@ Note that `AZURE_DNS_RESOURCE_GROUP` is hardcoded to `DNSControl`. If
 this is not true for you, please feel free to submit a PR that turns
 it into a secret.
 
-```
+```yaml
       AZURE_DNS_DOMAIN: ${{ secrets.AZURE_DNS_DOMAIN }}
       AZURE_DNS_CLIENT_ID: ${{ secrets.AZURE_DNS_CLIENT_ID }}
       AZURE_DNS_CLIENT_SECRET: ${{ secrets.AZURE_DNS_CLIENT_SECRET }}
@@ -159,7 +159,7 @@ secrets, we hard-code them into the `build.yml` file. Since
 `HEXONET_DOMAIN` does not come from secret storage, everyone can run
 these tests. (We are grateful to HEXONET for this public service!)
 
-```
+```yaml
       HEXONET_DOMAIN: a-b-c-movies.com
       HEXONET_ENTITY: OTE
       HEXONET_PW: test.passw0rd

--- a/docs/caa-builder.md
+++ b/docs/caa-builder.md
@@ -15,7 +15,7 @@ authorized certificate authorities and the builder cares about the rest.
 
 For example you can use:
 
-```
+```js
 CAA_BUILDER({
   label: "@",
   iodef: "mailto:test@domain.tld",
@@ -42,5 +42,4 @@ The parameters are:
   * `CAA("@", "issue", "letsencrypt.org")`
   * `CAA("@", "issue", "comodoca.com")`
   * `CAA("@", "issuewild", ";")`
-
 ```

--- a/docs/code-tricks.md
+++ b/docs/code-tricks.md
@@ -24,7 +24,7 @@ Domains that use Google G-Suite require a specific list of MX
 records, plus there are some CNAMEs that are useful (but we only
 want the CNAMEs on a subset of domains).
 
-```
+```js
 var GOOGLE_APPS_DOMAIN_MX = [
   MX("@", 1, "aspmx.l.google.com."),
   MX("@", 5, "alt1.aspmx.l.google.com."),
@@ -63,7 +63,7 @@ records.
 
 Solution: Use a loop. (Note: See caveats below.)
 
-```
+```js
 // The domains are parked. Use the exact same records for each.
 _.each(
   [

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -10,8 +10,7 @@ title: Examples
 
 ## Typical DNS Records
 
-{% highlight javascript %}
-
+```js
 D('example.com', REG, DnsProvider('GCLOUD'),
     A('@', '1.2.3.4'),  // The naked or 'apex' domain.
     A('server1', '2.3.4.5'),
@@ -24,13 +23,11 @@ D('example.com', REG, DnsProvider('GCLOUD'),
     NS('department2', 'ns1.dnsexample.com.'), // use different nameservers
     NS('department2', 'ns2.dnsexample.com.') // for department2.example.com
 )
-
-{% endhighlight %}
+```
 
 ## Set TTLs
 
-{% highlight javascript %}
-
+```js
 var mailTTL = TTL('1h');
 
 D('example.com', registrar,
@@ -43,25 +40,22 @@ D('example.com', registrar,
     A('@', '1.2.3.4', TTL('10m')), // individual record
     CNAME('mail', 'mx01') // TTL of 5m, as defined per DefaultTTL()
 );
-
-{% endhighlight %}
+```
 
 ## Variables for common IP Addresses
 
-{% highlight javascript %}
-
+```js
 var addrA = IP('1.2.3.4')
 
 D('example.com', REG, DnsProvider('R53'),
     A('@', addrA), // 1.2.3.4
     A('www', addrA + 1), // 1.2.3.5
 )
-{% endhighlight %}
+```
 
 ## Variables to swap active Data Center
 
-{% highlight javascript %}
-
+```js
 var dcA = IP('5.5.5.5');
 var dcB = IP('6.6.6.6');
 
@@ -71,12 +65,11 @@ var activeDC = dcA;
 D('example.com', REG, DnsProvider('R53'),
     A('@', activeDC + 5), // fixed address based on activeDC
 )
-{% endhighlight %}
+```
 
 ## Macro to for repeated records
 
-{% highlight javascript %}
-
+```js
 var GOOGLE_APPS_RECORDS = [
     MX('@', 1, 'aspmx.l.google.com.'),
     MX('@', 5, 'alt1.aspmx.l.google.com.'),
@@ -95,8 +88,7 @@ D('example.com', REG, DnsProvider('R53'),
    GOOGLE_APPS_RECORDS,
    A('@', '1.2.3.4')
 )
-
-{% endhighlight %}
+```
 
 ## Add comments along complex SPF records
 
@@ -104,8 +96,7 @@ You normally can't put comments in the middle of a string,
 but with a little bit of creativity you can document
 each element of an SPF record this way.
 
-{% highlight javascript %}
-
+```js
 var SPF_RECORDS = TXT('@', [
     'v=spf1',
     'ip4:1.2.3.0/24',           // NY mail server
@@ -121,13 +112,11 @@ var SPF_RECORDS = TXT('@', [
 D('example.com', REG, DnsProvider('R53'),
    SPF_RECORDS,
 )
-
-{% endhighlight %}
+```
 
 ## Dual DNS Providers
 
-{% highlight javascript %}
-
+```js
 D('example.com', REG, DnsProvider('R53'), DnsProvider('GCLOUD'),
    A('@', '1.2.3.4')
 )
@@ -143,17 +132,14 @@ D('example2.com', REG, DnsProvider('R53',2), DnsProvider('GCLOUD',2),
 D('example3.com', REG, DnsProvider('R53'), DnsProvider('GCLOUD',0),
    A('@', '1.2.3.4')
 )
-
-{% endhighlight %}
+```
 
 ## Set default records modifiers
 
-{% highlight javascript %}
-
+```js
 DEFAULTS(
 	NAMESERVER_TTL('24h'),
 	DefaultTTL('12h'),
 	CF_PROXY_DEFAULT_OFF
 );
-
-{% endhighlight %}
+```

--- a/docs/get-certs.md
+++ b/docs/get-certs.md
@@ -53,7 +53,7 @@ specify any number of certificates, with up to 100 SAN entries each. Subject nam
 
 The format of the file is a simple json array of objects:
 
-```
+```json
 [
     {
         "cert_name": "mainCert",
@@ -92,7 +92,7 @@ The working directory should generally contain:
 - `certs.json` to describe what certificates to issue.
 - `dnsconfig.js` and `creds.json` are the main files for other dnscontrol commands.
 
-```
+```text
 ┏━━.letsencrypt
 ┃  ┗━(*Let's Encrypt* account keys and metadata)
 ┃
@@ -110,6 +110,7 @@ The working directory should generally contain:
 ┣━━creds.json
 ┗━━dnsconfig.js
 ```
+
 ## Command line flags
 
 ### Required Flags
@@ -148,8 +149,7 @@ The push to the certificate repo can trigger further automation to deploy certs 
 
 ## Example script
 
-```
-
+```bash
 #!/bin/bash
 
 set -e

--- a/docs/get-zones.md
+++ b/docs/get-zones.md
@@ -115,7 +115,7 @@ In the `*Provider.go` file, change the setting to implemented.
 
 **Step 2. Update the docs**
 
-```
+```bash
 go generate
 ```
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -37,7 +37,7 @@ Alternatively, on Mac you can install it using homebrew:
 
 ## Via [docker](https://hub.docker.com/r/stackexchange/dnscontrol/)
 
-```
+```bash
 docker run --rm -it -v $(pwd)/dnsconfig.js:/dns/dnsconfig.js -v $(pwd)/creds.json:/dns/creds.json stackexchange/dnscontrol dnscontrol preview
 ```
 
@@ -72,8 +72,7 @@ and renaming it.
 
 The file looks like:
 
-{% highlight js %}
-
+```js
 // Providers:
 
 var REG_NONE = NewRegistrar('none', 'NONE');    // No registrar.
@@ -84,12 +83,12 @@ var DNS_BIND = NewDnsProvider('bind', 'BIND');  // ISC BIND.
 D('example.com', REG_NONE, DnsProvider(DNS_BIND),
     A('@', '1.2.3.4')
 );
-{%endhighlight%}
+```
 
 You may modify this file to match your particular providers and domains. See [the javascript docs]({{site.github.url}}/js) and  [the provider docs]({{site.github.url}}/provider-list) for more details.
 If you are using other providers, you will likely need to make a `creds.json` file with api tokens and other account information. For example, to use both name.com and Cloudflare, you would have:
 
-{% highlight js %}
+```js
 {
   "cloudflare":{ // provider name to be used in dnsconfig.js
     "apitoken": "token" // API token
@@ -99,7 +98,7 @@ If you are using other providers, you will likely need to make a `creds.json` fi
     "apiuser": "username" // username for name.com
   }
 }
-{%endhighlight%}
+```
 
 There are 2 types of providers:
 
@@ -126,7 +125,7 @@ and renaming it.
 
 The file looks like:
 
-{% highlight js %}
+```js
 {
   "bind": {
   },
@@ -135,7 +134,7 @@ The file looks like:
     "SecretKey": "change_to_your_secretkey"
   }
 }
-{%endhighlight%}
+```
 
 Ignore the `r53_ACCOUNTNAME` section.  It is a placeholder and will be ignored. You
 can use it later when you define your first set of API credentials.
@@ -167,9 +166,8 @@ exist.
 
 It should look something like this:
 
-{% highlight js %}
-
-$ dnscontrol preview
+```text
+dnscontrol preview
 Initialized 1 registrars and 1 dns service providers.
 ******************** Domain: example.com
 ----- Getting nameservers from: bind
@@ -179,14 +177,14 @@ Initialized 1 registrars and 1 dns service providers.
 
 ----- Registrar: none
 Done. 1 corrections.
-{%endhighlight%}
+```
 
 Next run `dnscontrol push` to actually make the changes. In this
 case, the change will be to create a zone file where one didn't
 previously exist.
 
-{% highlight js %}
-$ dnscontrol push
+```bash
+dnscontrol push
 Initialized 1 registrars and 1 dns service providers.
 ******************** Domain: example.com
 ----- Getting nameservers from: bind
@@ -198,7 +196,7 @@ CREATING ZONEFILE: zones/example.com.zone
 SUCCESS!
 ----- Registrar: none
 Done. 1 corrections.
-{%endhighlight%}
+```
 
 
 ## 6. Make a change.
@@ -209,8 +207,8 @@ address of in `A('@', '1.2.3.4')` or add an additional A record.
 In our case, we changed the IP address to 10.10.10.10. Previewing
 our change looks like this:
 
-{% highlight js %}
-$ dnscontrol preview
+```bash
+dnscontrol preview
 Initialized 1 registrars and 1 dns service providers.
 ******************** Domain: example.com
 ----- Getting nameservers from: bind
@@ -220,7 +218,7 @@ MODIFY A example.com: (1.2.3.4 300) -> (10.10.10.10 300)
 
 ----- Registrar: none
 Done. 1 corrections.
-{%endhighlight%}
+```
 
 Notice that it read the old zone file and was able to produce a
 "diff" between the old `A` record and the new one.  If the zonefile
@@ -236,11 +234,11 @@ specific records.
 Take a look at the `zones/example.com.zone` file.  It should look
 like:
 
-{% highlight js %}
+```text
 $TTL 300
 @                IN SOA   DEFAULT_NOT_SET. DEFAULT_NOT_SET. 1 3600 600 604800 1440
                  IN A     10.10.10.10
-{%endhighlight%}
+```
 
 You can change the "DEFAULT_NOT_SET" text by following the documentation
 for the [BIND provider]({{site.github.url}}/providers/bind) to set

--- a/docs/migrating.md
+++ b/docs/migrating.md
@@ -55,7 +55,7 @@ Example 1: Read a BIND zonefile
 
 Most DNS Service Providers have an 'export to zonefile' feature.
 
-```
+```bash
 dnscontrol get-zones --format=js bind BIND example.com
 dnscontrol get-zones --format=js --out=draft.js bind BIND example.com
 ```
@@ -74,7 +74,7 @@ This requires creating a `creds.json` file as described in
 Suppose your `creds.json` file has the name `global_aws`
 for the provider `ROUTE53`.  Your command would look like this:
 
-```
+```bash
 dnscontrol get-zones --format=js global_aws ROUTE53 example.com
 dnscontrol get-zones --format=js --out=draft.js global_aws ROUTE53 example.com
 ```

--- a/docs/nameservers.md
+++ b/docs/nameservers.md
@@ -16,7 +16,7 @@ The document shows examples of many common and uncommon configurations.
 
 All the examples use the variables.  Substitute your own.
 
-{% highlight javascript %}
+```js
 // ========== Registrars:
 
 // A typical registrar.
@@ -34,7 +34,7 @@ var DNS_AWS = NewDnsProvider("aws_main", "ROUTE53");
 var DNS_GOOGLE = NewDnsProvider("gcp_main", "GCLOUD");
 var DNS_CLOUDFLARE = NewDnsProvider("cloudflare_main", "CLOUDFLAREAPI");
 var DNS_BIND = NewDnsProvider("bind", "BIND");
-{% endhighlight %}
+```
 
 # Typical Delegations
 
@@ -46,12 +46,12 @@ Use the same provider as a registrar and DNS service.
 Why?
 Simplicity.
 
-{% highlight javascript %}
+```js
 D("example1.com", REG_NAMECOM,
   DnsProvider(DNS_NAMECOM),
   A("@", "10.2.3.4")
 );
-{% endhighlight %}
+```
 
 ## Different provider for REG and DNS
 
@@ -63,12 +63,12 @@ Some registrars do not provide DNS server, or their service is sub-standard and
 you want to use a high-performance DNS server.
 
 
-{% highlight javascript %}
+```js
 D("example1.com", REG_NAMECOM,
   DnsProvider(DNS_AWS),
   A("@", "10.2.3.4")
 );
-{% endhighlight %}
+```
 
 ## Registrar is elsewhere
 
@@ -81,12 +81,12 @@ You don't have access to the registrar, or the registrar is not
 supported by DNSControl. However you do have API access for
 updating the zone's records (most likely at a different provider).
 
-{% highlight javascript %}
+```js
 D("example1.com", REG_THIRDPARTY,
   DnsProvider(DNS_NAMECOM),
   A("@", "10.2.3.4")
 );
-{% endhighlight %}
+```
 
 ## Zone is elsewhere
 
@@ -98,14 +98,14 @@ We are delegating the domain to someone else. In this example we're
 pointing the domain to the nsone.net DNS service, which someone else is
 controlling.
 
-{% highlight javascript %}
+```js
 D("example1.com", REG_NAMECOM,
   NAMESERVER("dns1.p03.nsone.net."),
   NAMESERVER("dns2.p03.nsone.net."),
   NAMESERVER("dns3.p03.nsone.net."),
   NAMESERVER("dns4.p03.nsone.net."),
 );
-{% endhighlight %}
+```
 
 ## Override nameservers
 
@@ -118,14 +118,14 @@ nameservers are, or the API is returning invalid data, or if the API returns no
 information.  Sometimes APIs return no (useful) information when the domain
 is new; this is a good temporary work-around until the API starts working.
 
-{% highlight javascript %}
+```js
 D("example1.com", REG_NAMECOM,
   DnsProvider(DNS_CLOUDFLARE, 0),  // Set the DNS provider but ignore the nameservers it suggests (0 == take none of the names it reports)
   NAMESERVER("kim.ns.cloudflare.com."),
   NAMESERVER("walt.ns.cloudflare.com."),
   A("@", "10.2.3.4")
 );
-{% endhighlight %}
+```
 
 ## Add nameservers
 
@@ -135,13 +135,13 @@ Use the default nameservers from the registrar but add additional ones.
 Why?
 Usually only to correct a bug or misconfiguration elsewhere.
 
-{% highlight javascript %}
+```js
 D("example1.com", REG_NAMECOM,
   DnsProvider(DNS_NAMECOM),
   NAMESERVER("ns1.myexample.tld"),
   A("@", "10.2.3.4")
 );
-{% endhighlight %}
+```
 
 ## Shadow nameservers
 
@@ -155,14 +155,14 @@ There are many reasons to do this:
 * You want your DNS records stored somewhere else in case you have to switch over in an emergency.
 * You are sending the zone to a local caching DNS server.
 
-{% highlight javascript %}
+```js
 D("example1.com", REG_NAMECOM,
   DnsProvider(DNS_NAMECOM), // Our real DNS server
   DnsProvider(DNS_CLOUDFLARE, 0), // Quietly send a copy of the zone here.
   DnsProvider(DNS_BIND, 0), // And here too!
   A("@", "10.2.3.4")
 );
-{% endhighlight %}
+```
 
 ## Dual DNS Providers
 
@@ -181,13 +181,13 @@ More info: https://www.dns-oarc.net/files/workshop-201203/OARC-workshop-London-2
 
 NOTE: This is overkill unless you have millions of users and strict up-time requirements.
 
-{% highlight javascript %}
+```js
 D("example1.com", REG_NAMECOM,
   DnsProvider(DNS_AWS, 2),  // Take 2 nameservers from AWS
   DnsProvider(DNS_GOOGLE, 2),  // Take 2 nameservers from GCP
   A("@", "10.2.3.4")
 );
-{% endhighlight %}
+```
 
 # Other uses
 
@@ -205,13 +205,13 @@ this is the output of DNSControl, not the input.
 
 NOTE: This won't work if you use pseudo rtypes that BIND doesn't support.
 
-{% highlight javascript %}
+```js
 D("example1.com", REG_NAMECOM,
   DnsProvider(DNS_NAMECOM),
   DnsProvider(DNS_BIND, 0), // Don't activate any nameservers related to BIND.
   A("@", "10.2.3.4")
 );
-{% endhighlight %}
+```
 
 ## Monitor delegation
 
@@ -225,14 +225,14 @@ Sometimes you just want to know if something changes!
 
 See the <a href="{{site.github.url}}/providers/doh">DNS-over-HTTPS Provider</a> documentation for more info.
 
-{% highlight javascript %}
+```js
 var REG_MONITOR = NewRegistrar('DNS-over-HTTPS', 'DNSOVERHTTPS');
 
 D("example1.com", REG_MONITOR,
   NAMESERVER("ns1.example1.com."),
   NAMESERVER("ns2.example1.com."),
 );
-{% endhighlight %}
+```
 
 # Helper macros
 
@@ -242,13 +242,13 @@ DNSControl has some built-in macros that you might find useful.
 
 Easily delegate a domain to a specific list of nameservers.
 
-{% highlight javascript %}
+```js
 DOMAIN_ELSEWHERE("example1.com", REG_NAMECOM, [
     "dns1.example.net.",
     "dns2.example.net.",
     "dns3.example.net.",
 ]);
-{% endhighlight %}
+```
 
 ## `DOMAIN_ELSEWHERE_AUTO`
 
@@ -257,10 +257,10 @@ Easily delegate a domain to a nameservers via an API query.
 This is similar to `DOMAIN_ELSEWHERE` but the list
 of nameservers is queried from the API of a single DNS provider.
 
-{% highlight javascript %}
+```js
 DOMAIN_ELSEWHERE_AUTO("example1.com", REG_NAMECOM, DNS_AWS);
 DOMAIN_ELSEWHERE_AUTO("example2.com", REG_NAMECOM, DNS_GOOGLE);
-{% endhighlight %}
+```
 
 # Limits
 

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -13,7 +13,7 @@ new types or destinations.
 
 Notifications are set up in your credentials json file. They will use the `notifications` key to look for keys or configuration needed for various notification types.
 
-```
+```json
   "r53": {
       ...
     },

--- a/docs/release-engineering.md
+++ b/docs/release-engineering.md
@@ -14,7 +14,7 @@ Please change the version number as appropriate.
 Make sure you are using the latest version of `go`
 (listed on [https://golang.org/dl/](https://golang.org/dl/))
 
-```
+```bash
 go version
 ```
 
@@ -39,7 +39,7 @@ NOTE: If you bump the major version, you need to change all the source
 files.  The last time this was done (v2 -> v3) these two commands
 automated all that:
 
-```
+```bash
 #  Make all the changes:
 sed -i.bak -e 's@github.com.StackExchange.dnscontrol.v2@github.com/StackExchange/dnscontrol/v3@g' go.* $(fgrep -lri --include '*.go' github.com/StackExchange/dnscontrol/v2 *)
 # Delete the backup files:
@@ -51,8 +51,8 @@ find * -name \*.bak -delete
 
 Verify the version string was updated:
 
-```
-$ grep Version main.go
+```bash
+grep Version main.go
 ```
 
 (Make sure that it lists the new version number.)
@@ -88,7 +88,7 @@ See [https://github.com/StackExchange/dnscontrol/releases for examples](https://
 
 Example/template:
 
-```
+```text
 This release includes many new providers (JoeDNS and MaryDNS), dozens
 of bug fixes, and a new testing framework that makes it easier to add
 big features without fear of breaking old ones.
@@ -161,7 +161,7 @@ see dnscontrol-Darwin, dnscontrol-Linux, and dnscontrol.exe attached as assets.
 
 Email the release notes to the mailing list: (note the format of the Subject line and that the first line of the email is the URL of the release)
 
-```
+```text
 To: dnscontrol-discuss@googlegroups.com
 Subject: New release: dnscontrol v$VERSION
 
@@ -178,7 +178,7 @@ it.  [Click here to join](https://groups.google.com/forum/#!forum/dnscontrol-dis
 
 Mention on [https://gitter.im/dnscontrol/Lobby](https://gitter.im/dnscontrol/Lobby) that the new release has shipped.
 
-```
+```text
 ANNOUNCEMENT: dnscontrol v$VERSION has been released! https://github.com/StackExchange/dnscontrol/releases/tag/v$VERSION
 ```
 
@@ -197,7 +197,7 @@ If you are at Stack Overflow:
 
 List out-of-date modules and update any that seem worth updating:
 
-```
+```bash
 go install github.com/oligot/go-mod-upgrade@latest
 go-mod-upgrade
 go mod tidy
@@ -205,7 +205,7 @@ go mod tidy
 
 OLD WAY:
 
-```
+```bash
 go install github.com/psampaz/go-mod-outdated@latest
 go list -mod=mod -u -m -json all | go-mod-outdated -update -direct
 

--- a/docs/spf-optimizer.md
+++ b/docs/spf-optimizer.md
@@ -19,7 +19,7 @@ enforce the "10 lookup rule".
 
 Here is an example of how SPF settings are normally done:
 
-```
+```js
 D("example.tld", REG, DNS, ...
   TXT("v=spf1 ip4:198.252.206.0/24 ip4:192.111.0.0/24 include:_spf.google.com include:mailgun.org include:spf-basic.fogcreek.com include:mail.zendesk.com include:servers.mcsv.net include:sendgrid.net include:450622.spf05.hubspotemail.net ~all")
 )
@@ -33,7 +33,7 @@ This has a few problems:
 
 ## The dnscontrol way
 
-```
+```js
 D("example.tld", REG, DSP, ...
   A("@", "10.2.2.2"),
   MX("@", "example.tld."),
@@ -74,7 +74,7 @@ By using the `SPF_BUILDER()` we gain many benefits:
 When you want to specify SPF settings for a domain, use the
 `SPF_BUILDER()` function.
 
-```
+```js
 D("example.tld", REG, DSP, ...
   ...
   ...
@@ -151,15 +151,15 @@ is no longer truncated.
 
 Example:
 
-```
-$ dig +short whatexit.org txt | wc -c
+```bash
+dig +short whatexit.org txt | wc -c
    118
 ```
 
 Setting `overhead1` to 118 should be sufficient.
 
-```
-$ dig +short stackoverflow.com txt | wc -c
+```bash
+dig +short stackoverflow.com txt | wc -c
      582
 ```
 
@@ -185,8 +185,8 @@ to be updated, the proper data will be written to a file called
 `spfcache.updated.json` and instructions such as the ones below
 will be output telling you exactly what to do:
 
-```
-$ dnscontrol preview
+```bash
+dnscontrol preview
 1 Validation errors:
 WARNING: 2 spf record lookups are out of date with cache (_spf.google.com,_netblocks3.google.com).
 Wrote changes to spfcache.updated.json. Please rename and commit:
@@ -265,7 +265,7 @@ record an include is added.
 In some situations we define an SPF setting once and want to re-use
 it on many domains. Here's how to do this:
 
-```
+```js
 var SPF_MYSETTINGS = SPF_BUILDER({
   label: "@",
   overflow: "_spf%d",

--- a/docs/why-the-dot.md
+++ b/docs/why-the-dot.md
@@ -7,13 +7,13 @@ title: Why CNAME/MX/NS targets require a "dot"
 
 You received this error message:
 
-```
+```text
  1: ERROR: target (ghs.googlehosted.com) includes a (.), must end with a (.)
 ```
 
 This means you should add a "." to the end of the target.
 
-```
+```js
 OLD   CNAME("foo", "ghs.googlehosted.com"),
 NEW   CNAME("foo", "ghs.googlehosted.com."),
                                         ^
@@ -27,7 +27,7 @@ NEW   CNAME("foo", "ghs.googlehosted.com."),
 
 People are often confused about this error message:
 
-```
+```text
  1: ERROR: target (ghs.googlehosted.com) includes a (.), must end with a (.)
 ```
 
@@ -39,12 +39,11 @@ add the domain to it.
 
 Here are four examples:
 
-```
+```js
     CNAME("foo", "bar")        // Permitted. (expands to bar.$DOMAIN)
     CNAME("foo", "bar.com.")  // Permitted. (we are certain what the user wants)
     CNAME("foo", "bar.com")   // ERROR (ambiguous)
     CNAME("foo", "meta.xyz")  // ERROR (ambiguous)
-
 ```
 
 The first 2 examples are permitted.  The last 2 examples are

--- a/docs/writing-providers.md
+++ b/docs/writing-providers.md
@@ -167,7 +167,7 @@ Integration tests use a test account and a real domain.
 
 For example, this will run the tests using BIND:
 
-```
+```bash
 cd dnscontrol/integrationTest
 go test -v -verbose -provider BIND
 ```
@@ -176,7 +176,7 @@ go test -v -verbose -provider BIND
 
 This will run the tests on Amazon AWS Route53:
 
-```
+```bash
 export R53_DOMAIN=dnscontroltest-r53.com  # Use a test domain.
 export R53_KEY_ID='CHANGE_TO_THE_ID'
 export R53_KEY='CHANGE_TO_THE_KEY'
@@ -253,7 +253,7 @@ the documentation.
 
 Run "go vet" and "golint" and clean up any errors found.
 
-```
+```bash
 go vet ./...
 golint ./...
 ```
@@ -262,7 +262,7 @@ Please use `go vet` from the [newest release of Go](https://golang.org/doc/devel
 
 If [golint](https://github.com/golang/lint) isn't installed on your machine:
 
-```
+```bash
 go get -u golang.org/x/lint/golint
 ```
 

--- a/integrationTest/readme.md
+++ b/integrationTest/readme.md
@@ -17,15 +17,15 @@ For each step, it will run the config once and expect changes. It will run it ag
 
 Example:
 
-```
-$ egrep ROUTE53 providers.json
+```bash
+egrep ROUTE53 providers.json
     "KeyId": "$ROUTE53_KEY_ID",
     "SecretKey": "$ROUTE53_KEY",
     "domain": "$ROUTE53_DOMAIN"
-$ export ROUTE53_KEY_ID="redacted"
-$ export ROUTE53_KEY="also redacted"
-$ export ROUTE53_DOMAIN="testdomain.tld"
-$ go test -v -verbose -provider ROUTE53
+export ROUTE53_KEY_ID="redacted"
+export ROUTE53_KEY="also redacted"
+export ROUTE53_DOMAIN="testdomain.tld"
+go test -v -verbose -provider ROUTE53
 ```
 
 WARNING: The records in the test domain will be deleted.  Only use

--- a/providers/activedir/doc.md
+++ b/providers/activedir/doc.md
@@ -28,7 +28,7 @@ No "creds.json" configuration is expected.
 
 ## example dns config js:
 
-```
+```js
 var REG_NONE = NewRegistrar('none', 'NONE')
 var DSP_ACTIVEDIRECTORY_DS = NewDSP("activedir", "ACTIVEDIRECTORY_PS");
 

--- a/providers/octodns/TESTING.md
+++ b/providers/octodns/TESTING.md
@@ -4,7 +4,7 @@
 
 These variables are used in all other sections of this doc.
 
-```
+```bash
 export DNSCONFIGDIR=~/gitwork/fakeroot/ExternalDNS
 export OCTCONFIGDIR=~/gitwork/octodns/dns
 export SRCDIR=~/src/github.com/StackExchange/dnscontrol
@@ -14,14 +14,14 @@ export SRCDIR=~/src/github.com/StackExchange/dnscontrol
 
 Unit tests:
 
-```
+```bash
 cd $SRCDIR/providers/octodns/octoyaml
 go test -v
 ```
 
 Integration tests:
 
-```
+```bash
 cd $SRCDIR/integrationTest
 go test -v -verbose -provider OCTODNS
 ```
@@ -30,7 +30,7 @@ go test -v -verbose -provider OCTODNS
 
 ### Download OctoDNS:
 
-```
+```bash
 cd $DNSCONFIGDIR
 mkdir dns
 cd dns
@@ -44,7 +44,7 @@ ln -s ~/gitwork/fakeroot/ExternalDNS/config config
 
 Make a copy of dnsconfig.js and modify it to use OCTODNS as a provider. We did it this way:
 
-```
+```bash
 cd $DNSCONFIGDIR/dns
 cp ../dnsconfig.js .
 cp ../creds.json .
@@ -52,13 +52,13 @@ cp ../creds.json .
 
 Add:
 
-```
+```js
 var OCT = NewDnsProvider("octodns", "OCTODNS");
 ```
 
 Add:
 
-```
+```diff
  DEFAULTS(
    DnsProvider(SERVERFAULT, 0),
 +  DnsProvider(OCT, 0),
@@ -68,7 +68,7 @@ Add:
 
 Add:
 
-```
+```diff
  var NO_BIND = function(d) {
    delete d.dnsProviders[SERVERFAULT];
 +  delete d.dnsProviders[OCT];
@@ -81,7 +81,7 @@ Add:
 
 This builds the software then generates the yaml files in the config directory:
 
-```
+```bash
 (cd $SRCDIR && go install ) && cd $DNSCONFIGDIR/dns && rm -f config/*.yaml && dnscontrol push -providers=octodns
 ```
 
@@ -92,13 +92,13 @@ list each domain.
 
 We create production.yaml like this:
 
-```
+```bash
 cd $DNSCONFIGDIR/dns && $SRCDIR/providers/octodns/mkprodyaml.sh
 ```
 
 Now we can run the validation:
 
-```
+```bash
 cd $DNSCONFIGDIR/dns
 cp $SRCDIR/providers/octodns/testdata/production.yaml config/. && env/bin/octodns-validate --log-stream-stdout
 ```


### PR DESCRIPTION
Replace Jekyll highlight tags with fenced code blocks.
Canonicalize javascript to js.
Correct highlighting languages.
Add highlighting to code blocks.
Remove leading $ from bash blocks.
Remove empty lines at start and end of code blocks.
Stripped trailing whitespace.