### PR TITLE
DOCS: [AXFR+DDNS] Fixed broken GitHub link.

### DIFF
--- a/documentation/providers/axfrddns.md
+++ b/documentation/providers/axfrddns.md
@@ -206,4 +206,4 @@ When AutoDNSSEC is not enabled or disabled, no checking is done.
 
 ## FYI: MD5 Support
 
-By default the used DNS Go package by miekg has deprecated supporting the (insecure) MD5 algorithm [https://github.com/miekg/dns/commit/93945c284489394b77653323d11d5de83a2a6fb5](Link). Some providers like the Leibniz Supercomputing Centre (LRZ) located in Munich still use this algorithm to authenticate internal dynamic DNS updates. To compensate the lack of MD5 a custom MD5 TSIG Provider was added into DNSControl.
+By default the used DNS Go package by miekg has deprecated supporting the (insecure) MD5 algorithm [https://github.com/miekg/dns/commit/93945c284489394b77653323d11d5de83a2a6fb5](https://github.com/miekg/dns/commit/93945c284489394b77653323d11d5de83a2a6fb5). Some providers like the Leibniz Supercomputing Centre (LRZ) located in Munich still use this algorithm to authenticate internal dynamic DNS updates. To compensate the lack of MD5 a custom MD5 TSIG Provider was added into DNSControl.


### PR DESCRIPTION
Fixed the broken GitHub link on the [AXFR+DDNS page](https://docs.dnscontrol.org/service-providers/providers/axfrddns#fyi-md5-support:~:text=the%20used%20DNS-,Go%20package%20by%20miekg,-has%20deprecated%20supporting).
