### PR TITLE
FEATURE: Detect simple CNAME loops

### DIFF
--- a/pkg/normalize/validate.go
+++ b/pkg/normalize/validate.go
@@ -187,6 +187,11 @@ func checkTargets(rec *models.RecordConfig, domain string) (errs []error) {
 		if label == "@" {
 			check(fmt.Errorf("cannot create CNAME record for bare domain"))
 		}
+		labelFQDN := dnsutil.AddOrigin(label, domain)
+		targetFQDN := dnsutil.AddOrigin(target, domain)
+		if labelFQDN == targetFQDN {
+			check(fmt.Errorf("CNAME loop (target points at itself)"))
+		}
 	case "MX":
 		check(checkTarget(target))
 	case "NAPTR":


### PR DESCRIPTION
This makes check/preview/push fail if a CNAME is pointing at itself.  That would be a loop.

This doesn't stop someone from creating a longer loop (a -> b -> c -> a) but at least it will catch the most simple case.