### PR TITLE
DOCS: Typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ brew install dnscontrol
 sudo port install dnscontrol
 ````
 
-## Via [docker](https://hub.docker.com/r/stackexchange/dnscontrol/)
+## Via [Docker](https://hub.docker.com/r/stackexchange/dnscontrol/)
 
 ```bash
 docker run --rm -it -v $(pwd)/dnsconfig.js:/dns/dnsconfig.js -v $(pwd)/creds.json:/dns/creds.json stackexchange/dnscontrol preview

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ See [dnscontrol-action](https://github.com/koenrh/dnscontrol-action)
 - **Provider OCTODNS is frozen and will be removed after Nov 1, 2022.** It was written as a joke and nobody laughed. It's time to remove the code and move on.
 - **get-zones syntax changes in v3.16** Starting in v3.16, the command line arguments for `dnscontrol get-zones` changes. For backwards compatibility change `provider` to `-`. See documentation for details.
 
-## More info at our web site
+## More info at our website
 
 The website: [https://stackexchange.github.io/dnscontrol/](https://stackexchange.github.io/dnscontrol/)
 

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ docker run --rm -it --volume="$PWD:/srv/jekyll" --volume="$PWD/vendor/bundle:/us
 # (Note: The preview isn't perfect. Links that use the site.github.url variable won't work.
 ```
 
-## Via Github Actions (GHA)
+## Via GitHub Actions (GHA)
 
 See [dnscontrol-action](https://github.com/koenrh/dnscontrol-action)
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,7 +10,6 @@ When a major version is incremented, we'll support the previous major version fo
 
 ## Reporting a Vulnerability
 
-To report a vulnerability please [create a new Github "issue"](https://github.com/StackExchange/dnscontrol/issues/new/choose).
+To report a vulnerability please [create a new GitHub "issue"](https://github.com/StackExchange/dnscontrol/issues/new/choose).
 
-We will respond in a best-effort manner, usually within 1 week. We will communciate via the Github issue unless we need to communicate privately, in which case we'll arrange a way to communicate directly.
-
+We will respond in a best-effort manner, usually within 1 week. We will communciate via the GitHub issue unless we need to communicate privately, in which case we'll arrange a way to communicate directly.

--- a/docs/_functions/domain/DefaultTTL.md
+++ b/docs/_functions/domain/DefaultTTL.md
@@ -4,7 +4,7 @@ parameters:
   - ttl
 ---
 
-DefaultTTL sets the TTL for all records in a domain that do not explicitly set one with [TTL](#TTL). If neither `DefaultTTl` or `TTL` exist for a record,
+DefaultTTL sets the TTL for all records in a domain that do not explicitly set one with [TTL](#TTL). If neither `DefaultTTL` or `TTL` exist for a record,
 it will use the DNSControl global default of 300 seconds.
 
 {% capture example %}

--- a/docs/_functions/domain/IGNORE_NAME.md
+++ b/docs/_functions/domain/IGNORE_NAME.md
@@ -80,4 +80,4 @@ You can override this error by adding the
 Disabling this safety check creates two risks:
 
 1. Two owners (DNSControl and some other entity) toggling a record between two settings.
-2. The other owner wiping all records at this label, which won't be noticed until the next time dnscontrol is run.
+2. The other owner wiping all records at this label, which won't be noticed until the next time DNSControl is run.

--- a/docs/_functions/domain/NO_PURGE.md
+++ b/docs/_functions/domain/NO_PURGE.md
@@ -13,7 +13,7 @@ NO_PURGE is generally used in very specific situations:
 In this example DNSControl will insert "foo.example.com" into the
 zone, but otherwise leave the zone alone.  Changes to "foo"'s IP
 address will update the record. Removing the A("foo", ...) record
-from dnscontrol will leave the record in place.
+from DNSControl will leave the record in place.
 
 {% capture example %}
 ```js

--- a/docs/_functions/domain/R53_ALIAS.md
+++ b/docs/_functions/domain/R53_ALIAS.md
@@ -31,7 +31,7 @@ The zone id can be found depending on the target type:
 * _Elastic Beanstalk environment_: specify the hosted zone ID for the region in which the environment has been created. Refer to the [List of regions and hosted Zone IDs](http://docs.aws.amazon.com/general/latest/gr/rande.html#elasticbeanstalk_region).
 * _ELB load balancer_: specify the value of the hosted zone ID for the load balancer. You can find it in [the List of regions and hosted Zone IDs](http://docs.aws.amazon.com/general/latest/gr/rande.html#elb_region)
 * _S3 bucket_ (configured as website): specify the hosted zone ID for the region that you created the bucket in. You can find it in [the List of regions and hosted Zone IDs](http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region)
-* _Another Route 53 record_: you can either specify the correct zone id or do not specify anything and dnscontrol will figure out the right zone id. (Note: Route53 alias can't reference a record in a different zone).
+* _Another Route 53 record_: you can either specify the correct zone id or do not specify anything and DNSControl will figure out the right zone id. (Note: Route53 alias can't reference a record in a different zone).
 
 {% capture example %}
 ```js

--- a/docs/_functions/record/DMARC_BUILDER.md
+++ b/docs/_functions/record/DMARC_BUILDER.md
@@ -4,7 +4,7 @@ name: DMARC_BUILDER
 
 # DMARC Builder
 
-dnscontrol contains a DMARC_BUILDER which can be used to simply create
+DNSControl contains a DMARC_BUILDER which can be used to simply create
 DMARC policies for your domains.
 
 

--- a/docs/_providers/bind.md
+++ b/docs/_providers/bind.md
@@ -125,7 +125,7 @@ forth.
 
 # FYI: get-zones
 
-The dnscontrol `get-zones all` subcommand scans the directory for
+The DNSControl `get-zones all` subcommand scans the directory for
 any files named `*.zone` and assumes they are zone files.
 
 ```bash

--- a/docs/_providers/gcloud.md
+++ b/docs/_providers/gcloud.md
@@ -57,7 +57,7 @@ Example:
 }
 ```
 
-**Note:** To use ADC, make sure to not add any `private_key` value to your configuration as that will prevent dnscontrol from attempting to use ADC.
+**Note:** To use ADC, make sure to not add any `private_key` value to your configuration as that will prevent DNSControl from attempting to use ADC.
 
 ## Metadata
 This provider does not recognize any special metadata fields unique to google cloud dns.

--- a/docs/_providers/inwx.md
+++ b/docs/_providers/inwx.md
@@ -30,8 +30,8 @@ Example:
 INWX supports two factor authentication via TOTP and does not allow TOTP codes to be reused. This means that you will only be able to log into your INWX account once every 30 seconds.
 You will hit this limitation in the following two scenarios:
 
-* You run dnscontrol twice very quickly (to e.g. first use preview and then push). Waiting for 30 seconds to pass between these two invocations will work fine though.
-* You use INWX as both the registrar and the DNS provider. In this case, dnscontrol will try to login twice too quickly and the second login will fail because a TOTP code will be reused. The only way to support this configuration is to use a INWX account without two factor authentication.
+* You run DNSControl twice very quickly (to e.g. first use preview and then push). Waiting for 30 seconds to pass between these two invocations will work fine though.
+* You use INWX as both the registrar and the DNS provider. In this case, DNSControl will try to login twice too quickly and the second login will fail because a TOTP code will be reused. The only way to support this configuration is to use a INWX account without two factor authentication.
 
 If you cannot work around these two limitation it is possible to contact the INWX support to request a sub-account for API access only without two factor authentication.
 See issue [issue 848](https://github.com/StackExchange/dnscontrol/issues/848#issuecomment-692288859) for details.

--- a/docs/_providers/route53.md
+++ b/docs/_providers/route53.md
@@ -159,7 +159,7 @@ You will see some weirdness if:
 1.  A CNAME was created using the web UI
 2.  The CNAME's target does NOT end with a dot.
 
-What you will see: When dnscontrol tries to update such records, R53
+What you will see: When DNSControl tries to update such records, R53
 only updates the first one.  For example if DNSControl is updating 3
 such records, you will need to run `dnscontrol push` three times for
 all three records to update.  Each time DNSControl is sending three

--- a/docs/adding-new-rtypes.md
+++ b/docs/adding-new-rtypes.md
@@ -54,7 +54,7 @@ a minimum.
 it to the end of the list.)
 * Add this feature to the feature matrix in `dnscontrol/build/generate/featureMatrix.go` (Add it to the variable `matrix` then add it later in the file with a `setCap()` statement.
 * Add the capability to the list of features that zones are validated
-  against (i.e. if you want dnscontrol to report an error if this
+  against (i.e. if you want DNSControl to report an error if this
   feature is used with a DNS provider that doesn't support it). That's
   in the `checkProviderCapabilities` function in
   `pkg/normalize/validate.go`.

--- a/docs/byo-secrets.md
+++ b/docs/byo-secrets.md
@@ -26,9 +26,9 @@ secrets.
 
 # Background: How GitHub Actions protects secrets
 
-Github Actions has a secure
+GitHub Actions has a secure
 [secrets storage system](https://docs.github.com/en/free-pro-team@latest/actions/reference/encrypted-secrets).
-Those secrets are available to Github Actions and are required for the
+Those secrets are available to GitHub Actions and are required for the
 integration tests to communicate with the various DNS providers that
 DNSControl supports.
 

--- a/docs/caa-builder.md
+++ b/docs/caa-builder.md
@@ -5,7 +5,7 @@ title: CAA Builder
 
 # CAA Builder
 
-dnscontrol contains a CAA_BUILDER which can be used to simply create
+DNSControl contains a CAA_BUILDER which can be used to simply create
 CAA records for your domains. Instead of creating each CAA record
 individually, you can simply configure your report mail address, the
 authorized certificate authorities and the builder cares about the rest.

--- a/docs/creds-json.md
+++ b/docs/creds-json.md
@@ -5,7 +5,7 @@ title: creds.json file format
 
 # creds.json
 
-When dnscontrol interacts with a provider, any API keys, credentials, or other
+When DNSControl interacts with a provider, any API keys, credentials, or other
 configuration parameters required are stored in `creds.json`.   The file contains a set of key/value pairs for each configuration.  That is, since a provider can be used multiple times with different credentials, the file contains a section for each set of credentials.
 
 Here's a sample file:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -78,7 +78,7 @@ D('example.com', REG_NONE, DnsProvider(DNS_BIND),
 );
 ```
 
-Modify this file to match your particular providers and domains. See [the dnsconfig docs]({{site.github.url}}/js) and  [the provider docs]({{site.github.url}}/provider-list) for more details.
+Modify this file to match your particular providers and domains. See [the DNSConfig docs]({{site.github.url}}/js) and  [the provider docs]({{site.github.url}}/provider-list) for more details.
 
 Create a file called `creds.json` for storing provider configurations (API tokens and other account information).
 For example, to use both name.com and Cloudflare, you would have:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -35,7 +35,7 @@ Alternatively, on Mac you can install it using homebrew:
 
 `brew install dnscontrol`
 
-## Via [docker](https://hub.docker.com/r/stackexchange/dnscontrol/)
+## Via [Docker](https://hub.docker.com/r/stackexchange/dnscontrol/)
 
 ```bash
 docker run --rm -it -v $(pwd)/dnsconfig.js:/dns/dnsconfig.js -v $(pwd)/creds.json:/dns/creds.json stackexchange/dnscontrol preview

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -29,7 +29,7 @@ If these don't work, more info is in [#805](https://github.com/StackExchange/dns
 
 ## Via packages
 
-Get prebuilt binaries from [github releases](https://github.com/StackExchange/dnscontrol/releases/latest)
+Get prebuilt binaries from [GitHub releases](https://github.com/StackExchange/dnscontrol/releases/latest)
 
 Alternatively, on Mac you can install it using homebrew:
 
@@ -293,5 +293,5 @@ If you are going to use this in production, we highly recommend the following:
 * Store the configuration files in Git.
 * Encrypt the `creds.json` file before storing it in Git. Do NOT store
   API keys or other credentials without encrypting them.
-* Use a CI/CD tool like Jenkins/CircleCI/Github Actions/etc. to automatically push DNS changes.
+* Use a CI/CD tool like Jenkins/CircleCI/GitHub Actions/etc. to automatically push DNS changes.
 * Join the DNSControl community. File [issues and PRs](https://github.com/StackExchange/dnscontrol).

--- a/docs/index.md
+++ b/docs/index.md
@@ -196,7 +196,7 @@ title: DNSControl
             </p>
             <ul>
                 <li>
-                    Github: <a href="https://github.com/StackExchange/dnscontrol">https://github.com/StackExchange/dnscontrol</a>
+                    GitHub: <a href="https://github.com/StackExchange/dnscontrol">https://github.com/StackExchange/dnscontrol</a>
                 </li>
                 <li>
                     Mailing list: <a href="https://groups.google.com/forum/#!forum/dnscontrol-discuss">dnscontrol-discuss</a>: The friendly best place to ask questions and propose new features

--- a/docs/js.md
+++ b/docs/js.md
@@ -3,9 +3,9 @@ layout: default
 title: JavaScript DSL
 ---
 
-# Javascript DSL
+# JavaScript DSL
 
-DNSControl uses javascript as its primary input language to provide power and flexibility to configure your domains. The ultimate purpose of the javascript is to construct a
+DNSControl uses JavaScript as its primary input language to provide power and flexibility to configure your domains. The ultimate purpose of the JavaScript is to construct a
 [DNSConfig](https://godoc.org/github.com/StackExchange/dnscontrol/models#DNSConfig) object that will be passed to the go backend and operated on.
 
 <table class="table-of-contents">

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -46,7 +46,7 @@ Configure `teams_url` to this webhook.
 
 ### Bonfire
 
-This is stack overflow's built in chat system. This is probably not useful for most people.
+This is Stack Overflow's built in chat system. This is probably not useful for most people.
 
 Configure `bonfire_url` to be the full url including room and api key.
 

--- a/docs/spf-optimizer.md
+++ b/docs/spf-optimizer.md
@@ -5,8 +5,8 @@ title: SPF Optimizer
 
 # SPF Optimizer
 
-dnscontrol can optimize the SPF settings on a domain by flattening
-(inlining) includes and removing duplicates.  dnscontrol also makes
+DNSControl can optimize the SPF settings on a domain by flattening
+(inlining) includes and removing duplicates. DNSControl also makes
 it easier to document your SPF configuration.
 
 **Warning:** Flattening SPF includes is risky.  Only flatten an SPF
@@ -31,7 +31,7 @@ This has a few problems:
 * Ugly diffs.  If you add an element to the SPF setting, the diff will show the entire line changed, which is difficult to read.
 * Too many lookups. The SPF RFC says that SPF settings should not require more than 10 DNS lookups. If we manually flatten (i.e. "inline") an include, we have to remember to check back to see if the settings have changed. Humans are not good at that kind of thing.
 
-## The dnscontrol way
+## The DNSControl way
 
 ```js
 D("example.tld", REG, DSP, ...
@@ -67,7 +67,7 @@ By using the `SPF_BUILDER()` we gain many benefits:
 
 * Comments can appear next to the element they refer to.
 * Diffs will be shorter and more specific; therefore easier to read.
-* Automatic flattening.  We can specify which includes should be flattened and dnscontrol will do the work. It will even warn us if the includes change.
+* Automatic flattening.  We can specify which includes should be flattened and DNSControl will do the work. It will even warn us if the includes change.
 
 ## Syntax
 
@@ -101,7 +101,7 @@ D("example.tld", REG, DSP, ...
 The parameters are:
 
 * `label:` The label of the first TXT record. (Optional. Default: `"@"`)
-* `overflow:` If set, SPF strings longer than 255 chars will be split into multiple TXT records. The value of this setting determines the template for what the additional labels will be named. If not set, no splitting will occur and dnscontrol may generate TXT strings that are too long.
+* `overflow:` If set, SPF strings longer than 255 chars will be split into multiple TXT records. The value of this setting determines the template for what the additional labels will be named. If not set, no splitting will occur and DNSControl may generate TXT strings that are too long.
 * `overhead1:` "Overhead for the 1st TXT record".  When calculating the max length of each TXT record, reduce the maximum for the first TXT record in the chain by this amount.
 * `raw:` The label of the unaltered SPF settings. Setting to an empty string `''` will disable this. (Optional. Default: `"_rawspf"`)
 * `ttl:` This allows setting a specific TTL on this SPF record. (Optional. Default: using default record TTL)
@@ -174,7 +174,7 @@ to get the entire record. (Sadly it caches heavily.)
 
 ## Notes about the `spfcache.json`
 
-dnscontrol keeps a cache of the DNS lookups performed during
+DNSControl keeps a cache of the DNS lookups performed during
 optimization.  The cache is maintained so that the optimizer does
 not produce different results depending on the ups and downs of
 other people's DNS servers. This makes it possible to do `dnscontrol
@@ -233,7 +233,7 @@ In which case, it is equivalent to `include:`.
 
 ## Advanced Technique: Interactive SPF Debugger
 
-dnscontrol includes an experimental system for viewing
+DNSControl includes an experimental system for viewing
 SPF settings:
 
 [https://stackexchange.github.io/dnscontrol/flattener/index.html](https://stackexchange.github.io/dnscontrol/flattener/index.html)

--- a/docs/writing-providers.md
+++ b/docs/writing-providers.md
@@ -79,7 +79,7 @@ A provider can be a DnsProvider, a Registrar, or both. We recommend
 you write the DnsProvider first, release it, and then write the
 Registrar if needed.
 
-If you have any questions, please discuss them in the Github issue
+If you have any questions, please discuss them in the GitHub issue
 related to the request for this provider. Please let us know what
 was confusing so we can update this document with advice for future
 authors (or even better, update [this document](https://github.com/StackExchange/dnscontrol/blob/master/docs/writing-providers.md)
@@ -211,7 +211,7 @@ an automated way to test for this bug.  The manual steps are here in
 * Edit [README.md](https://github.com/StackExchange/dnscontrol): Add the provider to the bullet list.
 * Edit [docs/provider-list.md](https://github.com/StackExchange/dnscontrol/blob/master/docs/provider-list.md): Add the provider to the provider list.
 * Create `docs/_providers/PROVIDERNAME.md`: Use one of the other files in that directory as a base.
-* Edit [OWNERS](https://github.com/StackExchange/dnscontrol/blob/master/OWNERS): Add the directory name and your github id.
+* Edit [OWNERS](https://github.com/StackExchange/dnscontrol/blob/master/OWNERS): Add the directory name and your GitHub id.
 
 ## Step 10: Submit a PR
 

--- a/providers/cloudflare/rest.go
+++ b/providers/cloudflare/rest.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"github.com/StackExchange/dnscontrol/v3/models"
-	"github.com/cloudflare/cloudflare-go"
 )
 
 // get list of domains for account. Cache so the ids can be looked up from domain name
@@ -313,7 +312,7 @@ func (c *cloudflareProvider) deleteWorkerRoute(recordID, domainID string) error 
 }
 
 func (c *cloudflareProvider) updateWorkerRoute(recordID, domainID string, target string) error {
-	// Causing stack overflow (!?)
+	// Causing Stack Overflow (!?)
 	// return c.updateWorkerRoute(recordID, domainID, target)
 
 	if err := c.deleteWorkerRoute(recordID, domainID); err != nil {


### PR DESCRIPTION
Fixed several smaller typos.

- `Github` = `GitHub`
- `web site` = `website`
- `stack overflow` = `Stack Overflow`
- `dnscontrol` = `DNSControl`
- `docker` = `Docker`
- `dnsconfig` = `DNSConfig`
- `Javascript` = `JavaScript`
- `DefaultTTl` = `DefaultTTL`