### PR TITLE
docker: Add CA certificates to Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,7 @@
+FROM alpine as alpine
+RUN apk add -U --no-cache ca-certificates
+
 FROM scratch
+COPY --from=alpine /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 ENTRYPOINT ["/dnscontrol"]
 COPY dnscontrol /


### PR DESCRIPTION
This change makes sure dnscontrol can connect to the providers over https when the Docker image is used.