### PR TITLE
 FEATURE: New flag --delete-unmanaged: Remove unmanaged domains & zones (implements #1976)

### DIFF
--- a/commands/createDomains.go
+++ b/commands/createDomains.go
@@ -47,9 +47,9 @@ func CreateDomains(args CreateDomainsArgs) error {
 	if err != nil {
 		return err
 	}
-	_, _, _, err = InitializeProviders(cfg, providerConfigs, false)
-	if err != nil {
-		return err
+	providerInitResult := InitializeProviders(cfg, providerConfigs, false)
+	if providerInitResult.err != nil {
+		return providerInitResult.err
 	}
 	for _, domain := range cfg.Domains {
 		fmt.Println("*** ", domain.Name)

--- a/commands/createDomains.go
+++ b/commands/createDomains.go
@@ -25,7 +25,7 @@ var _ = cmd(catUtils, func() *cli.Command {
 	}
 }())
 
-// CreateDomainsArgs args required for the create-domain subcommand.
+// CreateDomaimap[string]providers.Registrar{}nsArgs args required for the create-domain subcommand.
 type CreateDomainsArgs struct {
 	GetDNSConfigArgs
 	GetCredentialsArgs
@@ -47,7 +47,7 @@ func CreateDomains(args CreateDomainsArgs) error {
 	if err != nil {
 		return err
 	}
-	_, err = InitializeProviders(cfg, providerConfigs, false)
+	_, _, _, err = InitializeProviders(cfg, providerConfigs, false)
 	if err != nil {
 		return err
 	}

--- a/commands/createDomains.go
+++ b/commands/createDomains.go
@@ -47,9 +47,9 @@ func CreateDomains(args CreateDomainsArgs) error {
 	if err != nil {
 		return err
 	}
-	providerInitResult := InitializeProviders(cfg, providerConfigs, false)
-	if providerInitResult.err != nil {
-		return providerInitResult.err
+	providerState := InitializeProviders(cfg, providerConfigs, false)
+	if providerState.err != nil {
+		return providerState.err
 	}
 	for _, domain := range cfg.Domains {
 		fmt.Println("*** ", domain.Name)

--- a/commands/createDomains.go
+++ b/commands/createDomains.go
@@ -47,9 +47,9 @@ func CreateDomains(args CreateDomainsArgs) error {
 	if err != nil {
 		return err
 	}
-	providerState := InitializeProviders(cfg, providerConfigs, false)
-	if providerState.err != nil {
-		return providerState.err
+	_, err = InitializeProviders(cfg, providerConfigs, false)
+	if err != nil {
+		return err
 	}
 	for _, domain := range cfg.Domains {
 		fmt.Println("*** ", domain.Name)

--- a/commands/createDomains.go
+++ b/commands/createDomains.go
@@ -25,7 +25,7 @@ var _ = cmd(catUtils, func() *cli.Command {
 	}
 }())
 
-// CreateDomaimap[string]providers.Registrar{}nsArgs args required for the create-domain subcommand.
+// CreateDomainsArgs args required for the create-domain subcommand.
 type CreateDomainsArgs struct {
 	GetDNSConfigArgs
 	GetCredentialsArgs

--- a/commands/getCerts.go
+++ b/commands/getCerts.go
@@ -146,7 +146,7 @@ func GetCerts(args GetCertsArgs) error {
 	if err != nil {
 		return err
 	}
-	notifier, err := InitializeProviders(cfg, providerConfigs, args.Notify)
+	_, _, notifier, err := InitializeProviders(cfg, providerConfigs, args.Notify)
 	if err != nil {
 		return err
 	}

--- a/commands/getCerts.go
+++ b/commands/getCerts.go
@@ -146,9 +146,9 @@ func GetCerts(args GetCertsArgs) error {
 	if err != nil {
 		return err
 	}
-	providerState := InitializeProviders(cfg, providerConfigs, args.Notify)
-	if providerState.err != nil {
-		return providerState.err
+	providerState, err := InitializeProviders(cfg, providerConfigs, args.Notify)
+	if err != nil {
+		return err
 	}
 
 	for _, skip := range strings.Split(args.IgnoredProviders, ",") {

--- a/commands/getCerts.go
+++ b/commands/getCerts.go
@@ -146,9 +146,9 @@ func GetCerts(args GetCertsArgs) error {
 	if err != nil {
 		return err
 	}
-	providerInitResult := InitializeProviders(cfg, providerConfigs, args.Notify)
-	if providerInitResult.err != nil {
-		return providerInitResult.err
+	providerState := InitializeProviders(cfg, providerConfigs, args.Notify)
+	if providerState.err != nil {
+		return providerState.err
 	}
 
 	for _, skip := range strings.Split(args.IgnoredProviders, ",") {
@@ -184,9 +184,9 @@ func GetCerts(args GetCertsArgs) error {
 	var client acme.Client
 
 	if args.Vault {
-		client, err = acme.NewVault(cfg, args.VaultPath, args.Email, acmeServer, providerInitResult.notifier)
+		client, err = acme.NewVault(cfg, args.VaultPath, args.Email, acmeServer, providerState.notifier)
 	} else {
-		client, err = acme.New(cfg, args.CertDirectory, args.Email, acmeServer, providerInitResult.notifier)
+		client, err = acme.New(cfg, args.CertDirectory, args.Email, acmeServer, providerState.notifier)
 	}
 	if err != nil {
 		return err
@@ -199,7 +199,7 @@ func GetCerts(args GetCertsArgs) error {
 		v := args.Verbose || printer.DefaultPrinter.Verbose
 		issued, err := client.IssueOrRenewCert(cert, args.RenewUnderDays, v)
 		if issued || err != nil {
-			providerInitResult.notifier.Notify(cert.CertName, "certificate", "Issued new certificate", err, false)
+			providerState.notifier.Notify(cert.CertName, "certificate", "Issued new certificate", err, false)
 		}
 		if err != nil {
 			if manyerr == nil {
@@ -209,7 +209,7 @@ func GetCerts(args GetCertsArgs) error {
 			}
 		}
 	}
-	providerInitResult.notifier.Done()
+	providerState.notifier.Done()
 	return manyerr
 }
 

--- a/commands/getCerts.go
+++ b/commands/getCerts.go
@@ -146,9 +146,9 @@ func GetCerts(args GetCertsArgs) error {
 	if err != nil {
 		return err
 	}
-	_, _, notifier, err := InitializeProviders(cfg, providerConfigs, args.Notify)
-	if err != nil {
-		return err
+	providerInitResult := InitializeProviders(cfg, providerConfigs, args.Notify)
+	if providerInitResult.err != nil {
+		return providerInitResult.err
 	}
 
 	for _, skip := range strings.Split(args.IgnoredProviders, ",") {
@@ -184,9 +184,9 @@ func GetCerts(args GetCertsArgs) error {
 	var client acme.Client
 
 	if args.Vault {
-		client, err = acme.NewVault(cfg, args.VaultPath, args.Email, acmeServer, notifier)
+		client, err = acme.NewVault(cfg, args.VaultPath, args.Email, acmeServer, providerInitResult.notifier)
 	} else {
-		client, err = acme.New(cfg, args.CertDirectory, args.Email, acmeServer, notifier)
+		client, err = acme.New(cfg, args.CertDirectory, args.Email, acmeServer, providerInitResult.notifier)
 	}
 	if err != nil {
 		return err
@@ -199,7 +199,7 @@ func GetCerts(args GetCertsArgs) error {
 		v := args.Verbose || printer.DefaultPrinter.Verbose
 		issued, err := client.IssueOrRenewCert(cert, args.RenewUnderDays, v)
 		if issued || err != nil {
-			notifier.Notify(cert.CertName, "certificate", "Issued new certificate", err, false)
+			providerInitResult.notifier.Notify(cert.CertName, "certificate", "Issued new certificate", err, false)
 		}
 		if err != nil {
 			if manyerr == nil {
@@ -209,7 +209,7 @@ func GetCerts(args GetCertsArgs) error {
 			}
 		}
 	}
-	notifier.Done()
+	providerInitResult.notifier.Done()
 	return manyerr
 }
 

--- a/commands/previewPush.go
+++ b/commands/previewPush.go
@@ -38,6 +38,7 @@ type PreviewArgs struct {
 	WarnChanges            bool
 	NoPopulate             bool
 	Full                   bool
+	DeleteUnmanaged        bool
 	DeleteUnmanagedDomains bool
 	DeleteUnmanagedZones   bool
 }
@@ -66,6 +67,12 @@ func (args *PreviewArgs) flags() []cli.Flag {
 		Destination: &args.DeleteUnmanagedDomains,
 		Usage:       `Use this flag to delete unmanaged domains`,
 	})
+	flags = append(flags, &cli.BoolFlag{
+		Name:        "delete-unmanaged",
+		Destination: &args.DeleteUnmanaged,
+		Usage:       `Use this flag to delete unmanaged domains and zones`,
+	})
+
 	flags = append(flags, &cli.BoolFlag{
 		Name:        "delete-unmanaged-zones",
 		Destination: &args.DeleteUnmanagedZones,
@@ -229,7 +236,7 @@ DomainLoop:
 		anyErrors = printOrRunCorrections(domain.Name, domain.RegistrarName, corrections, out, push, interactive, notifier) || anyErrors
 	}
 
-	if args.DeleteUnmanagedDomains {
+	if args.DeleteUnmanaged || args.DeleteUnmanagedDomains {
 		fmt.Printf("Checking Domain Removal:\n")
 		for registrarName, registrar := range createdRegistrars {
 			domainLister, ok := registrar.(providers.DomainLister)
@@ -254,7 +261,7 @@ DomainLoop:
 		}
 	}
 
-	if args.DeleteUnmanagedZones {
+	if args.DeleteUnmanaged || args.DeleteUnmanagedZones {
 		fmt.Printf("Checking Zone Removal:\n")
 
 		for providerName, provider := range createdProviders {

--- a/commands/previewPush.go
+++ b/commands/previewPush.go
@@ -281,7 +281,7 @@ func DeleteUnmanagedDomains(cfg *models.DNSConfig, createdRegistrars map[string]
 		for _, domain := range deployedDomains {
 			if !IsDomainManagedByRegistrar(cfg, domain, registrarName) {
 
-				fmt.Printf("Removing from provider %s: domain %s\n", registrarName, domain)
+				fmt.Printf("Removing domain from provider %s: %s\n", registrarName, domain)
 				*totalCorrections += 1
 				if domainRemover, ok := registrar.(providers.DomainRemover); ok && push {
 					err := domainRemover.EnsureDomainAbsent(domain)
@@ -311,7 +311,7 @@ func DeleteUnmanagedZones(cfg *models.DNSConfig, createdProviders map[string]pro
 		}
 		for _, zone := range deployedZones {
 			if !IsZoneManagedByProvider(cfg, zone, providerName) {
-				fmt.Printf("Removing from provider %s: zone %s\n", providerName, zone)
+				fmt.Printf("Removing zone from provider %s: %s\n", providerName, zone)
 				*totalCorrections += 1
 				if zoneRemover, ok := provider.(providers.ZoneRemover); ok && push {
 					err := zoneRemover.EnsureZoneAbsent(zone)

--- a/commands/previewPush.go
+++ b/commands/previewPush.go
@@ -363,9 +363,6 @@ type ProviderState struct {
 func InitializeProviders(cfg *models.DNSConfig, providerConfigs map[string]map[string]string, notifyFlag bool) ProviderState {
 	var notificationCfg map[string]string
 	result := ProviderState{}
-	defer func() {
-		result.notifier = notifications.Init(notificationCfg)
-	}()
 	if notifyFlag {
 		notificationCfg = providerConfigs["notifications"]
 	}
@@ -418,6 +415,7 @@ func InitializeProviders(cfg *models.DNSConfig, providerConfigs map[string]map[s
 	}
 	result.createdRegistrars = registrars
 	result.createdDnsProviders = dnsProviders
+	result.notifier = notifications.Init(notificationCfg)
 	return result
 }
 

--- a/commands/previewPush.go
+++ b/commands/previewPush.go
@@ -264,6 +264,8 @@ DomainLoop:
 	return nil
 }
 
+// DeleteUnmanagedDomains iterates over all registrars and their respective deployed domains, and removes those, which
+// are not configured within dnscontrol
 func DeleteUnmanagedDomains(cfg *models.DNSConfig, createdRegistrars map[string]providers.Registrar, push bool, out printer.CLI, totalCorrections *int) error {
 	fmt.Printf("Checking Domain Removal:\n")
 	for registrarName, registrar := range createdRegistrars {
@@ -292,6 +294,8 @@ func DeleteUnmanagedDomains(cfg *models.DNSConfig, createdRegistrars map[string]
 	return nil
 }
 
+// DeleteUnmanagedZones iterates over all providers and their respective deployed zones, and removes those, which
+// are not configured within dnscontrol
 func DeleteUnmanagedZones(cfg *models.DNSConfig, createdProviders map[string]providers.DNSServiceProvider, push bool, out printer.CLI, totalCorrections *int) error {
 	fmt.Printf("Checking Zone Removal:\n")
 	for providerName, provider := range createdProviders {

--- a/commands/previewPush.go
+++ b/commands/previewPush.go
@@ -241,7 +241,7 @@ DomainLoop:
 		for registrarName, registrar := range createdRegistrars {
 			domainLister, ok := registrar.(providers.DomainLister)
 			if !ok {
-				fmt.Errorf("provider type of %s cannot list zones\n", registrarName)
+				fmt.Errorf("provider type of %s cannot list domains\n", registrarName)
 			}
 			deployedDomains, err := domainLister.ListDomains()
 			if err != nil {

--- a/commands/previewPush.go
+++ b/commands/previewPush.go
@@ -267,8 +267,8 @@ DomainLoop:
 // DeleteUnmanagedDomains iterates over all registrars and their respective deployed domains, and removes those, which
 // are not configured within dnscontrol
 func DeleteUnmanagedDomains(cfg *models.DNSConfig, createdRegistrars map[string]providers.Registrar, push bool, out printer.CLI, totalCorrections *int) error {
-	fmt.Printf("Checking Domain Removal:\n")
 	for registrarName, registrar := range createdRegistrars {
+		out.StartUnmanagedDomainCheck(registrarName)
 		domainLister, ok := registrar.(providers.DomainLister)
 		if !ok {
 			out.Warnf("--purge-unmanaged-domains not implemented: provider %s\n", registrarName)
@@ -280,6 +280,7 @@ func DeleteUnmanagedDomains(cfg *models.DNSConfig, createdRegistrars map[string]
 		}
 		for _, domain := range deployedDomains {
 			if !IsDomainManagedByRegistrar(cfg, domain, registrarName) {
+
 				fmt.Printf("Removing from provider %s: domain %s\n", registrarName, domain)
 				*totalCorrections += 1
 				if domainRemover, ok := registrar.(providers.DomainRemover); ok && push {
@@ -297,8 +298,8 @@ func DeleteUnmanagedDomains(cfg *models.DNSConfig, createdRegistrars map[string]
 // DeleteUnmanagedZones iterates over all providers and their respective deployed zones, and removes those, which
 // are not configured within dnscontrol
 func DeleteUnmanagedZones(cfg *models.DNSConfig, createdProviders map[string]providers.DNSServiceProvider, push bool, out printer.CLI, totalCorrections *int) error {
-	fmt.Printf("Checking Zone Removal:\n")
 	for providerName, provider := range createdProviders {
+		out.StartUnmanagedDomainCheck(providerName)
 		zoneLister, ok := provider.(providers.ZoneLister)
 		if !ok {
 			out.Warnf("--purge-unmanaged-zones not implemented: provider %s\n", providerName)

--- a/commands/previewPush.go
+++ b/commands/previewPush.go
@@ -299,7 +299,7 @@ func DeleteUnmanagedDomains(cfg *models.DNSConfig, createdRegistrars map[string]
 // are not configured within dnscontrol
 func DeleteUnmanagedZones(cfg *models.DNSConfig, createdProviders map[string]providers.DNSServiceProvider, push bool, out printer.CLI, totalCorrections *int) error {
 	for providerName, provider := range createdProviders {
-		out.StartUnmanagedDomainCheck(providerName)
+		out.StartUnmanagedZonesCheck(providerName)
 		zoneLister, ok := provider.(providers.ZoneLister)
 		if !ok {
 			out.Warnf("--purge-unmanaged-zones not implemented: provider %s\n", providerName)

--- a/commands/previewPush.go
+++ b/commands/previewPush.go
@@ -140,8 +140,8 @@ func run(args PreviewArgs, push bool, interactive bool, out printer.CLI) error {
 		return err
 	}
 	providerState := InitializeProviders(cfg, providerConfigs, args.Notify)
-	if err != nil {
-		return err
+	if providerState.err != nil {
+		return providerState.err
 	}
 
 	errs := normalize.ValidateAndNormalizeConfig(cfg)
@@ -416,6 +416,8 @@ func InitializeProviders(cfg *models.DNSConfig, providerConfigs map[string]map[s
 			pInst.IsDefault = !isNonDefault[pInst.Name]
 		}
 	}
+	result.createdRegistrars = registrars
+	result.createdDnsProviders = dnsProviders
 	return result
 }
 

--- a/commands/previewPush.go
+++ b/commands/previewPush.go
@@ -324,6 +324,7 @@ func DeleteUnmanagedZones(cfg *models.DNSConfig, createdProviders map[string]pro
 	return nil
 }
 
+// GetDomainCfg returns the configuration defined for a domain within dnscontrol, or nil if the domain is not configured
 func GetDomainCfg(cfg *models.DNSConfig, domain string) *models.DomainConfig {
 	for _, domainCfg := range cfg.Domains {
 		if domainCfg.Name == domain {

--- a/commands/previewPush.go
+++ b/commands/previewPush.go
@@ -241,7 +241,8 @@ DomainLoop:
 		for registrarName, registrar := range createdRegistrars {
 			domainLister, ok := registrar.(providers.DomainLister)
 			if !ok {
-				fmt.Errorf("provider type of %s cannot list domains\n", registrarName)
+				out.Warnf("provider type of %s cannot list domains\n", registrarName)
+				continue
 			}
 			deployedDomains, err := domainLister.ListDomains()
 			if err != nil {
@@ -267,7 +268,8 @@ DomainLoop:
 		for providerName, provider := range createdProviders {
 			zoneLister, ok := provider.(providers.ZoneLister)
 			if !ok {
-				fmt.Errorf("provider type of %s cannot list zones\n", providerName)
+				out.Warnf("provider type of %s cannot list zones\n", providerName)
+				continue
 			}
 			deployedZones, err := zoneLister.ListZones()
 			if err != nil {

--- a/commands/previewPush.go
+++ b/commands/previewPush.go
@@ -329,27 +329,35 @@ func GetDomainCfg(cfg *models.DNSConfig, domain string) *models.DomainConfig {
 	return nil
 }
 
-func IsDomainManagedByRegistrar(cfg *models.DNSConfig, zone string, registrarName string) bool {
-	domainCfg := GetDomainCfg(cfg, zone)
+// IsDomainManagedByRegistrar checks whether `domain` is configured to be managed by `registrarName`
+func IsDomainManagedByRegistrar(cfg *models.DNSConfig, domain string, registrarName string) bool {
+	domainCfg := GetDomainCfg(cfg, domain)
 
-	if domainCfg == nil || domainCfg.RegistrarName != registrarName {
+	// domain is not configured in dnscontrol at all
+	if domainCfg == nil {
+		return false
+	}
+	// domain is configured within dnscontrol, but with a different registrar
+	if domainCfg.RegistrarName != registrarName {
 		return false
 	}
 	return true
 }
 
+// IsZoneManagedByProvider checks whether `zone` is configured to be managed by `dnsProviderName
 func IsZoneManagedByProvider(cfg *models.DNSConfig, zone string, dnsProviderName string) bool {
 	domainCfg := GetDomainCfg(cfg, zone)
 
+	// domain is not configured in dnscontrol at all
 	if domainCfg == nil {
 		return false
 	}
-	for managedProviderName, _ := range domainCfg.DNSProviderNames {
-		if managedProviderName == dnsProviderName {
-			return true
-		}
+	_, ok := domainCfg.DNSProviderNames[dnsProviderName]
+	// domain is configured within dnscontrol, but not for this dns provider
+	if !ok {
+		return false
 	}
-	return false
+	return true
 }
 
 type ProviderState struct {

--- a/commands/previewPush_test.go
+++ b/commands/previewPush_test.go
@@ -75,10 +75,10 @@ func TestIsDomainOrZoneManaged(t *testing.T) {
 		t.Errorf("failed loading provider config. err: %s", err)
 	}
 
-	providerState := InitializeProviders(cfg, providerConfigs, false)
+	_, err = InitializeProviders(cfg, providerConfigs, false)
 
-	if providerState.err != nil {
-		t.Errorf("error initializing providers. err: %s", providerState.err)
+	if err != nil {
+		t.Errorf("error initializing providers. err: %s", err)
 	}
 	tests := []struct {
 		name          string

--- a/commands/previewPush_test.go
+++ b/commands/previewPush_test.go
@@ -75,10 +75,10 @@ func TestIsDomainOrZoneManaged(t *testing.T) {
 		t.Errorf("failed loading provider config. err: %s", err)
 	}
 
-	_, _, _, err = InitializeProviders(cfg, providerConfigs, false)
+	providerState := InitializeProviders(cfg, providerConfigs, false)
 
-	if err != nil {
-		t.Errorf("error initializing providers. err: %s", err)
+	if providerState.err != nil {
+		t.Errorf("error initializing providers. err: %s", providerState.err)
 	}
 	tests := []struct {
 		name          string

--- a/commands/test_data/bind-creds.json
+++ b/commands/test_data/bind-creds.json
@@ -1,5 +1,19 @@
 {
-    "bind": {
-        "directory": "test_data"
-    }
+  "bind": {
+    "directory": "test_data"
+  },
+  "dsp1": {
+    "TYPE": "BIND"
+  },
+  "dsp2": {
+    "TYPE": "BIND"
+  },
+  "registrar1": {
+    "TYPE": "HOSTINGDE",
+    "authToken": "empty"
+  },
+  "registrar2": {
+    "TYPE": "HOSTINGDE",
+    "authToken": "empty"
+  }
 }

--- a/commands/test_data/dnsconfig.js
+++ b/commands/test_data/dnsconfig.js
@@ -1,0 +1,10 @@
+var REGISTRAR1 = NewRegistrar("registrar1");
+var REGISTRAR2 = NewRegistrar("registrar2");
+
+var DSP1 = NewDnsProvider("dsp1");
+var DSP2 = NewDnsProvider("dsp2");
+
+D("example.org", REGISTRAR1, DnsProvider(DSP1))
+
+D("example.com", REGISTRAR2, DnsProvider(DSP2))
+

--- a/documentation/getting-started.md
+++ b/documentation/getting-started.md
@@ -328,3 +328,8 @@ If you are going to use this in production, we highly recommend the following:
   API keys or other credentials without encrypting them.
 * Use a CI/CD tool like [Gitlab](ci-cd-gitlab.md), Jenkins, CircleCI, [GitHub Actions](https://github.com/StackExchange/dnscontrol#via-github-actions-gha), etc. to automatically push DNS changes.
 * Join the DNSControl community. File [issues](https://github.com/StackExchange/dnscontrol/issues) and [PRs](https://github.com/StackExchange/dnscontrol/pulls).
+
+## 9. Fully manage your domains and zones through dnscontrol
+Once you have configured all your domains and zones in dnscontrol, you can use the `dnscontrol preview --delete-unmanaged` and `dnscontrol push --delete-unmanaged` (or just `--delete-unmanaged-domains`/`--delete-unmanaged-zones`) to automatically delete domains/zones you have deleted in your `dnsconfig.js` from your provider.
+
+When first using this, make sure to first check with preview that you didn't forget any domains/zones! Otherwise, deleted domains/zones might be irreversibly lost.

--- a/documentation/index.md
+++ b/documentation/index.md
@@ -12,6 +12,7 @@ Take advantage of the advanced features. Use macros and variables for easier upd
 
 {% hint style="success" %}
 * Maintain your DNS data as a high-level DS, with macros, and variables for easier updates.
+* Full lifecycle management of your domains and zones: creation, modification and deletion.
 * Super extensible! Plug-in architecture makes adding new DNS providers and Registrars easy!
 * Eliminate vendor lock-in. Switch DNS providers easily, any time, with full fidelity.
 * Reduce points of failure: Easily maintain dual DNS providers and easily drop one that is down.

--- a/pkg/printer/printer.go
+++ b/pkg/printer/printer.go
@@ -17,6 +17,8 @@ type CLI interface {
 	StartDNSProvider(name string, skip bool)
 	EndProvider(numCorrections int, err error)
 	StartRegistrar(name string, skip bool)
+	StartUnmanagedDomainCheck(registrar string)
+	StartUnmanagedZonesCheck(provider string)
 
 	PrintCorrection(n int, c *models.Correction)
 	EndCorrection(err error)
@@ -114,6 +116,16 @@ func (c ConsolePrinter) EndCorrection(err error) {
 	} else {
 		fmt.Fprintln(c.Writer, "SUCCESS!")
 	}
+}
+
+// StartUnmanagedDomainCheck is called at the start of each new registrar.
+func (c ConsolePrinter) StartUnmanagedDomainCheck(registrar string) {
+	fmt.Fprintf(c.Writer, "******************** Checking for unmanaged domains on registrar: %s\n", registrar)
+}
+
+// StartUnmanagedZonesCheck is called at the start of each new dns provider.
+func (c ConsolePrinter) StartUnmanagedZonesCheck(provider string) {
+	fmt.Fprintf(c.Writer, "******************** Checking for unmanaged zones on provider: %s\n", provider)
 }
 
 // StartDNSProvider is called at the start of each new provider.

--- a/providers/hostingde/api.go
+++ b/providers/hostingde/api.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"github.com/StackExchange/dnscontrol/v3/models"
 	"io"
 	"net/http"
 
@@ -47,6 +48,23 @@ func (hp *hostingdeProvider) getDomainConfig(domain string) (*domainConfig, erro
 	return domainConf[0], nil
 }
 
+func (hp *hostingdeProvider) deleteDomain(domain string) error {
+	t, err := idna.ToASCII(domain)
+	if err != nil {
+		return err
+	}
+
+	params := request{
+		DomainName: t,
+	}
+
+	_, err = hp.get("dns", "domainDelete", params)
+	if err != nil {
+		return fmt.Errorf("error deleting domain: %w", err)
+	}
+	return nil
+}
+
 func (hp *hostingdeProvider) createZone(domain string) error {
 	t, err := idna.ToASCII(domain)
 	if err != nil {
@@ -75,6 +93,29 @@ func (hp *hostingdeProvider) createZone(domain string) error {
 	if err != nil {
 		return fmt.Errorf("error creating zone: %w", err)
 	}
+	return nil
+}
+
+func (hp *hostingdeProvider) deleteZone(domain string) error {
+	t, err := idna.ToASCII(domain)
+	if err != nil {
+		return err
+	}
+
+	params := request{
+		ZoneName: t,
+	}
+
+	_, err = hp.get("dns", "zoneDelete", params)
+	if err != nil {
+		return fmt.Errorf("error deleting zone: %w", err)
+	}
+
+	_, err = hp.get("dns", "zonePurgeRestorable", params)
+	if err != nil {
+		return fmt.Errorf("error purging restorable zone: %w", err)
+	}
+
 	return nil
 }
 

--- a/providers/hostingde/api.go
+++ b/providers/hostingde/api.go
@@ -320,3 +320,27 @@ func (hp *hostingdeProvider) getAllZoneConfigs() ([]*zoneConfig, error) {
 
 	return zc, nil
 }
+
+func (hp *hostingdeProvider) getAllDomainConfigs() ([]*domainConfig, error) {
+	params := request{
+		Limit: 10000,
+	}
+	if hp.filterAccountId != "" {
+		params.Filter = &filter{
+			Field: "accountId",
+			Value: hp.filterAccountId,
+		}
+	}
+
+	resp, err := hp.get("domain", "domainsFind", params)
+	if err != nil {
+		return nil, fmt.Errorf("could not domains zones: %w", err)
+	}
+
+	zc := []*domainConfig{}
+	if err := json.Unmarshal(resp.Data, &zc); err != nil {
+		return nil, fmt.Errorf("could not parse response: %w", err)
+	}
+
+	return zc, nil
+}

--- a/providers/hostingde/api.go
+++ b/providers/hostingde/api.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/StackExchange/dnscontrol/v3/models"
 	"io"
 	"net/http"
 

--- a/providers/hostingde/hostingdeProvider.go
+++ b/providers/hostingde/hostingdeProvider.go
@@ -371,7 +371,6 @@ func (hp *hostingdeProvider) ListZones() ([]string, error) {
 		zones = append(zones, zoneConfig.Name)
 	}
 	return zones, nil
-
 }
 
 func (hp *hostingdeProvider) ListDomains() ([]string, error) {

--- a/providers/hostingde/hostingdeProvider.go
+++ b/providers/hostingde/hostingdeProvider.go
@@ -373,3 +373,15 @@ func (hp *hostingdeProvider) ListZones() ([]string, error) {
 	return zones, nil
 
 }
+
+func (hp *hostingdeProvider) ListDomains() ([]string, error) {
+	domainConfigs, err := hp.getAllDomainConfigs()
+	if err != nil {
+		return nil, err
+	}
+	zones := make([]string, 0, len(domainConfigs))
+	for _, config := range domainConfigs {
+		zones = append(zones, config.Name)
+	}
+	return zones, nil
+}

--- a/providers/hostingde/hostingdeProvider.go
+++ b/providers/hostingde/hostingdeProvider.go
@@ -361,6 +361,28 @@ func (hp *hostingdeProvider) EnsureZoneExists(domain string) error {
 	return nil
 }
 
+func (hp *hostingdeProvider) EnsureDomainAbsent(domain string) error {
+	dc, _ := hp.getDomainConfig(domain)
+	if dc == nil {
+		return nil
+	}
+	if err := hp.deleteDomain(domain); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (hp *hostingdeProvider) EnsureZoneAbsent(domain string) error {
+	_, err := hp.getZoneConfig(domain)
+	if err == errZoneNotFound {
+		return nil
+	}
+	if err := hp.deleteZone(domain); err != nil {
+		return err
+	}
+	return nil
+}
+
 func (hp *hostingdeProvider) ListZones() ([]string, error) {
 	zcs, err := hp.getAllZoneConfigs()
 	if err != nil {

--- a/providers/hostingde/types.go
+++ b/providers/hostingde/types.go
@@ -35,6 +35,12 @@ type request struct {
 	Add        []dnsSecEntry `json:"add,omitempty"`
 	Remove     []dnsSecEntry `json:"remove,omitempty"`
 
+	// various zone operations
+	ZoneName string `json:"zoneName"`
+
+	// various domain operations
+	DomainName string `json:"domainName"`
+
 	// Domain
 	Domain *domainConfig `json:"domain"`
 

--- a/providers/hostingde/types.go
+++ b/providers/hostingde/types.go
@@ -38,9 +38,6 @@ type request struct {
 	// various zone operations
 	ZoneName string `json:"zoneName"`
 
-	// various domain operations
-	DomainName string `json:"domainName"`
-
 	// Domain
 	Domain *domainConfig `json:"domain"`
 

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -24,11 +24,35 @@ type ZoneCreator interface {
 	EnsureZoneExists(domain string) error
 }
 
+// ZoneRemover should be implemented by providers that have the ability to add domains to an account. the create-domains command
+// can be run to ensure all domains are present before running preview/push.  Implement this only if the provider supoprts the `dnscontrol create-domain` command.
+type ZoneRemover interface {
+	EnsureZoneAbsent(domain string) error
+}
+
+// DomainCreator should be implemented by providers that have the ability to add domains to an account.
+// Used by `--delete-unmanaged-domains`
+type DomainCreator interface {
+	EnsureDomainExists(domain string) error
+}
+
+// DomainRemover should be implemented by providers that have the ability to add domains to an account.
+// Used by `--delete-unmanaged-domains`
+type DomainRemover interface {
+	EnsureDomainAbsent(domain string) error
+}
+
 // ZoneLister should be implemented by providers that have the
 // ability to list the zones they manage. This facilitates using the
 // "get-zones" command for "all" zones.
 type ZoneLister interface {
 	ListZones() ([]string, error)
+}
+
+// DomainLister should be implemented by providers supporting
+// `--delete-unmanaged-domains`
+type DomainLister interface {
+	ListDomains() ([]string, error)
 }
 
 // RegistrarInitializer is a function to create a registrar. Function will be passed the unprocessed json payload from the configuration file for the given provider.


### PR DESCRIPTION
@tlimoncelli 

This is an implementation of the feature we discussed in #1976. 

The feature can be used like this:

```
dnscontrol preview --delete-unmanaged-domains
``` 

```
dnscontrol preview --delete-unmanaged-zones
``` 

```
dnscontrol preview --delete-unmanaged # same as --delete-unmanaged-domains --delete-unmanaged-zones
``` 

The output looks like this:

```
Checking Domain Removal:
Removing domain mydomain.com from provider hosting.de
Checking Zone Removal:
Removing zone mydomain.com from provider hosting.de
```
