### PR TITLE
DOCS: NAMESERVER_TTL wrong domain-modifiers name

### DIFF
--- a/documentation/functions/domain/NAMESERVER_TTL.md
+++ b/documentation/functions/domain/NAMESERVER_TTL.md
@@ -8,7 +8,7 @@ parameter_types:
   modifiers...: RecordModifier[]
 ---
 
-TTL sets the TTL on the domain apex NS RRs defined by [NAMESERVER](NAMESERVER.md).
+NAMESERVER_TTL sets the TTL on the domain apex NS RRs defined by [NAMESERVER](NAMESERVER.md).
 
 The value can be an integer or a string. See [TTL](../record/TTL.md) for examples.
 


### PR DESCRIPTION
The wrong domain-modifiers name was applied for `NAMESERVER_TTL()`.