### PR TITLE
Don't add extra dot after dnsimple SRV record contents

### DIFF
--- a/providers/dnsimple/dnsimpleProvider.go
+++ b/providers/dnsimple/dnsimpleProvider.go
@@ -119,10 +119,6 @@ func (c *dnsimpleProvider) GetZoneRecords(domain string) (models.Records, error)
 		case "MX":
 			err = rec.SetTargetMX(uint16(r.Priority), r.Content)
 		case "SRV":
-			parts := strings.Fields(r.Content)
-			if len(parts) == 3 {
-				r.Content += "."
-			}
 			err = rec.SetTargetSRVPriorityString(uint16(r.Priority), r.Content)
 		case "TXT":
 			err = rec.SetTargetTXT(r.Content)


### PR DESCRIPTION
Fix #2157 

The dnsimple API returns
```
Content:"1 993 mail.messagingengine.com."
```
when fetching the records.

The code here I think was to make up for the lack of a `.` for the final field.  This would work if the contents were `1 993 mail.messagingengine.com. ` which would become `1 993 mail.messagingengine.com. .` but since there's no final space it becomes `1 993 mail.messagingengine.com..` (unlike `Split`, `Fields` ignores trailing delimiters).

I think this was not necessary anyways, since `SetTargetSRVPriorityString` does the same thing, but skips this extra work (and encoding error risk) of re-encode-decode by passing `"."` as a separate parameter to the next function.

This solved my reported issue, but I'm not sure if it's possible to get other SRV record formats from the API and so I haven't tested anything else.