### PR TITLE
ns1: workaround an issue with ns1 API

### DIFF
--- a/providers/ns1/ns1Provider.go
+++ b/providers/ns1/ns1Provider.go
@@ -2,6 +2,7 @@ package ns1
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -58,6 +59,12 @@ func (n *nsone) EnsureDomainExists(domain string) error {
 
 	if err == rest.ErrZoneExists {
 		// if domain exists already, just return nil, nothing to do here.
+		return nil
+	}
+
+	newZoneExistsError := errors.New("invalid: FQDN already exists in the view")
+	if errors.As(err, &newZoneExistsError) {
+		// XXX: FIX: This is an ugly workaround for https://github.com/ns1/ns1-go/issues/163. Remove when resolved.
 		return nil
 	}
 


### PR DESCRIPTION
NS1 api returns a different message these days, which breaks error handling.

Until a fix is merged upstream, work around the issue by attempting to match the
stray error ourselves.

relates to #1667.

integration & manual tests seem to pass.