### PR TITLE
FIX: Preventing segfault when Cloudflare API limit is reached

### DIFF
--- a/providers/cloudflare/rest.go
+++ b/providers/cloudflare/rest.go
@@ -150,9 +150,12 @@ func (c *cloudflareProvider) createRec(rec *models.RecordConfig, domainID string
 			} else if rec.Type == "DS" {
 				cf.Data = cfDSData(rec)
 			}
-			resp, err := c.cfClient.CreateDNSRecord(context.Background(), domainID, cf)
-			id = resp.Result.ID
-			return err
+			if resp, err := c.cfClient.CreateDNSRecord(context.Background(), domainID, cf); err != nil {
+				return err
+			} else {
+				id = resp.Result.ID
+				return nil
+			}
 		},
 	}}
 	if rec.Metadata[metaProxy] != "off" {

--- a/providers/cloudflare/rest.go
+++ b/providers/cloudflare/rest.go
@@ -153,6 +153,7 @@ func (c *cloudflareProvider) createRec(rec *models.RecordConfig, domainID string
 			if resp, err := c.cfClient.CreateDNSRecord(context.Background(), domainID, cf); err != nil {
 				return err
 			} else {
+				// Updating id (from the outer scope) by side-effect, required for updating proxy mode
 				id = resp.Result.ID
 				return nil
 			}


### PR DESCRIPTION
This PR prevents segfaults when the Cloudflare API limit (1.2k req per 5mins) is reached and should be handled correctly. 

This PR partially fix #1440, DNSControl will no longer panic and provide a meaningful error message to the user.