### PR TITLE
Add calling an executable for credentials

### DIFF
--- a/pkg/credsfile/providerConfig.go
+++ b/pkg/credsfile/providerConfig.go
@@ -57,6 +57,11 @@ func LoadProviderConfigs(fname string) (map[string]map[string]string, error) {
 		if err != nil {
 			return nil, err
 		}
+	} else if strings.HasPrefix(fname, "@") {
+		dat, err = executeCredsCommand(strings.TrimPrefix(fname, "@"))
+		if err != nil {
+			return nil, err
+		}
 	} else {
 		// no executable bit found nor marked as executable so read it in
 		dat, err = readCredsFile(fname)
@@ -108,6 +113,13 @@ func readCredsFile(filename string) ([]byte, error) {
 		return nil, fmt.Errorf("failed reading provider credentials file %v: %v", filename, err)
 	}
 	return dat, nil
+}
+
+func executeCredsCommand(filename string) ([]byte, error) {
+	cmd := strings.Fields(filename)
+	args := cmd[1:]
+	out, err := exec.Command(cmd[0], args...).Output()
+	return out, err
 }
 
 func executeCredsFile(filename string) ([]byte, error) {


### PR DESCRIPTION
Certain password managers include a CLI that allows for injecting credentials into a template file. Using `!` works for a single shell script, but doesn't work so well for calling a program, considering it explicitly ignores items in the path. This allows for tools like 1Password CLI to be used to inject the secrets into the json, without ever needing to write the credentials to disk.

As a note, I didn't write any tests for this (simply because I don't really know Go 😅), so while I've tested it with intentional correct input on both macOS and Windows (successfully on both), it may fail spectacularly if bad input is entered.

`dnscontrol preview --creds="@op inject -i creds.json.tpl"` will result in `op` injecting the credentials into the templated file, outputting it via stdout, and `dnscontrol` working as expected. 