### PR TITLE
CHORE: Removed docs/_site from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@ dnscontrol
 /dnsconfig.js
 /creds.json
 ExternalDNS
-docs/_site
 powershell.log
 integrationTest/env.sh
 integrationTest/.env


### PR DESCRIPTION
The directory `docs/_site` no longer exists.