### PR TITLE
Added link to the alternative GitHub action

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ docker run --rm -it --volume="$PWD:/srv/jekyll" --volume="$PWD/vendor/bundle:/us
 
 ## Via GitHub Actions (GHA)
 
-See [dnscontrol-action](https://github.com/koenrh/dnscontrol-action)
+See [dnscontrol-action](https://github.com/koenrh/dnscontrol-action) or [gacts/install-dnscontrol](https://github.com/gacts/install-dnscontrol).
 
 ## Deprecation warnings (updated 2022-06-04)
 


### PR DESCRIPTION
Added link to the alternative Github action to install the DNSContron inside GitHub workflow.

Previous PR: https://github.com/StackExchange/dnscontrol/pull/1781