### PR TITLE
Make repeated domain name error message easier to understand

### DIFF
--- a/pkg/js/helpers.js
+++ b/pkg/js/helpers.js
@@ -1185,3 +1185,18 @@ function DOMAIN_ELSEWHERE_AUTO(domain, registrar, dsplist) {
         D_EXTEND(domain, DnsProvider(arguments[i]));
     }
 }
+
+var END = {}; // This is null. It permits the last item to include a comma.
+// D("foo.com", ...
+//    A(...),
+//    A(...),
+//    A(...),
+// END)
+
+// Record modifiers:
+
+// Permit labels like "foo.bar.com.bar.com" (normally an error):
+var DISABLE_REPEATED_DOMAIN_CHECK = { skip_fqdn_check: "true" };
+// D("bar.com", ...
+//     A("foo.bar.com", "10.1.1.1", DISABLE_REPEATED_DOMAIN_CHECK),
+// )

--- a/pkg/normalize/validate.go
+++ b/pkg/normalize/validate.go
@@ -89,6 +89,16 @@ func validateRecordTypes(rec *models.RecordConfig, domain string, pTypes []strin
 	return nil
 }
 
+func errorRepeat(label, domain string) string {
+	shortname := strings.TrimSuffix(label, "."+domain)
+	return fmt.Sprintf(
+		`The name "%s.%s." is an error (repeats the domain). Maybe instead of "%s" you intended "%s"? If not add DISABLE_REPEATED_DOMAIN_CHECK to this record to permit this as-is.`,
+		label, domain,
+		label,
+		shortname,
+	)
+}
+
 func checkLabel(label string, rType string, target, domain string, meta map[string]string) error {
 	if label == "@" {
 		return nil
@@ -101,7 +111,7 @@ func checkLabel(label string, rType string, target, domain string, meta map[stri
 	}
 	if label == domain || strings.HasSuffix(label, "."+domain) {
 		if m := meta["skip_fqdn_check"]; m != "true" {
-			return fmt.Errorf(`label %q ends with domain name %q. Record names should not be fully qualified. Add {skip_fqdn_check:"true"} to this record if you really want to make %s.%s`, label, domain, label, domain)
+			return fmt.Errorf(errorRepeat(label, domain))
 		}
 	}
 

--- a/pkg/normalize/validate_test.go
+++ b/pkg/normalize/validate_test.go
@@ -1,9 +1,8 @@
 package normalize
 
 import (
-	"testing"
-
 	"fmt"
+	"testing"
 
 	"github.com/StackExchange/dnscontrol/v3/models"
 	"github.com/StackExchange/dnscontrol/v3/providers"
@@ -431,4 +430,31 @@ func Test_DSChecks(t *testing.T) {
 			}
 		})
 	})
+}
+
+func Test_errorRepeat(t *testing.T) {
+	type args struct {
+		label  string
+		domain string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "1",
+			args: args{label: "foo.bar.com", domain: "bar.com"},
+			want: `The name "foo.bar.com.bar.com." is an error (repeats the domain).` +
+				` Maybe instead of "foo.bar.com" you intended "foo"?` +
+				` If not add DISABLE_REPEATED_DOMAIN_CHECK to this record to permit this as-is.`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := errorRepeat(tt.args.label, tt.args.domain); got != tt.want {
+				t.Errorf("errorRepeat() = \n'%s', want\n'%s'", got, tt.want)
+			}
+		})
+	}
 }


### PR DESCRIPTION
Fixes https://github.com/StackExchange/dnscontrol/issues/1476

New error message looks like:
