### PR TITLE
CLOUDNS: Fix creation of intra-zone NS records

### DIFF
--- a/providers/cloudns/cloudnsProvider.go
+++ b/providers/cloudns/cloudnsProvider.go
@@ -138,6 +138,12 @@ func (c *cloudnsProvider) GetDomainCorrections(dc *models.DomainConfig) ([]*mode
 			return nil, err
 		}
 
+		// ClouDNS does not require the trailing period to be specified when creating an NS record where the A or AAAA record exists in the zone.
+		// So, modify it to remove the trailing period.
+		if req["record-type"] == "NS" && strings.HasSuffix(req["record"], domainID+".") {
+			req["record"] = strings.TrimSuffix(req["record"], ".")
+		}
+
 		corr := &models.Correction{
 			Msg: m.String(),
 			F: func() error {


### PR DESCRIPTION
Let me start by saying thanks for this awesome project - it's exactly what I've been looking for to manage a larger amount of ClouDNS zones with templating support, which I would have almost started implementing myself at a smaller scale if I didn't happen to stumble across DNSControl.

When setting up new ClouDNS zones I've noticed that the error mentioned in issue #1263 occurs due to the API limitation of not supporting a trailing dot for NS records which point to a host within the same zone. The previously merged PR #1303 introduced a fix, but the workaround was only added for modify corrections.

This PR introduces the same workaround when creating new NS records and should therefor fully fix issue #1263. I tested these changes myself and was able to confirm that both create and modify corrections now succeed for this given scenario.