### PR TITLE
chore(DigitalOcean): Support semicolon as CAA target

### DIFF
--- a/providers/digitalocean/auditrecords.go
+++ b/providers/digitalocean/auditrecords.go
@@ -15,8 +15,6 @@ func AuditRecords(records []*models.RecordConfig) []error {
 
 	a.Add("CAA", rejectif.CaaTargetContainsWhitespace) // Last verified xxxx-xx-xx
 
-	a.Add("CAA", rejectif.CaaTargetHasSemicolon) // Last verified 2021-03-01
-
 	a.Add("MX", rejectif.MxNull) // Last verified 2020-12-28
 
 	a.Add("TXT", MaxLengthDO) // Last verified 2021-03-01

--- a/providers/digitalocean/digitaloceanProvider.go
+++ b/providers/digitalocean/digitaloceanProvider.go
@@ -72,7 +72,7 @@ retry:
 
 var features = providers.DocumentationNotes{
 	providers.CanGetZones:            providers.Can(),
-	providers.CanUseCAA:              providers.Can("Semicolons not supported in issue/issuewild fields.", "https://www.digitalocean.com/docs/networking/dns/how-to/create-caa-records"),
+	providers.CanUseCAA:              providers.Can(),
 	providers.CanUseSRV:              providers.Can(),
 	providers.DocCreateDomains:       providers.Can(),
 	providers.DocOfficiallySupported: providers.Cannot(),


### PR DESCRIPTION
This appears to be a change as it is supported in the interface and in the API. Verified with my own personal domains (e.g. brianandjenny.net)