### PR TITLE
CLOUDFLARE: Fix domain list cache error

### DIFF
--- a/docs/testing-txt-records.md
+++ b/docs/testing-txt-records.md
@@ -61,7 +61,7 @@ When you do a `dnscontrol preview`, you should see changes for t1 and t2.
 ```
 
 If you don't see those changes, that's a bug.  For example, we found that
-Cloudflare leave t2 alone but would try to add double-quotes to t3!  This was
+Cloudflare left t2 alone but would try to add double-quotes to t3!  This was
 fixed in https://github.com/StackExchange/dnscontrol/pull/1543.
 
 Step 3: Push

--- a/pkg/prettyzone/prettyzone_test.go
+++ b/pkg/prettyzone/prettyzone_test.go
@@ -423,7 +423,7 @@ func TestFormatLine(t *testing.T) {
 		{[]int{2, 2, 0}, []string{"aaaaa", "b", "c"}, "aaaaa b c"},
 	}
 	for _, ts := range tests {
-		actual := formatLine(ts.lengths, ts.fields)
+		actual := FormatLine(ts.lengths, ts.fields)
 		if actual != ts.expected {
 			t.Errorf("\"%s\" != \"%s\"", actual, ts.expected)
 		}

--- a/providers/cloudflare/cloudflareProvider.go
+++ b/providers/cloudflare/cloudflareProvider.go
@@ -63,7 +63,7 @@ func init() {
 
 // cloudflareProvider is the handle for API calls.
 type cloudflareProvider struct {
-	domainIndex     map[string]string
+	domainIndex     map[string]string // Call c.fetchDomainList() to populate before use.
 	nameservers     map[string][]string
 	ipConversions   []transform.IPConversion
 	ignoredLabels   []string
@@ -708,6 +708,11 @@ func getProxyMetadata(r *models.RecordConfig) map[string]string {
 
 // EnsureDomainExists returns an error of domain does not exist.
 func (c *cloudflareProvider) EnsureDomainExists(domain string) error {
+	if c.domainIndex == nil {
+		if err := c.fetchDomainList(); err != nil {
+			return err
+		}
+	}
 	if _, ok := c.domainIndex[domain]; ok {
 		return nil
 	}

--- a/providers/cscglobal/api.go
+++ b/providers/cscglobal/api.go
@@ -490,7 +490,6 @@ func (client *providerClient) clearRequests(domain string) error {
 			printer.Printf("INFO: Deleting request status=%s id=%s\n", ze.Status, ze.ID)
 			client.cancelRequest(ze.ID)
 		case "COMPLETED", "CANCELED":
-			printer.Printf("INFO: Waiting for id=%s status=%s\n", ze.ID, ze.Status)
 			continue
 		default:
 			return fmt.Errorf("cscglobal ClearRequests: unimplemented status: %q", ze.Status)

--- a/providers/cscglobal/api.go
+++ b/providers/cscglobal/api.go
@@ -326,7 +326,7 @@ func (client *providerClient) getDomains() ([]string, error) {
 	json.Unmarshal(bodyString, &dr)
 
 	if dr.Meta.Pages > 1 {
-		return nil, fmt.Errorf("cscglobal getDomains: unimplemented  paganation")
+		return nil, fmt.Errorf("cscglobal getDomains: unimplemented paganation")
 	}
 
 	var r []string
@@ -483,7 +483,7 @@ func (client *providerClient) clearRequests(domain string) error {
 			}
 		}
 		switch ze.Status {
-		case "PROPAGATING":
+		case "NEW", "SUBMITTED", "PROCESSING", "PROPAGATING":
 			printer.Printf("INFO: Waiting for id=%s status=%s\n", ze.ID, ze.Status)
 			client.waitRequest(ze.ID)
 		case "FAILED":

--- a/providers/cscglobal/api.go
+++ b/providers/cscglobal/api.go
@@ -490,6 +490,7 @@ func (client *providerClient) clearRequests(domain string) error {
 			printer.Printf("INFO: Deleting request status=%s id=%s\n", ze.Status, ze.ID)
 			client.cancelRequest(ze.ID)
 		case "COMPLETED", "CANCELED":
+			printer.Printf("INFO: Waiting for id=%s status=%s\n", ze.ID, ze.Status)
 			continue
 		default:
 			return fmt.Errorf("cscglobal ClearRequests: unimplemented status: %q", ze.Status)


### PR DESCRIPTION
Due to a stale (empty) cache, we got a number of bugs:

In this example, the provider thinks the zone needs to be added to the account (it doesn't), and the lack of nameservers (they do exist).

```
******************** Domain: collectivesonstackoverflow.co
Added zone for collectivesonstackoverflow.co to Cloudflare account: 
WARNING: Error creating domain: collectivesonstackoverflow.co already exists (1061)
----- Registrar: cscglobal_ltom215...
WARNING: No nameservers declared; skipping registrar. Add {no_ns:'true'} to force.
```
