### PR TITLE
HEDNS: Re-enable CI integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,6 +90,11 @@ jobs:
       NAMEDOTCOM_URL: api.name.com
       NAMEDOTCOM_USER: dnscontroltest
 
+      HEDNS_DOMAIN: dnscontrol.net
+      HEDNS_USERNAME: dnscontroltest
+      HEDNS_PASSWORD: $HEDNS_PASSWORD
+      HEDNS_TOTP_SECRET: $HEDNS_TOTP_SECRET
+
     parameters:
       provider:
         type: string


### PR DESCRIPTION
This re-enables the CI integrations test now that CircleCI is used for CI testing.