### PR TITLE
DNSIMPLE: Change code owner/maintainer

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -9,7 +9,7 @@ providers/cloudns @pragmaton
 providers/cscglobal @mikenz
 providers/desec @D3luxee
 providers/digitalocean @Deraen
-providers/dnsimple @aeden
+providers/dnsimple @onlyhavecans
 providers/dnsmadeeasy @vojtad
 providers/doh @mikenz
 providers/easyname @tresni

--- a/docs/provider-list.md
+++ b/docs/provider-list.md
@@ -80,7 +80,7 @@ Providers in this category and their maintainers are:
 * `DESEC` @D3luxee
 * `DIGITALOCEAN` @Deraen
 * `DNSOVERHTTPS` @mikenz
-* `DNSIMPLE` @aeden
+* `DNSIMPLE` @onlyhavecans
 * `DNSMADEEASY` @vojtad
 * `EASYNAME` @tresni
 * `EXOSCALE` @pierre-emmanuelJ


### PR DESCRIPTION
Anthony delegates all tasks relating to our DNSControl DNSimple integration to me. It would be more efficient to set me as the code owner.

I am an employee of DNSimple and use DNSControl's DNSimple integration in my other projects as well.

CC @aeden in case he needs to sign off.