### PR TITLE
HOSTINGDE: Remove dnssec key from domain upon autodnssec disable

### DIFF
--- a/providers/hostingde/api.go
+++ b/providers/hostingde/api.go
@@ -247,6 +247,20 @@ func (hp *hostingdeProvider) getDNSSECOptions(zoneConfigId string) (*dnsSecOptio
 	return dnsSecOptions[0], nil
 }
 
+func (hp *hostingdeProvider) dnsSecKeyModify(domain string, add []dnsSecEntry, remove []dnsSecEntry) error {
+	params := request{
+		DomainName: domain,
+		Add:        add,
+		Remove:     remove,
+	}
+
+	_, err := hp.get("domain", "dnsSecKeyModify", params)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 func (hp *hostingdeProvider) get(service, method string, params request) (*responseData, error) {
 	params.AuthToken = hp.authToken
 	params.OwnerAccountID = hp.ownerAccountID

--- a/providers/hostingde/types.go
+++ b/providers/hostingde/types.go
@@ -23,13 +23,17 @@ type request struct {
 	Page           uint    `json:"page,omitempty"`
 
 	// Update Zone
-	ZoneConfig      *zoneConfig `json:"zoneConfig"`
-	RecordsToAdd    []*record   `json:"recordsToAdd"`
-	RecordsToModify []*record   `json:"recordsToModify"`
-	RecordsToDelete []*record   `json:"recordsToDelete"`
+	ZoneConfig      *zoneConfig `json:"zoneConfig,omitempty"`
+	RecordsToAdd    []*record   `json:"recordsToAdd,omitempty"`
+	RecordsToModify []*record   `json:"recordsToModify,omitempty"`
+	RecordsToDelete []*record   `json:"recordsToDelete,omitempty"`
 
 	// Create Zone
-	Records []*record `json:"records"`
+	Records []*record `json:"records,omitempty"`
+
+	DomainName string        `json:"domainName,omitempty"`
+	Add        []dnsSecEntry `json:"add,omitempty"`
+	Remove     []dnsSecEntry `json:"remove,omitempty"`
 
 	// Domain
 	Domain *domainConfig `json:"domain"`
@@ -52,7 +56,14 @@ type domainConfig struct {
 	Name                string          `json:"name"`
 	Contacts            json.RawMessage `json:"contacts"`
 	Nameservers         []nameserver    `json:"nameservers"`
+	DNSSecEntries       []dnsSecEntry   `json:"dnsSecEntries"`
 	TransferLockEnabled bool            `json:"transferLockEnabled"`
+}
+
+type dnsSecEntry struct {
+	KeyData dnsSecKey `json:"keyData"`
+	Comment string    `json:"comment"`
+	KeyTag  uint32    `json:"keyTag"`
 }
 
 type zoneConfig struct {
@@ -80,10 +91,10 @@ type zone struct {
 }
 
 type dnsSecOptions struct {
-	Keys       []dnsSecKey `json:"flags,omitempty"`
-	Algorithms []string    `json:"algorithms,omitempty"`
-	NSECMode   string      `json:"nsecMode"`
-	PublishKSK bool        `json:"publishKsk"`
+	Keys       []dnsSecEntry `json:"keys,omitempty"`
+	Algorithms []string      `json:"algorithms,omitempty"`
+	NSECMode   string        `json:"nsecMode"`
+	PublishKSK bool          `json:"publishKsk"`
 }
 
 type dnsSecKey struct {


### PR DESCRIPTION
I noticed an issue where if you enable autodnssec, and then disable it, the DS key is left at the domain, resulting in the zone not being able to be used anymore. (Because it's not signed anymore)

This PR fixes that.
