### PR TITLE
CHORE: Define Release parameters

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -135,8 +135,8 @@ checksum:
   name_template: 'checksums.txt'
 snapshot:
   name_template: "{{ incpatch .Version }}-next"
-announce:
-  # Skip the announcing feature in some conditions, for instance, when publishing patch releases.
-  # Valid options are `true`, `false`, empty, or a template that evaluates to a boolean (`true` or `false`).
-  # Defaults to empty (which means false).
-  skip: true
+
+release:
+  draft: true
+  prerelease: auto
+  mode: append


### PR DESCRIPTION
Fixes #1709 

Releases are marked Draft now and if you tag with a semver suffix, you'll get a prerelease tagged Release.

![image](https://user-images.githubusercontent.com/114173/185656671-a83762d0-9aa5-4f72-955f-f6395a138bdd.png)
![image](https://user-images.githubusercontent.com/114173/185657009-fb4f45bc-3d80-4ee4-80a5-337858734a80.png)

