### PR TITLE
HOSTINGDE: Implement subaccount filtering feature (fixes #1974)

### DIFF
--- a/providers/hostingde/api.go
+++ b/providers/hostingde/api.go
@@ -14,10 +14,11 @@ import (
 const endpoint = "%s/api/%s/v1/json/%s"
 
 type hostingdeProvider struct {
-	authToken      string
-	ownerAccountID string
-	baseURL        string
-	nameservers    []string
+	authToken       string
+	ownerAccountID  string
+	filterAccountId string
+	baseURL         string
+	nameservers     []string
 }
 
 func (hp *hostingdeProvider) getDomainConfig(domain string) (*domainConfig, error) {
@@ -271,6 +272,12 @@ func (hp *hostingdeProvider) get(service, method string, params request) (*respo
 func (hp *hostingdeProvider) getAllZoneConfigs() ([]*zoneConfig, error) {
 	params := request{
 		Limit: 10000,
+	}
+	if hp.filterAccountId != "" {
+		params.Filter = &filter{
+			Field: "accountId",
+			Value: hp.filterAccountId,
+		}
 	}
 
 	resp, err := hp.get("dns", "zoneConfigsFind", params)

--- a/providers/hostingde/hostingdeProvider.go
+++ b/providers/hostingde/hostingdeProvider.go
@@ -46,7 +46,7 @@ type providerMeta struct {
 }
 
 func newHostingde(m map[string]string, providermeta json.RawMessage) (*hostingdeProvider, error) {
-	authToken, ownerAccountID, baseURL := m["authToken"], m["ownerAccountId"], m["baseURL"]
+	authToken, ownerAccountID, filterAccountId, baseURL := m["authToken"], m["ownerAccountId"], m["filterAccountId"], m["baseURL"]
 
 	if authToken == "" {
 		return nil, fmt.Errorf("hosting.de: authtoken must be provided")
@@ -58,10 +58,11 @@ func newHostingde(m map[string]string, providermeta json.RawMessage) (*hostingde
 	baseURL = strings.TrimSuffix(baseURL, "/")
 
 	hp := &hostingdeProvider{
-		authToken:      authToken,
-		ownerAccountID: ownerAccountID,
-		baseURL:        baseURL,
-		nameservers:    defaultNameservers,
+		authToken:       authToken,
+		ownerAccountID:  ownerAccountID,
+		filterAccountId: filterAccountId,
+		baseURL:         baseURL,
+		nameservers:     defaultNameservers,
 	}
 
 	if len(providermeta) > 0 {


### PR DESCRIPTION
Fixes #1974

Note: This includes the changes from #2019, because subaccount filtering is meant for the listing all zones feature.