### PR TITLE
DOCS: Typo `CloudFlare`

### DIFF
--- a/docs/_providers/inwx.md
+++ b/docs/_providers/inwx.md
@@ -100,7 +100,7 @@ INWX.
 ## Usage
 An example `dnsconfig.js` configuration file
 for `example.tld` registered with INWX
-and delegated to CloudFlare:
+and delegated to Cloudflare:
 
 ```js
 var REG_INWX = NewRegistrar("inwx");
@@ -110,6 +110,3 @@ D("example.tld", REG_INWX, DnsProvider(DSP_CF),
     A("test", "1.2.3.4")
 );
 ```
-
-
-


### PR DESCRIPTION
Small typo in the name `Cloudflare`.

```diff
-CloudFlare
+Cloudflare
```

_https://www.cloudflare.com/en-gb/#:~:text=Cloudflare_
