### PR TITLE
DOCS: [GitBook] Added code blocks syntax for dnsconfig.js

### DIFF
--- a/documentation/providers/akamaiedgedns.md
+++ b/documentation/providers/akamaiedgedns.md
@@ -50,14 +50,17 @@ The NS records for these authorities have a TTL of 86400.
 
 Add:
 
+{% code title="dnsconfig.js" %}
 ```javascript
 NAMESERVER_TTL(86400)
 ```
+{% endcode %}
 
 modifier to the dnscontrol.js D() function so that DNSControl does not change the TTL of the authoritative NS records.
 
 Example `dnsconfig.js`:
 
+{% code title="dnsconfig.js" %}
 ```javascript
 var REG_NONE = NewRegistrar("none");
 var DSP_AKAMAIEDGEDNS = NewDnsProvider("akamaiedgedns");
@@ -69,6 +72,7 @@ D("example.com", REG_NONE, DnsProvider(DSP_AKAMAIEDGEDNS),
   A("foo", "1.2.3.4")
 );
 ```
+{% endcode %}
 
 AKAMAICDN is a proprietary record type that is used to configure [Zone Apex Mapping](https://www.akamai.com/blog/security/edge-dns--zone-apex-mapping---dnssec).
 The AKAMAICDN target must be preconfigured in the Akamai network.

--- a/documentation/providers/autodns.md
+++ b/documentation/providers/autodns.md
@@ -22,6 +22,7 @@ Example:
 
 An example `dnsconfig.js` configuration:
 
+{% code title="dnsconfig.js" %}
 ```javascript
 var REG_NONE = NewRegistrar("none");
 var DSP_AUTODNS = NewDnsProvider("autodns");
@@ -30,3 +31,4 @@ D("example.tld", REG_NONE, DnsProvider(DSP_AUTODNS),
     A("test", "1.2.3.4")
 );
 ```
+{% endcode %}

--- a/documentation/providers/autodns.md
+++ b/documentation/providers/autodns.md
@@ -20,7 +20,7 @@ Example:
 
 ## Usage
 
-An example `dnsconfig.js` configuration:
+An example configuration:
 
 {% code title="dnsconfig.js" %}
 ```javascript

--- a/documentation/providers/axfrddns.md
+++ b/documentation/providers/axfrddns.md
@@ -53,10 +53,12 @@ operations, which is the least secure option.
 If distinct zones require distinct keys, you will need to instantiate the
 provider once for each key:
 
+{% code title="dnsconfig.js" %}
 ```javascript
 var DSP_AXFRDDNS_A = NewDnsProvider("axfrddns-a");
 var DSP_AXFRDDNS_B = NewDnsProvider("axfrddns-b");
 ```
+{% endcode %}
 
 And update `creds.json` accordingly:
 
@@ -84,6 +86,7 @@ provider.
 This list can be provided either as metadata or in `creds.json`. Only
 the later allows `get-zones` to work properly.
 
+{% code title="dnsconfig.js" %}
 ```javascript
 var DSP_AXFRDDNS = NewDnsProvider("axfrddns", {
         "default_ns": [
@@ -95,6 +98,7 @@ var DSP_AXFRDDNS = NewDnsProvider("axfrddns", {
     }
 }
 ```
+{% endcode %}
 
 ```json
 {

--- a/documentation/providers/azure_dns.md
+++ b/documentation/providers/azure_dns.md
@@ -49,7 +49,7 @@ export AZURE_CLIENT_SECRET=BBBBBBBBB
 This provider does not recognize any special metadata fields unique to Azure DNS.
 
 ## Usage
-An example `dnsconfig.js` configuration:
+An example configuration:
 
 {% code title="dnsconfig.js" %}
 ```javascript

--- a/documentation/providers/azure_dns.md
+++ b/documentation/providers/azure_dns.md
@@ -51,6 +51,7 @@ This provider does not recognize any special metadata fields unique to Azure DNS
 ## Usage
 An example `dnsconfig.js` configuration:
 
+{% code title="dnsconfig.js" %}
 ```javascript
 var REG_NONE = NewRegistrar("none");
 var DSP_AZURE_MAIN = NewDnsProvider("azuredns_main");
@@ -59,6 +60,7 @@ D("example.tld", REG_NONE, DnsProvider(DSP_AZURE_MAIN),
     A("test", "1.2.3.4")
 );
 ```
+{% endcode %}
 
 ## Activation
 DNSControl depends on a standard [Client credentials Authentication](https://docs.microsoft.com/en-us/cli/azure/create-an-azure-service-principal-azure-cli?view=azure-cli-latest) with permission to list, create and update hosted zones.

--- a/documentation/providers/bind.md
+++ b/documentation/providers/bind.md
@@ -37,6 +37,7 @@ This provider accepts some optional metadata in the NewDnsProvider() call.
 
 In this example we set the default SOA settings and NS records.
 
+{% code title="dnsconfig.js" %}
 ```javascript
 var DSP_BIND = NewDnsProvider("bind", {
     "default_soa": {
@@ -55,6 +56,7 @@ var DSP_BIND = NewDnsProvider("bind", {
     ]
 })
 ```
+{% endcode %}
 
 # FYI: SOA Records
 

--- a/documentation/providers/cloudflareapi.md
+++ b/documentation/providers/cloudflareapi.md
@@ -164,7 +164,7 @@ D("example.tld", REG_NONE, DnsProvider(DSP_CLOUDFLARE),
 {% endcode %}
 
 ## Usage
-An example `dnsconfig.js` configuration:
+An example configuration:
 
 {% code title="dnsconfig.js" %}
 ```javascript

--- a/documentation/providers/cloudflareapi.md
+++ b/documentation/providers/cloudflareapi.md
@@ -120,17 +120,20 @@ What does on/off/full mean?
 
 You can also set the default proxy mode using `DEFAULTS()` function. For example:
 
+{% code title="dnsconfig.js" %}
 ```javascript
 DEFAULTS(
   CF_PROXY_DEFAULT_OFF // turn proxy off when not specified otherwise
 );
 ```
+{% endcode %}
 
 **Aliases:**
 
 To make configuration files more readable and less prone to errors,
 the following aliases are *pre-defined*:
 
+{% code title="dnsconfig.js" %}
 ```javascript
 // Meta settings for individual records.
 var CF_PROXY_OFF = {"cloudflare_proxy": "off"};     // Proxy disabled.
@@ -146,9 +149,11 @@ var CF_UNIVERSALSSL_OFF = { cloudflare_universalssl: "off" };
 // UniversalSSL on for entire domain:
 var CF_UNIVERSALSSL_ON = { cloudflare_universalssl: "on" };
 ```
+{% endcode %}
 
 The following example shows how to set meta variables with and without aliases:
 
+{% code title="dnsconfig.js" %}
 ```javascript
 D("example.tld", REG_NONE, DnsProvider(DSP_CLOUDFLARE),
     A("www1","1.2.3.11", CF_PROXY_ON),        // turn proxy ON.
@@ -156,10 +161,12 @@ D("example.tld", REG_NONE, DnsProvider(DSP_CLOUDFLARE),
     A("www3","1.2.3.13", {"cloudflare_proxy": "on"}) // Old format.
 );
 ```
+{% endcode %}
 
 ## Usage
 An example `dnsconfig.js` configuration:
 
+{% code title="dnsconfig.js" %}
 ```javascript
 var REG_NONE = NewRegistrar("none");
 var DSP_CLOUDFLARE = NewDnsProvider("cloudflare");
@@ -183,7 +190,7 @@ D("example2.tld", REG_NONE, DnsProvider(DSP_CLOUDFLARE),
     CNAME("myalias", "www.example2.tld.")
 );
 ```
-
+{% endcode %}
 
 ## New domains
 If a domain does not exist in your Cloudflare account, DNSControl
@@ -194,6 +201,7 @@ control panel manually or via the `dnscontrol create-domains` command.
 ## Redirects
 The Cloudflare provider can manage "Forwarding URL" Page Rules (redirects) for your domains. Simply use the `CF_REDIRECT` and `CF_TEMP_REDIRECT` functions to make redirects:
 
+{% code title="dnsconfig.js" %}
 ```javascript
 // chiphacker.com should redirect to electronics.stackexchange.com
 
@@ -214,6 +222,7 @@ D("chiphacker.com", REG_NONE, DnsProvider(DSP_CLOUDFLARE),
     // ...
 );
 ```
+{% endcode %}
 
 Notice a few details:
 
@@ -225,6 +234,7 @@ Notice a few details:
 ## Worker routes
 The Cloudflare provider can manage Worker Routes for your domains. Simply use the `CF_WORKER_ROUTE` function passing the route pattern and the worker name:
 
+{% code title="dnsconfig.js" %}
 ```javascript
 var DSP_CLOUDFLARE = NewDnsProvider("cloudflare", {"manage_workers": true}); // enable managing worker routes
 
@@ -234,6 +244,7 @@ D("foo.com", REG_NONE, DnsProvider(DSP_CLOUDFLARE),
     CF_WORKER_ROUTE("foo.com/api/*", "my-worker"),
 );
 ```
+{% endcode %}
 
 The API key you use must be enabled to edit workers.  In the portal, edit the API key,
 under "Permissions" add "Account", "Workers Scripts", "Edit". Without this permission you may see errors that mention "failed fetching worker route list from cloudflare: bad status code from cloudflare: 403 not 200"

--- a/documentation/providers/cloudns.md
+++ b/documentation/providers/cloudns.md
@@ -35,6 +35,7 @@ This provider does not recognize any special metadata fields unique to ClouDNS.
 ClouDNS supports ClouDNS-specific "WR record (web redirects)" for your domains.
 Simply use the `CLOUDNS_WR` functions to make redirects like any other record:
 
+{% code title="dnsconfig.js" %}
 ```javascript
 var REG_NONE = NewRegistrar("none");
 var DSP_CLOUDNS = NewDnsProvider("cloudns");
@@ -44,10 +45,12 @@ D("example.tld", REG_NONE, DnsProvider(DSP_CLOUDNS),
   CLOUDNS_WR("www", "http://example.com/")
 )
 ```
+{% endcode %}
 
 ## Usage
 An example `dnsconfig.js` configuration:
 
+{% code title="dnsconfig.js" %}
 ```javascript
 var REG_NONE = NewRegistrar("none");
 var DSP_CLOUDNS = NewDnsProvider("cloudns");
@@ -56,6 +59,7 @@ D("example.tld", REG_NONE, DnsProvider(DSP_CLOUDNS),
     A("test", "1.2.3.4")
 );
 ```
+{% endcode %}
 
 ## Activation
 [Create Auth ID](https://www.cloudns.net/api-settings/).  Only paid account can use API

--- a/documentation/providers/cloudns.md
+++ b/documentation/providers/cloudns.md
@@ -48,7 +48,7 @@ D("example.tld", REG_NONE, DnsProvider(DSP_CLOUDNS),
 {% endcode %}
 
 ## Usage
-An example `dnsconfig.js` configuration:
+An example configuration:
 
 {% code title="dnsconfig.js" %}
 ```javascript

--- a/documentation/providers/cscglobal.md
+++ b/documentation/providers/cscglobal.md
@@ -29,7 +29,7 @@ Example:
 {% endcode %}
 
 ## Usage
-An example `dnsconfig.js` configuration:
+An example configuration:
 
 {% code title="dnsconfig.js" %}
 ```javascript

--- a/documentation/providers/cscglobal.md
+++ b/documentation/providers/cscglobal.md
@@ -31,6 +31,7 @@ Example:
 ## Usage
 An example `dnsconfig.js` configuration:
 
+{% code title="dnsconfig.js" %}
 ```javascript
 var REG_CSCGLOBAL = NewRegistrar("cscglobal");
 var DSP_BIND = NewDnsProvider("bind");
@@ -39,6 +40,7 @@ D("example.tld", REG_CSCGLOBAL, DnsProvider(DSP_BIND),
   A("test", "1.2.3.4")
 );
 ```
+{% endcode %}
 
 ## Activation
 To get access to the [CSC Global API](https://www.cscglobal.com/cscglobal/docs/dbs/domainmanager/api-v2/) contact your account manager.

--- a/documentation/providers/desec.md
+++ b/documentation/providers/desec.md
@@ -20,7 +20,7 @@ Example:
 This provider does not recognize any special metadata fields unique to deSEC.
 
 ## Usage
-An example `dnsconfig.js` configuration:
+An example configuration:
 
 {% code title="dnsconfig.js" %}
 ```javascript

--- a/documentation/providers/desec.md
+++ b/documentation/providers/desec.md
@@ -22,6 +22,7 @@ This provider does not recognize any special metadata fields unique to deSEC.
 ## Usage
 An example `dnsconfig.js` configuration:
 
+{% code title="dnsconfig.js" %}
 ```javascript
 var REG_NONE = NewRegistrar("none");    // No registrar.
 var DSP_DESEC = NewDnsProvider("desec");  // deSEC
@@ -30,6 +31,7 @@ D("example.tld", REG_NONE, DnsProvider(DSP_DESEC),
     A("test", "1.2.3.4")
 );
 ```
+{% endcode %}
 
 ## Activation
 DNSControl depends on a deSEC account auth token.

--- a/documentation/providers/digitalocean.md
+++ b/documentation/providers/digitalocean.md
@@ -20,7 +20,7 @@ Example:
 This provider does not recognize any special metadata fields unique to DigitalOcean.
 
 ## Usage
-An example `dnsconfig.js` configuration:
+An example configuration:
 
 {% code title="dnsconfig.js" %}
 ```javascript

--- a/documentation/providers/digitalocean.md
+++ b/documentation/providers/digitalocean.md
@@ -22,6 +22,7 @@ This provider does not recognize any special metadata fields unique to DigitalOc
 ## Usage
 An example `dnsconfig.js` configuration:
 
+{% code title="dnsconfig.js" %}
 ```javascript
 var REG_NONE = NewRegistrar("none");
 var DSP_DIGITALOCEAN = NewDnsProvider("mydigitalocean");
@@ -30,6 +31,7 @@ D("example.tld", REG_NONE, DnsProvider(DSP_DIGITALOCEAN),
     A("test", "1.2.3.4")
 );
 ```
+{% endcode %}
 
 ## Activation
 [Create OAuth Token](https://cloud.digitalocean.com/settings/applications)

--- a/documentation/providers/dnsimple.md
+++ b/documentation/providers/dnsimple.md
@@ -27,7 +27,7 @@ Examples:
 This provider does not recognize any special metadata fields unique to DNSimple.
 
 ## Usage
-An example `dnsconfig.js` configuration:
+An example configuration:
 
 {% code title="dnsconfig.js" %}
 ```javascript

--- a/documentation/providers/dnsimple.md
+++ b/documentation/providers/dnsimple.md
@@ -29,6 +29,7 @@ This provider does not recognize any special metadata fields unique to DNSimple.
 ## Usage
 An example `dnsconfig.js` configuration:
 
+{% code title="dnsconfig.js" %}
 ```javascript
 var REG_DNSIMPLE = NewRegistrar("dnsimple");
 var DSP_DNSIMPLE = NewDnsProvider("dnsimple");
@@ -37,6 +38,7 @@ D("example.tld", REG_DNSIMPLE, DnsProvider(DSP_DNSIMPLE),
     A("test", "1.2.3.4")
 );
 ```
+{% endcode %}
 
 ## Activation
 DNSControl depends on a DNSimple account access token.

--- a/documentation/providers/dnsmadeeasy.md
+++ b/documentation/providers/dnsmadeeasy.md
@@ -29,7 +29,7 @@ SPF records are ignored by this provider. Use TXT records instead.
 This provider does not recognize any special metadata fields unique to DNS Made Easy.
 
 ## Usage
-An example `dnsconfig.js` configuration:
+An example configuration:
 
 {% code title="dnsconfig.js" %}
 ```javascript

--- a/documentation/providers/dnsmadeeasy.md
+++ b/documentation/providers/dnsmadeeasy.md
@@ -31,6 +31,7 @@ This provider does not recognize any special metadata fields unique to DNS Made 
 ## Usage
 An example `dnsconfig.js` configuration:
 
+{% code title="dnsconfig.js" %}
 ```javascript
 var REG_NONE = NewRegistrar("none");
 var DSP_DNSMADEEASY = NewDnsProvider("dnsmadeeasy");
@@ -39,6 +40,7 @@ D("example.tld", REG_NONE, DnsProvider(DSP_DNSMADEEASY),
     A("test", "1.2.3.4")
 );
 ```
+{% endcode %}
 
 ## Activation
 You can generate your `api_key` and `secret_key` in [Control Panel](https://cp.dnsmadeeasy.com/) in Account Information in Config menu.

--- a/documentation/providers/dnsoverhttps.md
+++ b/documentation/providers/dnsoverhttps.md
@@ -39,7 +39,7 @@ Some common DoH providers are:
 This provider does not recognize any special metadata fields unique to DOH.
 
 ## Usage
-An example `dnsconfig.js` configuration:
+An example configuration:
 
 {% code title="dnsconfig.js" %}
 ```javascript

--- a/documentation/providers/dnsoverhttps.md
+++ b/documentation/providers/dnsoverhttps.md
@@ -41,6 +41,7 @@ This provider does not recognize any special metadata fields unique to DOH.
 ## Usage
 An example `dnsconfig.js` configuration:
 
+{% code title="dnsconfig.js" %}
 ```javascript
 var REG_MONITOR = NewRegistrar("dohcloudflare");
 
@@ -49,6 +50,7 @@ D("example.com", REG_MONITOR,
   NAMESERVER("ns2.example.com."),
 );
 ```
+{% endcode %}
 
 {% hint style="info" %}
 **NOTE**: This checks the NS records via a DNS query.  It does not check the

--- a/documentation/providers/domainnameshop.md
+++ b/documentation/providers/domainnameshop.md
@@ -23,6 +23,7 @@ This provider does not recognize any special metadata fields unique to Domainnam
 ## Usage
 An example `dnsconfig.js` configuration:
 
+{% code title="dnsconfig.js" %}
 ```javascript
 var REG_NONE = NewRegistrar("none");
 var DSP_DOMAINNAMESHOP = NewDnsProvider("mydomainnameshop");
@@ -31,6 +32,7 @@ D("example.tld", REG_NONE, DnsProvider(DSP_DOMAINNAMESHOP),
     A("test", "1.2.3.4")
 );
 ```
+{% endcode %}
 
 ## Activation
 [Create API Token and secret](https://www.domeneshop.no/admin?view=api)

--- a/documentation/providers/domainnameshop.md
+++ b/documentation/providers/domainnameshop.md
@@ -21,7 +21,7 @@ Example:
 This provider does not recognize any special metadata fields unique to Domainnameshop.
 
 ## Usage
-An example `dnsconfig.js` configuration:
+An example configuration:
 
 {% code title="dnsconfig.js" %}
 ```javascript

--- a/documentation/providers/easyname.md
+++ b/documentation/providers/easyname.md
@@ -26,7 +26,7 @@ Example:
 This provider does not recognize any special metadata fields unique to easyname.
 
 ## Usage
-An example `dnsconfig.js` configuration:
+An example configuration:
 
 {% code title="dnsconfig.js" %}
 ```javascript

--- a/documentation/providers/easyname.md
+++ b/documentation/providers/easyname.md
@@ -28,6 +28,7 @@ This provider does not recognize any special metadata fields unique to easyname.
 ## Usage
 An example `dnsconfig.js` configuration:
 
+{% code title="dnsconfig.js" %}
 ```javascript
 var REG_EASYNAME = NewRegistrar("easyname");
 
@@ -36,6 +37,7 @@ D("example.com", REG_EASYNAME,
   NAMESERVER("ns2.example.com."),
 );
 ```
+{% endcode %}
 
 ## Activation
 

--- a/documentation/providers/gandi_v5.md
+++ b/documentation/providers/gandi_v5.md
@@ -53,6 +53,7 @@ names.
 ## Usage
 An example `dnsconfig.js` configuration:
 
+{% code title="dnsconfig.js" %}
 ```javascript
 var REG_GANDI = NewRegistrar("gandi");
 var DSP_GANDI = NewDnsProvider("gandi");
@@ -61,6 +62,7 @@ D("example.tld", REG_GANDI, DnsProvider(DSP_GANDI),
     A("test", "1.2.3.4")
 );
 ```
+{% endcode %}
 
 If you are converting from the old "GANDI" provider,
 simply change "GANDI" to "GANDI_V5" in `dnsconfig.js`.

--- a/documentation/providers/gandi_v5.md
+++ b/documentation/providers/gandi_v5.md
@@ -51,7 +51,7 @@ This provider only supports `ALIAS` on the `"@"` zone apex, not on any other
 names.
 
 ## Usage
-An example `dnsconfig.js` configuration:
+An example configuration:
 
 {% code title="dnsconfig.js" %}
 ```javascript

--- a/documentation/providers/gcloud.md
+++ b/documentation/providers/gcloud.md
@@ -59,6 +59,7 @@ This provider does not recognize any special metadata fields unique to google cl
 ## Usage
 An example `dnsconfig.js` configuration:
 
+{% code title="dnsconfig.js" %}
 ```javascript
 var REG_NONE = NewRegistrar("name.com");
 var DSP_GCLOUD = NewDnsProvider("gcloud");
@@ -67,6 +68,7 @@ D("example.tld", REG_NONE, DnsProvider(DSP_GCLOUD),
     A("test", "1.2.3.4")
 );
 ```
+{% endcode %}
 
 ## Activation
 1. Go to your app-engine console and select the appropriate project.

--- a/documentation/providers/gcloud.md
+++ b/documentation/providers/gcloud.md
@@ -57,7 +57,7 @@ Example:
 This provider does not recognize any special metadata fields unique to google cloud dns.
 
 ## Usage
-An example `dnsconfig.js` configuration:
+An example configuration:
 
 {% code title="dnsconfig.js" %}
 ```javascript

--- a/documentation/providers/gcore.md
+++ b/documentation/providers/gcore.md
@@ -20,7 +20,7 @@ Example:
 This provider does not recognize any special metadata fields unique to Gcore.
 
 ## Usage
-An example `dnsconfig.js` configuration:
+An example configuration:
 
 {% code title="dnsconfig.js" %}
 ```javascript

--- a/documentation/providers/gcore.md
+++ b/documentation/providers/gcore.md
@@ -22,6 +22,7 @@ This provider does not recognize any special metadata fields unique to Gcore.
 ## Usage
 An example `dnsconfig.js` configuration:
 
+{% code title="dnsconfig.js" %}
 ```javascript
 var REG_NONE = NewRegistrar("none");    // No registrar.
 var DSP_GCORE = NewDnsProvider("gcore");  // Gcore
@@ -30,6 +31,7 @@ D("example.tld", REG_NONE, DnsProvider(DSP_GCORE),
     A("test", "1.2.3.4")
 );
 ```
+{% endcode %}
 
 ## Activation
 

--- a/documentation/providers/hedns.md
+++ b/documentation/providers/hedns.md
@@ -101,7 +101,7 @@ This option is disabled by default when this key is not present,
 This provider does not recognize any special metadata fields unique to Hurricane Electric DNS.
 
 ## Usage
-An example `dnsconfig.js` configuration:
+An example configuration:
 
 {% code title="dnsconfig.js" %}
 ```javascript

--- a/documentation/providers/hedns.md
+++ b/documentation/providers/hedns.md
@@ -103,6 +103,7 @@ This provider does not recognize any special metadata fields unique to Hurricane
 ## Usage
 An example `dnsconfig.js` configuration:
 
+{% code title="dnsconfig.js" %}
 ```javascript
 var REG_NONE = NewRegistrar("none");
 var DSP_HEDNS = NewDnsProvider("hedns");
@@ -111,3 +112,4 @@ D("example.tld", REG_NONE, DnsProvider(DSP_HEDNS),
     A("test", "1.2.3.4")
 );
 ```
+{% endcode %}

--- a/documentation/providers/hetzner.md
+++ b/documentation/providers/hetzner.md
@@ -25,6 +25,7 @@ This provider does not recognize any special metadata fields unique to Hetzner
 
 An example `dnsconfig.js` configuration:
 
+{% code title="dnsconfig.js" %}
 ```javascript
 var REG_NONE = NewRegistrar("none");
 var DSP_HETZNER = NewDnsProvider("hetzner");
@@ -33,6 +34,7 @@ D("example.tld", REG_NONE, DnsProvider(DSP_HETZNER),
     A("test", "1.2.3.4")
 );
 ```
+{% endcode %}
 
 ## Activation
 

--- a/documentation/providers/hetzner.md
+++ b/documentation/providers/hetzner.md
@@ -23,7 +23,7 @@ This provider does not recognize any special metadata fields unique to Hetzner
 
 ## Usage
 
-An example `dnsconfig.js` configuration:
+An example configuration:
 
 {% code title="dnsconfig.js" %}
 ```javascript

--- a/documentation/providers/hexonet.md
+++ b/documentation/providers/hexonet.md
@@ -71,6 +71,7 @@ Here's an example DNS Configuration `dnsconfig.js` using our provider module.
 Even though it shows how you use us as Domain Registrar AND DNS Provider, we don't force you to do that.
 You are free to decide if you want to use both of our provider technology or just one of them.
 
+{% code title="dnsconfig.js" %}
 ```javascript
 // Providers:
 var REG_HX = NewRegistrar("hexonet");
@@ -95,6 +96,7 @@ D("abhoster.com", REG_HX, DnsProvider(DSP_HX),
     A("test", "56.123.54.12")
 );
 ```
+{% endcode %}
 
 ## Metadata
 

--- a/documentation/providers/hostingde.md
+++ b/documentation/providers/hostingde.md
@@ -20,6 +20,7 @@ Example:
 
 An example `dnsconfig.js` configuration:
 
+{% code title="dnsconfig.js" %}
 ```javascript
 var REG_HOSTINGDE = NewRegistrar("hosting.de");
 var DSP_HOSTINGDE = NewDnsProvider("hosting.de");
@@ -28,6 +29,7 @@ D("example.tld", REG_HOSTINGDE, DnsProvider(DSP_HOSTINGDE),
     A("test", "1.2.3.4")
 );
 ```
+{% endcode %}
 
 ## Using this provider with http.net and others
 
@@ -52,6 +54,7 @@ An example `creds.json` configuration:
 
 An example `dnsconfig.js` configuration:
 
+{% code title="dnsconfig.js" %}
 ```javascript
 var REG_HTTPNET = NewRegistrar("http.net");
 
@@ -63,6 +66,7 @@ var DSP_HTTPNET = NewDnsProvider("http.net", {
   ],
 });
 ```
+{% endcode %}
 
 #### Why this works
 

--- a/documentation/providers/hostingde.md
+++ b/documentation/providers/hostingde.md
@@ -18,7 +18,7 @@ Example:
 
 ## Usage
 
-An example `dnsconfig.js` configuration:
+An example configuration:
 
 {% code title="dnsconfig.js" %}
 ```javascript
@@ -52,7 +52,7 @@ An example `creds.json` configuration:
 ```
 {% endcode %}
 
-An example `dnsconfig.js` configuration:
+An example configuration:
 
 {% code title="dnsconfig.js" %}
 ```javascript

--- a/documentation/providers/internetbs.md
+++ b/documentation/providers/internetbs.md
@@ -25,6 +25,7 @@ This provider does not recognize any special metadata fields unique to Internet.
 ## Usage
 An example `dnsconfig.js` configuration:
 
+{% code title="dnsconfig.js" %}
 ```javascript
 var REG_INTERNETBS = NewRegistrar("internetbs");
 
@@ -33,6 +34,7 @@ D("example.com", REG_INTERNETBS,
   NAMESERVER("ns2.example.com."),
 );
 ```
+{% endcode %}
 
 ## Activation
 

--- a/documentation/providers/internetbs.md
+++ b/documentation/providers/internetbs.md
@@ -23,7 +23,7 @@ Example:
 This provider does not recognize any special metadata fields unique to Internet.bs.
 
 ## Usage
-An example `dnsconfig.js` configuration:
+An example configuration:
 
 {% code title="dnsconfig.js" %}
 ```javascript

--- a/documentation/providers/inwx.md
+++ b/documentation/providers/inwx.md
@@ -101,6 +101,7 @@ An example `dnsconfig.js` configuration file
 for `example.tld` registered with INWX
 and delegated to Cloudflare:
 
+{% code title="dnsconfig.js" %}
 ```javascript
 var REG_INWX = NewRegistrar("inwx");
 var DSP_CF = NewDnsProvider("cloudflare");
@@ -109,3 +110,4 @@ D("example.tld", REG_INWX, DnsProvider(DSP_CF),
     A("test", "1.2.3.4")
 );
 ```
+{% endcode %}

--- a/documentation/providers/linode.md
+++ b/documentation/providers/linode.md
@@ -22,6 +22,7 @@ This provider does not recognize any special metadata fields unique to Linode.
 ## Usage
 An example `dnsconfig.js` configuration:
 
+{% code title="dnsconfig.js" %}
 ```javascript
 var REG_NONE = NewRegistrar("none");
 var DSP_LINODE = NewDnsProvider("linode");
@@ -30,6 +31,7 @@ D("example.tld", REG_NONE, DnsProvider(DSP_LINODE),
     A("test", "1.2.3.4")
 );
 ```
+{% endcode %}
 
 ## Activation
 [Create Personal Access Token](https://cloud.linode.com/profile/tokens)

--- a/documentation/providers/linode.md
+++ b/documentation/providers/linode.md
@@ -20,7 +20,7 @@ Example:
 This provider does not recognize any special metadata fields unique to Linode.
 
 ## Usage
-An example `dnsconfig.js` configuration:
+An example configuration:
 
 {% code title="dnsconfig.js" %}
 ```javascript

--- a/documentation/providers/luadns.md
+++ b/documentation/providers/luadns.md
@@ -23,6 +23,7 @@ This provider does not recognize any special metadata fields unique to LuaDNS.
 ## Usage
 An example `dnsconfig.js` configuration:
 
+{% code title="dnsconfig.js" %}
 ```javascript
 var REG_NONE = NewRegistrar("none");
 var DSP_LUADNS = NewDnsProvider("luadns");
@@ -31,6 +32,7 @@ D("example.tld", REG_NONE, DnsProvider(DSP_LUADNS),
     A("test", "1.2.3.4")
 );
 ```
+{% endcode %}
 
 ## Activation
 [Create API key](https://api.luadns.com/api_keys).

--- a/documentation/providers/luadns.md
+++ b/documentation/providers/luadns.md
@@ -21,7 +21,7 @@ Example:
 This provider does not recognize any special metadata fields unique to LuaDNS.
 
 ## Usage
-An example `dnsconfig.js` configuration:
+An example configuration:
 
 {% code title="dnsconfig.js" %}
 ```javascript

--- a/documentation/providers/msdns.md
+++ b/documentation/providers/msdns.md
@@ -48,6 +48,7 @@ Example:
 
 An example DNS configuration:
 
+{% code title="dnsconfig.js" %}
 ```javascript
 var REG_NONE = NewRegistrar("none");
 var DSP_MSDNS = NewDnsProvider("msdns");
@@ -56,3 +57,4 @@ D("example.tld", REG_NONE, DnsProvider(DSP_MSDNS),
       A("test", "1.2.3.4")
 )
 ```
+{% endcode %}

--- a/documentation/providers/namecheap.md
+++ b/documentation/providers/namecheap.md
@@ -45,6 +45,7 @@ Namecheap.
 ## Usage
 An example `dnsconfig.js` configuration:
 
+{% code title="dnsconfig.js" %}
 ```javascript
 var REG_NAMECHEAP = NewRegistrar("namecheap");
 var DSP_BIND = NewDnsProvider("bind");
@@ -53,10 +54,12 @@ D("example.tld", REG_NAMECHEAP, DnsProvider(DSP_BIND),
     A("test", "1.2.3.4")
 );
 ```
+{% endcode %}
 
 Namecheap provides custom redirect records URL, URL301, and FRAME.  These
 records can be used like any other record:
 
+{% code title="dnsconfig.js" %}
 ```javascript
 var REG_NAMECHEAP = NewRegistrar("namecheap");
 var DSP_NAMECHEAP = NewDnsProvider("namecheap");
@@ -67,6 +70,7 @@ D("example.tld", REG_NAMECHEAP, DnsProvider(DSP_NAMECHEAP),
   URL301("backup", "http://backup.example.com/")
 )
 ```
+{% endcode %}
 
 ## Activation
 In order to activate API functionality on your Namecheap account, you must

--- a/documentation/providers/namecheap.md
+++ b/documentation/providers/namecheap.md
@@ -43,7 +43,7 @@ This provider does not recognize any special metadata fields unique to
 Namecheap.
 
 ## Usage
-An example `dnsconfig.js` configuration:
+An example configuration:
 
 {% code title="dnsconfig.js" %}
 ```javascript

--- a/documentation/providers/namedotcom.md
+++ b/documentation/providers/namedotcom.md
@@ -38,6 +38,7 @@ This provider does not recognize any special metadata fields unique to name.com.
 An example `dnsconfig.js` configuration with NAMEDOTCOM
 as the registrar and DNS service provider:
 
+{% code title="dnsconfig.js" %}
 ```javascript
 var REG_NAMECOM = NewRegistrar("name.com");
 var DSP_NAMECOM = NewDnsProvider("name.com");
@@ -46,10 +47,12 @@ D("example.tld", REG_NAMECOM, DnsProvider(DSP_NAMECOM),
     A("test", "1.2.3.4")
 );
 ```
+{% endcode %}
 
 An example `dnsconfig.js` configuration with NAMEDOTCOM
 as the registrar and DNS only, DNS hosted elsewhere:
 
+{% code title="dnsconfig.js" %}
 ```javascript
 var REG_NAMECOM = NewRegistrar("name.com");
 var DSP_R53 = NewDnsProvider("r53");
@@ -58,6 +61,7 @@ D("example.tld", REG_NAMECOM, DnsProvider(DSP_R53),
     A("test","1.2.3.4")
 );
 ```
+{% endcode %}
 
 {% hint style="info" %}
 **NOTE**: name.com does not allow control over the NS records of your zones via the api. It is not recommended to use name.com's dns provider unless it is your only dns host.

--- a/documentation/providers/netcup.md
+++ b/documentation/providers/netcup.md
@@ -19,7 +19,7 @@ Example:
 {% endcode %}
 
 ## Usage
-An example `dnsconfig.js` configuration:
+An example configuration:
 
 {% code title="dnsconfig.js" %}
 ```javascript

--- a/documentation/providers/netcup.md
+++ b/documentation/providers/netcup.md
@@ -21,6 +21,7 @@ Example:
 ## Usage
 An example `dnsconfig.js` configuration:
 
+{% code title="dnsconfig.js" %}
 ```javascript
 var REG_NONE = NewRegistrar("none");
 var DSP_NETCUP = NewDnsProvider("netcup");
@@ -29,7 +30,7 @@ D("example.tld", REG_NONE, DnsProvider(DSP_NETCUP),
     A("test", "1.2.3.4")
 );
 ```
-
+{% endcode %}
 
 ## Caveats
 Netcup does not allow any TTLs to be set for individual records. Thus in

--- a/documentation/providers/netlify.md
+++ b/documentation/providers/netlify.md
@@ -22,7 +22,7 @@ Examples:
 This provider does not recognize any special metadata fields unique to Netlify.
 
 ## Usage
-An example `dnsconfig.js` configuration:
+An example configuration:
 
 {% code title="dnsconfig.js" %}
 ```javascript

--- a/documentation/providers/netlify.md
+++ b/documentation/providers/netlify.md
@@ -24,6 +24,7 @@ This provider does not recognize any special metadata fields unique to Netlify.
 ## Usage
 An example `dnsconfig.js` configuration:
 
+{% code title="dnsconfig.js" %}
 ```javascript
 var REG_NETLIFY = NewRegistrar("netlify");
 var DSP_NETLIFY = NewDnsProvider("netlify");
@@ -32,6 +33,7 @@ D("example.tld", REG_NETLIFY, DnsProvider(DSP_NETLIFY),
     A("test", "1.2.3.4")
 );
 ```
+{% endcode %}
 
 ## Activation
 DNSControl depends on a Netlify account personal access token.

--- a/documentation/providers/ns1.md
+++ b/documentation/providers/ns1.md
@@ -20,7 +20,7 @@ Example:
 This provider does not recognize any special metadata fields unique to NS1.
 
 ## Usage
-An example `dnsconfig.js` configuration:
+An example configuration:
 
 {% code title="dnsconfig.js" %}
 ```javascript

--- a/documentation/providers/ns1.md
+++ b/documentation/providers/ns1.md
@@ -22,6 +22,7 @@ This provider does not recognize any special metadata fields unique to NS1.
 ## Usage
 An example `dnsconfig.js` configuration:
 
+{% code title="dnsconfig.js" %}
 ```javascript
 var REG_NONE = NewRegistrar("none");
 var DSP_NS1 = NewDnsProvider("ns1");
@@ -30,4 +31,4 @@ D("example.tld", REG_NONE, DnsProvider(DSP_NS1),
     A("test", "1.2.3.4")
 );
 ```
-
+{% endcode %}

--- a/documentation/providers/oracle.md
+++ b/documentation/providers/oracle.md
@@ -28,7 +28,7 @@ Example:
 This provider does not recognize any special metadata fields unique to Oracle Cloud.
 
 ## Usage
-An example `dnsconfig.js` configuration:
+An example configuration:
 
 {% code title="dnsconfig.js" %}
 ```javascript

--- a/documentation/providers/oracle.md
+++ b/documentation/providers/oracle.md
@@ -30,6 +30,7 @@ This provider does not recognize any special metadata fields unique to Oracle Cl
 ## Usage
 An example `dnsconfig.js` configuration:
 
+{% code title="dnsconfig.js" %}
 ```javascript
 var REG_NONE = NewRegistrar("none");
 var DSP_ORACLE = NewDnsProvider("oracle");
@@ -40,4 +41,4 @@ D("example.tld", REG_NONE, DnsProvider(DSP_ORACLE),
     A("test", "1.2.3.4")
 );
 ```
-
+{% endcode %}

--- a/documentation/providers/ovh.md
+++ b/documentation/providers/ovh.md
@@ -26,7 +26,7 @@ This provider does not recognize any special metadata fields unique to OVH.
 
 ## Usage
 
-An example `dnsconfig.js` configuration: (DNS hosted with OVH):
+An example configuration: (DNS hosted with OVH):
 
 {% code title="dnsconfig.js" %}
 ```javascript
@@ -39,7 +39,7 @@ D("example.tld", REG_OVH, DnsProvider(DSP_OVH),
 ```
 {% endcode %}
 
-An example `dnsconfig.js` configuration: (Registrar only. DNS hosted elsewhere)
+An example configuration: (Registrar only. DNS hosted elsewhere)
 
 {% code title="dnsconfig.js" %}
 ```javascript

--- a/documentation/providers/ovh.md
+++ b/documentation/providers/ovh.md
@@ -28,6 +28,7 @@ This provider does not recognize any special metadata fields unique to OVH.
 
 An example `dnsconfig.js` configuration: (DNS hosted with OVH):
 
+{% code title="dnsconfig.js" %}
 ```javascript
 var REG_OVH = NewRegistrar("ovh");
 var DSP_OVH = NewDnsProvider("ovh");
@@ -36,9 +37,11 @@ D("example.tld", REG_OVH, DnsProvider(DSP_OVH),
     A("test", "1.2.3.4")
 );
 ```
+{% endcode %}
 
 An example `dnsconfig.js` configuration: (Registrar only. DNS hosted elsewhere)
 
+{% code title="dnsconfig.js" %}
 ```javascript
 var REG_OVH = NewRegistrar("ovh");
 var DSP_R53 = NewDnsProvider("r53");
@@ -47,7 +50,7 @@ D("example.tld", REG_OVH, DnsProvider(DSP_R53),
     A("test", "1.2.3.4")
 );
 ```
-
+{% endcode %}
 
 ## Activation
 

--- a/documentation/providers/packetframe.md
+++ b/documentation/providers/packetframe.md
@@ -20,7 +20,7 @@ Example:
 This provider does not recognize any special metadata fields unique to Packetframe.
 
 ## Usage
-An example `dnsconfig.js` configuration:
+An example configuration:
 
 {% code title="dnsconfig.js" %}
 ```javascript

--- a/documentation/providers/packetframe.md
+++ b/documentation/providers/packetframe.md
@@ -22,6 +22,7 @@ This provider does not recognize any special metadata fields unique to Packetfra
 ## Usage
 An example `dnsconfig.js` configuration:
 
+{% code title="dnsconfig.js" %}
 ```javascript
 var REG_NONE = NewRegistrar("none");
 var DSP_PACKETFRAME = NewDnsProvider("packetframe");
@@ -30,3 +31,4 @@ D("example.tld", REG_NONE, DnsProvider(DSP_PACKETFRAME),
     A("test", "1.2.3.4")
 );
 ```
+{% endcode %}

--- a/documentation/providers/porkbun.md
+++ b/documentation/providers/porkbun.md
@@ -23,7 +23,7 @@ This provider does not recognize any special metadata fields unique to Porkbun.
 
 ## Usage
 
-An example `dnsconfig.js` configuration:
+An example configuration:
 
 {% code title="dnsconfig.js" %}
 ```javascript

--- a/documentation/providers/porkbun.md
+++ b/documentation/providers/porkbun.md
@@ -25,6 +25,7 @@ This provider does not recognize any special metadata fields unique to Porkbun.
 
 An example `dnsconfig.js` configuration:
 
+{% code title="dnsconfig.js" %}
 ```javascript
 var REG_NONE = NewRegistrar("none");
 var DSP_PORKBUN = NewDnsProvider("porkbun");
@@ -33,3 +34,4 @@ D("example.tld", REG_NONE, DnsProvider(DSP_PORKBUN),
     A("test", "1.2.3.4")
 );
 ```
+{% endcode %}

--- a/documentation/providers/powerdns.md
+++ b/documentation/providers/powerdns.md
@@ -22,6 +22,7 @@ Example:
 ## Metadata
 Following metadata are available:
 
+{% code title="dnsconfig.js" %}
 ```javascript
 {
     'default_ns': [
@@ -31,6 +32,7 @@ Following metadata are available:
     'dnssec_on_create': false
 }
 ```
+{% endcode %}
 
 - `default_ns` sets the nameserver which are used
 - `dnssec_on_create` specifies if DNSSEC should be enabled when creating zones
@@ -38,6 +40,7 @@ Following metadata are available:
 ## Usage
 An example `dnsconfig.js` configuration:
 
+{% code title="dnsconfig.js" %}
 ```javascript
 var REG_NONE = NewRegistrar("none");
 var DSP_POWERDNS = NewDnsProvider("powerdns");
@@ -46,6 +49,7 @@ D("example.tld", REG_NONE, DnsProvider(DSP_POWERDNS),
     A("test", "1.2.3.4")
 );
 ```
+{% endcode %}
 
 ## Activation
 See the [PowerDNS documentation](https://doc.powerdns.com/authoritative/http-api/index.html) how the API can be enabled.

--- a/documentation/providers/powerdns.md
+++ b/documentation/providers/powerdns.md
@@ -38,7 +38,7 @@ Following metadata are available:
 - `dnssec_on_create` specifies if DNSSEC should be enabled when creating zones
 
 ## Usage
-An example `dnsconfig.js` configuration:
+An example configuration:
 
 {% code title="dnsconfig.js" %}
 ```javascript

--- a/documentation/providers/route53.md
+++ b/documentation/providers/route53.md
@@ -65,7 +65,7 @@ You can find some other ways to authenticate to Route53 in the [go sdk configura
 This provider does not recognize any special metadata fields unique to route 53.
 
 ## Usage
-An example `dnsconfig.js` configuration:
+An example configuration:
 
 {% code title="dnsconfig.js" %}
 ```javascript

--- a/documentation/providers/route53.md
+++ b/documentation/providers/route53.md
@@ -67,6 +67,7 @@ This provider does not recognize any special metadata fields unique to route 53.
 ## Usage
 An example `dnsconfig.js` configuration:
 
+{% code title="dnsconfig.js" %}
 ```javascript
 var REG_NONE = NewRegistrar("none");
 var DSP_R53 = NewDnsProvider("r53_main");
@@ -75,6 +76,7 @@ D("example.tld", REG_NONE, DnsProvider(DSP_R53),
     A("test", "1.2.3.4")
 );
 ```
+{% endcode %}
 
 ## Activation
 DNSControl depends on a standard [AWS access key](https://aws.amazon.com/developers/access-keys/) with permission to list, create and update hosted zones. If you do not have the permissions required you will receive the following error message `Check your credentials, your not authorized to perform actions on Route 53 AWS Service`.

--- a/documentation/providers/rwth.md
+++ b/documentation/providers/rwth.md
@@ -20,7 +20,7 @@ Example:
 This provider does not recognize any special metadata fields unique to it.
 
 ## Usage
-An example `dnsconfig.js` configuration:
+An example configuration:
 
 {% code title="dnsconfig.js" %}
 ```javascript

--- a/documentation/providers/rwth.md
+++ b/documentation/providers/rwth.md
@@ -22,6 +22,7 @@ This provider does not recognize any special metadata fields unique to it.
 ## Usage
 An example `dnsconfig.js` configuration:
 
+{% code title="dnsconfig.js" %}
 ```javascript
 var REG_NONE = NewRegistrar("none");
 var DSP_RWTH = NewDnsProvider("rwth");
@@ -30,6 +31,7 @@ D("example.rwth-aachen.de", REG_NONE, DnsProvider(DSP_RWTH),
     A("test", "1.2.3.4")
 );
 ```
+{% endcode %}
 
 ## Caveats
 The default TTL is not automatically fetched, as the API does not provide such an endpoint.

--- a/documentation/providers/softlayer.md
+++ b/documentation/providers/softlayer.md
@@ -30,6 +30,7 @@ To maintain compatibility with existing softlayer CLI services these can also be
 
 An example `dnsconfig.js` configuration:
 
+{% code title="dnsconfig.js" %}
 ```javascript
 var REG_NONE = NewRegistrar("none"); // no registrar
 var DSP_SOFTLAYER = NewDnsProvider("softlayer");
@@ -38,11 +39,13 @@ D("example.tld", registrary, DnsProvider(DSP_SOFTLAYER),
     A("test", "1.2.3.4")
 );
 ```
+{% endcode %}
 
 ## Metadata
 This provider does not recognize any special metadata fields unique to SoftLayer dns.
 For compatibility with the pre-generated NAMESERVER fields it's recommended to set the NS TTL to 86400 such as:
 
+{% code title="dnsconfig.js" %}
 ```javascript
 D("example.tld", REG_NONE, DnsProvider(SOFTLAYER),
     NAMESERVER_TTL(86400),
@@ -50,3 +53,4 @@ D("example.tld", REG_NONE, DnsProvider(SOFTLAYER),
     A("test", "1.2.3.4")
 );
 ```
+{% endcode %}

--- a/documentation/providers/softlayer.md
+++ b/documentation/providers/softlayer.md
@@ -28,7 +28,7 @@ To maintain compatibility with existing softlayer CLI services these can also be
 
 ## Usage
 
-An example `dnsconfig.js` configuration:
+An example configuration:
 
 {% code title="dnsconfig.js" %}
 ```javascript

--- a/documentation/providers/transip.md
+++ b/documentation/providers/transip.md
@@ -43,7 +43,7 @@ This provider does not recognize any special metadata fields unique to TransIP.
 
 ## Usage
 
-An example `dnsconfig.js` configuration:
+An example configuration:
 
 {% code title="dnsconfig.js" %}
 ```javascript

--- a/documentation/providers/transip.md
+++ b/documentation/providers/transip.md
@@ -45,6 +45,7 @@ This provider does not recognize any special metadata fields unique to TransIP.
 
 An example `dnsconfig.js` configuration:
 
+{% code title="dnsconfig.js" %}
 ```javascript
 var DSP_TRANSIP = NewDnsProvider("transip");
 
@@ -52,6 +53,7 @@ D("example.tld", REG_DNSIMPLE, DnsProvider(DSP_TRANSIP),
     A("test", "1.2.3.4")
 );
 ```
+{% endcode %}
 
 ## Activation
 

--- a/documentation/providers/vultr.md
+++ b/documentation/providers/vultr.md
@@ -24,6 +24,7 @@ This provider does not recognize any special metadata fields unique to Vultr.
 
 An example `dnsconfig.js` configuration:
 
+{% code title="dnsconfig.js" %}
 ```javascript
 var DSP_VULTR = NewDnsProvider("vultr");
 
@@ -31,6 +32,7 @@ D("example.tld", REG_DNSIMPLE, DnsProvider(DSP_VULTR),
     A("test", "1.2.3.4")
 );
 ```
+{% endcode %}
 
 ## Activation
 

--- a/documentation/providers/vultr.md
+++ b/documentation/providers/vultr.md
@@ -22,7 +22,7 @@ This provider does not recognize any special metadata fields unique to Vultr.
 
 ## Usage
 
-An example `dnsconfig.js` configuration:
+An example configuration:
 
 {% code title="dnsconfig.js" %}
 ```javascript


### PR DESCRIPTION
Added [GitBook code blocks](https://docs.gitbook.com/tour/editor/blocks/code-block) syntax for `dnsconfig.js` and removed the filename `dnsconfig.js` from example configuration sentence.

<!--
Before you submit a pull request, please make sure you've run the following commands from the root directory.

go fmt ./...
go generate
go mod tidy
!-->
