### PR TITLE
Add deprecation notice to create-domains command

### DIFF
--- a/commands/createDomains.go
+++ b/commands/createDomains.go
@@ -2,21 +2,26 @@ package commands
 
 import (
 	"fmt"
+	"github.com/urfave/cli/v2"
 
 	"github.com/StackExchange/dnscontrol/v3/pkg/credsfile"
 	"github.com/StackExchange/dnscontrol/v3/providers"
-	"github.com/urfave/cli/v2"
 )
 
 var _ = cmd(catUtils, func() *cli.Command {
 	var args CreateDomainsArgs
 	return &cli.Command{
 		Name:  "create-domains",
-		Usage: "Ensures that all domains in your configuration are activated at their Domain Service Provider (This does not purchase the domain or otherwise interact with Registrars.)",
+		Usage: "DEPRECATED: Ensures that all domains in your configuration are activated at their Domain Service Provider (This does not purchase the domain or otherwise interact with Registrars.)",
 		Action: func(ctx *cli.Context) error {
 			return exit(CreateDomains(args))
 		},
 		Flags: args.flags(),
+		Before: func(context *cli.Context) error {
+			fmt.Println("DEPRECATED: This command is deprecated. The domain is automatically created at the Domain Service Provider during the push command.")
+			fmt.Println("DEPRECATED: To prevent disable auto-creating, use --no-populate with the push command.")
+			return nil
+		},
 	}
 }())
 


### PR DESCRIPTION
As we now auto-populate (#1528) domains at the DSP with the `push` command, this PR adds a deprecation notice when running the `create-domains` command.