### PR TITLE
BUGFIX: PrettySort helper doesn't sort

### DIFF
--- a/pkg/prettyzone/prettyzone.go
+++ b/pkg/prettyzone/prettyzone.go
@@ -90,6 +90,7 @@ func PrettySort(records models.Records, origin string, defaultTTL uint32, commen
 	}
 	z.Records = nil
 	z.Records = append(z.Records, records...)
+	sort.Sort(z)
 	return z
 }
 


### PR DESCRIPTION
PrettySort doesn't call sort!  Luckily the only code that calls this is the "get-zones" subcommand, and nobody noticed that the output isn't sorted.

By making this change, people using "get-zones" to make their initial dnsconfig.js file will find that their draft D() code is a little prettier.