### PR TITLE
Rename DomainCreator to the more accurate ZoneCreator

### DIFF
--- a/commands/createDomains.go
+++ b/commands/createDomains.go
@@ -54,9 +54,9 @@ func CreateDomains(args CreateDomainsArgs) error {
 	for _, domain := range cfg.Domains {
 		fmt.Println("*** ", domain.Name)
 		for _, provider := range domain.DNSProviderInstances {
-			if creator, ok := provider.Driver.(providers.DomainCreator); ok {
+			if creator, ok := provider.Driver.(providers.ZoneCreator); ok {
 				fmt.Println("  -", provider.Name)
-				err := creator.EnsureDomainExists(domain.Name)
+				err := creator.EnsureZoneExists(domain.Name)
 				if err != nil {
 					fmt.Printf("Error creating domain: %s\n", err)
 				}

--- a/commands/previewPush.go
+++ b/commands/previewPush.go
@@ -151,12 +151,12 @@ DomainLoop:
 						out.Warnf("DEBUG: zones: %v\n", zones)
 						out.Warnf("DEBUG: Name: %v\n", domain.Name)
 
-						out.Warnf("Domain '%s' does not exist in the '%s' profile and will be added automatically.\n", domain.Name, provider.Name)
+						out.Warnf("Zone '%s' does not exist in the '%s' profile and will be added automatically.\n", domain.Name, provider.Name)
 						continue // continue with next provider, as we can not determine corrections without an existing zone
 					}
-				} else if creator, ok := provider.Driver.(providers.DomainCreator); ok && push {
+				} else if creator, ok := provider.Driver.(providers.ZoneCreator); ok && push {
 					// this is the actual push, ensure domain exists at DSP
-					if err := creator.EnsureDomainExists(domain.Name); err != nil {
+					if err := creator.EnsureZoneExists(domain.Name); err != nil {
 						out.Warnf("Error creating domain: %s\n", err)
 						continue // continue with next provider, as we couldn't create this one
 					}

--- a/providers/akamaiedgedns/akamaiEdgeDnsProvider.go
+++ b/providers/akamaiedgedns/akamaiEdgeDnsProvider.go
@@ -96,12 +96,12 @@ func newEdgeDNSDSP(config map[string]string, metadata json.RawMessage) (provider
 }
 
 // EnsureZoneExists creates a zone if it does not exist
-func (a *edgeDNSProvider) EnsureZoneExists(zoneName string) error {
-	if zoneDoesExist(zoneName) {
-		printer.Debugf("Zone %s already exists\n", zoneName)
+func (a *edgeDNSProvider) EnsureZoneExists(domain string) error {
+	if zoneDoesExist(domain) {
+		printer.Debugf("Zone %s already exists\n", domain)
 		return nil
 	}
-	return createZone(zoneName, a.contractID, a.groupID)
+	return createZone(domain, a.contractID, a.groupID)
 }
 
 // GetDomainCorrections return a list of corrections. Each correction is a text string describing the change

--- a/providers/akamaiedgedns/akamaiEdgeDnsProvider.go
+++ b/providers/akamaiedgedns/akamaiEdgeDnsProvider.go
@@ -95,13 +95,13 @@ func newEdgeDNSDSP(config map[string]string, metadata json.RawMessage) (provider
 	return api, nil
 }
 
-// EnsureDomainExists configures a new zone if the zone does not already exist.
-func (a *edgeDNSProvider) EnsureDomainExists(domain string) error {
-	if zoneDoesExist(domain) {
-		printer.Debugf("Zone %s already exists\n", domain)
+// EnsureZoneExists creates a zone if it does not exist
+func (a *edgeDNSProvider) EnsureZoneExists(zoneName string) error {
+	if zoneDoesExist(zoneName) {
+		printer.Debugf("Zone %s already exists\n", zoneName)
 		return nil
 	}
-	return createZone(domain, a.contractID, a.groupID)
+	return createZone(zoneName, a.contractID, a.groupID)
 }
 
 // GetDomainCorrections return a list of corrections. Each correction is a text string describing the change

--- a/providers/azuredns/azureDnsProvider.go
+++ b/providers/azuredns/azureDnsProvider.go
@@ -662,7 +662,7 @@ func (a *azurednsProvider) fetchRecordSets(zoneName string) ([]*adns.RecordSet, 
 	return records, nil
 }
 
-func (a *azurednsProvider) EnsureDomainExists(domain string) error {
+func (a *azurednsProvider) EnsureZoneExists(domain string) error {
 	if _, ok := a.zones[domain]; ok {
 		return nil
 	}

--- a/providers/cloudflare/cloudflareProvider.go
+++ b/providers/cloudflare/cloudflareProvider.go
@@ -871,18 +871,18 @@ func getProxyMetadata(r *models.RecordConfig) map[string]string {
 }
 
 // EnsureZoneExists creates a zone if it does not exist
-func (c *cloudflareProvider) EnsureZoneExists(zoneName string) error {
+func (c *cloudflareProvider) EnsureZoneExists(domain string) error {
 	if c.domainIndex == nil {
 		if err := c.fetchDomainList(); err != nil {
 			return err
 		}
 	}
-	if _, ok := c.domainIndex[zoneName]; ok {
+	if _, ok := c.domainIndex[domain]; ok {
 		return nil
 	}
 	var id string
-	id, err := c.createZone(zoneName)
-	printer.Printf("Added zone for %s to Cloudflare account: %s\n", zoneName, id)
+	id, err := c.createZone(domain)
+	printer.Printf("Added zone for %s to Cloudflare account: %s\n", domain, id)
 	return err
 }
 

--- a/providers/cloudflare/cloudflareProvider.go
+++ b/providers/cloudflare/cloudflareProvider.go
@@ -870,19 +870,19 @@ func getProxyMetadata(r *models.RecordConfig) map[string]string {
 	}
 }
 
-// EnsureDomainExists returns an error of domain does not exist.
-func (c *cloudflareProvider) EnsureDomainExists(domain string) error {
+// EnsureZoneExists creates a zone if it does not exist
+func (c *cloudflareProvider) EnsureZoneExists(zoneName string) error {
 	if c.domainIndex == nil {
 		if err := c.fetchDomainList(); err != nil {
 			return err
 		}
 	}
-	if _, ok := c.domainIndex[domain]; ok {
+	if _, ok := c.domainIndex[zoneName]; ok {
 		return nil
 	}
 	var id string
-	id, err := c.createZone(domain)
-	printer.Printf("Added zone for %s to Cloudflare account: %s\n", domain, id)
+	id, err := c.createZone(zoneName)
+	printer.Printf("Added zone for %s to Cloudflare account: %s\n", zoneName, id)
 	return err
 }
 

--- a/providers/cloudns/cloudnsProvider.go
+++ b/providers/cloudns/cloudnsProvider.go
@@ -207,15 +207,15 @@ func (c *cloudnsProvider) GetZoneRecords(domain string) (models.Records, error) 
 }
 
 // EnsureZoneExists creates a zone if it does not exist
-func (c *cloudnsProvider) EnsureZoneExists(zoneName string) error {
+func (c *cloudnsProvider) EnsureZoneExists(domain string) error {
 	if err := c.fetchDomainList(); err != nil {
 		return err
 	}
 	// zone already exists
-	if _, ok := c.domainIndex[zoneName]; ok {
+	if _, ok := c.domainIndex[domain]; ok {
 		return nil
 	}
-	return c.createDomain(zoneName)
+	return c.createDomain(domain)
 }
 
 // parses the ClouDNS format into our standard RecordConfig

--- a/providers/cloudns/cloudnsProvider.go
+++ b/providers/cloudns/cloudnsProvider.go
@@ -206,16 +206,16 @@ func (c *cloudnsProvider) GetZoneRecords(domain string) (models.Records, error) 
 	return existingRecords, nil
 }
 
-// EnsureDomainExists returns an error if domain doesn't exist.
-func (c *cloudnsProvider) EnsureDomainExists(domain string) error {
+// EnsureZoneExists creates a zone if it does not exist
+func (c *cloudnsProvider) EnsureZoneExists(zoneName string) error {
 	if err := c.fetchDomainList(); err != nil {
 		return err
 	}
-	// domain already exists
-	if _, ok := c.domainIndex[domain]; ok {
+	// zone already exists
+	if _, ok := c.domainIndex[zoneName]; ok {
 		return nil
 	}
-	return c.createDomain(domain)
+	return c.createDomain(zoneName)
 }
 
 // parses the ClouDNS format into our standard RecordConfig

--- a/providers/desec/desecProvider.go
+++ b/providers/desec/desecProvider.go
@@ -113,13 +113,13 @@ func (c *desecProvider) GetZoneRecords(domain string) (models.Records, error) {
 }
 
 // EnsureZoneExists creates a zone if it does not exist
-func (c *desecProvider) EnsureZoneExists(zoneName string) error {
+func (c *desecProvider) EnsureZoneExists(domain string) error {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
-	if _, ok := c.domainIndex[zoneName]; ok {
+	if _, ok := c.domainIndex[domain]; ok {
 		return nil
 	}
-	return c.createDomain(zoneName)
+	return c.createDomain(domain)
 }
 
 // PrepFoundRecords munges any records to make them compatible with

--- a/providers/desec/desecProvider.go
+++ b/providers/desec/desecProvider.go
@@ -112,15 +112,14 @@ func (c *desecProvider) GetZoneRecords(domain string) (models.Records, error) {
 	return existingRecords, nil
 }
 
-// EnsureDomainExists returns an error if domain doesn't exist.
-func (c *desecProvider) EnsureDomainExists(domain string) error {
-	// domain already exists
+// EnsureZoneExists creates a zone if it does not exist
+func (c *desecProvider) EnsureZoneExists(zoneName string) error {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
-	if _, ok := c.domainIndex[domain]; ok {
+	if _, ok := c.domainIndex[zoneName]; ok {
 		return nil
 	}
-	return c.createDomain(domain)
+	return c.createDomain(zoneName)
 }
 
 // PrepFoundRecords munges any records to make them compatible with

--- a/providers/digitalocean/digitaloceanProvider.go
+++ b/providers/digitalocean/digitaloceanProvider.go
@@ -88,10 +88,10 @@ func init() {
 }
 
 // EnsureZoneExists creates a zone if it does not exist
-func (api *digitaloceanProvider) EnsureZoneExists(zoneName string) error {
+func (api *digitaloceanProvider) EnsureZoneExists(domain string) error {
 retry:
 	ctx := context.Background()
-	_, resp, err := api.client.Domains.Get(ctx, zoneName)
+	_, resp, err := api.client.Domains.Get(ctx, domain)
 	if err != nil {
 		if pauseAndRetry(resp) {
 			goto retry
@@ -100,7 +100,7 @@ retry:
 	}
 	if resp.StatusCode == http.StatusNotFound {
 		_, _, err := api.client.Domains.Create(ctx, &godo.DomainCreateRequest{
-			Name:      zoneName,
+			Name:      domain,
 			IPAddress: "",
 		})
 		return err

--- a/providers/digitalocean/digitaloceanProvider.go
+++ b/providers/digitalocean/digitaloceanProvider.go
@@ -87,11 +87,11 @@ func init() {
 	providers.RegisterDomainServiceProviderType("DIGITALOCEAN", fns, features)
 }
 
-// EnsureDomainExists returns an error if domain doesn't exist.
-func (api *digitaloceanProvider) EnsureDomainExists(domain string) error {
+// EnsureZoneExists creates a zone if it does not exist
+func (api *digitaloceanProvider) EnsureZoneExists(zoneName string) error {
 retry:
 	ctx := context.Background()
-	_, resp, err := api.client.Domains.Get(ctx, domain)
+	_, resp, err := api.client.Domains.Get(ctx, zoneName)
 	if err != nil {
 		if pauseAndRetry(resp) {
 			goto retry
@@ -100,7 +100,7 @@ retry:
 	}
 	if resp.StatusCode == http.StatusNotFound {
 		_, _, err := api.client.Domains.Create(ctx, &godo.DomainCreateRequest{
-			Name:      domain,
+			Name:      zoneName,
 			IPAddress: "",
 		})
 		return err

--- a/providers/dnsmadeeasy/dnsMadeEasyProvider.go
+++ b/providers/dnsmadeeasy/dnsMadeEasyProvider.go
@@ -178,8 +178,8 @@ func (api *dnsMadeEasyProvider) GetDomainCorrections(dc *models.DomainConfig) ([
 }
 
 // EnsureZoneExists creates a zone if it does not exist
-func (api *dnsMadeEasyProvider) EnsureZoneExists(zoneName string) error {
-	exists, err := api.domainExists(zoneName)
+func (api *dnsMadeEasyProvider) EnsureZoneExists(domain string) error {
+	exists, err := api.domainExists(domain)
 	if err != nil {
 		return err
 	}
@@ -189,7 +189,7 @@ func (api *dnsMadeEasyProvider) EnsureZoneExists(zoneName string) error {
 		return nil
 	}
 
-	return api.createDomain(zoneName)
+	return api.createDomain(domain)
 }
 
 // GetNameservers returns the nameservers for a domain.

--- a/providers/dnsmadeeasy/dnsMadeEasyProvider.go
+++ b/providers/dnsmadeeasy/dnsMadeEasyProvider.go
@@ -177,9 +177,9 @@ func (api *dnsMadeEasyProvider) GetDomainCorrections(dc *models.DomainConfig) ([
 	return corrections, nil
 }
 
-// EnsureDomainExists returns an error if domain doesn't exist.
-func (api *dnsMadeEasyProvider) EnsureDomainExists(domainName string) error {
-	exists, err := api.domainExists(domainName)
+// EnsureZoneExists creates a zone if it does not exist
+func (api *dnsMadeEasyProvider) EnsureZoneExists(zoneName string) error {
+	exists, err := api.domainExists(zoneName)
 	if err != nil {
 		return err
 	}
@@ -189,7 +189,7 @@ func (api *dnsMadeEasyProvider) EnsureDomainExists(domainName string) error {
 		return nil
 	}
 
-	return api.createDomain(domainName)
+	return api.createDomain(zoneName)
 }
 
 // GetNameservers returns the nameservers for a domain.

--- a/providers/exoscale/exoscaleProvider.go
+++ b/providers/exoscale/exoscaleProvider.go
@@ -75,8 +75,8 @@ func init() {
 }
 
 // EnsureZoneExists creates a zone if it does not exist
-func (c *exoscaleProvider) EnsureZoneExists(zoneName string) error {
-	_, err := c.findDomainByName(zoneName)
+func (c *exoscaleProvider) EnsureZoneExists(domain string) error {
+	_, err := c.findDomainByName(domain)
 
 	return err
 }

--- a/providers/exoscale/exoscaleProvider.go
+++ b/providers/exoscale/exoscaleProvider.go
@@ -74,9 +74,9 @@ func init() {
 	providers.RegisterDomainServiceProviderType("EXOSCALE", fns, features)
 }
 
-// EnsureDomainExists returns an error if domain doesn't exist.
-func (c *exoscaleProvider) EnsureDomainExists(domainName string) error {
-	_, err := c.findDomainByName(domainName)
+// EnsureZoneExists creates a zone if it does not exist
+func (c *exoscaleProvider) EnsureZoneExists(zoneName string) error {
+	_, err := c.findDomainByName(zoneName)
 
 	return err
 }

--- a/providers/gcloud/gcloudProvider.go
+++ b/providers/gcloud/gcloudProvider.go
@@ -327,7 +327,7 @@ func (g *gcloudProvider) getRecords(domain string) ([]*gdns.ResourceRecordSet, s
 	return sets, zone.Name, nil
 }
 
-func (g *gcloudProvider) EnsureDomainExists(domain string) error {
+func (g *gcloudProvider) EnsureZoneExists(domain string) error {
 	z, err := g.getZone(domain)
 	if err != nil {
 		if _, ok := err.(errNoExist); !ok {

--- a/providers/gcore/gcoreProvider.go
+++ b/providers/gcore/gcoreProvider.go
@@ -115,19 +115,19 @@ func (c *gcoreProvider) GetZoneRecords(domain string) (models.Records, error) {
 }
 
 // EnsureZoneExists creates a zone if it does not exist
-func (c *gcoreProvider) EnsureZoneExists(zoneName string) error {
+func (c *gcoreProvider) EnsureZoneExists(domain string) error {
 	zones, err := c.provider.Zones(c.ctx)
 	if err != nil {
 		return err
 	}
 
 	for _, zone := range zones {
-		if zone.Name == zoneName {
+		if zone.Name == domain {
 			return nil
 		}
 	}
 
-	_, err = c.provider.CreateZone(c.ctx, zoneName)
+	_, err = c.provider.CreateZone(c.ctx, domain)
 	return err
 }
 

--- a/providers/gcore/gcoreProvider.go
+++ b/providers/gcore/gcoreProvider.go
@@ -114,20 +114,20 @@ func (c *gcoreProvider) GetZoneRecords(domain string) (models.Records, error) {
 	return existingRecords, nil
 }
 
-// EnsureDomainExists returns an error if domain doesn't exist.
-func (c *gcoreProvider) EnsureDomainExists(domain string) error {
+// EnsureZoneExists creates a zone if it does not exist
+func (c *gcoreProvider) EnsureZoneExists(zoneName string) error {
 	zones, err := c.provider.Zones(c.ctx)
 	if err != nil {
 		return err
 	}
 
 	for _, zone := range zones {
-		if zone.Name == domain {
+		if zone.Name == zoneName {
 			return nil
 		}
 	}
 
-	_, err = c.provider.CreateZone(c.ctx, domain)
+	_, err = c.provider.CreateZone(c.ctx, zoneName)
 	return err
 }
 

--- a/providers/hedns/hednsProvider.go
+++ b/providers/hedns/hednsProvider.go
@@ -157,19 +157,19 @@ func (c *hednsProvider) ListZones() ([]string, error) {
 }
 
 // EnsureZoneExists creates a zone if it does not exist
-func (c *hednsProvider) EnsureZoneExists(zoneName string) error {
+func (c *hednsProvider) EnsureZoneExists(domain string) error {
 	domains, err := c.ListZones()
 	if err != nil {
 		return err
 	}
 
 	for _, d := range domains {
-		if d == zoneName {
+		if d == domain {
 			return nil
 		}
 	}
 
-	return c.createDomain(zoneName)
+	return c.createDomain(domain)
 }
 
 // GetNameservers returns the default HEDNS nameservers.

--- a/providers/hedns/hednsProvider.go
+++ b/providers/hedns/hednsProvider.go
@@ -156,20 +156,20 @@ func (c *hednsProvider) ListZones() ([]string, error) {
 	return domains, err
 }
 
-// EnsureDomainExists creates the domain if it does not exist.
-func (c *hednsProvider) EnsureDomainExists(domain string) error {
+// EnsureZoneExists creates a zone if it does not exist
+func (c *hednsProvider) EnsureZoneExists(zoneName string) error {
 	domains, err := c.ListZones()
 	if err != nil {
 		return err
 	}
 
 	for _, d := range domains {
-		if d == domain {
+		if d == zoneName {
 			return nil
 		}
 	}
 
-	return c.createDomain(domain)
+	return c.createDomain(zoneName)
 }
 
 // GetNameservers returns the default HEDNS nameservers.

--- a/providers/hetzner/hetznerProvider.go
+++ b/providers/hetzner/hetznerProvider.go
@@ -61,22 +61,22 @@ func New(settings map[string]string, _ json.RawMessage) (providers.DNSServicePro
 	return api, nil
 }
 
-// EnsureDomainExists creates the domain if it does not exist.
-func (api *hetznerProvider) EnsureDomainExists(domain string) error {
+// EnsureZoneExists creates a zone if it does not exist
+func (api *hetznerProvider) EnsureZoneExists(zoneName string) error {
 	domains, err := api.ListZones()
 	if err != nil {
 		return err
 	}
 
 	for _, d := range domains {
-		if d == domain {
+		if d == zoneName {
 			return nil
 		}
 	}
 
 	// reset zone cache
 	api.zones = nil
-	return api.createZone(domain)
+	return api.createZone(zoneName)
 }
 
 // GetDomainCorrections returns the corrections for a domain.

--- a/providers/hetzner/hetznerProvider.go
+++ b/providers/hetzner/hetznerProvider.go
@@ -62,21 +62,21 @@ func New(settings map[string]string, _ json.RawMessage) (providers.DNSServicePro
 }
 
 // EnsureZoneExists creates a zone if it does not exist
-func (api *hetznerProvider) EnsureZoneExists(zoneName string) error {
+func (api *hetznerProvider) EnsureZoneExists(domain string) error {
 	domains, err := api.ListZones()
 	if err != nil {
 		return err
 	}
 
 	for _, d := range domains {
-		if d == zoneName {
+		if d == domain {
 			return nil
 		}
 	}
 
 	// reset zone cache
 	api.zones = nil
-	return api.createZone(zoneName)
+	return api.createZone(domain)
 }
 
 // GetDomainCorrections returns the corrections for a domain.

--- a/providers/hexonet/domains.go
+++ b/providers/hexonet/domains.go
@@ -5,24 +5,24 @@ import "fmt"
 // EnsureZoneExists returns an error
 // * if access to dnszone is not allowed (not authorized) or
 // * if it doesn't exist and creating it fails
-func (n *HXClient) EnsureZoneExists(zoneName string) error {
+func (n *HXClient) EnsureZoneExists(domain string) error {
 	r := n.client.Request(map[string]interface{}{
 		"COMMAND": "StatusDNSZone",
-		"DNSZONE": zoneName + ".",
+		"DNSZONE": domain + ".",
 	})
 	code := r.GetCode()
 	if code == 545 {
 		r = n.client.Request(map[string]interface{}{
 			"COMMAND": "CreateDNSZone",
-			"DNSZONE": zoneName + ".",
+			"DNSZONE": domain + ".",
 		})
 		if !r.IsSuccess() {
-			return n.GetHXApiError("Failed to create not existing zone ", zoneName, r)
+			return n.GetHXApiError("Failed to create not existing zone ", domain, r)
 		}
 	} else if code == 531 {
-		return n.GetHXApiError("Not authorized to manage dnszone", zoneName, r)
+		return n.GetHXApiError("Not authorized to manage dnszone", domain, r)
 	} else if r.IsError() || r.IsTmpError() {
-		return n.GetHXApiError("Error while checking status of dnszone", zoneName, r)
+		return n.GetHXApiError("Error while checking status of dnszone", domain, r)
 	}
 	return nil
 }

--- a/providers/hexonet/domains.go
+++ b/providers/hexonet/domains.go
@@ -2,27 +2,27 @@ package hexonet
 
 import "fmt"
 
-// EnsureDomainExists returns an error
+// EnsureZoneExists returns an error
 // * if access to dnszone is not allowed (not authorized) or
 // * if it doesn't exist and creating it fails
-func (n *HXClient) EnsureDomainExists(domain string) error {
+func (n *HXClient) EnsureZoneExists(zoneName string) error {
 	r := n.client.Request(map[string]interface{}{
 		"COMMAND": "StatusDNSZone",
-		"DNSZONE": domain + ".",
+		"DNSZONE": zoneName + ".",
 	})
 	code := r.GetCode()
 	if code == 545 {
 		r = n.client.Request(map[string]interface{}{
 			"COMMAND": "CreateDNSZone",
-			"DNSZONE": domain + ".",
+			"DNSZONE": zoneName + ".",
 		})
 		if !r.IsSuccess() {
-			return n.GetHXApiError("Failed to create not existing zone for domain", domain, r)
+			return n.GetHXApiError("Failed to create not existing zone ", zoneName, r)
 		}
 	} else if code == 531 {
-		return n.GetHXApiError("Not authorized to manage dnszone", domain, r)
+		return n.GetHXApiError("Not authorized to manage dnszone", zoneName, r)
 	} else if r.IsError() || r.IsTmpError() {
-		return n.GetHXApiError("Error while checking status of dnszone", domain, r)
+		return n.GetHXApiError("Error while checking status of dnszone", zoneName, r)
 	}
 	return nil
 }

--- a/providers/hostingde/hostingdeProvider.go
+++ b/providers/hostingde/hostingdeProvider.go
@@ -246,7 +246,7 @@ func (hp *hostingdeProvider) GetRegistrarCorrections(dc *models.DomainConfig) ([
 	return nil, nil
 }
 
-func (hp *hostingdeProvider) EnsureDomainExists(domain string) error {
+func (hp *hostingdeProvider) EnsureZoneExists(domain string) error {
 	_, err := hp.getZoneConfig(domain)
 	if err == errZoneNotFound {
 		if err := hp.createZone(domain); err != nil {

--- a/providers/inwx/inwxProvider.go
+++ b/providers/inwx/inwxProvider.go
@@ -399,21 +399,21 @@ func (api *inwxAPI) fetchNameserverDomains() error {
 	return nil
 }
 
-// EnsureDomainExists returns an error if domain does not exist.
-func (api *inwxAPI) EnsureDomainExists(domain string) error {
+// EnsureZoneExists creates a zone if it does not exist
+func (api *inwxAPI) EnsureZoneExists(zoneName string) error {
 	if api.domainIndex == nil { // only pull the data once.
 		if err := api.fetchNameserverDomains(); err != nil {
 			return err
 		}
 	}
 
-	if _, ok := api.domainIndex[domain]; ok {
-		return nil // domain exists.
+	if _, ok := api.domainIndex[zoneName]; ok {
+		return nil // zone exists.
 	}
 
-	// creating the domain.
+	// creating the zone.
 	request := &goinwx.NameserverCreateRequest{
-		Domain:      domain,
+		Domain:      zoneName,
 		Type:        "MASTER",
 		Nameservers: api.getDefaultNameservers(),
 	}
@@ -422,6 +422,6 @@ func (api *inwxAPI) EnsureDomainExists(domain string) error {
 	if err != nil {
 		return err
 	}
-	printer.Printf("Added zone for %s to INWX account with id %d\n", domain, id)
+	printer.Printf("Added zone for %s to INWX account with id %d\n", zoneName, id)
 	return nil
 }

--- a/providers/inwx/inwxProvider.go
+++ b/providers/inwx/inwxProvider.go
@@ -400,20 +400,20 @@ func (api *inwxAPI) fetchNameserverDomains() error {
 }
 
 // EnsureZoneExists creates a zone if it does not exist
-func (api *inwxAPI) EnsureZoneExists(zoneName string) error {
+func (api *inwxAPI) EnsureZoneExists(domain string) error {
 	if api.domainIndex == nil { // only pull the data once.
 		if err := api.fetchNameserverDomains(); err != nil {
 			return err
 		}
 	}
 
-	if _, ok := api.domainIndex[zoneName]; ok {
+	if _, ok := api.domainIndex[domain]; ok {
 		return nil // zone exists.
 	}
 
 	// creating the zone.
 	request := &goinwx.NameserverCreateRequest{
-		Domain:      zoneName,
+		Domain:      domain,
 		Type:        "MASTER",
 		Nameservers: api.getDefaultNameservers(),
 	}
@@ -422,6 +422,6 @@ func (api *inwxAPI) EnsureZoneExists(zoneName string) error {
 	if err != nil {
 		return err
 	}
-	printer.Printf("Added zone for %s to INWX account with id %d\n", zoneName, id)
+	printer.Printf("Added zone for %s to INWX account with id %d\n", domain, id)
 	return nil
 }

--- a/providers/ns1/ns1Provider.go
+++ b/providers/ns1/ns1Provider.go
@@ -50,7 +50,7 @@ func newProvider(creds map[string]string, meta json.RawMessage) (providers.DNSSe
 	return &nsone{rest.NewClient(http.DefaultClient, rest.SetAPIKey(creds["api_token"]))}, nil
 }
 
-func (n *nsone) EnsureDomainExists(domain string) error {
+func (n *nsone) EnsureZoneExists(domain string) error {
 	// This enables the create-domains subcommand
 
 	zone := dns.NewZone(domain)

--- a/providers/oracle/oracleProvider.go
+++ b/providers/oracle/oracleProvider.go
@@ -84,13 +84,13 @@ func (o *oracleProvider) ListZones() ([]string, error) {
 	return zones, nil
 }
 
-// EnsureDomainExists creates the domain if it does not exist.
-func (o *oracleProvider) EnsureDomainExists(domain string) error {
+// EnsureZoneExists creates a zone if it does not exist
+func (o *oracleProvider) EnsureZoneExists(zoneName string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
 
 	getResp, err := o.client.GetZone(ctx, dns.GetZoneRequest{
-		ZoneNameOrId:  &domain,
+		ZoneNameOrId:  &zoneName,
 		CompartmentId: &o.compartment,
 	})
 	if err == nil {
@@ -103,7 +103,7 @@ func (o *oracleProvider) EnsureDomainExists(domain string) error {
 	_, err = o.client.CreateZone(ctx, dns.CreateZoneRequest{
 		CreateZoneDetails: dns.CreateZoneDetails{
 			CompartmentId: &o.compartment,
-			Name:          &domain,
+			Name:          &zoneName,
 			ZoneType:      dns.CreateZoneDetailsZoneTypePrimary,
 		},
 	})
@@ -119,7 +119,7 @@ func (o *oracleProvider) EnsureDomainExists(domain string) error {
 		return true
 	}
 	_, err = o.client.GetZone(ctx, dns.GetZoneRequest{
-		ZoneNameOrId:    &domain,
+		ZoneNameOrId:    &zoneName,
 		CompartmentId:   &o.compartment,
 		RequestMetadata: helpers.GetRequestMetadataWithCustomizedRetryPolicy(pollUntilAvailable),
 	})

--- a/providers/oracle/oracleProvider.go
+++ b/providers/oracle/oracleProvider.go
@@ -85,12 +85,12 @@ func (o *oracleProvider) ListZones() ([]string, error) {
 }
 
 // EnsureZoneExists creates a zone if it does not exist
-func (o *oracleProvider) EnsureZoneExists(zoneName string) error {
+func (o *oracleProvider) EnsureZoneExists(domain string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
 
 	getResp, err := o.client.GetZone(ctx, dns.GetZoneRequest{
-		ZoneNameOrId:  &zoneName,
+		ZoneNameOrId:  &domain,
 		CompartmentId: &o.compartment,
 	})
 	if err == nil {
@@ -103,7 +103,7 @@ func (o *oracleProvider) EnsureZoneExists(zoneName string) error {
 	_, err = o.client.CreateZone(ctx, dns.CreateZoneRequest{
 		CreateZoneDetails: dns.CreateZoneDetails{
 			CompartmentId: &o.compartment,
-			Name:          &zoneName,
+			Name:          &domain,
 			ZoneType:      dns.CreateZoneDetailsZoneTypePrimary,
 		},
 	})
@@ -119,7 +119,7 @@ func (o *oracleProvider) EnsureZoneExists(zoneName string) error {
 		return true
 	}
 	_, err = o.client.GetZone(ctx, dns.GetZoneRequest{
-		ZoneNameOrId:    &zoneName,
+		ZoneNameOrId:    &domain,
 		CompartmentId:   &o.compartment,
 		RequestMetadata: helpers.GetRequestMetadataWithCustomizedRetryPolicy(pollUntilAvailable),
 	})

--- a/providers/powerdns/dns.go
+++ b/providers/powerdns/dns.go
@@ -131,20 +131,20 @@ func (dsp *powerdnsProvider) GetDomainCorrections(dc *models.DomainConfig) ([]*m
 	return corrections, nil
 }
 
-// EnsureDomainExists adds a domain to the DNS service if it does not exist
-func (dsp *powerdnsProvider) EnsureDomainExists(domain string) error {
-	if _, err := dsp.client.Zones().GetZone(context.Background(), dsp.ServerName, domain+"."); err != nil {
+// EnsureZoneExists creates a zone if it does not exist
+func (dsp *powerdnsProvider) EnsureZoneExists(zoneName string) error {
+	if _, err := dsp.client.Zones().GetZone(context.Background(), dsp.ServerName, zoneName+"."); err != nil {
 		if e, ok := err.(pdnshttp.ErrUnexpectedStatus); ok {
 			if e.StatusCode != http.StatusNotFound {
 				return err
 			}
 		}
-	} else { // domain seems to be there
+	} else { // zone seems to exist
 		return nil
 	}
 
 	_, err := dsp.client.Zones().CreateZone(context.Background(), dsp.ServerName, zones.Zone{
-		Name:        domain + ".",
+		Name:        zoneName + ".",
 		Type:        zones.ZoneTypeZone,
 		DNSSec:      dsp.DNSSecOnCreate,
 		Nameservers: dsp.DefaultNS,

--- a/providers/powerdns/dns.go
+++ b/providers/powerdns/dns.go
@@ -132,8 +132,8 @@ func (dsp *powerdnsProvider) GetDomainCorrections(dc *models.DomainConfig) ([]*m
 }
 
 // EnsureZoneExists creates a zone if it does not exist
-func (dsp *powerdnsProvider) EnsureZoneExists(zoneName string) error {
-	if _, err := dsp.client.Zones().GetZone(context.Background(), dsp.ServerName, zoneName+"."); err != nil {
+func (dsp *powerdnsProvider) EnsureZoneExists(domain string) error {
+	if _, err := dsp.client.Zones().GetZone(context.Background(), dsp.ServerName, domain+"."); err != nil {
 		if e, ok := err.(pdnshttp.ErrUnexpectedStatus); ok {
 			if e.StatusCode != http.StatusNotFound {
 				return err
@@ -144,7 +144,7 @@ func (dsp *powerdnsProvider) EnsureZoneExists(zoneName string) error {
 	}
 
 	_, err := dsp.client.Zones().CreateZone(context.Background(), dsp.ServerName, zones.Zone{
-		Name:        zoneName + ".",
+		Name:        domain + ".",
 		Type:        zones.ZoneTypeZone,
 		DNSSec:      dsp.DNSSecOnCreate,
 		Nameservers: dsp.DefaultNS,

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -18,10 +18,10 @@ type DNSServiceProvider interface {
 	models.DNSProvider
 }
 
-// DomainCreator should be implemented by providers that have the ability to add domains to an account. the create-domains command
-// can be run to ensure all domains are present before running preview/push.  Implement this only if the provider supoprts the `dnscontrol create-domain` command.
-type DomainCreator interface {
-	EnsureDomainExists(domain string) error
+// ZoneCreator should be implemented by providers that have the ability to create zones
+// (used for automatically creating zones if they don't exist)
+type ZoneCreator interface {
+	EnsureZoneExists(domain string) error
 }
 
 // ZoneLister should be implemented by providers that have the

--- a/providers/route53/route53Provider.go
+++ b/providers/route53/route53Provider.go
@@ -818,7 +818,7 @@ func unescape(s *string) string {
 	return name
 }
 
-func (r *route53Provider) EnsureDomainExists(domain string) error {
+func (r *route53Provider) EnsureZoneExists(domain string) error {
 	if err := r.getZones(); err != nil {
 		return err
 	}

--- a/providers/vultr/vultrProvider.go
+++ b/providers/vultr/vultrProvider.go
@@ -223,16 +223,16 @@ func (api *vultrProvider) GetNameservers(domain string) ([]*models.Nameserver, e
 	return models.ToNameservers(defaultNS)
 }
 
-// EnsureDomainExists adds a domain to the Vutr DNS service if it does not exist
-func (api *vultrProvider) EnsureDomainExists(domain string) error {
-	if ok, err := api.isDomainInAccount(domain); err != nil {
+// EnsureZoneExists creates a zone if it does not exist
+func (api *vultrProvider) EnsureZoneExists(zoneName string) error {
+	if ok, err := api.isDomainInAccount(zoneName); err != nil {
 		return err
 	} else if ok {
 		return nil
 	}
 
 	// Vultr requires an initial IP, use a dummy one.
-	_, err := api.client.Domain.Create(context.Background(), &govultr.DomainReq{Domain: domain, IP: "0.0.0.0", DNSSec: "disabled"})
+	_, err := api.client.Domain.Create(context.Background(), &govultr.DomainReq{Domain: zoneName, IP: "0.0.0.0", DNSSec: "disabled"})
 	return err
 }
 

--- a/providers/vultr/vultrProvider.go
+++ b/providers/vultr/vultrProvider.go
@@ -224,15 +224,15 @@ func (api *vultrProvider) GetNameservers(domain string) ([]*models.Nameserver, e
 }
 
 // EnsureZoneExists creates a zone if it does not exist
-func (api *vultrProvider) EnsureZoneExists(zoneName string) error {
-	if ok, err := api.isDomainInAccount(zoneName); err != nil {
+func (api *vultrProvider) EnsureZoneExists(domain string) error {
+	if ok, err := api.isDomainInAccount(domain); err != nil {
 		return err
 	} else if ok {
 		return nil
 	}
 
 	// Vultr requires an initial IP, use a dummy one.
-	_, err := api.client.Domain.Create(context.Background(), &govultr.DomainReq{Domain: zoneName, IP: "0.0.0.0", DNSSec: "disabled"})
+	_, err := api.client.Domain.Create(context.Background(), &govultr.DomainReq{Domain: domain, IP: "0.0.0.0", DNSSec: "disabled"})
 	return err
 }
 


### PR DESCRIPTION
`DomainCreator` and `EnsureDomainExists` are misleading, because it actually creates zones, not domains.