### PR TITLE
Fix autodns documentation

### DIFF
--- a/docs/_providers/autodns.md
+++ b/docs/_providers/autodns.md
@@ -27,7 +27,7 @@ Example Javascript:
 
 {% highlight js %}
 var REG_NONE = NewRegistrar('none', 'NONE');
-var HETZNER = NewDnsProvider("autodns", "AUTODNS");
+var AUTODNS = NewDnsProvider("autodns", "AUTODNS");
 
 D("example.tld", REG_NONE, DnsProvider(AUTODNS),
     A("test","1.2.3.4")


### PR DESCRIPTION
Fix autodns documentation example javascript.
The provider name was "HETZNER" instead of "AUTODNS".