### PR TITLE
get-zones "js" format should generate better DSP variable

### DIFF
--- a/commands/getZones.go
+++ b/commands/getZones.go
@@ -209,10 +209,18 @@ func GetZone(args GetZoneArgs) error {
 
 	// Write the heading:
 
+	dspVariableName := "DSP_" + strings.ToUpper(args.CredName)
+
 	if args.OutputFormat == "js" || args.OutputFormat == "djs" {
-		fmt.Fprintf(w, `var %s = NewDnsProvider("%s", "%s");`+"\n",
-			args.CredName, args.CredName, args.ProviderName)
-		fmt.Fprintf(w, `var REG_CHANGEME = NewRegistrar("ThirdParty", "NONE");`+"\n")
+
+		if args.ProviderName == "-" {
+			fmt.Fprintf(w, `var %s = NewDnsProvider("%s");`+"\n",
+				dspVariableName, args.CredName)
+		} else {
+			fmt.Fprintf(w, `var %s = NewDnsProvider("%s", "%s");`+"\n",
+				dspVariableName, args.CredName, args.ProviderName)
+		}
+		fmt.Fprintf(w, `var REG_CHANGEME = NewRegistrar("none");`+"\n")
 	}
 
 	// print each zone
@@ -234,7 +242,7 @@ func GetZone(args GetZoneArgs) error {
 			}
 			fmt.Fprintf(w, `D("%s", REG_CHANGEME%s`, zoneName, sep)
 			var o []string
-			o = append(o, fmt.Sprintf("DnsProvider(%s)", args.CredName))
+			o = append(o, fmt.Sprintf("DnsProvider(%s)", dspVariableName))
 			defaultTTL := uint32(args.DefaultTTL)
 			if defaultTTL == 0 {
 				defaultTTL = prettyzone.MostCommonTTL(recs)

--- a/commands/test_data/example.org.zone.js
+++ b/commands/test_data/example.org.zone.js
@@ -1,7 +1,7 @@
-var bind = NewDnsProvider("bind", "BIND");
-var REG_CHANGEME = NewRegistrar("ThirdParty", "NONE");
+var DSP_BIND = NewDnsProvider("bind", "BIND");
+var REG_CHANGEME = NewRegistrar("none");
 D("example.org", REG_CHANGEME,
-	DnsProvider(bind),
+	DnsProvider(DSP_BIND),
 	DefaultTTL(7200),
 	//SOA('@', 'ns1.example.org.', 'hostmaster.example.org.', 2020030700, 7200, 3600, 864000, 7200, TTL(43200)),
 	//NAMESERVER('ns1.example.org.'),

--- a/commands/test_data/simple.com.zone.js
+++ b/commands/test_data/simple.com.zone.js
@@ -1,7 +1,7 @@
-var bind = NewDnsProvider("bind", "BIND");
-var REG_CHANGEME = NewRegistrar("ThirdParty", "NONE");
+var DSP_BIND = NewDnsProvider("bind", "BIND");
+var REG_CHANGEME = NewRegistrar("none");
 D("simple.com", REG_CHANGEME,
-	DnsProvider(bind),
+	DnsProvider(DSP_BIND),
 	//SOA('@', 'ns3.serverfault.com.', 'sysadmin.stackoverflow.com.', 2020022300, 3600, 600, 604800, 1440),
 	//NAMESERVER('ns-1313.awsdns-36.org.'),
 	//NAMESERVER('ns-736.awsdns-28.net.'),


### PR DESCRIPTION
* Adopt new single-argument `NewDnsProvider()` syntax.
* Make a `DSP_` variable that is all uppercase.

OLD:

```
$ dnscontrol get-zone --format js providercredkey - stackoverflow.co.il 
var providercredkey = NewDnsProvider("providercredkey", "-");
var REG_CHANGEME = NewRegistrar("ThirdParty", "NONE");
D("stackoverflow.co.il", REG_CHANGEME,
	DnsProvider(providercredkey),
	DefaultTTL(14400),
	A('www', '165.160.15.20'),
	...
	...
	...
	//NAMESERVER('dns1.cscdns.net.'),
	//NAMESERVER('dns2.cscdns.net.')
)
```

NEW:

```
$ dnscontrol get-zone --format js providercredkey - stackoverflow.co.il
var DSP_PROVIDERCREDKEY = NewDnsProvider("providercredkey");
var REG_CHANGEME = NewRegistrar("none");
D("stackoverflow.co.il", REG_CHANGEME,
	DnsProvider(DSP_PROVIDERCREDKEY),
	DefaultTTL(14400),
	A('www', '165.160.15.20'),
	...
	...
	...
	//NAMESERVER('dns1.cscdns.net.'),
	//NAMESERVER('dns2.cscdns.net.')
)
```