### PR TITLE
NETLIFY: Fix TXT record handling

### DIFF
--- a/providers/netlify/auditrecords.go
+++ b/providers/netlify/auditrecords.go
@@ -11,7 +11,9 @@ import (
 func AuditRecords(records []*models.RecordConfig) []error {
 	a := rejectif.Auditor{}
 
-	a.Add("MX", rejectif.MxNull) // Last verified 2022-11-20
+	a.Add("TXT", rejectif.TxtIsEmpty) // Last verified 2023-01-19
+
+	a.Add("MX", rejectif.MxNull) // Last verified 2023-01-19
 
 	return a.Audit(records)
 }

--- a/providers/netlify/netlifyProvider.go
+++ b/providers/netlify/netlifyProvider.go
@@ -9,7 +9,6 @@ import (
 	"github.com/StackExchange/dnscontrol/v3/pkg/diff"
 	"github.com/StackExchange/dnscontrol/v3/pkg/diff2"
 	"github.com/StackExchange/dnscontrol/v3/pkg/printer"
-	"github.com/StackExchange/dnscontrol/v3/pkg/txtutil"
 	"github.com/StackExchange/dnscontrol/v3/providers"
 	"github.com/miekg/dns"
 )
@@ -190,7 +189,6 @@ func (n *netlifyProvider) GetDomainCorrections(dc *models.DomainConfig) ([]*mode
 
 	// Normalize
 	models.PostProcessRecords(records)
-	txtutil.SplitSingleLongTxt(dc.Records) // Auto split long TXT records
 	removeOtherApexNS(dc)
 
 	var corrections []*models.Correction


### PR DESCRIPTION
Netlify no longer splits TXT records into multiple, and cannot handle empty TXT records

Tests: All integration tests pass on `diff` and `diff2`