### PR TITLE
gandiv5: drop null MX rejection

### DIFF
--- a/providers/gandiv5/auditrecords.go
+++ b/providers/gandiv5/auditrecords.go
@@ -9,9 +9,5 @@ import (
 // that aren't supported by this provider.  If all records are
 // supported, an empty list is returned.
 func AuditRecords(records []*models.RecordConfig) []error {
-	a := rejectif.Auditor{}
-
-	a.Add("MX", rejectif.MxNull) // Last verified 2020-12-28
-
-	return a.Audit(records)
+	return nil
 }

--- a/providers/gandiv5/auditrecords.go
+++ b/providers/gandiv5/auditrecords.go
@@ -2,7 +2,6 @@ package gandiv5
 
 import (
 	"github.com/StackExchange/dnscontrol/v3/models"
-	"github.com/StackExchange/dnscontrol/v3/pkg/rejectif"
 )
 
 // AuditRecords returns a list of errors corresponding to the records


### PR DESCRIPTION
Fixes https://github.com/StackExchange/dnscontrol/pull/1846

I have no issues setting an MX to `.`.

```
filosottile.info.	1800	IN	MX	0 .
filosottile.info.	10800	IN	NS	ns-189-c.gandi.net.
filosottile.info.	10800	IN	NS	ns-232-a.gandi.net.
filosottile.info.	10800	IN	NS	ns-92-b.gandi.net.
```