### PR TITLE
DOCS: Providers remove anchor

### DIFF
--- a/documentation/providers.md
+++ b/documentation/providers.md
@@ -1,6 +1,6 @@
 # Service Providers
 
-## Provider Features {#features}
+## Provider Features
 
 The table below shows various features supported, or not supported by DNSControl providers.
 This table is automatically generated from metadata supplied by the provider when they register themselves inside dnscontrol.


### PR DESCRIPTION
Remove the superfluous anchor from the Markdown header.