### PR TITLE
TransIP

### DIFF
--- a/pkg/diff2/diff2.go
+++ b/pkg/diff2/diff2.go
@@ -8,6 +8,7 @@ package diff2
 import (
 	"bytes"
 	"fmt"
+	"strings"
 
 	"github.com/StackExchange/dnscontrol/v3/models"
 )
@@ -31,6 +32,29 @@ type Change struct {
 	New       models.Records                // any changed or added records at Key.
 	Msgs      []string                      // Human-friendly explanation of what changed
 	MsgsByKey map[models.RecordKey][]string // Messages for a given key
+}
+
+func (c *Change) Msg() string {
+	return strings.Join(c.Msgs, "\n")
+}
+
+// CreateCorrection creates a new Correction based on the given
+// function and prefills it with the Msg of the current Change
+func (c *Change) CreateCorrection(correctionFunction func() error) *models.Correction {
+	return &models.Correction{
+		F:   correctionFunction,
+		Msg: c.Msg(),
+	}
+}
+
+// CreateCorrectionWithMessage creates a new Correction based on the
+// given function and prefixes given function with the Msg of the
+// current change
+func (c *Change) CreateCorrectionWithMessage(msg string, correctionFunction func() error) *models.Correction {
+	return &models.Correction{
+		F:   correctionFunction,
+		Msg: fmt.Sprintf("%s: %s", msg, c.Msg()),
+	}
 }
 
 // ByRecordSet takes two lists of records (existing and desired) and

--- a/providers/transip/transipProvider.go
+++ b/providers/transip/transipProvider.go
@@ -98,12 +98,8 @@ func (n *transipProvider) GetDomainCorrections(dc *models.DomainConfig) ([]*mode
 		return corrections, err
 	}
 
-	if diff2.EnableDiff2 {
-		corrections, err := n.getCorrectionsUsingDiff2(dc, curRecords)
-		return corrections, err
-	}
-
-	return nil, fmt.Errorf("unexpected error: unreachable code. should either use old Diff or Diff2, but neither used")
+	corrections, err := n.getCorrectionsUsingDiff2(dc, curRecords)
+	return corrections, err
 }
 
 func (n *transipProvider) getCorrectionsUsingDiff2(dc *models.DomainConfig, records models.Records) ([]*models.Correction, error) {

--- a/providers/transip/transipProvider.go
+++ b/providers/transip/transipProvider.go
@@ -136,7 +136,7 @@ func (n *transipProvider) getChangeFunction(changeType diff2.Verb, dc *models.Do
 		return wrapChangeFunction(change.Old, func(rec domain.DNSEntry) error { return n.domains.UpdateDNSEntry(dc.Name, rec) })
 	}
 
-	panic(fmt.Sprintf("Unsupported change type %s", changeType))
+	return nil
 }
 
 func wrapChangeFunction(records models.Records, executer func(rec domain.DNSEntry) error) func() error {

--- a/providers/transip/transipProvider.go
+++ b/providers/transip/transipProvider.go
@@ -114,42 +114,33 @@ func (n *transipProvider) getCorrectionsUsingDiff2(dc *models.DomainConfig, reco
 	}
 
 	for _, change := range instructions {
-		msg := strings.Join(change.Msgs, "\n")
 
-		switch change.Type {
-
-		case diff2.CREATE:
-			corrections = append(corrections, &models.Correction{
-				Msg: msg,
-				F:   wrapChangeFunction(change.New, func(rec domain.DNSEntry) error { return n.domains.AddDNSEntry(dc.Name, rec) }),
-			})
-
-		case diff2.CHANGE:
-			if canUpdateDNSEntries(change.New, change.Old) {
-				corrections = append(corrections, &models.Correction{
-					Msg: msg,
-					F:   wrapChangeFunction(change.New, func(rec domain.DNSEntry) error { return n.domains.UpdateDNSEntry(dc.Name, rec) }),
-				})
-			} else {
-				corrections = append(corrections, &models.Correction{
-					Msg: fmt.Sprintf("[1/2] delete of %s", msg),
-					F:   wrapChangeFunction(change.Old, func(rec domain.DNSEntry) error { return n.domains.RemoveDNSEntry(dc.Name, rec) }),
-				})
-				corrections = append(corrections, &models.Correction{
-					Msg: fmt.Sprintf("[2/2] create of %s", msg),
-					F:   wrapChangeFunction(change.New, func(rec domain.DNSEntry) error { return n.domains.AddDNSEntry(dc.Name, rec) }),
-				})
-			}
-
-		case diff2.DELETE:
-			corrections = append(corrections, &models.Correction{
-				Msg: msg,
-				F:   wrapChangeFunction(change.Old, func(rec domain.DNSEntry) error { return n.domains.RemoveDNSEntry(dc.Name, rec) }),
-			})
+		if canDirectApplyDNSEntries(change) {
+			changeFunction := n.getChangeFunction(change.Type, dc, change)
+			corrections = append(corrections, change.CreateCorrection(changeFunction))
+		} else {
+			deleteFunction := n.getChangeFunction(diff2.DELETE, dc, change)
+			createFunction := n.getChangeFunction(diff2.CREATE, dc, change)
+			corrections = append(corrections, change.CreateCorrectionWithMessage("[1/2] delete", deleteFunction), change.CreateCorrectionWithMessage("[2/2] create", createFunction))
 		}
 	}
 
 	return corrections, nil
+}
+
+func (n *transipProvider) getChangeFunction(changeType diff2.Verb, dc *models.DomainConfig, change diff2.Change) func() error {
+	switch changeType {
+	case diff2.DELETE:
+		return wrapChangeFunction(change.Old, func(rec domain.DNSEntry) error { return n.domains.RemoveDNSEntry(dc.Name, rec) })
+
+	case diff2.CREATE:
+		return wrapChangeFunction(change.New, func(rec domain.DNSEntry) error { return n.domains.AddDNSEntry(dc.Name, rec) })
+
+	case diff2.CHANGE:
+		return wrapChangeFunction(change.Old, func(rec domain.DNSEntry) error { return n.domains.UpdateDNSEntry(dc.Name, rec) })
+	}
+
+	panic(fmt.Sprintf("Unsupported change type %s", changeType))
 }
 
 func wrapChangeFunction(records models.Records, executer func(rec domain.DNSEntry) error) func() error {
@@ -170,7 +161,13 @@ func wrapChangeFunction(records models.Records, executer func(rec domain.DNSEntr
 	}
 }
 
-func canUpdateDNSEntries(desired models.Records, existing models.Records) bool {
+func canDirectApplyDNSEntries(change diff2.Change) bool {
+	desired, existing := change.New, change.Old
+
+	if change.Type != diff2.CHANGE {
+		return true
+	}
+
 	if len(desired) != len(existing) {
 		return false
 	}

--- a/providers/transip/transipProvider.go
+++ b/providers/transip/transipProvider.go
@@ -80,7 +80,6 @@ func init() {
 }
 
 func (n *transipProvider) GetDomainCorrections(dc *models.DomainConfig) ([]*models.Correction, error) {
-
 	curRecords, err := n.GetZoneRecords(dc.Name)
 	if err != nil {
 		return nil, err
@@ -94,76 +93,167 @@ func (n *transipProvider) GetDomainCorrections(dc *models.DomainConfig) ([]*mode
 
 	models.PostProcessRecords(curRecords)
 
-	var corrections []*models.Correction
-	if !diff2.EnableDiff2 || true { // Remove "|| true" when diff2 version arrives
+	if !diff2.EnableDiff2 {
+		corrections, err := n.getCorrectionsUsingOldDiff(dc, curRecords)
+		return corrections, err
+	}
 
-		differ := diff.New(dc)
-		_, create, del, modify, err := differ.IncrementalDiff(curRecords)
+	if diff2.EnableDiff2 {
+		corrections, err := n.getCorrectionsUsingDiff2(dc, curRecords)
+		return corrections, err
+	}
+
+	return nil, fmt.Errorf("unexpected error: unreachable code. should either use old Diff or Diff2, but neither used")
+}
+
+func (n *transipProvider) getCorrectionsUsingDiff2(dc *models.DomainConfig, records models.Records) ([]*models.Correction, error) {
+	var corrections []*models.Correction
+	instructions, err := diff2.ByRecordSet(records, dc, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, change := range instructions {
+		msg := strings.Join(change.Msgs, "\n")
+
+		switch change.Type {
+
+		case diff2.CREATE:
+			corrections = append(corrections, &models.Correction{
+				Msg: msg,
+				F:   wrapChangeFunction(change.New, func(rec domain.DNSEntry) error { return n.domains.AddDNSEntry(dc.Name, rec) }),
+			})
+
+		case diff2.CHANGE:
+			if canUpdateDNSEntries(change.New, change.Old) {
+				corrections = append(corrections, &models.Correction{
+					Msg: msg,
+					F:   wrapChangeFunction(change.New, func(rec domain.DNSEntry) error { return n.domains.UpdateDNSEntry(dc.Name, rec) }),
+				})
+			} else {
+				corrections = append(corrections, &models.Correction{
+					Msg: fmt.Sprintf("[1/2] delete of %s", msg),
+					F:   wrapChangeFunction(change.Old, func(rec domain.DNSEntry) error { return n.domains.RemoveDNSEntry(dc.Name, rec) }),
+				})
+				corrections = append(corrections, &models.Correction{
+					Msg: fmt.Sprintf("[2/2] create of %s", msg),
+					F:   wrapChangeFunction(change.New, func(rec domain.DNSEntry) error { return n.domains.AddDNSEntry(dc.Name, rec) }),
+				})
+			}
+
+		case diff2.DELETE:
+			corrections = append(corrections, &models.Correction{
+				Msg: msg,
+				F:   wrapChangeFunction(change.Old, func(rec domain.DNSEntry) error { return n.domains.RemoveDNSEntry(dc.Name, rec) }),
+			})
+		}
+	}
+
+	return corrections, nil
+}
+
+func wrapChangeFunction(records models.Records, executer func(rec domain.DNSEntry) error) func() error {
+	return func() error {
+		for _, record := range records {
+			nativeRec, err := recordToNative(record)
+
+			if err != nil {
+				return err
+			}
+
+			if err := executer(nativeRec); err != nil {
+				return err
+			}
+		}
+
+		return nil
+	}
+}
+
+func canUpdateDNSEntries(desired models.Records, existing models.Records) bool {
+	if len(desired) != len(existing) {
+		return false
+	}
+
+	if len(desired) > 1 {
+		return false
+	}
+
+	for i := 0; i < len(desired); i++ {
+		if !canUpdateDNSEntry(desired[i], existing[i]) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func (n *transipProvider) getCorrectionsUsingOldDiff(dc *models.DomainConfig, records models.Records) ([]*models.Correction, error) {
+	var corrections []*models.Correction
+
+	differ := diff.New(dc)
+	_, create, del, modify, err := differ.IncrementalDiff(records)
+
+	if err != nil {
+		return nil, err
+	}
+
+	for _, del := range del {
+		entry, err := recordToNative(del.Existing)
 		if err != nil {
 			return nil, err
 		}
 
-		for _, del := range del {
-			entry, err := recordToNative(del.Existing)
-			if err != nil {
-				return nil, err
-			}
-
-			corrections = append(corrections, &models.Correction{
-				Msg: del.String(),
-				F:   func() error { return n.domains.RemoveDNSEntry(dc.Name, entry) },
-			})
-		}
-
-		for _, cre := range create {
-			entry, err := recordToNative(cre.Desired)
-			if err != nil {
-				return nil, err
-			}
-
-			corrections = append(corrections, &models.Correction{
-				Msg: cre.String(),
-				F:   func() error { return n.domains.AddDNSEntry(dc.Name, entry) },
-			})
-		}
-
-		for _, mod := range modify {
-			targetEntry, err := recordToNative(mod.Desired)
-			if err != nil {
-				return nil, err
-			}
-
-			// TransIP identifies records by (Label, TTL Type), we can only update it if only the contents
-			// has changed. Otherwise we delete the old record and create the new one
-			if canUpdateDNSEntry(mod.Desired, mod.Existing) {
-				corrections = append(corrections, &models.Correction{
-					Msg: mod.String(),
-					F:   func() error { return n.domains.UpdateDNSEntry(dc.Name, targetEntry) },
-				})
-			} else {
-				oldEntry, err := recordToNative(mod.Existing)
-				if err != nil {
-					return nil, err
-				}
-
-				corrections = append(corrections,
-					&models.Correction{
-						Msg: mod.String() + "[1/2]",
-						F:   func() error { return n.domains.RemoveDNSEntry(dc.Name, oldEntry) },
-					},
-					&models.Correction{
-						Msg: mod.String() + "[2/2]",
-						F:   func() error { return n.domains.AddDNSEntry(dc.Name, targetEntry) },
-					},
-				)
-			}
-
-		}
-
-		return corrections, nil
+		corrections = append(corrections, &models.Correction{
+			Msg: del.String(),
+			F:   func() error { return n.domains.RemoveDNSEntry(dc.Name, entry) },
+		})
 	}
 
-	// Insert Future diff2 version here.
+	for _, cre := range create {
+		entry, err := recordToNative(cre.Desired)
+		if err != nil {
+			return nil, err
+		}
+
+		corrections = append(corrections, &models.Correction{
+			Msg: cre.String(),
+			F:   func() error { return n.domains.AddDNSEntry(dc.Name, entry) },
+		})
+	}
+
+	for _, mod := range modify {
+		targetEntry, err := recordToNative(mod.Desired)
+		if err != nil {
+			return nil, err
+		}
+
+		// TransIP identifies records by (Label, TTL Type), we can only update it if only the contents
+		// has changed. Otherwise we delete the old record and create the new one
+		if canUpdateDNSEntry(mod.Desired, mod.Existing) {
+			corrections = append(corrections, &models.Correction{
+				Msg: mod.String(),
+				F:   func() error { return n.domains.UpdateDNSEntry(dc.Name, targetEntry) },
+			})
+		} else {
+			oldEntry, err := recordToNative(mod.Existing)
+			if err != nil {
+				return nil, err
+			}
+
+			corrections = append(corrections,
+				&models.Correction{
+					Msg: mod.String() + "[1/2]",
+					F:   func() error { return n.domains.RemoveDNSEntry(dc.Name, oldEntry) },
+				},
+				&models.Correction{
+					Msg: mod.String() + "[2/2]",
+					F:   func() error { return n.domains.AddDNSEntry(dc.Name, targetEntry) },
+				},
+			)
+		}
+
+	}
 
 	return corrections, nil
 }


### PR DESCRIPTION
Hi Tom,

I believe this will be required changes for the new diff2 differ.

I tested it using `go test -v -verbose -provider TRANSIP -diff2 -end 1` and I ran a preview against my own DNS config.

I notices same annoyances with the new differ package which I like to state as well. Do note, I get that sometimes you have to choose a solution rather than maintain many differences ones to please everybody. So don't see this as a show stopper. But rather suggestions which can maybe help you obtain a easier to integrate package.

- First, the `Change` fields. The rename from `Desired` and `Existing` to `Old` and `New` really took me by surprise. I liked the old field names allot more because it ties more into what we are doing. It is really weird for me te 'remove' old DNS record, instead of 'Existing' DNS records. It seems also weird to 'Change' using the 'New' field instead of the 'Desired'. 
- Second, In every example I see people doing `strings.Join(change.Msgs, "\n")` to pass to `models.Correction`'s `Msg` field. Why not make it an public function on `Change` or `Change.Msgs`?
- The rest API of TransIP does everything record for record, but your new differ seems to favor batching in some form or another. This required me to introduce allot of helper functions and boilerplate functions to 'get around' it. A solution is just assuming the `New` and `Old` fields are always a slice of length 1 or 0, but this to me is just bad design and will lead to bugs down the road. I rather see a separate return structure for the `diff2.ByRecord` version. In the defence of your design, it came to rescue as I needed to switch to `diff2.ByRecordSet` (and even tried diff2.ByLabel) because TransIP's API really can't handle updating a record from a multi record set. If this design intentionally favors batching updates, good job, I am just a terrible person trying my best to go against your better judgement. If your new design stays I am thinking about rewriting my provider to always replace the whole zone, it is allot more destructive, but it seems easier from my perspective. If this is unintentional, you should try and mold the `ChangeList` to support these `ByRecord` changes more fluently.
