### PR TITLE
CHORE: linting

### DIFF
--- a/build/generate/functionTypes.go
+++ b/build/generate/functionTypes.go
@@ -34,19 +34,18 @@ var delimiterRegex = regexp.MustCompile(`(?m)^---\n`)
 
 func parseFrontMatter(content string) (map[string]interface{}, string, error) {
 	delimiterIndices := delimiterRegex.FindAllStringIndex(content, 2)
-	if len(delimiterIndices) > 0 {
-		startIndex := delimiterIndices[0][0]
-		endIndex := delimiterIndices[1][0]
-		yamlString := content[startIndex+4 : endIndex]
-		var frontMatter map[string]interface{}
-		err := yaml.Unmarshal([]byte(yamlString), &frontMatter)
-		if err != nil {
-			return nil, "", err
-		}
-		return frontMatter, content[endIndex+4:], nil
-	} else {
-		return nil, "", fmt.Errorf("Failed to parse file. Remove it and try again.")
+	if len(delimiterIndices) < 1 {
+		return nil, "", fmt.Errorf("failed to parse file. Remove it and try again")
 	}
+	startIndex := delimiterIndices[0][0]
+	endIndex := delimiterIndices[1][0]
+	yamlString := content[startIndex+4 : endIndex]
+	var frontMatter map[string]interface{}
+	err := yaml.Unmarshal([]byte(yamlString), &frontMatter)
+	if err != nil {
+		return nil, "", err
+	}
+	return frontMatter, content[endIndex+4:], nil
 }
 
 var returnTypes = map[string]string{

--- a/pkg/diff2/compareconfig.go
+++ b/pkg/diff2/compareconfig.go
@@ -43,8 +43,11 @@ differencing engine, such as maps of which labels and RecordKeys
 exist.
 */
 
+// ComparableFunc is a signature for functions used to generate a comparable
+// blob for custom records and records with metadata.
 type ComparableFunc func(*models.RecordConfig) string
 
+// CompareConfig stores a zone's records in a structure that makes comparing two zones convenient.
 type CompareConfig struct {
 	// The primary data. Each record stored once, grouped by label then
 	// by rType:
@@ -88,6 +91,7 @@ type targetConfig struct {
 	rec *models.RecordConfig // The RecordConfig itself.
 }
 
+// NewCompareConfig creates a CompareConfig from a set of records and other data.
 func NewCompareConfig(origin string, existing, desired models.Records, compFn ComparableFunc) *CompareConfig {
 	cc := &CompareConfig{
 		existing: existing,
@@ -101,14 +105,15 @@ func NewCompareConfig(origin string, existing, desired models.Records, compFn Co
 	}
 	cc.addRecords(existing, true) // Must be called first so that CNAME manipulations happen in the correct order.
 	cc.addRecords(desired, false)
-	cc.VerifyCNAMEAssertions()
+	cc.verifyCNAMEAssertions()
 	sort.Slice(cc.ldata, func(i, j int) bool {
 		return prettyzone.LabelLess(cc.ldata[i].label, cc.ldata[j].label)
 	})
 	return cc
 }
 
-func (cc *CompareConfig) VerifyCNAMEAssertions() {
+// verifyCNAMEAssertions verifies assertions about CNAME updates ordering.
+func (cc *CompareConfig) verifyCNAMEAssertions() {
 
 	// According to the RFCs if a label has a CNAME, it can not have any other
 	// records at that label... even other CNAMEs.  Therefore, we need to be

--- a/pkg/diff2/diff2.go
+++ b/pkg/diff2/diff2.go
@@ -13,8 +13,10 @@ import (
 	"github.com/StackExchange/dnscontrol/v3/models"
 )
 
+// Verb indicates the Change's type (create, delete, etc.)
 type Verb int
 
+// CREATE and other verbs.
 const (
 	_      Verb = iota // Skip the first value of 0
 	CREATE             // Create a record/recordset/label where none existed before.
@@ -23,8 +25,11 @@ const (
 	REPORT             // No change, but I have something to say!
 )
 
+// ChangeList is a list of Change
 type ChangeList []Change
 
+// Change is an instruction to the provider. Generally if one properly executes
+// all the changes, an "existing" zone will turn into the "desired" zone.
 type Change struct {
 	Type Verb // Add, Change, Delete
 


### PR DESCRIPTION
Fixing these...

```
build/generate/functionTypes.go:47:9: if block ends with a return statement, so drop this else and outdent its block
build/generate/functionTypes.go:48:30: error strings should not be capitalized or end with punctuation or a newline
pkg/diff2/compareconfig.go:46:6: exported type ComparableFunc should have comment or be unexported
pkg/diff2/compareconfig.go:48:6: exported type CompareConfig should have comment or be unexported
pkg/diff2/compareconfig.go:91:1: exported function NewCompareConfig should have comment or be unexported
pkg/diff2/compareconfig.go:111:1: exported method CompareConfig.VerifyCNAMEAssertions should have comment or be unexported
pkg/diff2/diff2.go:16:6: exported type Verb should have comment or be unexported
pkg/diff2/diff2.go:20:2: exported const CREATE should have comment (or a comment on this block) or be unexported
pkg/diff2/diff2.go:26:6: exported type ChangeList should have comment or be unexported
pkg/diff2/diff2.go:28:6: exported type Change should have comment or be unexported
```
