### PR TITLE
ns1: ignore DNSKEY & RRSIG entries

### DIFF
--- a/providers/ns1/ns1Provider.go
+++ b/providers/ns1/ns1Provider.go
@@ -204,6 +204,11 @@ func convert(zr *dns.ZoneRecord, domain string) ([]*models.RecordConfig, error) 
 		}
 		rec.SetLabelFromFQDN(zr.Domain, domain)
 		switch rtype := zr.Type; rtype {
+		case "DNSKEY", "RRSIG":
+			// if a zone is enabled for DNSSEC, NS1 autoconfigures DNSKEY & RRSIG records.
+			// these entries are not modifiable via the API though, so we have to ignore them while converting.
+			// 	ie. API returns "405 Operation on DNSSEC record is not allowed" on such operations
+			continue
 		case "ALIAS":
 			rec.Type = rtype
 			if err := rec.SetTarget(ans); err != nil {


### PR DESCRIPTION
These entries are autoconfigured by NS1 when a zone is enabled for DNSSEC and can't be
modified via the API, producing a 405 API error on modification attempts.

While unmodifiable, these records are returned by the API, so we have to ignore them.

relates to #859