### PR TITLE
DOCS: Fixed incorrect documentation directory path

### DIFF
--- a/documentation/adding-new-rtypes.md
+++ b/documentation/adding-new-rtypes.md
@@ -218,7 +218,7 @@ tests, please ask!
 
 ## Step 8: Write documentation
 
-Add a new Markdown file to `docs/functions/domain`. Copy an existing file (`CNAME.md` is a good example). The section between the lines of `---` is called the front matter and it has the following keys:
+Add a new Markdown file to `documentation/functions/domain`. Copy an existing file (`CNAME.md` is a good example). The section between the lines of `---` is called the front matter and it has the following keys:
 
 -   `name`: The name of the record. This should match the file name and the name of the record in `helpers.js`.
 -   `parameters`: A list of parameter names, in order. Feel free to use spaces in the name if necessary. Your last parameter should be `modifiers...` to allow arbitrary modifiers like `TTL` to be applied to your record.

--- a/documentation/get-zones.md
+++ b/documentation/get-zones.md
@@ -192,4 +192,4 @@ provider.)
 Implementing the `ListZones` function also activates the `check-creds`
 subcommand for that provider. Please add to the provider documentation
 a list of error messages that people might see if the credentials are
-invalid.  See `docs/providers/gcloud.md` for examples.
+invalid.  See `documentation/providers/gcloud.md` for examples.

--- a/documentation/writing-providers.md
+++ b/documentation/writing-providers.md
@@ -198,14 +198,14 @@ Some useful `go test` flags:
 
 There is a potential bug in how TXT records are handled. Sadly we haven't found
 an automated way to test for this bug.  The manual steps are here in
-[docs/testing-txt-records.md](testing-txt-records.md)
+[documentation/testing-txt-records.md](testing-txt-records.md)
 
 
 ## Step 9: Update docs
 
 * Edit [README.md](https://github.com/StackExchange/dnscontrol): Add the provider to the bullet list.
-* Edit [docs/providers.md](https://github.com/StackExchange/dnscontrol/blob/master/documentation/providers.md): Add the provider to the provider list.
-* Create `docs/providers/PROVIDERNAME.md`: Use one of the other files in that directory as a base.
+* Edit [documentation/providers.md](https://github.com/StackExchange/dnscontrol/blob/master/documentation/providers.md): Add the provider to the provider list.
+* Create `documentation/providers/PROVIDERNAME.md`: Use one of the other files in that directory as a base.
 * Edit [OWNERS](https://github.com/StackExchange/dnscontrol/blob/master/OWNERS): Add the directory name and your GitHub username.
 
 ## Step 10: Submit a PR
@@ -271,7 +271,7 @@ go get -u golang.org/x/lint/golint
 
 ## Step 13: Dependencies
 
-See [docs/release-engineering.md](release-engineering.md)
+See [documentation/release-engineering.md](release-engineering.md)
 for tips about managing modules and checking for outdated
 dependencies.
 
@@ -288,4 +288,4 @@ Here are some last-minute things to check before you submit your PR.
 ## Step 15: After the PR is merged
 
 1. Remove the "provider-request" label from the PR.
-2. Verify that [docs/providers.md](providers.md) no longer shows the provider as "requested"
+2. Verify that [documentation/providers.md](providers.md) no longer shows the provider as "requested"


### PR DESCRIPTION
<!--
Before you submit a pull request, please make sure you've run the following commands from the root directory.

go fmt ./...
go generate
go mod tidy
!-->

Fixed the incorrect directory path `docs` to `documentation`.