### PR TITLE
MSDNS: Fix TXT records handling. Make debugging easier by outputting PS code on error

### DIFF
--- a/providers/msdns/auditrecords.go
+++ b/providers/msdns/auditrecords.go
@@ -27,5 +27,7 @@ func AuditRecords(records []*models.RecordConfig) []error {
 
 	a.Add("TXT", rejectif.TxtIsEmpty) // Last verified 2021-03-01
 
+	a.Add("TXT", rejectif.TxtIsExactlyLen255) // Last verified 2023-02-02
+
 	return a.Audit(records)
 }

--- a/providers/msdns/convert.go
+++ b/providers/msdns/convert.go
@@ -115,7 +115,7 @@ func nativeToRecords(nr nativeRecord, origin string) (*models.RecordConfig, erro
 		//	uprops["ExpireLimit"], uprops["MinimumTimeToLive"])
 	case "TXT":
 		//rc.SetTargetTXTString(sprops["DescriptiveText"])
-		rc.SetTargetTXTfromRFC1035Quoted(sprops["DescriptiveText"])
+		rc.SetTargetTXT(sprops["DescriptiveText"])
 	default:
 		return nil, fmt.Errorf(
 			"msdns/convert.go:nativeToRecord rtype=%q unknown: props=%+v and %+v",


### PR DESCRIPTION
* BUGFIX: TXT records were not being created properly.  SetTargetTXTfromRFC1035Quoted was used when SetTargetTXT() was needed.
* FEATURE: When a PowerShell command has an error, output the PowerShell code to assist in debugging.
