### PR TITLE
Create non-existing zones while push or print warning while preview

### DIFF
--- a/commands/previewPush.go
+++ b/commands/previewPush.go
@@ -469,9 +469,6 @@ func printOrRunCorrections(domain string, provider string, corrections []*models
 	if len(corrections) == 0 {
 		return false
 	}
-	for i := 0; i < len(corrections); i += 900 {
-
-	}
 	for i, correction := range corrections {
 		out.PrintCorrection(i, correction)
 		var err error

--- a/commands/previewPush.go
+++ b/commands/previewPush.go
@@ -36,9 +36,9 @@ type PreviewArgs struct {
 	GetDNSConfigArgs
 	GetCredentialsArgs
 	FilterArgs
-	Notify          bool
-	WarnChanges     bool
-	CreateWhilePush bool
+	Notify             bool
+	WarnChanges        bool
+	PopulateAtProvider bool
 }
 
 func (args *PreviewArgs) flags() []cli.Flag {
@@ -56,9 +56,9 @@ func (args *PreviewArgs) flags() []cli.Flag {
 		Usage:       `set to true for non-zero return code if there are changes`,
 	})
 	flags = append(flags, &cli.BoolFlag{
-		Name:        "create-while-push",
-		Destination: &args.CreateWhilePush,
-		Usage:       `set to true to create non-existing zones on provider`,
+		Name:        "populate-at-provider",
+		Destination: &args.PopulateAtProvider,
+		Usage:       `set to true to create non-existing zones at provider`,
 	})
 	return flags
 }
@@ -137,7 +137,7 @@ DomainLoop:
 		nameservers.AddNSRecords(domain)
 		for _, provider := range domain.DNSProviderInstances {
 
-			if args.CreateWhilePush {
+			if args.PopulateAtProvider {
 				// preview run: check if zone is already there, if not print a warning
 				if lister, ok := provider.Driver.(providers.ZoneLister); ok && !push {
 					zones, err := lister.ListZones()

--- a/commands/previewPush.go
+++ b/commands/previewPush.go
@@ -58,7 +58,7 @@ func (args *PreviewArgs) flags() []cli.Flag {
 	flags = append(flags, &cli.BoolFlag{
 		Name:        "populate-at-provider",
 		Destination: &args.PopulateAtProvider,
-		Usage:       `set to true to create non-existing zones at provider`,
+		Usage:       `Use this flag to create non-existing zones at the provider`,
 	})
 	return flags
 }

--- a/go.mod
+++ b/go.mod
@@ -60,7 +60,10 @@ require (
 	gopkg.in/yaml.v2 v2.4.0
 )
 
-require github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
+require (
+	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
+	golang.org/x/exp v0.0.0-20220602145555-4a0574d9293f
+)
 
 require (
 	cloud.google.com/go/compute v1.6.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -664,6 +664,8 @@ golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
+golang.org/x/exp v0.0.0-20220602145555-4a0574d9293f h1:KK6mxegmt5hGJRcAnEDjSNLxIRhZxDcgwMbcO/lMCRM=
+golang.org/x/exp v0.0.0-20220602145555-4a0574d9293f/go.mod h1:yh0Ynu2b5ZUe3MQfp2nM0ecK7wsgouWTDN0FNeJuIys=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/providers/powerdns/powerdnsProvider.go
+++ b/providers/powerdns/powerdnsProvider.go
@@ -113,7 +113,7 @@ func (api *powerdnsProvider) ListZones() ([]string, error) {
 		return result, err
 	}
 	for _, zone := range myZones {
-		result = append(result, zone.Name)
+		result = append(result, strings.TrimSuffix(zone.Name, "."))
 	}
 	return result, nil
 }


### PR DESCRIPTION
Proposal which fixes https://github.com/StackExchange/dnscontrol/issues/1369.

It checks with `ListZones()`during preview if the zone already exists, if not, a warning is issued. During push it is ensured that the domain exists. But I'm not quite happy with the flag name, do you have a suggestion?