### PR TITLE
DOCS: [GitBook] Code block syntax

### DIFF
--- a/documentation/functions/global/DOMAIN_ELSEWHERE.md
+++ b/documentation/functions/global/DOMAIN_ELSEWHERE.md
@@ -25,9 +25,9 @@ For example these two statements are equivalent:
 
 ```javascript
 DOMAIN_ELSEWHERE("example.com", REG_NAMEDOTCOM, ["ns1.foo.com", "ns2.foo.com"]);
+```
 
-// ...is equivalent to...
-
+```javascript
 D("example.com", REG_NAMEDOTCOM,
     NO_PURGE,
     NAMESERVER("ns1.foo.com"),

--- a/documentation/functions/global/DOMAIN_ELSEWHERE_AUTO.md
+++ b/documentation/functions/global/DOMAIN_ELSEWHERE_AUTO.md
@@ -30,9 +30,9 @@ For example these two statements are equivalent:
 
 ```javascript
 DOMAIN_ELSEWHERE_AUTO("example.com", REG_NAMEDOTCOM, DSP_AZURE);
+```
 
-// ...is equivalent to...
-
+```javascript
 D("example.com", REG_NAMEDOTCOM,
     NO_PURGE,
     DnsProvider(DSP_AZURE)


### PR DESCRIPTION
I've split the two comparison [`DOMAIN_ELSEWHERE()`](https://docs.dnscontrol.org/language-reference/top-level-functions/domain_elsewhere) and [`DOMAIN_ELSEWHERE_AUTO()`](https://docs.dnscontrol.org/language-reference/top-level-functions/domain_elsewhere_auto) code blocks for better readability and copy/paste development.