### PR TITLE
DOCS: [README] Fixed Changelog v3.16.0 URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ See [dnscontrol-action](https://github.com/koenrh/dnscontrol-action) or [gacts/i
 
 - **Call for new volunteer maintainers for NAMECHEAP, NAMEDOTCOM, and SOFTLAYER.** These providers have no maintainer. Maintainers respond to PRs and fix bugs in a timely manner, and try to stay on top of protocol changes.
 - **ACME/Let's Encrypt support is frozen and will be removed after December 31, 2022.**  The `get-certs` command (renews certs via Let's Encrypt) has no maintainer. There are other projects that do a better job. If you don't use this feature, please do not start. If you do use this feature, please plan on migrating to something else.  See discussion in [issues/1400](https://github.com/StackExchange/dnscontrol/issues/1400)
-- **get-zones syntax changes in v3.16** Starting in [v3.16](v316.md), the command line arguments for `dnscontrol get-zones` changes. For backwards compatibility change `provider` to `-`. See documentation for details.
+- **get-zones syntax changes in v3.16** Starting in [v3.16](documentation/v316.md), the command line arguments for `dnscontrol get-zones` changes. For backwards compatibility change `provider` to `-`. See documentation for details.
 
 ## More info at our website
 


### PR DESCRIPTION
Fixed the [Changelog v3.16.0](https://docs.dnscontrol.org/release/v316) URL in the [README](https://github.com/StackExchange/dnscontrol#:~:text=get%2Dzones%20syntax%20changes%20in%20v3.16).
