### PR TITLE
DOCS: Replace stackexchange.github.io

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -49,7 +49,7 @@ universal_binaries:
 nfpms:
   - file_name_template: '{{ .ProjectName }}-{{ .Version }}.{{ .Arch }}'
     id: packages_rpm
-    homepage:  https://stackexchange.github.io/dnscontrol/
+    homepage:  https://docs.dnscontrol.org/
     description: "DNSControl: Infrastructure as Code for DNS Zones"
     maintainer: 'Tom Limoncelli <tlimoncelli@stackoverflow.com>'
     license: MIT
@@ -60,7 +60,7 @@ nfpms:
       amd64: x86_64
   - file_name_template: '{{ .ProjectName }}-{{ .Version }}.{{ .Arch }}'
     id: packages_deb
-    homepage:  https://stackexchange.github.io/dnscontrol/
+    homepage:  https://docs.dnscontrol.org/
     description: "DNSControl: Infrastructure as Code for DNS Zones"
     maintainer: 'Tom Limoncelli <tlimoncelli@stackoverflow.com>'
     license: MIT

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 [![CircleCI](https://dl.circleci.com/insights-snapshot/gh/StackExchange/dnscontrol/master/build/badge.svg?window=30d)](https://app.circleci.com/insights/github/StackExchange/dnscontrol/workflows/build/overview?branch=master&reporting-window=last-30-days&insights-snapshot=true)
 
-[DNSControl](https://stackexchange.github.io/dnscontrol/) is a system
+[DNSControl](https://docs.dnscontrol.org/) is a system
 for maintaining DNS zones.  It has two parts:
 a domain specific language (DSL) for describing DNS zones plus
 software that processes the DSL and pushes the resulting zones to
@@ -155,6 +155,6 @@ See [dnscontrol-action](https://github.com/koenrh/dnscontrol-action) or [gacts/i
 
 ## More info at our website
 
-The website: [https://stackexchange.github.io/dnscontrol/](https://stackexchange.github.io/dnscontrol/)
+The website: [https://docs.dnscontrol.org/](https://docs.dnscontrol.org/)
 
 The getting started guide: [https://docs.dnscontrol.org/getting-started/getting-started](https://docs.dnscontrol.org/getting-started/getting-started)

--- a/commands/getZones.go
+++ b/commands/getZones.go
@@ -33,7 +33,7 @@ var _ = cmd(catUtils, func() *cli.Command {
 				// NB(tlim): In v4.0 this "if" can be removed.
 				fmt.Fprintf(os.Stderr, "WARNING: To retain compatibility in future versions, please change %q to %q. See %q\n",
 					arg1, "-",
-					"https://stackexchange.github.io/dnscontrol/get-zones.html",
+					"https://docs.dnscontrol.org/commands/get-zones",
 				)
 			}
 

--- a/commands/previewPush.go
+++ b/commands/previewPush.go
@@ -290,7 +290,7 @@ func InitializeProviders(cfg *models.DNSConfig, providerConfigs map[string]map[s
 const providerTypeFieldName = "TYPE"
 
 // url is the documentation URL to list in the warnings related to missing provider type ids.
-const url = "https://stackexchange.github.io/dnscontrol/creds-json"
+const url = "https://docs.dnscontrol.org/commands/creds-json"
 
 // populateProviderTypes scans a DNSConfig for blank provider types and fills them in based on providerConfigs.
 // That is, if the provider type is "-" or "", we take that as an flag

--- a/dnscontrol.nuspec
+++ b/dnscontrol.nuspec
@@ -11,7 +11,7 @@
     <licenseUrl>https://github.com/StackExchange/dnscontrol/blob/master/LICENSE</licenseUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <projectSourceUrl>https://github.com/stackexchange/dnscontrol</projectSourceUrl>
-    <docsUrl>https://stackexchange.github.io/dnscontrol/</docsUrl>
+    <docsUrl>https://docs.dnscontrol.org/</docsUrl>
     <tags>dns</tags>
     <summary>Synchronize your DNS to multiple providers from a simple DSL</summary>
     <description>This package simply installs the dnscontrol tool on your system</description>

--- a/pkg/normalize/validate.go
+++ b/pkg/normalize/validate.go
@@ -44,7 +44,7 @@ func checkTarget(target string) error {
 	}
 	// If it contains a ".", it must end in a ".".
 	if strings.ContainsRune(target, '.') && target[len(target)-1] != '.' {
-		return fmt.Errorf("target (%v) must end with a (.) [https://stackexchange.github.io/dnscontrol/why-the-dot]", target)
+		return fmt.Errorf("target (%v) must end with a (.) [https://docs.dnscontrol.org/language-reference/why-the-dot]", target)
 	}
 	return nil
 }

--- a/providers/bind/bindProvider.go
+++ b/providers/bind/bindProvider.go
@@ -75,7 +75,7 @@ func initBind(config map[string]string, providermeta json.RawMessage) (providers
 		}
 		// If it contains a ".", it must end in a ".".
 		if strings.ContainsRune(ns, '.') && ns[len(ns)-1] != '.' {
-			return nil, fmt.Errorf("default_ns (%v) must end with a (.) [https://stackexchange.github.io/dnscontrol/why-the-dot]", ns)
+			return nil, fmt.Errorf("default_ns (%v) must end with a (.) [https://docs.dnscontrol.org/language-reference/why-the-dot]", ns)
 		}
 		// This is one of the (increasingly rare) cases where we store a
 		// name without the trailing dot to indicate a FQDN.


### PR DESCRIPTION
Replace `stackexchange.github.io` with `docs.dnscontrol.org` for the homepage and pages.