### PR TITLE
DOCS: [CAA] General improvements

### DIFF
--- a/documentation/functions/domain/CAA.md
+++ b/documentation/functions/domain/CAA.md
@@ -14,7 +14,10 @@ parameter_types:
 
 `CAA()` adds a CAA record to a domain. The name should be the relative label for the record. Use `@` for the domain apex.
 
-Tag can be one of "issue", "issuewild" or "iodef".
+Tag can be one of
+1. `"issue"`
+2. `"issuewild"`
+3. `"iodef"`
 
 Value is a string. The format of the contents is different depending on the tag. DNSControl will handle any escaping or quoting required, similar to TXT records. For example use `CAA("@", "issue", "letsencrypt.org")` rather than `CAA("@", "issue", "\"letsencrypt.org\"")`.
 

--- a/documentation/functions/domain/CAA.md
+++ b/documentation/functions/domain/CAA.md
@@ -12,15 +12,14 @@ parameter_types:
   "modifiers...": RecordModifier[]
 ---
 
-CAA adds a CAA record to a domain. The name should be the relative label for the record. Use `@` for the domain apex.
+`CAA()` adds a CAA record to a domain. The name should be the relative label for the record. Use `@` for the domain apex.
 
 Tag can be one of "issue", "issuewild" or "iodef".
 
 Value is a string. The format of the contents is different depending on the tag. DNSControl will handle any escaping or quoting required, similar to TXT records. For example use `CAA("@", "issue", "letsencrypt.org")` rather than `CAA("@", "issue", "\"letsencrypt.org\"")`.
 
 Flags are controlled by modifier:
-
-- CAA_CRITICAL: Issuer critical flag. CA that does not understand this tag will refuse to issue certificate for this domain.
+- `CAA_CRITICAL`: Issuer critical flag. CA that does not understand this tag will refuse to issue certificate for this domain.
 
 ```javascript
 D("example.com", REGISTRAR, DnsProvider("GCLOUD"),

--- a/documentation/functions/domain/CAA.md
+++ b/documentation/functions/domain/CAA.md
@@ -16,13 +16,11 @@ CAA adds a CAA record to a domain. The name should be the relative label for the
 
 Tag can be one of "issue", "issuewild" or "iodef".
 
-Value is a string. The format of the contents is different depending on the tag.  DNSControl will handle any escaping or quoting required, similar to TXT records.  For example use `CAA("@", "issue", "letsencrypt.org")` rather than `CAA("@", "issue", "\"letsencrypt.org\"")`.
+Value is a string. The format of the contents is different depending on the tag. DNSControl will handle any escaping or quoting required, similar to TXT records. For example use `CAA("@", "issue", "letsencrypt.org")` rather than `CAA("@", "issue", "\"letsencrypt.org\"")`.
 
 Flags are controlled by modifier:
 
 - CAA_CRITICAL: Issuer critical flag. CA that does not understand this tag will refuse to issue certificate for this domain.
-
-CAA record is supported only by BIND, Google Cloud DNS, Amazon Route 53 and OVH. Some certificate authorities may not support this record until the mandatory date of September 2017.
 
 ```javascript
 D("example.com", REGISTRAR, DnsProvider("GCLOUD"),

--- a/documentation/functions/domain/CAA.md
+++ b/documentation/functions/domain/CAA.md
@@ -35,3 +35,5 @@ D("example.com", REGISTRAR, DnsProvider("GCLOUD"),
   CAA("@", "iodef", "mailto:test@example.com", CAA_CRITICAL)
 );
 ```
+
+DNSControl contains a [`CAA_BUILDER`](../record/CAA_BUILDER.md) which can be used to simply create `CAA()` records for your domains. Instead of creating each CAA record individually, you can simply configure your report mail address, the authorized certificate authorities and the builder cares about the rest.

--- a/documentation/functions/record/CAA_BUILDER.md
+++ b/documentation/functions/record/CAA_BUILDER.md
@@ -47,7 +47,9 @@ The parameters are:
 
 `CAA_BUILDER()` returns multiple records (when configured as example above):
 
-  * `CAA("@", "iodef", "mailto:test@domain.tld", CAA_CRITICAL)`
-  * `CAA("@", "issue", "letsencrypt.org")`
-  * `CAA("@", "issue", "comodoca.com")`
-  * `CAA("@", "issuewild", ";")`
+```javascript
+CAA("@", "iodef", "mailto:test@domain.tld", CAA_CRITICAL)
+CAA("@", "issue", "letsencrypt.org")
+CAA("@", "issue", "comodoca.com")
+CAA("@", "issuewild", ";")
+```

--- a/documentation/functions/record/CAA_BUILDER.md
+++ b/documentation/functions/record/CAA_BUILDER.md
@@ -16,7 +16,7 @@ parameter_types:
 ---
 
 DNSControl contains a `CAA_BUILDER` which can be used to simply create
-CAA records for your domains. Instead of creating each CAA record
+[`CAA()`](../domain/CAA.md) records for your domains. Instead of creating each [`CAA()`](../domain/CAA.md) record
 individually, you can simply configure your report mail address, the
 authorized certificate authorities and the builder cares about the rest.
 


### PR DESCRIPTION
- Remove the supported disclaimer, `CAA()` is [supported by almost all DNSControl providers](https://docs.dnscontrol.org/service-providers/providers#:~:text=CAA).
- Added code highlights.
- Applied number list.
- Crosslink to `CAA_BUILDER()` and  `CAA()`.
