### PR TITLE
gandiv5: Wrong directory name in OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -14,7 +14,7 @@ providers/doh @mikenz
 providers/domainnameshop @SimenBai
 providers/easyname @tresni
 providers/exoscale @pierre-emmanuelJ
-providers/gandi_v5 @TomOnTime
+providers/gandiv5 @TomOnTime
 providers/gcore @xddxdd
 providers/gcloud @riyadhalnur
 providers/hedns @rblenkinsopp


### PR DESCRIPTION
Corrected the wrong directory name in `OWNERS` for `GandiV5`.

```diff
-providers/gandi_v5 @TomOnTime
+providers/gandiv5 @TomOnTime
```

_https://github.com/StackExchange/dnscontrol/tree/master/providers/gandiv5_