### PR TITLE
DOCS: fix docker usage in "Getting Started"

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -38,7 +38,7 @@ Alternatively, on Mac you can install it using homebrew:
 ## Via [docker](https://hub.docker.com/r/stackexchange/dnscontrol/)
 
 ```bash
-docker run --rm -it -v $(pwd)/dnsconfig.js:/dns/dnsconfig.js -v $(pwd)/creds.json:/dns/creds.json stackexchange/dnscontrol dnscontrol preview
+docker run --rm -it -v $(pwd)/dnsconfig.js:/dns/dnsconfig.js -v $(pwd)/creds.json:/dns/creds.json stackexchange/dnscontrol preview
 ```
 
 


### PR DESCRIPTION
The docker image sets the entrypoint to /usr/local/bin/dnscontrol (same issue as fixed with https://github.com/StackExchange/dnscontrol/pull/1751)