### PR TITLE
HOSTINGDE: Implement SOA record (fixes #1972)

### DIFF
--- a/providers/hostingde/api.go
+++ b/providers/hostingde/api.go
@@ -18,6 +18,7 @@ type hostingdeProvider struct {
 	ownerAccountID string
 	baseURL        string
 	nameservers    []string
+	defaultSoa     soaValues
 }
 
 func (hp *hostingdeProvider) getDomainConfig(domain string) (*domainConfig, error) {

--- a/providers/hostingde/api.go
+++ b/providers/hostingde/api.go
@@ -125,12 +125,7 @@ func (hp *hostingdeProvider) updateNameservers(nss []string, domain string) func
 	}
 }
 
-func (hp *hostingdeProvider) updateRecords(domain string, create, del, mod diff.Changeset) error {
-	zc, err := hp.getZoneConfig(domain)
-	if err != nil {
-		return err
-	}
-
+func (hp *hostingdeProvider) updateZone(zc *zoneConfig, create, del, mod diff.Changeset) error {
 	toAdd := []*record{}
 	for _, c := range create {
 		r := recordToNative(c.Desired)
@@ -158,7 +153,7 @@ func (hp *hostingdeProvider) updateRecords(domain string, create, del, mod diff.
 		RecordsToModify: toModify,
 	}
 
-	_, err = hp.get("dns", "zoneUpdate", params)
+	_, err := hp.get("dns", "zoneUpdate", params)
 	if err != nil {
 		return err
 	}

--- a/providers/hostingde/hostingdeProvider.go
+++ b/providers/hostingde/hostingdeProvider.go
@@ -125,11 +125,12 @@ func (hp *hostingdeProvider) GetDomainCorrections(dc *models.DomainConfig) ([]*m
 			r.TTL = 31556926
 		}
 	}
-
-	records, err := hp.GetZoneRecords(dc.Name)
+	zone, err := hp.getZone(dc.Name)
 	if err != nil {
 		return nil, err
 	}
+
+	records := hp.ApiRecordsToStandardRecordsModel(dc.Name, zone.Records)
 
 	var create, del, mod diff.Changeset
 	if !diff2.EnableDiff2 {
@@ -160,7 +161,7 @@ func (hp *hostingdeProvider) GetDomainCorrections(dc *models.DomainConfig) ([]*m
 			Msg: fmt.Sprintf("\n%s", strings.Join(msg, "\n")),
 			F: func() error {
 				for i := 0; i < 10; i++ {
-					err := hp.updateRecords(dc.Name, create, del, mod)
+					err := hp.updateZone(&zone.ZoneConfig, create, del, mod)
 					if err == nil {
 						return nil
 					}

--- a/providers/hostingde/hostingdeProvider.go
+++ b/providers/hostingde/hostingdeProvider.go
@@ -91,11 +91,14 @@ func (hp *hostingdeProvider) GetNameservers(domain string) ([]*models.Nameserver
 }
 
 func (hp *hostingdeProvider) GetZoneRecords(domain string) (models.Records, error) {
-	src, err := hp.getRecords(domain)
+	zone, err := hp.getZone(domain)
 	if err != nil {
 		return nil, err
 	}
+	return hp.ApiRecordsToStandardRecordsModel(domain, zone.Records), nil
+}
 
+func (hp *hostingdeProvider) ApiRecordsToStandardRecordsModel(domain string, src []record) models.Records {
 	records := []*models.RecordConfig{}
 	for _, r := range src {
 		if r.Type == "SOA" {
@@ -104,7 +107,7 @@ func (hp *hostingdeProvider) GetZoneRecords(domain string) (models.Records, erro
 		records = append(records, r.nativeToRecord(domain))
 	}
 
-	return records, nil
+	return records
 }
 
 func (hp *hostingdeProvider) GetDomainCorrections(dc *models.DomainConfig) ([]*models.Correction, error) {

--- a/providers/hostingde/types.go
+++ b/providers/hostingde/types.go
@@ -54,21 +54,23 @@ type domainConfig struct {
 }
 
 type zoneConfig struct {
-	ID           string `json:"id"`
-	DNSSECMode   string `json:"dnsSecMode"`
-	EmailAddress string `json:"emailAddress,omitempty"`
-	MasterIP     string `json:"masterIp"`
-	Name         string `json:"name"` // Not required per docs, but required IRL
-	NameUnicode  string `json:"nameUnicode"`
-	// SOAValues    struct {
-	// 	Refresh     uint32 `json:"refresh"`
-	// 	Retry       uint32 `json:"retry"`
-	// 	Expire      uint32 `json:"expire"`
-	// 	TTL         uint32 `json:"ttl"`
-	// 	NegativeTTL uint32 `json:"negativeTtl"`
-	// } `json:"soaValues,omitempty"`
-	Type                  string   `json:"type"`
-	ZoneTransferWhitelist []string `json:"zoneTransferWhitelist"`
+	ID                    string    `json:"id"`
+	DNSSECMode            string    `json:"dnsSecMode"`
+	EmailAddress          string    `json:"emailAddress,omitempty"`
+	MasterIP              string    `json:"masterIp"`
+	Name                  string    `json:"name"` // Not required per docs, but required IRL
+	NameUnicode           string    `json:"nameUnicode"`
+	SOAValues             soaValues `json:"soaValues,omitempty"`
+	Type                  string    `json:"type"`
+	ZoneTransferWhitelist []string  `json:"zoneTransferWhitelist"`
+}
+
+type soaValues struct {
+	Refresh     uint32 `json:"refresh"`
+	Retry       uint32 `json:"retry"`
+	Expire      uint32 `json:"expire"`
+	NegativeTTL uint32 `json:"negativeTtl"`
+	TTL         uint32 `json:"ttl"`
 }
 
 type zone struct {

--- a/providers/hostingde/types.go
+++ b/providers/hostingde/types.go
@@ -71,6 +71,11 @@ type zoneConfig struct {
 	ZoneTransferWhitelist []string `json:"zoneTransferWhitelist"`
 }
 
+type zone struct {
+	ZoneConfig zoneConfig `json:"zoneConfig"`
+	Records    []record   `json:"records"`
+}
+
 type record struct {
 	ID       string `json:"id"`
 	Name     string `json:"name"`


### PR DESCRIPTION
This is not 100% done, there is one open question:

Currently, the SOA record expects the zone mailaddress as `hostmaster.example.org.`.

This is the standard syntax bind expects, which is the only other provider currently supporting SOA records.
However, hosting.de expects a rfc5322-formatted emailadress (`hostmaster@example.org`), as do probably most api-based providers do.

Additionally, converting from rfc5322 to bind-format is trivial, the other way around is not. (I have not implemented such a conversion yet due to this)

Therefore, I'd suggest expecting a rfc5322 formatted emailaddress for `SOA(..)` and only converting it within bind.