### PR TITLE
DESEC: Check authentication via domains API

### DIFF
--- a/providers/desec/protocol.go
+++ b/providers/desec/protocol.go
@@ -67,7 +67,7 @@ type nonFieldError struct {
 }
 
 func (c *desecProvider) authenticate() error {
-	endpoint := "/auth/account/"
+	endpoint := "/domains/"
 	var _, _, err = c.get(endpoint, "GET")
 	if err != nil {
 		return err

--- a/providers/desec/protocol.go
+++ b/providers/desec/protocol.go
@@ -67,8 +67,13 @@ type nonFieldError struct {
 }
 
 func (c *desecProvider) authenticate() error {
-	endpoint := "/domains/"
-	var _, _, err = c.get(endpoint, "GET")
+	endpoint := "/auth/account/"
+	var _, resp, err = c.get(endpoint, "GET")
+	//restricted tokens are valid, but get 403 on /auth/account
+	//invalid tokens get 401
+	if resp.StatusCode == 403 {
+		return nil
+	}
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Hi all!

I want to use restricted tokens to manage the RRSets of a single domain from a specific server (i.e., this server shouldn't be able to modify other domains in my account). I've noted that while I can use `curl` to modify the domain, dnscontrol failed with `authentication failure`.

According to the [official documentation](https://desec.readthedocs.io/en/latest/auth/tokens.html#token-scoping-domain-policies): "Tokens with at least one policy are considered restricted, with their scope explicitly limited to DNS record management. They can perform neither [Retrieve Account Information](https://desec.readthedocs.io/en/latest/auth/account.html#retrieve-account-information) nor [Domain Management](https://desec.readthedocs.io/en/latest/dns/domains.html#domain-management) (such as domain creation or deletion)."

Thus my change to use `/domains`, as this enables to check the validity of restricted tokens too.

I do not have a Go development environment set up, so I've only tested that with `curl --header "Authorization: Token my-restricted-token" https://desec.io/api/v1/domains` I get return code 0 and the domain list. A invalid token returns HTTP 401 and `{"detail":"Invalid token."}`

Please let me know if should setup the development environment and test dnscontrol itself.

Thanks!