### PR TITLE
BUG: SPF split doesn't produce consistent output

### DIFF
--- a/pkg/normalize/flatten.go
+++ b/pkg/normalize/flatten.go
@@ -87,10 +87,8 @@ func flattenSPFs(cfg *models.DNSConfig) []error {
 					continue
 				}
 				recs := rec.TXTSplit(split+"."+domain.Name, overhead1, txtMaxSize)
-				recsKeys := sortedKeys(recs)
 
-				//for k, v := range recs {
-				for _, k := range recsKeys {
+				for _, k := range sortedKeys(recs) {
 					v := recs[k]
 					if k == "@" {
 						txt.SetTargetTXTs(v)


### PR DESCRIPTION
Every time the SPF optimizer splits an SPF record it doesn't it slightly differently even given the same input. The output is always correct, just different.  This makes it difficult to test the code, since every run is slightly different.

With this change the output is always the same given the same inputs.

Fixes https://github.com/StackExchange/dnscontrol/issues/1863