### PR TITLE
LINODE: Add support for CAA records and implement get-zones

### DIFF
--- a/docs/_includes/matrix.html
+++ b/docs/_includes/matrix.html
@@ -546,7 +546,9 @@
 		<td><i class="fa fa-minus dim"></i></td>
 		<td><i class="fa fa-minus dim"></i></td>
 		<td><i class="fa fa-minus dim"></i></td>
-		<td><i class="fa fa-minus dim"></i></td>
+		<td class="success">
+			<i class="fa fa-check text-success" aria-hidden="true"></i>
+		</td>
 		<td><i class="fa fa-minus dim"></i></td>
 		<td><i class="fa fa-minus dim"></i></td>
 		<td><i class="fa fa-minus dim"></i></td>
@@ -625,7 +627,9 @@
 		<td class="success">
 			<i class="fa fa-check text-success" aria-hidden="true"></i>
 		</td>
-		<td><i class="fa fa-minus dim"></i></td>
+		<td class="success" data-toggle="tooltip" data-container="body" data-placement="top" title="Linode doesn&#39;t support changing the CAA flag">
+			<i class="fa has-tooltip fa-check text-success" aria-hidden="true"></i>
+		</td>
 		<td class="danger">
 			<i class="fa fa-times text-danger" aria-hidden="true"></i>
 		</td>
@@ -1350,7 +1354,9 @@
 		<td><i class="fa fa-minus dim"></i></td>
 		<td><i class="fa fa-minus dim"></i></td>
 		<td><i class="fa fa-minus dim"></i></td>
-		<td><i class="fa fa-minus dim"></i></td>
+		<td class="success">
+			<i class="fa fa-check text-success" aria-hidden="true"></i>
+		</td>
 		<td><i class="fa fa-minus dim"></i></td>
 		<td><i class="fa fa-minus dim"></i></td>
 		<td class="danger">

--- a/docs/_includes/matrix.html
+++ b/docs/_includes/matrix.html
@@ -1821,8 +1821,8 @@
 		<td class="success">
 			<i class="fa fa-check text-success" aria-hidden="true"></i>
 		</td>
-		<td class="info">
-			<i class="fa fa-circle-o text-info" aria-hidden="true"></i>
+		<td class="success">
+			<i class="fa fa-check text-success" aria-hidden="true"></i>
 		</td>
 		<td class="success">
 			<i class="fa fa-check text-success" aria-hidden="true"></i>

--- a/providers/linode/api.go
+++ b/providers/linode/api.go
@@ -221,20 +221,21 @@ type domainRecord struct {
 	Port     uint16 `json:"port"`
 	Service  string `json:"service"`
 	Protocol string `json:"protocol"`
+	Tag      string `json:"tag"`
 	TTLSec   uint32 `json:"ttl_sec"`
 }
 
 type recordEditRequest struct {
 	Type     string `json:"type,omitempty"`
-	Name     string `json:"name,omitempty"`
-	Target   string `json:"target,omitempty"`
+	Name     string `json:"name"`
+	Target   string `json:"target"`
 	Priority int    `json:"priority,omitempty"`
 	Weight   int    `json:"weight,omitempty"`
 	Port     int    `json:"port,omitempty"`
 	Service  string `json:"service,omitempty"`
 	Protocol string `json:"protocol,omitempty"`
-	// Documented as field `ttl` in the documentation, but in reality `ttl_sec` should be used
-	TTL int `json:"ttl_sec,omitempty"`
+	Tag      string `json:"tag,omitempty"`
+	TTL      int    `json:"ttl_sec,omitempty"`
 }
 
 type errorResponse struct {


### PR DESCRIPTION
Closes #1453

This also fixes some existing integration tests, especially with regards to MX records.

Unfortunately Linode doesn't support setting the flag on a CAA record, so there is 1 failing integration test:

<details>
<summary>Integration test results</summary>

```
--- FAIL: TestDNSProviders (150.71s)                                                                                                                                         
    --- FAIL: TestDNSProviders/dnscontroltest-linode.com (150.31s)                                                                                                           
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/Clean_Slate:Empty (0.14s)                                                                                       
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/00:GeneralACD:Create_an_A_record (0.69s)                                                                        
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/00:GeneralACD:Change_it (0.51s)                                                                                 
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/00:GeneralACD:Add_another (0.69s)                                                                               
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/00:GeneralACD:Add_another(same_name) (0.75s)                                                                    
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/00:GeneralACD:Change_a_ttl (0.48s)                                                                              
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/00:GeneralACD:Change_single_target_from_set (0.49s)                                                             
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/00:GeneralACD:Change_all_ttls (0.66s)                                                                           
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/00:GeneralACD:Delete_one (0.48s)                                                                                
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/00:GeneralACD:Add_back_and_change_ttl (0.89s)                                                                   
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/00:GeneralACD:Change_targets_and_ttls (0.68s)                                                                   
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/Post_cleanup:Empty (0.53s)                                                                                      
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/01:WildcardACD:Create_wildcard (1.06s)                                                                          
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/01:WildcardACD:Delete_wildcard (0.48s)                                                                          
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/Post_cleanup:Empty#01 (0.35s)                                                                                   
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/02:CNAME:Create_a_CNAME (0.67s)                                                                                 
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/02:CNAME:Change_CNAME_target (0.50s)                                                                            
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/02:CNAME:Empty (0.35s)                                                                                          
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/02:CNAME:Record_pointing_to_@ (0.69s)                                                                           
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/Post_cleanup:Empty#02 (0.35s)                                                                                   
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/03:MX:MX_record (0.70s)                                                                                         
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/03:MX:Second_MX_record,_same_prio (0.69s)                                                                       
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/03:MX:3_MX (0.70s)                                                                                              
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/03:MX:Delete_one (0.49s)                                                                                        
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/03:MX:Change_to_other_name (0.86s)                                                                              
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/03:MX:Change_Preference (0.52s)                                                                                 
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/03:MX:Record_pointing_to_@ (1.09s)                                                                              
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/Post_cleanup:Empty#03 (0.34s)                                                                                   
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/04:Null_MX:Null_MX (0.72s)                                                                                      
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/Post_cleanup:Empty#04 (0.34s)                                                                                   
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/05:NS:NS_for_subdomain (0.68s)                                                                                  
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/05:NS:Dual_NS_for_subdomain (0.70s)                                                                             
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/05:NS:NS_Record_pointing_to_@ (1.46s)                                                                           
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/Post_cleanup:Empty#05 (0.59s)                                                                                   
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/06:IGNORE_NAME_function:Create_some_records (1.08s)                                                             
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/06:IGNORE_NAME_function:Add_a_new_record_-_ignoring_foo (0.70s)                                                 
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/06:IGNORE_NAME_function:Empty (0.72s)                                                                           
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/06:IGNORE_NAME_function:Create_some_records#01 (1.09s)                                                          
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/06:IGNORE_NAME_function:Add_a_new_record_-_ignoring_*.foo (0.69s)                                               
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/Post_cleanup:Empty#06 (0.72s)                                                                                   
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/07:IGNORE_NAME_apex:Create_some_records (1.84s)                                                                 
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/07:IGNORE_NAME_apex:Add_a_new_record_-_ignoring_apex (0.68s)                                                    
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/Post_cleanup:Empty#07 (1.12s)                                                                                   
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/08:IGNORE_TARGET_function:Create_some_records (1.13s)                                                           
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/08:IGNORE_TARGET_function:Add_a_new_record_-_ignoring_test.foo.com. (0.50s)                                     
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/08:IGNORE_TARGET_function:Empty (0.54s)                                                                         
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/08:IGNORE_TARGET_function:Create_some_records#01 (1.10s)                                                        
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/08:IGNORE_TARGET_function:Add_a_new_record_-_ignoring_**.foo.com._targets (0.88s)                               
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/Post_cleanup:Empty#08 (0.51s)                                                                                   
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/09:simple_TXT:Create_a_TXT (0.71s)                                                                              
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/09:simple_TXT:Change_a_TXT (0.48s)                                                                              
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/09:simple_TXT:Create_a_TXT_with_spaces (0.50s)                                                                  
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/Post_cleanup:Empty#09 (0.36s)                                                                                   
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/10:simple_TXT-spf1:Create_a_TXT/SPF (0.71s)                                                                     
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/Post_cleanup:Empty#10 (0.32s)                                                                                   
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/11:long_TXT:Create_long_TXT (0.69s)                                                                             
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/11:long_TXT:Change_long_TXT (0.52s)                                                                             
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/11:long_TXT:Create_long_TXT_with_spaces (0.52s)                                                                 
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/Post_cleanup:Empty#11 (0.34s)                                                                                   
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/12:complex_TXT:TXT_with_0-octel_string (0.68s)                                                                  
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/12:complex_TXT:Empty (0.35s)                                                                                    
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/12:complex_TXT:Create_a_254-byte_TXT (0.74s)                                                                    
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/12:complex_TXT:Empty#01 (0.35s)                                                                                 
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/12:complex_TXT:Create_a_255-byte_TXT (0.70s)                                                                    
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/12:complex_TXT:Empty#02 (0.35s)                                                                                 
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/12:complex_TXT:Create_a_256-byte_TXT (0.67s)                                                                    
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/12:complex_TXT:Empty#03 (0.35s)                                                                                 
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/12:complex_TXT:Create_TXT_with_single-quote (0.70s)                                                             
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/12:complex_TXT:Empty#04 (0.35s)                                                                                 
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/12:complex_TXT:Create_TXT_with_backtick (0.68s)                                                                 
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/12:complex_TXT:Empty#05 (0.35s)                                                                                 
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/12:complex_TXT:Create_TXT_with_double-quote (0.68s)                                                             
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/12:complex_TXT:Empty#06 (0.35s)                                                                                 
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/12:complex_TXT:Create_TXT_with_ws_at_end (0.72s)                                                                
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/12:complex_TXT:Empty#07 (0.32s)                                                                                 
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/12:complex_TXT:Create_TXT_0 (0.69s)                                                                             
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/12:complex_TXT:Create_TXT_1 (0.88s)                                                                             
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/12:complex_TXT:Create_TXT_10 (0.88s)                                                                            
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/12:complex_TXT:Create_TXT_11 (0.88s)                                                                            
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/12:complex_TXT:Create_TXT_100 (0.88s)                                                                           
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/12:complex_TXT:Create_TXT_101 (0.90s)                                                                           
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/12:complex_TXT:Create_TXT_110 (0.89s)                                                                           
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/12:complex_TXT:Create_TXT_111 (0.92s)                                                                           
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/12:complex_TXT:Create_TXT_1hh (0.94s)                                                                           
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/12:complex_TXT:Create_TXT_1hh0 (0.89s)                                                                          
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/Post_cleanup:Empty#12 (0.35s)                                                                                   
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/13:long_TXT:Create_a_505_TXT (0.68s)                                                                            
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/13:long_TXT:Create_a_506_TXT (0.55s)                                                                            
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/13:long_TXT:Create_a_507_TXT (0.49s)                                                                            
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/13:long_TXT:Create_a_508_TXT (0.48s)                                                                            
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/13:long_TXT:Create_a_509_TXT (0.48s)                                                                            
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/13:long_TXT:Create_a_510_TXT (0.52s)                                                                            
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/13:long_TXT:Create_a_511_TXT (0.51s)                                                                            
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/13:long_TXT:Create_a_512_TXT (0.49s)                                                                            
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/13:long_TXT:Create_a_513_TXT (0.48s)                                                                            
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/13:long_TXT:Create_a_514_TXT (0.52s)                                                                            
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/13:long_TXT:Create_a_515_TXT (0.49s)                                                                            
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/13:long_TXT:Create_a_516_TXT (0.50s)                                                                            
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/Post_cleanup:Empty#13 (0.33s)                                                                                   
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/14:TXTMulti:Create_TXTMulti_1 (0.68s)                                                                           
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/14:TXTMulti:Add_TXTMulti_2 (0.68s)                                                                              
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/14:TXTMulti:Add_TXTMulti_3 (0.67s)                                                                              
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/14:TXTMulti:Change_TXTMultii-0 (0.88s)                                                                          
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/14:TXTMulti:Change_TXTMulti-1[0] (0.48s)                                                                        
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/14:TXTMulti:Change_TXTMulti-1[1] (0.50s)                                                                        
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/Post_cleanup:Empty#14 (0.72s)                                                                                   
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/15:TXTMulti-same:Create_TXTMulti_1 (0.69s)                                                                      
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/15:TXTMulti-same:Add_TXTMulti_2 (0.71s)                                                                         
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/15:TXTMulti-same:Add_TXTMulti_3 (0.72s)                                                                         
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/15:TXTMulti-same:Change_TXTMultii-0 (0.87s)                                                                     
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/15:TXTMulti-same:Change_TXTMulti-1[0] (0.51s)                                                                   
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/15:TXTMulti-same:Change_TXTMulti-1[1] (0.50s)                                                                   
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/Post_cleanup:Empty#15 (0.71s)                                                                                   
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/16:TypeChange:Create_a_CNAME (0.73s)                                                                            
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/16:TypeChange:Change_to_A_record (0.92s)                                                                        
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/16:TypeChange:Change_back_to_CNAME (0.93s)                                                                      
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/Post_cleanup:Empty#16 (0.33s)                                                                                   
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/17:Case_Sensitivity:Create_CAPS (0.70s)                                                                         
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/17:Case_Sensitivity:Downcase_label (0.70s)                                                                      
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/17:Case_Sensitivity:Downcase_target (0.50s)                                                                     
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/17:Case_Sensitivity:Upcase_both (0.51s)                                                                         
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/Post_cleanup:Empty#17 (0.54s)                                                                                   
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/18:IDNA:Internationalized_name (0.69s)                                                                          
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/18:IDNA:Change_IDN (0.51s)                                                                                      
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/18:IDNA:Internationalized_CNAME_Target (0.91s)                                                                  
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/Post_cleanup:Empty#18 (0.33s)                                                                                   
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/19:IDNAs_in_CNAME_targets_***SKIPPED(excluded_by_not("LINODE"))***:Empty (0.15s)                                
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/20:pager101:99_records (40.00s)                                                                                 
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/20:pager101:100_records (0.72s)                                                                                 
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/20:pager101:101_records (0.87s)                                                                                 
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/Post_cleanup:Empty#19 (19.77s)                                                                                  
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/21:pager601_***SKIPPED(disabled_by_only)***:Empty (0.16s)                                                       
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/22:pager1201_***SKIPPED(disabled_by_only)***:Empty (0.15s)                                                      
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/23:CAA:CAA_record (0.69s)                                                                                       
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/23:CAA:CAA_change_tag (0.51s)                                                                                   
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/23:CAA:CAA_change_target (0.48s)                                                                                
        --- FAIL: TestDNSProviders/dnscontroltest-linode.com/23:CAA:CAA_change_flag (0.51s)                                                                                  
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/Post_cleanup:Empty#20 (0.33s)                                                                                   
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/24:CAA_with_;:CAA_many_records (0.72s)                                                                          
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/Post_cleanup:Empty#21 (0.33s)                                                                                   
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/25:Issue_1374:CAA_spaces (0.69s)                                                                                
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/Post_cleanup:Empty#22 (0.34s)                                                                                   
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/26:NAPTR_***SKIPPED(CanUseNAPTR_not_supported)***:Empty (0.15s)                                                 
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/27:PTR_***SKIPPED(CanUsePTR_not_supported)***:Empty (0.15s)                                                     
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/28:SOA_***SKIPPED(CanUseSOA_not_supported)***:Empty (0.15s)                                                     
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/29:SRV_***SKIPPED(CanUseSRV_not_supported)***:Empty (0.14s)                                                     
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/30:SRV_w/_null_target_***SKIPPED(CanUseSRV_not_supported)***:Empty (0.16s)                                      
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/31:SSHFP_***SKIPPED(CanUseSSHFP_not_supported)***:Empty (0.15s)                                                 
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/32:TLSA_***SKIPPED(CanUseTLSA_not_supported)***:Empty (0.15s)                                                   
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/33:DS_***SKIPPED(CanUseDS_not_supported)***:Empty (0.14s)                                                       
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/34:DS_(children_only)_***SKIPPED(CanUseDSForChildren_not_supported)***:Empty (0.15s)                            
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/35:DS_(children_only)_CLOUDNS_***SKIPPED(CanUseDSForChildren_not_supported)***:Empty (0.15s)                    
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/36:ALIAS_***SKIPPED(CanUseAlias_not_supported)***:Empty (0.15s)                                                 
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/37:AZURE_ALIAS_***SKIPPED(CanUseAzureAlias_not_supported)***:Empty (0.15s)                                      
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/38:R53_ALIAS2_***SKIPPED(CanUseRoute53Alias_not_supported)***:Empty (0.15s)                                     
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/39:R53_ALIAS_ORDER_***SKIPPED(CanUseRoute53Alias_not_supported)***:Empty (0.16s)                                
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/40:CF_REDIRECT_***SKIPPED(disabled_by_only)***:Empty (0.15s)                                                    
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/41:CF_PROXY_***SKIPPED(disabled_by_only)***:Empty (0.15s)                                                       
        --- PASS: TestDNSProviders/dnscontroltest-linode.com/42:CF_WORKER_ROUTE_***SKIPPED(disabled_by_only)***:Empty (0.15s)                                                
=== RUN   TestDualProviders                                                                                                                                                  
    integration_test.go:312: Skipping.  DocDualHost == Cannot                                                                                                                
--- SKIP: TestDualProviders (0.15s)                                                                                                                                          
FAIL                                                                                                                                                                         
exit status 1                                                                                                                                                                
FAIL    github.com/StackExchange/dnscontrol/v3/integrationTest  150.924s                                                                                                     
```

</details>