### PR TITLE
Fix handling of TXT for the OVH provider

### DIFF
--- a/docs/_providers/ovh.md
+++ b/docs/_providers/ovh.md
@@ -136,3 +136,7 @@ OVH now allows to host DNS zone for a domain that is not registered in their reg
 OVH doesn't allow resetting the zone to the OVH DNS through the API. If for any reasons OVH NS entries were
 removed the only way to add them back is by using the OVH Control Panel (in the DNS Servers tab, click on the "Reset the
 DNS servers" button.
+
+## Limitations
+
+* OVH doesn't support multiple TXT target for a given record name, but it supports arbitrary long target.

--- a/providers/ovh/auditrecords.go
+++ b/providers/ovh/auditrecords.go
@@ -2,10 +2,14 @@ package ovh
 
 import (
 	"github.com/StackExchange/dnscontrol/v3/models"
+	"github.com/StackExchange/dnscontrol/v3/pkg/recordaudit"
 )
 
 // AuditRecords returns an error if any records are not
 // supportable by this provider.
 func AuditRecords(records []*models.RecordConfig) error {
+	if err := recordaudit.TxtNoMultipleStrings(records); err != nil {
+		return err
+	}
 	return nil
 }

--- a/providers/ovh/ovhProvider.go
+++ b/providers/ovh/ovhProvider.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/StackExchange/dnscontrol/v3/models"
+	"github.com/StackExchange/dnscontrol/v3/pkg/decode"
 	"github.com/StackExchange/dnscontrol/v3/pkg/diff"
 	"github.com/StackExchange/dnscontrol/v3/providers"
 	"github.com/ovh/go-ovh/ovh"
@@ -190,7 +191,15 @@ func nativeToRecord(r *Record, origin string) (*models.RecordConfig, error) {
 	}
 
 	rec.SetLabel(r.SubDomain, origin)
-	if err := rec.PopulateFromString(rtype, r.Target, origin); err != nil {
+
+	var err error
+	switch r.FieldType {
+	case "TXT":
+		err = rec.SetTargetTXT(decode.StripQuotes(r.Target))
+	default:
+		err = rec.PopulateFromString(rtype, r.Target, origin)
+	}
+	if err != nil {
 		return nil, fmt.Errorf("unparsable record received from ovh: %w", err)
 	}
 


### PR DESCRIPTION
OVH only supports arbitrary long string even though it is possible to put more than
one quoted string in a TXT target with the API.

Consequently, the best solution for OVH is to:
* quote the string before emitting to OVH
* unquote if needed when getting the string from OVH
* let dnscontrol know OVH doesn't support multiple TXT strings