### PR TITLE
DOCS: GitHub pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+<!--
+$ go fmt ./...
+
+At this point, code style is not guaranteed within Github Action and/or Circle CI.
+Please run `go fmt ./...` from the root directory.
+
+@see https://github.com/StackExchange/dnscontrol/pull/1996#issuecomment-1407388782
+
+$ go mod tidy
+
+When you have made a change to the Go dependencies, please run the Go command.
+
+@see https://golangbyexample.com/go-mod-tidy/
+!-->
+

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,15 +1,8 @@
 <!--
-$ go fmt ./...
+Before you submit a pull request, please make sure you've run the following commands from the root directory.
 
-At this point, code style is not guaranteed within Github Action and/or Circle CI.
-Please run `go fmt ./...` from the root directory.
-
-@see https://github.com/StackExchange/dnscontrol/pull/1996#issuecomment-1407388782
-
-$ go mod tidy
-
-When you have made a change to the Go dependencies, please run the Go command.
-
-@see https://golangbyexample.com/go-mod-tidy/
+go fmt ./...
+go generate
+go tidy
 !-->
 


### PR DESCRIPTION
@tlimoncelli https://github.com/StackExchange/dnscontrol/pull/1996#issuecomment-1407388782
>Internally we're discussing moving to a new build pipeline. Until that decision is made, I don't want to invest too much in the pipeline. However adding it to the docs is fine.

The Go format and Go mod tidy commands listed within the GitHub pull request template.

See [GitHub docs](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository).