### PR TITLE
Update TransIP CanUseAlias

### DIFF
--- a/providers/transip/transipProvider.go
+++ b/providers/transip/transipProvider.go
@@ -30,7 +30,7 @@ type transipProvider struct {
 var features = providers.DocumentationNotes{
 	providers.CanAutoDNSSEC:          providers.Cannot(),
 	providers.CanGetZones:            providers.Can(),
-	providers.CanUseAlias:            providers.Cannot(),
+	providers.CanUseAlias:            providers.Can(),
 	providers.CanUseCAA:              providers.Can(),
 	providers.CanUseDS:               providers.Cannot(),
 	providers.CanUseDSForChildren:    providers.Cannot(),


### PR DESCRIPTION
You can use the ALIAS-record with TransIP since September 2021.
- https://www.transip.nl/nieuws/alias-records/