### PR TITLE
Add calling an executable for credentials.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -60,6 +60,8 @@ require (
 	gopkg.in/yaml.v2 v2.4.0
 )
 
+require github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
+
 require (
 	cloud.google.com/go/compute v1.6.1 // indirect
 	github.com/Azure/go-autorest v14.2.0+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -320,6 +320,8 @@ github.com/google/pprof v0.0.0-20210601050228-01bbb1931b22/go.mod h1:kpwsk12EmLe
 github.com/google/pprof v0.0.0-20210609004039-a478d1d731e9/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
+github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
+github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.2 h1:EVhdT+1Kseyi1/pUmXKaFxYsDNy9RQYkMWRH68J/W7Y=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=

--- a/pkg/credsfile/providerConfig.go
+++ b/pkg/credsfile/providerConfig.go
@@ -57,6 +57,11 @@ func LoadProviderConfigs(fname string) (map[string]map[string]string, error) {
 		if err != nil {
 			return nil, err
 		}
+	} else if strings.HasPrefix(fname, "@") {
+		dat, err = executeCredsCommand(strings.TrimPrefix(fname, "@"))
+		if err != nil {
+			return nil, err
+		}
 	} else {
 		// no executable bit found nor marked as executable so read it in
 		dat, err = readCredsFile(fname)
@@ -108,6 +113,13 @@ func readCredsFile(filename string) ([]byte, error) {
 		return nil, fmt.Errorf("failed reading provider credentials file %v: %v", filename, err)
 	}
 	return dat, nil
+}
+
+func executeCredsCommand(filename string) ([]byte, error) {
+	cmd := strings.Fields(filename)
+	args := cmd[1:]
+	out, err := exec.Command(cmd[0], args...).Output()
+	return out, err
 }
 
 func executeCredsFile(filename string) ([]byte, error) {

--- a/pkg/credsfile/providerConfig.go
+++ b/pkg/credsfile/providerConfig.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/DisposaBoy/JsonConfigReader"
 	"github.com/TomOnTime/utfutil"
+	"github.com/google/shlex"
 )
 
 func quotedList(l []string) string {
@@ -116,10 +117,14 @@ func readCredsFile(filename string) ([]byte, error) {
 }
 
 func executeCredsCommand(filename string) ([]byte, error) {
-	cmd := strings.Fields(filename)
+	cmd, err := shlex.Split(filename)
+	if err != nil {
+		fmt.Printf("INFO: failed parsing executable path")
+	}
 	args := cmd[1:]
 	out, err := exec.Command(cmd[0], args...).Output()
 	return out, err
+
 }
 
 func executeCredsFile(filename string) ([]byte, error) {


### PR DESCRIPTION
Certain password managers include a CLI that allows for injecting credentials into a template file. Using `!` works for a single shell script, but doesn't work so well for calling a program, considering it explicitly ignores items in the path. This allows for tools like 1Password CLI to be used to inject the secrets into the json, without ever needing to write the credentials to disk.

As a note, I didn't write any tests for this (simply because I don't really know Go 😅), so while I've tested it with intentional correct input on both macOS and Windows (successfully on both), it may fail spectacularly if bad input is entered.

`dnscontrol preview --creds="@op inject -i creds.json.tpl"` will result in op injecting the credentials into the templated file, outputting it via stdout, and dnscontrol working as expected.