### PR TITLE
DOCS: Provider TransIP improvements

### DIFF
--- a/docs/_providers/transip.md
+++ b/docs/_providers/transip.md
@@ -14,7 +14,7 @@ along with your TransIP credentials.
 
 ### Key Pairs
 
-You can login with your AccountName and a PrivateKey which can be generated in the TransIP control panel. The PrivateKey is a stringified version of the private key given by the API, see the example below, each newline is replaced by "\n".
+You can login with your AccountName and a PrivateKey which can be generated in the [TransIP control panel](https://www.transip.nl/cp/account/api/). The PrivateKey is a stringified version of the private key given by the API, see the example below, each newline is replaced by "\n".
 
 Example:
 
@@ -30,7 +30,7 @@ Example:
 
 ### Access tokens
 
-Or you can choose to have an AccessToken as credential. These can be generated in the TransIP control panel and have a limited lifetime
+Or you can choose to have an AccessToken as credential. These can be generated in the [TransIP control panel](https://www.transip.nl/cp/account/api/) and have a limited lifetime
 
 
 ```json

--- a/docs/_providers/transip.md
+++ b/docs/_providers/transip.md
@@ -14,7 +14,7 @@ along with your TransIP credentials.
 
 ### Key Pairs
 
-You can login with your AccountName and a PrivateKey which can be generated in the [TransIP control panel](https://www.transip.nl/cp/account/api/). The PrivateKey is a stringified version of the private key given by the API, see the example below, each newline is replaced by "\n".
+You can login with your `AccountName` and a `PrivateKey` which can be generated in the [TransIP control panel](https://www.transip.nl/cp/account/api/). The `PrivateKey` is a stringified version of the Private Key given by the API, see the example below, each newline is replaced by "\n".
 
 Example:
 
@@ -30,7 +30,7 @@ Example:
 
 ### Access tokens
 
-Or you can choose to have an AccessToken as credential. These can be generated in the [TransIP control panel](https://www.transip.nl/cp/account/api/) and have a limited lifetime
+Or you can choose to have an `AccessToken` as credential. These can be generated in the [TransIP control panel](https://www.transip.nl/cp/account/api/) and have a limited lifetime
 
 
 ```json

--- a/docs/_providers/transip.md
+++ b/docs/_providers/transip.md
@@ -12,6 +12,8 @@ jsId: TRANSIP
 To use this provider, add an entry to `creds.json` with `TYPE` set to `TRANSIP`
 along with your TransIP credentials.
 
+### Key Pairs
+
 You can login with your AccountName and a PrivateKey which can be generated in the TransIP control panel. The PrivateKey is a stringified version of the private key given by the API, see the example below, each newline is replaced by "\n".
 
 Example:
@@ -25,6 +27,8 @@ Example:
   }
 }
 ```
+
+### Access tokens
 
 Or you can choose to have an AccessToken as credential. These can be generated in the TransIP control panel and have a limited lifetime
 


### PR DESCRIPTION
- Added an split between the two possible authentications `Key Pairs` versus `Access tokens`.
- Added deeplinks to the TransIP control panel.
- Added highlight for the configuration values.

**Before**
![before](https://user-images.githubusercontent.com/1150425/198878617-cf6fa669-ef2a-48d1-8b9b-3576cd886b3f.png)

**After**
![after](https://user-images.githubusercontent.com/1150425/198878622-721cef95-526a-49b3-9a50-4225e9bd87c4.png)
