### PR TITLE
ROUTE53: R53_ALIAS loops should be detected earlier

### DIFF
--- a/integrationTest/integration_test.go
+++ b/integrationTest/integration_test.go
@@ -1256,6 +1256,16 @@ func makeTests(t *testing.T) []*TestGroup {
 			),
 		),
 
+		testgroup("R53_ALIAS_Loop",
+			// This will always be skipped because rejectifTargetEqualsLabel
+			// will always flag it as not permitted.
+			// See https://github.com/StackExchange/dnscontrol/issues/2107
+			requires(providers.CanUseRoute53Alias),
+			tc("loop should fail",
+				r53alias("test-islandora", "CNAME", "test-islandora.**current-domain**"),
+			),
+		),
+
 		// CLOUDFLAREAPI features
 
 		testgroup("CF_REDIRECT",

--- a/providers/route53/auditrecords.go
+++ b/providers/route53/auditrecords.go
@@ -1,10 +1,31 @@
 package route53
 
-import "github.com/StackExchange/dnscontrol/v3/models"
+import (
+	"fmt"
+
+	"github.com/StackExchange/dnscontrol/v3/models"
+	"github.com/StackExchange/dnscontrol/v3/pkg/rejectif"
+)
 
 // AuditRecords returns a list of errors corresponding to the records
 // that aren't supported by this provider.  If all records are
 // supported, an empty list is returned.
 func AuditRecords(records []*models.RecordConfig) []error {
+	a := rejectif.Auditor{}
+
+	a.Add("R53_ALIAS", rejectifTargetEqualsLabel) // Last verified 2023-03-01
+
+	return a.Audit(records)
+}
+
+// Normally this kind of function would be put in `pkg/rejectif` but
+// since this is ROUTE53-specific, we'll include it here.
+
+// rejectifTargetEqualsLabel rejects an ALIAS that would create a loop.
+
+func rejectifTargetEqualsLabel(rc *models.RecordConfig) error {
+	if (rc.GetLabelFQDN() + ".") == rc.GetTargetField() {
+		return fmt.Errorf("alias target loop")
+	}
 	return nil
 }


### PR DESCRIPTION
<!--
Before you submit a pull request, please make sure you've run the following commands from the root directory.

go fmt ./...
go generate
go mod tidy
!-->

