### PR TITLE
Remove all template tag lines from the .d.ts file

### DIFF
--- a/build/generate/functionTypes.go
+++ b/build/generate/functionTypes.go
@@ -88,12 +88,15 @@ func generateFunctionTypes() (string, error) {
 				continue
 			}
 
-			body = body + "\n"
-			body = strings.ReplaceAll(body, "{% hint style=\"danger\" %}", "")
-			body = strings.ReplaceAll(body, "{% hint style=\"info\" %}", "")
-			body = strings.ReplaceAll(body, "{% hint style=\"success\" %}", "")
-			body = strings.ReplaceAll(body, "{% hint style=\"warning\" %}", "")
-			body = strings.ReplaceAll(body, "{% endhint %}", "")
+			lines := strings.Split(body, "\n")
+			body = ""
+			for _, line := range lines {
+				if strings.HasPrefix(line, "{%") && strings.HasSuffix(line, "%}") {
+					continue
+				}
+				body += line + "\n"
+			}
+
 			body = strings.ReplaceAll(body, "**NOTE**", "NOTE")
 			body = strings.ReplaceAll(body, "**WARNING**", "WARNING")
 			body = fixRuns(body)

--- a/commands/types/dnscontrol.d.ts
+++ b/commands/types/dnscontrol.d.ts
@@ -1758,17 +1758,13 @@ declare function getConfiguredDomains(): string[];
  * One more important thing to note: `require_glob()` is as smart as `require()` is. It loads files always relative to the JavaScript
  * file where it's being executed in. Let's go with an example, as it describes it better:
  * 
- * {% code title="dnsconfig.js" %}
  * ```javascript
  * require("domains/index.js");
  * ```
- * {% endcode %}
  * 
- * {% code title="domains/index.js" %}
  * ```javascript
  * require_glob("./user1/");
  * ```
- * {% endcode %}
  * 
  * This will now load files being present underneath `./domains/user1/` and **NOT** at below `./domains/`, as `require_glob()`
  * is called in the subfolder `domains/`.


### PR DESCRIPTION
While looking at https://github.com/StackExchange/dnscontrol/pull/2029, I noticed that some template tags had made it into the generated doc comments.