### PR TITLE
Exoscale provider: migration to v2 API

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/digitalocean/godo v1.83.0
 	github.com/ditashi/jsbeautifier-go v0.0.0-20141206144643-2520a8026a9c
 	github.com/dnsimple/dnsimple-go v0.71.1
-	github.com/exoscale/egoscale v0.89.0
+	github.com/exoscale/egoscale v0.90.2
 	github.com/go-acme/lego v2.7.2+incompatible
 	github.com/go-gandi/go-gandi v0.5.0
 	github.com/gobwas/glob v0.2.4-0.20181002190808-e7a84e9525fe

--- a/go.sum
+++ b/go.sum
@@ -198,8 +198,8 @@ github.com/envoyproxy/go-control-plane v0.9.9-0.20210512163311-63b5d3c536b0/go.m
 github.com/envoyproxy/go-control-plane v0.9.10-0.20210907150352-cf90f659a021/go.mod h1:AFq3mo9L8Lqqiid3OhADV3RfLJnjiw63cSpi+fDTRC0=
 github.com/envoyproxy/go-control-plane v0.10.2-0.20220325020618-49ff273808a1/go.mod h1:KJwIaB5Mv44NWtYuAOFCVOjcI94vtpEz2JU/D2v6IjE=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
-github.com/exoscale/egoscale v0.89.0 h1:YEA3pG97j14diC6okttXMOH9mLwlMuv/184uZyUGxhk=
-github.com/exoscale/egoscale v0.89.0/go.mod h1:wyXE5zrnFynMXA0jMhwQqSe24CfUhmBk2WI5wFZcq6Y=
+github.com/exoscale/egoscale v0.90.2 h1:oGSJy5Dxbcn5m5F0/DcnU4WXJg+2j3g+UgEu4yyKG9M=
+github.com/exoscale/egoscale v0.90.2/go.mod h1:NDhQbdGNKwnLVC2YGTB6ds9WIPw+V5ckvEEV8ho7pFE=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.13.0 h1:8LOYc1KYPPmyKMuN8QV2DNRWNbLo6LZ0iLs8+mlH53w=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=

--- a/integrationTest/providers.json
+++ b/integrationTest/providers.json
@@ -78,9 +78,10 @@
   },
   "EXOSCALE": {
     "apikey": "$EXOSCALE_API_KEY",
-    "dns-endpoint": "https://api.exoscale.ch/dns",
+    "dns-endpoint": "https://api.exoscale.com/v2",
     "domain": "$EXOSCALE_DOMAIN",
-    "secretkey": "$EXOSCALE_SECRET_KEY"
+    "secretkey": "$EXOSCALE_SECRET_KEY",
+		"apizone": "ch-gva-2"
   },
   "GANDI_V5": {
     "apikey": "$GANDI_V5_APIKEY",

--- a/providers/exoscale/auditrecords.go
+++ b/providers/exoscale/auditrecords.go
@@ -17,5 +17,7 @@ func AuditRecords(records []*models.RecordConfig) []error {
 
 	a.Add("SRV", rejectif.SrvHasNullTarget) // Last verified 2020-12-28
 
+	a.Add("TXT", rejectif.TxtHasUnpairedDoubleQuotes) // Last verified 2022-09-14
+
 	return a.Audit(records)
 }

--- a/providers/exoscale/exoscaleProvider.go
+++ b/providers/exoscale/exoscaleProvider.go
@@ -155,15 +155,13 @@ func (c *exoscaleProvider) GetDomainCorrections(dc *models.DomainConfig) ([]*mod
 				prio = uint16(*record.Priority)
 			}
 			err = rc.SetTargetMX(prio, *record.Content)
-			if err != nil {
-				return nil, fmt.Errorf("unparsable record received from exoscale: %w", err)
-			}
 		default:
-			err := rc.PopulateFromString(*record.Type, *record.Content, dc.Name)
-			if err != nil {
-				return nil, fmt.Errorf("unparsable record received from exoscale: %w", err)
-			}
+			err = rc.PopulateFromString(*record.Type, *record.Content, dc.Name)
 		}
+		if err != nil {
+			return nil, fmt.Errorf("unparsable record received from exoscale: %w", err)
+		}
+
 		existingRecords = append(existingRecords, rc)
 	}
 	removeOtherNS(dc)

--- a/providers/exoscale/exoscaleProvider.go
+++ b/providers/exoscale/exoscaleProvider.go
@@ -72,13 +72,9 @@ func init() {
 	providers.RegisterDomainServiceProviderType("EXOSCALE", fns, features)
 }
 
-// EnsureDomainExists adds a domain if it is not managed by Exoscale.
+// EnsureDomainExists returns an error if domain doesn't exist.
 func (c *exoscaleProvider) EnsureDomainExists(domainName string) error {
-	ctx := context.Background()
 	_, err := c.findDomainByName(domainName)
-	if errors.Is(err, ErrDomainNotFound) {
-		_, err = c.client.CreateDNSDomain(ctx, c.apiZone, &egoscale.DNSDomain{UnicodeName: &domainName})
-	}
 
 	return err
 }


### PR DESCRIPTION
This PR reworks exoscale provider to use v2 API.
Also fixes https://github.com/StackExchange/dnscontrol/issues/1612

One test case (`07:complex_TXT:TXT_with_1_double-quotes`) fails, however it is not a regression (provider from master also stumbles on it).

Test suite:
```
$ go test -v -verbose -provider EXOSCALE -timeout 30m
...
--- FAIL: TestDNSProviders (1388.06s)                                                                                                                                                                                                [33/1840]
    --- FAIL: TestDNSProviders/example.net (1388.06s)                                                                  
        --- PASS: TestDNSProviders/example.net/Clean_Slate:Empty (2.88s)                                      
        --- PASS: TestDNSProviders/example.net/00:Protocol-Plain:Create_an_A_record (7.89s)
        --- PASS: TestDNSProviders/example.net/00:Protocol-Plain:Change_it (8.40s)
        --- PASS: TestDNSProviders/example.net/00:Protocol-Plain:Add_another (8.81s)                      
        --- PASS: TestDNSProviders/example.net/00:Protocol-Plain:Add_another(same_name) (9.42s)
        --- PASS: TestDNSProviders/example.net/00:Protocol-Plain:Change_a_ttl (9.42s)
        --- PASS: TestDNSProviders/example.net/00:Protocol-Plain:Change_single_target_from_set (9.31s)        
        --- PASS: TestDNSProviders/example.net/00:Protocol-Plain:Change_all_ttls (16.90s)                   
        --- PASS: TestDNSProviders/example.net/00:Protocol-Plain:Delete_one (9.11s)                     
        --- PASS: TestDNSProviders/example.net/00:Protocol-Plain:Add_back_and_change_ttl (16.12s)                                                                                                                                             
        --- PASS: TestDNSProviders/example.net/00:Protocol-Plain:Change_targets_and_ttls (12.04s)                                                                                                                                             
        --- PASS: TestDNSProviders/example.net/Post_cleanup:Empty (9.62s)    
        --- PASS: TestDNSProviders/example.net/01:Protocol-Wildcard:Create_wildcard (12.50s)
        --- PASS: TestDNSProviders/example.net/01:Protocol-Wildcard:Delete_wildcard (8.60s)                                                                                                                                                   
        --- PASS: TestDNSProviders/example.net/Post_cleanup:Empty#01 (5.93s)                                                                                                                                                                  
        --- PASS: TestDNSProviders/example.net/02:TypeChange:Create_a_CNAME (8.20s)                                                                                                                                                           
        --- PASS: TestDNSProviders/example.net/02:TypeChange:Change_to_A_record (11.98s)                   
        --- PASS: TestDNSProviders/example.net/02:TypeChange:Change_back_to_CNAME (12.29s)              
        --- PASS: TestDNSProviders/example.net/Post_cleanup:Empty#02 (5.82s)                                   
        --- PASS: TestDNSProviders/example.net/03:CommonDNS:Create_1_of_each (15.89s)              
        --- PASS: TestDNSProviders/example.net/03:CommonDNS:Change_param1 (16.39s)
        --- PASS: TestDNSProviders/example.net/03:CommonDNS:Change_param2 (9.42s)              
        --- PASS: TestDNSProviders/example.net/Post_cleanup:Empty#03 (14.12s)
        --- PASS: TestDNSProviders/example.net/04:CNAME:Record_pointing_to_@ (8.92s)                 
        --- PASS: TestDNSProviders/example.net/Post_cleanup:Empty#04 (6.24s)
        --- PASS: TestDNSProviders/example.net/05:MX:Record_pointing_to_@ (8.20s)
        --- SKIP: TestDNSProviders/example.net/05:MX:Null_MX (0.00s)
        --- PASS: TestDNSProviders/example.net/Post_cleanup:Empty#05 (6.04s)
        --- PASS: TestDNSProviders/example.net/Post_cleanup:Empty#05 (6.04s)
        --- PASS: TestDNSProviders/example.net/06:NS_***SKIPPED(excluded_by_not("EXOSCALE"))***:Empty (1.95s)
        --- PASS: TestDNSProviders/example.net/07:complex_TXT:TXT_with_0-octel_string (7.89s)
        --- PASS: TestDNSProviders/example.net/07:complex_TXT:a_255-byte_TXT (11.88s)
        --- PASS: TestDNSProviders/example.net/07:complex_TXT:a_256-byte_TXT (12.29s)                                                                                                                                                         
        --- PASS: TestDNSProviders/example.net/07:complex_TXT:a_512-byte_TXT (11.98s)
        --- PASS: TestDNSProviders/example.net/07:complex_TXT:a_513-byte_TXT (12.19s)
        --- PASS: TestDNSProviders/example.net/07:complex_TXT:TXT_with_1_single-quote (12.29s)
        --- PASS: TestDNSProviders/example.net/07:complex_TXT:TXT_with_1_backtick (11.88s)
        --- FAIL: TestDNSProviders/example.net/07:complex_TXT:TXT_with_1_double-quotes (6.14s)
        --- PASS: TestDNSProviders/example.net/Post_cleanup:Empty#06 (2.05s)
        --- PASS: TestDNSProviders/example.net/08:Case_Sensitivity:Create_CAPS (7.99s)
        --- PASS: TestDNSProviders/example.net/Post_cleanup:Empty#07 (5.72s)
        --- PASS: TestDNSProviders/example.net/09:IDNA:Internationalized_name (8.62s)
        --- PASS: TestDNSProviders/example.net/Post_cleanup:Empty#08 (5.94s)
        --- PASS: TestDNSProviders/example.net/10:IDNAs_in_CNAME_targets:IDN_CNAME_AND_Target (8.09s)
        --- PASS: TestDNSProviders/example.net/Post_cleanup:Empty#09 (5.83s)
        --- PASS: TestDNSProviders/example.net/11:pager101:99_records (417.68s)
        --- PASS: TestDNSProviders/example.net/Post_cleanup:Empty#10 (396.61s)
        --- PASS: TestDNSProviders/example.net/12:pager601_***SKIPPED(disabled_by_only)***:Empty (2.15s)
        --- PASS: TestDNSProviders/example.net/13:pager1201_***SKIPPED(disabled_by_only)***:Empty (2.09s)
        --- PASS: TestDNSProviders/example.net/14:CAA:CAA_record (8.77s)
        --- PASS: TestDNSProviders/example.net/Post_cleanup:Empty#11 (6.02s)
        --- PASS: TestDNSProviders/example.net/15:NAPTR_***SKIPPED(CanUseNAPTR_not_supported)***:Empty (1.75s)
        --- PASS: TestDNSProviders/example.net/16:PTR:Create_PTR_record (7.89s)
        --- PASS: TestDNSProviders/example.net/Post_cleanup:Empty#12 (6.13s)
        --- PASS: TestDNSProviders/example.net/17:SOA_***SKIPPED(CanUseSOA_not_supported)***:Empty (1.96s)
        --- PASS: TestDNSProviders/example.net/18:SRV:SRV_record (8.40s)
        --- PASS: TestDNSProviders/example.net/Post_cleanup:Empty#13 (5.68s)
        --- PASS: TestDNSProviders/example.net/19:SSHFP_***SKIPPED(CanUseSSHFP_not_supported)***:Empty (1.90s)
        --- PASS: TestDNSProviders/example.net/20:TLSA_***SKIPPED(CanUseTLSA_not_supported)***:Empty (1.95s)
        --- PASS: TestDNSProviders/example.net/21:DS_***SKIPPED(CanUseDS_not_supported)***:Empty (2.05s)
        --- PASS: TestDNSProviders/example.net/22:DS_(children_only)_***SKIPPED(CanUseDSForChildren_not_supported)***:Empty (1.85s)
        --- PASS: TestDNSProviders/example.net/23:DS_(children_only)_CLOUDNS_***SKIPPED(CanUseDSForChildren_not_supported)***:Empty (2.15s)
        --- PASS: TestDNSProviders/example.net/24:ALIAS:ALIAS_at_root (8.60s)
        --- PASS: TestDNSProviders/example.net/Post_cleanup:Empty#14 (6.45s)
        --- PASS: TestDNSProviders/example.net/25:AZURE_ALIAS_***SKIPPED(CanUseAzureAlias_not_supported)***:Empty (2.03s)
        --- PASS: TestDNSProviders/example.net/26:R53_ALIAS2_***SKIPPED(CanUseRoute53Alias_not_supported)***:Empty (1.86s)
        --- PASS: TestDNSProviders/example.net/27:R53_ALIAS_ORDER_***SKIPPED(CanUseRoute53Alias_not_supported)***:Empty (1.95s)
        --- PASS: TestDNSProviders/example.net/28:CF_REDIRECT_***SKIPPED(disabled_by_only)***:Empty (1.95s)
        --- PASS: TestDNSProviders/example.net/29:CF_PROXY_***SKIPPED(disabled_by_only)***:Empty (1.95s)
        --- PASS: TestDNSProviders/example.net/30:CF_WORKER_ROUTE_***SKIPPED(disabled_by_only)***:Empty (2.15s)
        --- PASS: TestDNSProviders/example.net/31:IGNORE_NAME_function:Create_some_records (12.39s)
        --- PASS: TestDNSProviders/example.net/Post_cleanup:Empty#15 (9.92s)
        --- PASS: TestDNSProviders/example.net/32:IGNORE_NAME_apex:Create_some_records (20.70s)
        --- PASS: TestDNSProviders/example.net/Post_cleanup:Empty#16 (17.39s)
        --- PASS: TestDNSProviders/example.net/33:IGNORE_TARGET_function:Create_some_records (12.71s)
        --- PASS: TestDNSProviders/example.net/Post_cleanup:Empty#17 (9.83s)
```