### PR TITLE
AXFRDNS: Add "TYPE" as valid key in creds.json

### DIFF
--- a/providers/axfrddns/axfrddnsProvider.go
+++ b/providers/axfrddns/axfrddnsProvider.go
@@ -138,7 +138,8 @@ func initAxfrDdns(config map[string]string, providermeta json.RawMessage) (provi
 			"update-key",
 			"transfer-key",
 			"update-mode",
-			"transfer-mode":
+			"transfer-mode",
+			"TYPE":
 			continue
 		default:
 			printer.Printf("[Warning] AXFRDDNS: unknown key in `creds.json` (%s)\n", key)


### PR DESCRIPTION
This pull request fixes false warning in axfrdns provider:

``[Warning] AXFRDDNS: unknown key in `creds.json` (TYPE)``