### PR TITLE
DNSimple: Update to 1.0.0 Client & expose error attributes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/cloudflare/cloudflare-go v0.50.0
 	github.com/digitalocean/godo v1.84.1
 	github.com/ditashi/jsbeautifier-go v0.0.0-20141206144643-2520a8026a9c
-	github.com/dnsimple/dnsimple-go v0.71.1
+	github.com/dnsimple/dnsimple-go v1.0.0
 	github.com/exoscale/egoscale v0.90.2
 	github.com/go-acme/lego v2.7.2+incompatible
 	github.com/go-gandi/go-gandi v0.5.0

--- a/go.sum
+++ b/go.sum
@@ -185,8 +185,8 @@ github.com/ditashi/jsbeautifier-go v0.0.0-20141206144643-2520a8026a9c h1:+Zo5Ca9
 github.com/ditashi/jsbeautifier-go v0.0.0-20141206144643-2520a8026a9c/go.mod h1:HJGU9ULdREjOcVGZVPB5s6zYmHi1RxzT71l2wQyLmnE=
 github.com/djherbis/atime v1.1.0/go.mod h1:28OF6Y8s3NQWwacXc5eZTsEsiMzp7LF8MbXE+XJPdBE=
 github.com/dnaeon/go-vcr v1.1.0 h1:ReYa/UBrRyQdant9B4fNHGoCNKw6qh6P0fsdGmZpR7c=
-github.com/dnsimple/dnsimple-go v0.71.1 h1:1hGoBA3CIjpjZj5DM3081xfxr4e2jYmYnkO2VuBF8Qc=
-github.com/dnsimple/dnsimple-go v0.71.1/go.mod h1:F9WHww9cC76hrnwGFfAfrqdW99j3MOYasQcIwTS/aUk=
+github.com/dnsimple/dnsimple-go v1.0.0 h1:x9UalQ0tHR68+sQxJYJmq746LdJou4OLTK+cZLR2Z9I=
+github.com/dnsimple/dnsimple-go v1.0.0/go.mod h1:oaAtPP8bIROK3QXUdc8rMlTN7SyvCBAogw2I31WVNnU=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=

--- a/providers/dnsimple/dnsimpleProvider.go
+++ b/providers/dnsimple/dnsimpleProvider.go
@@ -295,6 +295,10 @@ func (c *dnsimpleProvider) getRecords(domainName string) ([]dnsimpleapi.ZoneReco
 
 	accountID, err := c.getAccountID()
 	if err != nil {
+		var errorResponse *dnsimpleapi.ErrorResponse
+		if errors.As(err, &errorResponse) {
+			return nil, compileAttributeErrors(errorResponse)
+		}
 		return nil, err
 	}
 
@@ -305,6 +309,10 @@ func (c *dnsimpleProvider) getRecords(domainName string) ([]dnsimpleapi.ZoneReco
 		opts.Page = &page
 		recordsResponse, err := client.Zones.ListRecords(context.Background(), accountID, domainName, opts)
 		if err != nil {
+			var errorResponse *dnsimpleapi.ErrorResponse
+			if errors.As(err, &errorResponse) {
+				return nil, compileAttributeErrors(errorResponse)
+			}
 			return nil, err
 		}
 		recs = append(recs, recordsResponse.Data...)
@@ -326,11 +334,19 @@ func (c *dnsimpleProvider) getDnssec(domainName string) (bool, error) {
 	)
 	client = c.getClient()
 	if accountID, err = c.getAccountID(); err != nil {
+		var errorResponse *dnsimpleapi.ErrorResponse
+		if errors.As(err, &errorResponse) {
+			return false, compileAttributeErrors(errorResponse)
+		}
 		return false, err
 	}
 
 	dnssecResponse, err := client.Domains.GetDnssec(context.Background(), accountID, domainName)
 	if err != nil {
+		var errorResponse *dnsimpleapi.ErrorResponse
+		if errors.As(err, &errorResponse) {
+			return false, compileAttributeErrors(errorResponse)
+		}
 		return false, err
 	}
 	if dnssecResponse.Data == nil {
@@ -347,11 +363,19 @@ func (c *dnsimpleProvider) enableDnssec(domainName string) (bool, error) {
 	)
 	client = c.getClient()
 	if accountID, err = c.getAccountID(); err != nil {
+		var errorResponse *dnsimpleapi.ErrorResponse
+		if errors.As(err, &errorResponse) {
+			return false, compileAttributeErrors(errorResponse)
+		}
 		return false, err
 	}
 
 	dnssecResponse, err := client.Domains.EnableDnssec(context.Background(), accountID, domainName)
 	if err != nil {
+		var errorResponse *dnsimpleapi.ErrorResponse
+		if errors.As(err, &errorResponse) {
+			return false, compileAttributeErrors(errorResponse)
+		}
 		return false, err
 	}
 	if dnssecResponse.Data == nil {
@@ -368,11 +392,19 @@ func (c *dnsimpleProvider) disableDnssec(domainName string) (bool, error) {
 	)
 	client = c.getClient()
 	if accountID, err = c.getAccountID(); err != nil {
+		var errorResponse *dnsimpleapi.ErrorResponse
+		if errors.As(err, &errorResponse) {
+			return false, compileAttributeErrors(errorResponse)
+		}
 		return false, err
 	}
 
 	dnssecResponse, err := client.Domains.DisableDnssec(context.Background(), accountID, domainName)
 	if err != nil {
+		var errorResponse *dnsimpleapi.ErrorResponse
+		if errors.As(err, &errorResponse) {
+			return false, compileAttributeErrors(errorResponse)
+		}
 		return false, err
 	}
 	if dnssecResponse.Data == nil {
@@ -389,11 +421,19 @@ func (c *dnsimpleProvider) getNameservers(domainName string) ([]string, error) {
 
 	accountID, err := c.getAccountID()
 	if err != nil {
+		var errorResponse *dnsimpleapi.ErrorResponse
+		if errors.As(err, &errorResponse) {
+			return nil, compileAttributeErrors(errorResponse)
+		}
 		return nil, err
 	}
 
 	domainResponse, err := client.Domains.GetDomain(context.Background(), accountID, domainName)
 	if err != nil {
+		var errorResponse *dnsimpleapi.ErrorResponse
+		if errors.As(err, &errorResponse) {
+			return nil, compileAttributeErrors(errorResponse)
+		}
 		return nil, err
 	}
 
@@ -401,6 +441,10 @@ func (c *dnsimpleProvider) getNameservers(domainName string) ([]string, error) {
 
 		delegationResponse, err := client.Registrar.GetDomainDelegation(context.Background(), accountID, domainName)
 		if err != nil {
+			var errorResponse *dnsimpleapi.ErrorResponse
+			if errors.As(err, &errorResponse) {
+				return nil, compileAttributeErrors(errorResponse)
+			}
 			return nil, err
 		}
 
@@ -416,6 +460,10 @@ func (c *dnsimpleProvider) updateNameserversFunc(nameServerNames []string, domai
 
 		accountID, err := c.getAccountID()
 		if err != nil {
+			var errorResponse *dnsimpleapi.ErrorResponse
+			if errors.As(err, &errorResponse) {
+				return compileAttributeErrors(errorResponse)
+			}
 			return err
 		}
 
@@ -441,6 +489,10 @@ func (c *dnsimpleProvider) createRecordFunc(rc *models.RecordConfig, domainName 
 
 		accountID, err := c.getAccountID()
 		if err != nil {
+			var errorResponse *dnsimpleapi.ErrorResponse
+			if errors.As(err, &errorResponse) {
+				return compileAttributeErrors(errorResponse)
+			}
 			return err
 		}
 		record := dnsimpleapi.ZoneRecordAttributes{
@@ -470,6 +522,10 @@ func (c *dnsimpleProvider) deleteRecordFunc(recordID int64, domainName string) f
 
 		accountID, err := c.getAccountID()
 		if err != nil {
+			var errorResponse *dnsimpleapi.ErrorResponse
+			if errors.As(err, &errorResponse) {
+				return compileAttributeErrors(errorResponse)
+			}
 			return err
 		}
 
@@ -494,6 +550,10 @@ func (c *dnsimpleProvider) updateRecordFunc(old *dnsimpleapi.ZoneRecord, rc *mod
 
 		accountID, err := c.getAccountID()
 		if err != nil {
+			var errorResponse *dnsimpleapi.ErrorResponse
+			if errors.As(err, &errorResponse) {
+				return compileAttributeErrors(errorResponse)
+			}
 			return err
 		}
 
@@ -523,6 +583,10 @@ func (c *dnsimpleProvider) ListZones() ([]string, error) {
 	client := c.getClient()
 	accountID, err := c.getAccountID()
 	if err != nil {
+		var errorResponse *dnsimpleapi.ErrorResponse
+		if errors.As(err, &errorResponse) {
+			return nil, compileAttributeErrors(errorResponse)
+		}
 		return nil, err
 	}
 
@@ -533,6 +597,10 @@ func (c *dnsimpleProvider) ListZones() ([]string, error) {
 		opts.Page = &page
 		zonesResponse, err := client.Zones.ListZones(context.Background(), accountID, opts)
 		if err != nil {
+			var errorResponse *dnsimpleapi.ErrorResponse
+			if errors.As(err, &errorResponse) {
+				return nil, compileAttributeErrors(errorResponse)
+			}
 			return nil, err
 		}
 		for _, zone := range zonesResponse.Data {
@@ -631,7 +699,7 @@ func getTargetRecordPriority(rc *models.RecordConfig) int {
 }
 
 func compileAttributeErrors(err *dnsimpleapi.ErrorResponse) error {
-	message := err.Message
+	message := fmt.Sprintf("%d %s", err.HTTPResponse.StatusCode, err.Message)
 	for field, errors := range err.AttributeErrors {
 		e := strings.Join(errors, "& ")
 		message += fmt.Sprintf(": %s %s", field, e)


### PR DESCRIPTION
The title says it all! Now we have more validation information in our errors, which this formats and passes up in the error.