### PR TITLE
HETZNER: catch up with handling of TXT records

### DIFF
--- a/providers/hetzner/hetznerProvider.go
+++ b/providers/hetzner/hetznerProvider.go
@@ -183,7 +183,10 @@ func (api *hetznerProvider) GetZoneRecords(domain string) (models.Records, error
 	}
 	existingRecords := make([]*models.RecordConfig, len(records))
 	for i := range records {
-		existingRecords[i] = toRecordConfig(domain, &records[i])
+		existingRecords[i], err = toRecordConfig(domain, &records[i])
+		if err != nil {
+			return nil, err
+		}
 	}
 	return existingRecords, nil
 }


### PR DESCRIPTION
This PR Is updating the handling of TXT/SPF records for https://github.com/StackExchange/dnscontrol/issues/1568.

Together with https://github.com/StackExchange/dnscontrol/pull/1577 the integration tests are passing for the HETZNER provider.

Signed-off-by: Jakob Ackermann <das7pad@outlook.com>