### PR TITLE
RWTH: Fix expected key in documentation

### DIFF
--- a/docs/_providers/rwth.md
+++ b/docs/_providers/rwth.md
@@ -17,7 +17,7 @@ Example:
 {
   "rwth": {
     "TYPE": "RWTH",
-    "api_key": "bQGz0DOi0AkTzG...="
+    "api_token": "bQGz0DOi0AkTzG...="
   }
 }
 ```


### PR DESCRIPTION
Hi,

While testing the RWTH provider, I found a mistake in the documentation.

The provider takes `api_token` and not an `api_key`: https://github.com/StackExchange/dnscontrol/blob/master/providers/rwth/rwthProvider.go#L44