### PR TITLE
VULTR: Adopt diff2 in compatibility mode and fix handling of some integrations tests

### DIFF
--- a/providers/vultr/vultrProvider.go
+++ b/providers/vultr/vultrProvider.go
@@ -313,6 +313,9 @@ func toVultrRecord(dc *models.DomainConfig, rc *models.RecordConfig, vultrID str
 	}
 	switch rtype := rc.Type; rtype { // #rtype_variations
 	case "SRV":
+		if data == "" {
+			data = "."
+		}
 		r.Data = fmt.Sprintf("%v %v %s", rc.SrvWeight, rc.SrvPort, data)
 	case "CAA":
 		r.Data = fmt.Sprintf(`%v %s "%s"`, rc.CaaFlag, rc.CaaTag, rc.GetTargetField())


### PR DESCRIPTION
Overtake #1902

Tried both
```
    go test -v -verbose -provider VULTR
```
and
```
    go test -v -verbose -provider VULTR -diff2
```
and both succeed