### PR TITLE
Verify that registrar and dns providers match if autodnssec is enabled (#2056)

### DIFF
--- a/pkg/normalize/validate.go
+++ b/pkg/normalize/validate.go
@@ -550,6 +550,14 @@ func checkAutoDNSSEC(dc *models.DomainConfig) (errs []error) {
 	if dc.AutoDNSSEC != "" && dc.AutoDNSSEC != "on" && dc.AutoDNSSEC != "off" {
 		errs = append(errs, fmt.Errorf("domain %q AutoDNSSEC=%q is invalid (expecting \"\", \"off\", or \"on\")", dc.Name, dc.AutoDNSSEC))
 	}
+
+	if dc.AutoDNSSEC == "on" {
+		for providerName, _ := range dc.DNSProviderNames {
+			if dc.RegistrarName != providerName {
+				errs = append(errs, fmt.Errorf("AutoDNSSEC is enabled, but DNS provider %s does not match registrar %s", providerName, dc.RegistrarName))
+			}
+		}
+	}
 	return
 }
 


### PR DESCRIPTION
As discussed in #2056 