### PR TITLE
TRANSIP: Audit records

### DIFF
--- a/providers/transip/auditrecords.go
+++ b/providers/transip/auditrecords.go
@@ -1,10 +1,19 @@
 package transip
 
-import "github.com/StackExchange/dnscontrol/v3/models"
+import (
+	"github.com/StackExchange/dnscontrol/v3/models"
+	"github.com/StackExchange/dnscontrol/v3/pkg/rejectif"
+)
 
 // AuditRecords returns a list of errors corresponding to the records
 // that aren't supported by this provider.  If all records are
 // supported, an empty list is returned.
 func AuditRecords(records []*models.RecordConfig) []error {
-	return nil
+	a := rejectif.Auditor{}
+	a.Add("MX", rejectif.MxNull)               // Last verified 2023-01-28
+	a.Add("TXT", rejectif.TxtHasBackticks)     // Last verified 2023-01-28
+	a.Add("TXT", rejectif.TxtHasTrailingSpace) // Last verified 2023-01-28
+	a.Add("TXT", rejectif.TxtIsEmpty)          // Last verified 2023-01-28
+
+	return a.Audit(records)
 }


### PR DESCRIPTION
Checked the Audit records through the [TransIP API](https://api.transip.nl/rest/docs.html#domains-dns-post).

`POST /v6/domains/cafferata.dev/dns`

### rejectif.MxNull

**Request**

```json
{
  "dnsEntry": {
    "name": "@",
    "expire": 86400,
    "type": "MX",
    "content": ""
  }
}
```

**Response**

```json
{
  "error": "the content of an MX record must be in the format \"priority target\": @ 86400 MX \nrecord content cannot be empty: @ 86400 MX "
}
```

### rejectif.TxtHasBackticks

```json
{
  "dnsEntry": {
    "name": "@",
    "expire": 86400,
    "type": "TXT",
    "content": "`"
  }
}
```

**Response**

```json
{
  "error": "the content of a TXT record cannot contain invalid characters: @ 86400 TXT `"
}
```

### rejectif.TxtHasTrailingSpace

```json
{
  "dnsEntry": {
    "name": "@",
    "expire": 86400,
    "type": "TXT",
    "content": "ms=123456 "
  }
}
```

**Response**

```json
{
    "error": "whitespace at the end or start of the content of a record is not allowed: @ 86400 TXT ms=123456 "
}
```

### rejectif.TxtIsEmpty

```json
{
  "dnsEntry": {
    "name": "@",
    "expire": 86400,
    "type": "TXT",
    "content": ""
  }
}
```

**Response**

```json
{
  "error": "record content cannot be empty: @ 86400 TXT "
}
```
