### PR TITLE
FIX: Release binaries don't contain semver string

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,8 @@ jobs:
 
       - run:
           name: Build binaries
-          command: goreleaser build --snapshot
+          # If there is no tag run a snapshot build
+          command: goreleaser build<<^pipeline.git.tag>> --snapshot<</pipeline.git.tag>>
 
       - run:
           name: Enforce Go Formatted Code
@@ -148,7 +149,7 @@ jobs:
           name: Install goreleaser
           command: go install github.com/goreleaser/goreleaser@latest
 
-      - run: goreleaser release --rm-dist
+      - run: goreleaser release
 
       - store_artifacts:
           path: dist

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ jobs:
 
       - run:
           name: Build binaries
-          command: goreleaser build
+          command: goreleaser build --snapshot
 
       - run:
           name: Enforce Go Formatted Code

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ jobs:
 
       - run:
           name: Build binaries
-          command: goreleaser build --snapshot
+          command: goreleaser build
 
       - run:
           name: Enforce Go Formatted Code

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,7 +148,7 @@ jobs:
           name: Install goreleaser
           command: go install github.com/goreleaser/goreleaser@latest
 
-      - run: goreleaser release
+      - run: goreleaser release --rm-dist
 
       - store_artifacts:
           path: dist


### PR DESCRIPTION
Fixes #1844 

I believe the `release` job is reusing the binaries from the `build` job which was hard coded to build a "snapshot" which is unversioned.

This PR removes `--snapshot` flag for workflows triggered by a tag push - the trigger that invokes `release`.