### PR TITLE
DOCS: Updated Go Package URL's to latest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CircleCI](https://circleci.com/gh/StackExchange/dnscontrol/tree/master.svg?style=svg)](https://circleci.com/gh/StackExchange/dnscontrol/tree/master)
 [![Gitter chat](https://badges.gitter.im/dnscontrol/Lobby.png)](https://gitter.im/dnscontrol/Lobby)
 [![Google Group](https://img.shields.io/badge/google%20group-chat-green.svg)](https://groups.google.com/forum/#!forum/dnscontrol-discuss)
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/StackExchange/dnscontrol)](https://pkg.go.dev/github.com/StackExchange/dnscontrol)
+[![PkgGoDev](https://pkg.go.dev/badge/github.com/StackExchange/dnscontrol)](https://pkg.go.dev/github.com/StackExchange/dnscontrol/v3)
 
 [![CircleCI](https://dl.circleci.com/insights-snapshot/gh/StackExchange/dnscontrol/master/build/badge.svg?window=30d)](https://app.circleci.com/insights/github/StackExchange/dnscontrol/workflows/build/overview?branch=master&reporting-window=last-30-days&insights-snapshot=true)
 

--- a/docs/writing-providers.md
+++ b/docs/writing-providers.md
@@ -132,7 +132,7 @@ Add the provider list so DNSControl knows it exists.
 **If you are implementing a DNS Service Provider:**
 
 Implement all the calls in the
-[providers.DNSServiceProvider interface.](https://pkg.go.dev/github.com/StackExchange/dnscontrol/providers#DNSServiceProvider).
+[providers.DNSServiceProvider interface](https://pkg.go.dev/github.com/StackExchange/dnscontrol/v3/providers#DNSServiceProvider).
 
 The function `GetDomainCorrections()` is a bit interesting. It returns
 a list of corrections to be made. These are in the form of functions
@@ -141,7 +141,7 @@ that DNSControl can call to actually make the corrections.
 **If you are implementing a DNS Registrar:**
 
 Implement all the calls in the
-[providers.Registrar interface.](https://pkg.go.dev/github.com/StackExchange/dnscontrol/providers#Registrar).
+[providers.Registrar interface](https://pkg.go.dev/github.com/StackExchange/dnscontrol/v3/providers#Registrar).
 
 The function `GetRegistrarCorrections()` returns
 a list of corrections to be made. These are in the form of functions


### PR DESCRIPTION
It's better to always link to the latest version of the [Go Package](https://pkg.go.dev/github.com/StackExchange/dnscontrol/v3) instead of the [current outdated URL](https://pkg.go.dev/github.com/StackExchange/dnscontrol) with version `v0.2.8` as of `Dec 19, 2018`.

**Before**
https://pkg.go.dev/github.com/StackExchange/dnscontrol

**After**
https://pkg.go.dev/github.com/StackExchange/dnscontrol/v3