### PR TITLE
TypeScript typing: missing parameter

### DIFF
--- a/documentation/functions/global/DOMAIN_ELSEWHERE.md
+++ b/documentation/functions/global/DOMAIN_ELSEWHERE.md
@@ -1,9 +1,11 @@
 ---
 name: DOMAIN_ELSEWHERE
 parameters:
+  - name
   - registrar
   - nameserver_names
 parameter_types:
+  name: string
   registrar: string
   nameserver_names: string[]
 ---

--- a/documentation/functions/global/DOMAIN_ELSEWHERE_AUTO.md
+++ b/documentation/functions/global/DOMAIN_ELSEWHERE_AUTO.md
@@ -1,10 +1,12 @@
 ---
 name: DOMAIN_ELSEWHERE_AUTO
 parameters:
+  - name
   - domain
   - registrar
   - dns provider
 parameter_types:
+  name: string
   domain: string
   registrar: string
   dns provider: string


### PR DESCRIPTION
Added the TypeScript typing missing parameter `name` for `DOMAIN_ELSEWHERE` and `DOMAIN_ELSEWHERE_AUTO`.

cc: @j-f1 