### PR TITLE
Add list-unmanaged command (#1976)

### DIFF
--- a/commands/listUnmanaged.go
+++ b/commands/listUnmanaged.go
@@ -1,0 +1,107 @@
+package commands
+
+import (
+	"fmt"
+	"github.com/StackExchange/dnscontrol/v3/pkg/credsfile"
+	"github.com/StackExchange/dnscontrol/v3/providers"
+	"github.com/urfave/cli/v2"
+	"golang.org/x/exp/slices"
+)
+
+var _ = cmd(catUtils, func() *cli.Command {
+	var args GetUnmanagedArgs
+	return &cli.Command{
+		Name:  "list-unmanaged",
+		Usage: "gets a zone from a provider (stand-alone)",
+		Action: func(ctx *cli.Context) error {
+			if ctx.NArg() < 1 {
+				return cli.Exit("You need to supply a credential name as first argument", 1)
+			}
+			args.CredName = ctx.Args().Get(0)
+
+			return exit(GetUnmanaged(args))
+		},
+		Flags:     args.flags(),
+		UsageText: "dnscontrol list-unmanaged [command options] credkey",
+		Description: `List unmanaged domains and zones.  This is a stand-alone utility.
+
+ARGUMENTS:
+   credkey:  The name used in creds.json (first parameter to NewDnsProvider() in dnsconfig.js)
+
+EXAMPLES:
+   dnscontrol list-unmanaged mycred`,
+	}
+}())
+
+type GetUnmanagedArgs struct {
+	GetDNSConfigArgs
+	GetCredentialsArgs        // Args related to creds.json
+	CredName           string // key in creds.json
+}
+
+func (args *GetUnmanagedArgs) flags() []cli.Flag {
+	flags := args.GetDNSConfigArgs.flags()
+	flags = append(flags, args.GetCredentialsArgs.flags()...)
+	return flags
+}
+
+func GetUnmanaged(args GetUnmanagedArgs) error {
+	var providerConfigs map[string]map[string]string
+	var err error
+
+	// Read it in:
+	providerConfigs, err = credsfile.LoadProviderConfigs(args.CredsFile)
+	if err != nil {
+		return fmt.Errorf("failed GetZone LoadProviderConfigs(%q): %w", args.CredsFile, err)
+	}
+	provider, err := providers.CreateDNSProvider("-", providerConfigs[args.CredName], nil)
+	if err != nil {
+		return fmt.Errorf("failed GetZone CDP: %w", err)
+	}
+
+	cfg, err := GetDNSConfig(args.GetDNSConfigArgs)
+	if err != nil {
+		return fmt.Errorf("Error getting dnsconfig")
+	}
+
+	managedDomains := make([]string, 0, len(cfg.Domains))
+	for _, zone := range cfg.Domains {
+		managedDomains = append(managedDomains, zone.Name)
+	}
+
+	domainLister, ok := provider.(providers.DomainLister)
+	if ok {
+		deployedDomains, err := domainLister.ListDomains()
+		if err != nil {
+			return fmt.Errorf("failed ListDomains: %w\n", err)
+		}
+
+		fmt.Printf("Unmanaged domains:")
+		for _, deployedDomain := range deployedDomains {
+			if !slices.Contains(managedDomains, deployedDomain) {
+				fmt.Printf("%s\n", deployedDomain)
+			}
+		}
+	} else {
+		fmt.Printf("provider type of %s cannot list domains\n", args.CredName)
+	}
+
+	zoneLister, ok := provider.(providers.ZoneLister)
+	if ok {
+		deployedZones, err := zoneLister.ListZones()
+		if err != nil {
+			return fmt.Errorf("failed ListZones: %w\n", err)
+		}
+
+		fmt.Printf("\nUnmanaged zones:\n")
+		for _, deployedZone := range deployedZones {
+			if !slices.Contains(managedDomains, deployedZone) {
+				fmt.Printf("%s\n", deployedZone)
+			}
+		}
+	} else {
+		fmt.Printf("provider type of %s cannot list zones\n", args.CredName)
+	}
+
+	return nil
+}

--- a/providers/hostingde/api.go
+++ b/providers/hostingde/api.go
@@ -305,3 +305,27 @@ func (hp *hostingdeProvider) getAllZoneConfigs() ([]*zoneConfig, error) {
 
 	return zc, nil
 }
+
+func (hp *hostingdeProvider) getAllDomains() ([]*domainConfig, error) {
+	params := request{
+		Limit: 10000,
+	}
+	if hp.filterAccountId != "" {
+		params.Filter = &filter{
+			Field: "accountId",
+			Value: hp.filterAccountId,
+		}
+	}
+
+	resp, err := hp.get("domain", "domainsFind", params)
+	if err != nil {
+		return nil, fmt.Errorf("could not get domains: %w", err)
+	}
+
+	domains := []*domainConfig{}
+	if err := json.Unmarshal(resp.Data, &domains); err != nil {
+		return nil, fmt.Errorf("error parsing response: %w", err)
+	}
+
+	return domains, nil
+}

--- a/providers/hostingde/hostingdeProvider.go
+++ b/providers/hostingde/hostingdeProvider.go
@@ -268,3 +268,16 @@ func (hp *hostingdeProvider) ListZones() ([]string, error) {
 	return zones, nil
 
 }
+
+func (hp *hostingdeProvider) ListDomains() ([]string, error) {
+	DomainConfigs, err := hp.getAllDomains()
+	if err != nil {
+		return nil, err
+	}
+	domains := make([]string, 0, len(DomainConfigs))
+	for _, DomainConfig := range DomainConfigs {
+		domains = append(domains, DomainConfig.Name)
+	}
+	return domains, nil
+
+}

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -31,6 +31,13 @@ type ZoneLister interface {
 	ListZones() ([]string, error)
 }
 
+// DomainLister should be implemented by providers that have the
+// ability to list the domains they manage. This facilitates using the
+// "list-unmanaged" command.
+type DomainLister interface {
+	ListDomains() ([]string, error)
+}
+
 // RegistrarInitializer is a function to create a registrar. Function will be passed the unprocessed json payload from the configuration file for the given provider.
 type RegistrarInitializer func(map[string]string) (Registrar, error)
 


### PR DESCRIPTION
This PR adds a `list-unmanaged` command, which allows listing unmanaged domains and zones. For domains, a `ListDomains` interface has been added, which is similar to `ListZones`. I have additionally supplied a reference implementation for the hosting.de provider.