### PR TITLE
DOCS: Aligned/improved installation section package manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ See [Getting Started](https://stackexchange.github.io/dnscontrol/getting-started
 
 ## Installation
 
-Install DNSControl by following the [official instructions](https://stackexchange.github.io/dnscontrol/getting-started#1-install-the-software).
+DNSControl can be installed via packages for macOS, Linux and Windows, or from source code. See the [official instructions](https://stackexchange.github.io/dnscontrol/getting-started#1-install-the-software).
 
 ## Via GitHub Actions (GHA)
 

--- a/README.md
+++ b/README.md
@@ -139,66 +139,7 @@ See [Getting Started](https://stackexchange.github.io/dnscontrol/getting-started
 
 ## Installation
 
-### From source
-
-DNSControl can be built with Go version 1.16 or higher.
-
-The `go get` command will download the source, compile it, and
-install `dnscontrol` in your `$GOBIN` directory.
-
-To install, simply run
-
-```shell
-GO111MODULE=on go install github.com/StackExchange/dnscontrol/v3@latest
-```
-
-To download the source
-
-```shell
-git clone https://github.com/StackExchange/dnscontrol.git
-```
-
-If these don't work, more info is in [#805](https://github.com/StackExchange/dnscontrol/issues/805).
-
-### Via packages
-
-Get prebuilt binaries from [GitHub releases](https://github.com/StackExchange/dnscontrol/releases/latest).
-
-### Through a package manager
-
-Alternatively, on macOS (or Linux) you can install it using [Homebrew](https://brew.sh) or [MacPorts](https://www.macports.org):
-
-#### Homebrew
-
-```bash
-brew install dnscontrol
-```
-
-#### MacPorts
-
-```bash
-sudo port install dnscontrol
-````
-
-## Via [Docker](https://hub.docker.com/r/stackexchange/dnscontrol/)
-
-```bash
-docker run --rm -it -v $(pwd)/dnsconfig.js:/dns/dnsconfig.js -v $(pwd)/creds.json:/dns/creds.json stackexchange/dnscontrol preview
-```
-
-The documentation can be viewed via Docker:
-
-```bash
-cd docs
-./runDocker.sh
-```
-
-FYI: Alternative Docker command:
-```bash
-docker run --rm -it --volume="$PWD:/srv/jekyll" --volume="$PWD/vendor/bundle:/usr/local/bundle" --env JEKYLL_ENV=production jekyll/jekyll:3.8 jekyll build -V
-# Open docs/_site/index.html in your web browser to see the results.
-# (Note: The preview isn't perfect. Links that use the site.github.url variable won't work.
-```
+Install DNSControl by following the [official instructions](https://stackexchange.github.io/dnscontrol/getting-started#1-install-the-software).
 
 ## Via GitHub Actions (GHA)
 

--- a/README.md
+++ b/README.md
@@ -164,13 +164,19 @@ If these don't work, more info is in [#805](https://github.com/StackExchange/dns
 
 Get prebuilt binaries from [GitHub releases](https://github.com/StackExchange/dnscontrol/releases/latest).
 
-Alternatively, on Mac you can install it using Homebrew or MacPorts:
+### Through a package manager
+
+Alternatively, on macOS (or Linux) you can install it using [Homebrew](https://brew.sh) or [MacPorts](https://www.macports.org):
+
+#### Homebrew
 
 ```bash
-# Homebrew
 brew install dnscontrol
+```
 
-# MacPorts
+#### MacPorts
+
+```bash
 sudo port install dnscontrol
 ````
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -31,9 +31,21 @@ If these don't work, more info is in [#805](https://github.com/StackExchange/dns
 
 Get prebuilt binaries from [GitHub releases](https://github.com/StackExchange/dnscontrol/releases/latest)
 
-Alternatively, on Mac you can install it using homebrew:
+## Through a package manager
 
-`brew install dnscontrol`
+Alternatively, on macOS (or Linux) you can install it using [Homebrew](https://brew.sh) or [MacPorts](https://www.macports.org):
+
+### Homebrew
+
+```bash
+brew install dnscontrol
+```
+
+### MacPorts
+
+```bash
+sudo port install dnscontrol
+````
 
 ## Via [Docker](https://hub.docker.com/r/stackexchange/dnscontrol/)
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -7,9 +7,39 @@ title: Getting Started
 
 ## 1. Install the software
 
-## From source
+Choose one of the following installation methods:
 
-DNSControl can be built with Go version 1.18 or higher.
+### Homebrew
+
+On macOS (or Linux) you can install it using [Homebrew](https://brew.sh).
+
+```bash
+brew install dnscontrol
+```
+
+### MacPorts
+
+Alternatively on macOS you can install it using [MacPorts](https://www.macports.org).
+
+```bash
+sudo port install dnscontrol
+````
+
+### Docker
+
+You can use DNSControl locally using the Docker image from [Docker hub](https://hub.docker.com/r/stackexchange/dnscontrol/) and the command below.
+
+```bash
+docker run --rm -it -v $(pwd)/dnsconfig.js:/dns/dnsconfig.js -v $(pwd)/creds.json:/dns/creds.json stackexchange/dnscontrol preview
+```
+
+### Binaries
+
+Download binaries from [GitHub](https://github.com/StackExchange/dnscontrol/releases/latest) for Linux (binary, tar, RPM, DEB), FreeBSD (tar), Windows (exec, ZIP) for 32-bit, 64-bit, and ARM.
+
+### Source
+
+DNSControl can be built from source with Go version 1.18 or higher.
 
 The `go install` command will download the source, compile it, and
 install `dnscontrol` in your `$GOBIN` directory.
@@ -23,36 +53,6 @@ To download the source
     git clone https://github.com/StackExchange/dnscontrol
 
 If these don't work, more info is in [#805](https://github.com/StackExchange/dnscontrol/issues/805).
-
----
-
-
-## Via packages
-
-Get prebuilt binaries from [GitHub releases](https://github.com/StackExchange/dnscontrol/releases/latest)
-
-## Through a package manager
-
-Alternatively, on macOS (or Linux) you can install it using [Homebrew](https://brew.sh) or [MacPorts](https://www.macports.org):
-
-### Homebrew
-
-```bash
-brew install dnscontrol
-```
-
-### MacPorts
-
-```bash
-sudo port install dnscontrol
-````
-
-## Via [Docker](https://hub.docker.com/r/stackexchange/dnscontrol/)
-
-```bash
-docker run --rm -it -v $(pwd)/dnsconfig.js:/dns/dnsconfig.js -v $(pwd)/creds.json:/dns/creds.json stackexchange/dnscontrol preview
-```
-
 
 ## 2. Create a place for the config files
 


### PR DESCRIPTION
The installation section within `README.md` and [Getting started](https://stackexchange.github.io/dnscontrol/getting-started#via-packages) has been aligned/improved in terms of 'package manager'.

**Before**
![before](https://user-images.githubusercontent.com/1150425/198849085-1fa706f4-e53b-4366-bed7-96aa3a282038.png)

**After**
![after](https://user-images.githubusercontent.com/1150425/198849086-acb23002-3f6f-41bf-8df6-6559be4dccef.png)
