### PR TITLE
BUG: Re-introducing the `cloudflare/cloudflare-go` import

### DIFF
--- a/providers/cloudflare/rest.go
+++ b/providers/cloudflare/rest.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/StackExchange/dnscontrol/v3/models"
+	"github.com/cloudflare/cloudflare-go"
 )
 
 // get list of domains for account. Cache so the ids can be looked up from domain name


### PR DESCRIPTION
This import https://github.com/StackExchange/dnscontrol/commit/6b9bcd73399a653dfea8b5160c067fba4d078fe6#diff-ec08db23820e61a251ffbe513a350bb25b6fc4c6e2249fe41b07ccb39b6f1636L10 is automatically removed by the GoLand IDE clean-up functionality. Anyway, this PR brings back the missing import.

Fixes failing [CircleCI pipeline - unit tests](https://app.circleci.com/pipelines/github/StackExchange/dnscontrol/1525/workflows/25a81b5c-49fe-4167-9fe2-49a92d125403/jobs/11166).