### PR TITLE
MAINT: Enforcing formatted code

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ jobs:
 
       - run:
           name: Enforce Go Formatted Code
-          command: "[ `go fmt ./... 2>&1 | wc -l` -eq 0 ]"
+          command: "[ `go fmt ./... | wc -l` -eq 0 ]"
 
       - restore_cache: # restores saved cache if no changes are detected since last run
           keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,13 +23,13 @@ jobs:
     steps:
       - checkout
 
-      - run:
-          name: Enforce Go Formatted Code
-          command: "[ `go fmt ./... | wc -l` -eq 0 ]"
-
       - restore_cache: # restores saved cache if no changes are detected since last run
           keys:
             - linux-go-{{ checksum "go.sum" }}-<< pipeline.parameters.cache-key >>
+
+      - run:
+          name: Enforce Go Formatted Code
+          command: "[ `go fmt ./... 2>&1 | wc -l` -eq 0 ]"
 
       - run:
           name: Install goreleaser

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,10 @@ jobs:
     steps:
       - checkout
 
+      - run:
+          name: Enforce Go Formatted Code
+          command: "[ `go fmt ./... 2>&1 | wc -l` -eq 0 ]"
+
       - restore_cache: # restores saved cache if no changes are detected since last run
           keys:
             - linux-go-{{ checksum "go.sum" }}-<< pipeline.parameters.cache-key >>

--- a/pkg/normalize/validate_test.go
+++ b/pkg/normalize/validate_test.go
@@ -334,8 +334,8 @@ func TestCheckDuplicates_dup_ns(t *testing.T) {
 }
 
 func TestUniq(t *testing.T) {
-	a := []uint32 {1, 2, 2, 3, 4, 5, 5, 6}
-	expected := []uint32 {1, 2, 3, 4, 5, 6}
+	a := []uint32{1, 2, 2, 3, 4, 5, 5, 6}
+	expected := []uint32{1, 2, 3, 4, 5, 6}
 
 	r := uniq(a)
 	if !reflect.DeepEqual(r, expected) {

--- a/providers/autodns/api.go
+++ b/providers/autodns/api.go
@@ -13,11 +13,11 @@ import (
 )
 
 type ZoneListFilter struct {
-	Key string `json:"key"`
-	Value string `json:"value"`
-	Operator string `json:"operator"`
-	Link string `json:"link,omitempty"`
-	Filter []*ZoneListFilter `json:"filters,omitempty"`
+	Key      string            `json:"key"`
+	Value    string            `json:"value"`
+	Operator string            `json:"operator"`
+	Link     string            `json:"link,omitempty"`
+	Filter   []*ZoneListFilter `json:"filters,omitempty"`
 }
 
 type ZoneListRequest struct {
@@ -31,7 +31,7 @@ func (api *autoDnsProvider) request(method string, requestPath string, data inte
 	requestUrl.Path = api.baseURL.Path + requestPath
 
 	request := &http.Request{
-		URL: &requestUrl,
+		URL:    &requestUrl,
 		Header: api.defaultHeaders,
 		Method: method,
 	}
@@ -88,7 +88,7 @@ func (api *autoDnsProvider) getZone(domain string) (*Zone, error) {
 	}
 
 	// if resolving of a systemNameServer succeeds the system contains this zone
-	var responseData, _ = api.request("GET", "zone/" + domain + "/" + systemNameServer.Name, nil)
+	var responseData, _ = api.request("GET", "zone/"+domain+"/"+systemNameServer.Name, nil)
 	var responseObject JSONResponseDataZone
 	// make sure that the response is valid, the zone is in AutoDNS but we're not sure the returned data meets our expectation
 	unmErr := json.Unmarshal(responseData, &responseObject)
@@ -128,7 +128,7 @@ func (api *autoDnsProvider) updateZone(domain string, resourceRecords []*Resourc
 
 	zone.NameServers = append(zone.NameServers, nameServers...)
 
-	var _, putErr = api.request("PUT", "zone/" + domain + "/" + systemNameServer.Name, zone)
+	var _, putErr = api.request("PUT", "zone/"+domain+"/"+systemNameServer.Name, zone)
 
 	if putErr != nil {
 		return putErr

--- a/providers/autodns/autoDnsProvider.go
+++ b/providers/autodns/autoDnsProvider.go
@@ -30,8 +30,8 @@ var features = providers.DocumentationNotes{
 }
 
 type autoDnsProvider struct {
-	baseURL          url.URL
-	defaultHeaders   http.Header
+	baseURL        url.URL
+	defaultHeaders http.Header
 }
 
 func init() {
@@ -47,18 +47,18 @@ func New(settings map[string]string, _ json.RawMessage) (providers.DNSServicePro
 	api := &autoDnsProvider{}
 
 	api.baseURL = url.URL{
-		Scheme:      "https",
-		User:        url.UserPassword(
+		Scheme: "https",
+		User: url.UserPassword(
 			settings["username"],
 			settings["password"],
-			),
-		Host:        "api.autodns.com",
-		Path:        "/v1/",
+		),
+		Host: "api.autodns.com",
+		Path: "/v1/",
 	}
 
 	api.defaultHeaders = http.Header{
-		"Accept": []string{"application/json; charset=UTF-8"},
-		"Content-Type": []string{"application/json; charset=UTF-8"},
+		"Accept":                []string{"application/json; charset=UTF-8"},
+		"Content-Type":          []string{"application/json; charset=UTF-8"},
 		"X-Domainrobot-Context": []string{settings["context"]},
 	}
 
@@ -138,8 +138,8 @@ func (api *autoDnsProvider) GetDomainCorrections(dc *models.DomainConfig) ([]*mo
 						} else {
 							resourceRecord := &ResourceRecord{
 								Name:  record.Name,
-								TTL: int64(record.TTL),
-								Type: record.Type,
+								TTL:   int64(record.TTL),
+								Type:  record.Type,
 								Value: record.GetTargetField(),
 							}
 
@@ -212,7 +212,7 @@ func (api *autoDnsProvider) GetZoneRecords(domain string) (models.Records, error
 		nameServerRecord.SetLabel("", domain)
 
 		// make sure the value for this NS record is suffixed with a dot at the end
-		_ = nameServerRecord.PopulateFromString("NS", strings.TrimSuffix(nameServer.Name, ".") + ".", domain)
+		_ = nameServerRecord.PopulateFromString("NS", strings.TrimSuffix(nameServer.Name, ".")+".", domain)
 
 		existingRecords = append(existingRecords, nameServerRecord)
 	}

--- a/providers/autodns/types.go
+++ b/providers/autodns/types.go
@@ -39,10 +39,9 @@ type MainAddressRecord struct {
 }
 
 type Zone struct {
-
 	Origin string `json:"origin"`
 
-	Soa * bind.SoaDefaults `json:"soa,omitempty"`
+	Soa *bind.SoaDefaults `json:"soa,omitempty"`
 
 	// List of name servers
 	NameServers []*models.Nameserver `json:"nameServers,omitempty"`

--- a/providers/ns1/ns1Provider.go
+++ b/providers/ns1/ns1Provider.go
@@ -19,10 +19,10 @@ import (
 var docNotes = providers.DocumentationNotes{
 	providers.CanGetZones:            providers.Can(),
 	providers.CanUseAlias:            providers.Can(),
-	providers.CanAutoDNSSEC:	  providers.Can(),
+	providers.CanAutoDNSSEC:          providers.Can(),
 	providers.CanUseCAA:              providers.Can(),
-	providers.CanUseDS:		  providers.Can(),
-	providers.CanUseDSForChildren:	  providers.Can(),
+	providers.CanUseDS:               providers.Can(),
+	providers.CanUseDSForChildren:    providers.Can(),
 	providers.CanUseNAPTR:            providers.Can(),
 	providers.CanUsePTR:              providers.Can(),
 	providers.DocCreateDomains:       providers.Can(),
@@ -113,7 +113,7 @@ func (n *nsone) GetZoneDNSSEC(domain string) (bool, error) {
 }
 
 // getDomainCorrectionsDNSSEC creates DNSSEC zone corrections based on current state and preference
-func (n *nsone) getDomainCorrectionsDNSSEC(domain, toggleDNSSEC string) (*models.Correction) {
+func (n *nsone) getDomainCorrectionsDNSSEC(domain, toggleDNSSEC string) *models.Correction {
 
 	// get dnssec status from NS1 for domain
 	// if errors are returned, we bail out without any DNSSEC corrections
@@ -164,7 +164,7 @@ func (n *nsone) GetDomainCorrections(dc *models.DomainConfig) ([]*models.Correct
 
 	corrections := []*models.Correction{}
 
-        if dnssecCorrections := n.getDomainCorrectionsDNSSEC(domain, dc.AutoDNSSEC); dnssecCorrections != nil {
+	if dnssecCorrections := n.getDomainCorrectionsDNSSEC(domain, dc.AutoDNSSEC); dnssecCorrections != nil {
 		corrections = append(corrections, dnssecCorrections)
 	}
 


### PR DESCRIPTION
I would like to suggest that the code must be formatted with `go fmt ./...`, which is checked and enforced by CircleCI.
This results in consistent formatting and has proven to work well in our company.