### PR TITLE
TRANSIP: Implementation get-zones all

### DIFF
--- a/providers/transip/transipProvider.go
+++ b/providers/transip/transipProvider.go
@@ -3,6 +3,7 @@ package transip
 import (
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/StackExchange/dnscontrol/v3/models"
@@ -77,6 +78,19 @@ func init() {
 		RecordAuditor: AuditRecords,
 	}
 	providers.RegisterDomainServiceProviderType("TRANSIP", fns, features)
+}
+
+func (n *transipProvider) ListZones() ([]string, error) {
+	var domains []string
+
+	domainsMap, _ := n.domains.GetAll()
+	for _, domainname := range domainsMap {
+		domains = append(domains, domainname.Name)
+	}
+
+	sort.Strings(domains)
+
+	return domains, nil
 }
 
 func (n *transipProvider) GetDomainCorrections(dc *models.DomainConfig) ([]*models.Correction, error) {


### PR DESCRIPTION
```shell
~/dnscontrol/ dnscontrol get-zones transip - all
```
```text
$ORIGIN cafferata.dev.
$TTL 86400
@                IN MX    10 ASPMX.l.google.com.
                 IN MX    20 alt1.ASPMX.l.google.com.
                 IN MX    30 alt2.ASPMX.l.google.com.
                 IN MX    40 ASPMX2.googlemail.com.
                 IN MX    50 ASPMX3.googlemail.com.
                 IN MX    60 ASPMX4.googlemail.com.
                 IN MX    70 ASPMX5.googlemail.com.
                 IN TXT   "v=spf1 -all"
```

cc: @blackshadev