### PR TITLE
FIX: Run go fmt after build, so deps are there

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,10 +28,6 @@ jobs:
             - linux-go-{{ checksum "go.sum" }}-<< pipeline.parameters.cache-key >>
 
       - run:
-          name: Enforce Go Formatted Code
-          command: "[ `go fmt ./... 2>&1 | wc -l` -eq 0 ]"
-
-      - run:
           name: Install goreleaser
           command: go install github.com/goreleaser/goreleaser@latest
 
@@ -49,6 +45,10 @@ jobs:
       - run:
           name: Build binaries
           command: goreleaser build --snapshot
+
+      - run:
+          name: Enforce Go Formatted Code
+          command: "[ `go fmt ./... | wc -l` -eq 0 ]"
 
       - save_cache: # restores saved cache if no changes are detected since last run
           key: linux-go-{{ checksum "go.sum" }}-<< pipeline.parameters.cache-key >>


### PR DESCRIPTION
In #1556, the CI started with an empty dependency cache, which caused `go fmt` to fail because it fetched the deps first which causes log lines.

This PR change makes the gofmt check run after the build. 