### PR TITLE
HETZNER: do not support spaces in CAA records

### DIFF
--- a/docs/_providers/hetzner.md
+++ b/docs/_providers/hetzner.md
@@ -48,6 +48,19 @@ Create a new API Key in the
 
 ## Caveats
 
+### CAA
+
+As of June 2022, the Hetzner DNS Console API does not accept spaces in CAA
+ records.
+```
+0 issue "letsencrypt.org; validationmethods=dns-01; accounturi=https://acme-v02.api.letsencrypt.org/acme/acct/1234"
+```
+
+Removing the spaces might still work for any consumer of the record.
+```
+0 issue "letsencrypt.org;validationmethods=dns-01;accounturi=https://acme-v02.api.letsencrypt.org/acme/acct/1234"
+```
+
 ### SOA
 
 Hetzner DNS Console does not allow changing the SOA record via their API.

--- a/integrationTest/integration_test.go
+++ b/integrationTest/integration_test.go
@@ -1107,7 +1107,7 @@ func makeTests(t *testing.T) []*TestGroup {
 			tc("CAA many records", caa("@", "issuewild", 0, ";")),
 		),
 		testgroup("CAA Issue 1374",
-			requires(providers.CanUseCAA), not("DIGITALOCEAN"),
+			requires(providers.CanUseCAA), not("DIGITALOCEAN", "HETZNER"),
 			// Test support of spaces in the 3rd field.
 			tc("CAA spaces", caa("@", "issue", 0, "letsencrypt.org; validationmethods=dns-01; accounturi=https://acme-v02.api.letsencrypt.org/acme/acct/1234")),
 		),


### PR DESCRIPTION
As of 2022-06-23, the Hetzner DNS API is still responding with a 422
 when a CAA record contains a quoted value with spaces.
```
format: number of fields does not match record type, expecting 3
```
Their support acknowledged my bug report a few weeks back and suggested
 the removal of spaces to get past the limitation.
Spaces in CAA records are not common. Let's just skip the test and put
 a notice in the docs.

Signed-off-by: Jakob Ackermann <das7pad@outlook.com>