### PR TITLE
HOSTINGDE: Fix dnssec error resulting from non-go-conformant comparison of three values

### DIFF
--- a/providers/hostingde/hostingdeProvider.go
+++ b/providers/hostingde/hostingdeProvider.go
@@ -159,7 +159,7 @@ func (hp *hostingdeProvider) GetDomainCorrections(dc *models.DomainConfig) ([]*m
 	var DnsSecOptions *dnsSecOptions = nil
 
 	// ensure that publishKsk is set for domains with AutoDNSSec
-	if existingAutoDNSSecEnabled == desiredAutoDNSSecEnabled == true {
+	if existingAutoDNSSecEnabled && desiredAutoDNSSecEnabled {
 		CurrentDnsSecOptions, err := hp.getDNSSECOptions(zone.ZoneConfig.ID)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
This fixes an dnssec error resulting from non-go-conformant comparison of three values (introduced due to my limited go experience :-))