### PR TITLE
BUG: AutoDNSSEC validation is too aggressive

### DIFF
--- a/pkg/normalize/validate.go
+++ b/pkg/normalize/validate.go
@@ -559,7 +559,7 @@ func checkAutoDNSSEC(dc *models.DomainConfig) (errs []error) {
 	if dc.AutoDNSSEC == "on" {
 		for providerName := range dc.DNSProviderNames {
 			if dc.RegistrarName != providerName {
-				errs = append(errs, fmt.Errorf("AutoDNSSEC is enabled, but DNS provider %s does not match registrar %s", providerName, dc.RegistrarName))
+				errs = append(errs, Warning{fmt.Errorf("AutoDNSSEC is enabled, but DNS provider %s does not match registrar %s", providerName, dc.RegistrarName)})
 			}
 		}
 	}

--- a/pkg/normalize/validate.go
+++ b/pkg/normalize/validate.go
@@ -556,6 +556,9 @@ func processSplitHorizonDomains(config *models.DNSConfig) error {
 //}
 
 func checkAutoDNSSEC(dc *models.DomainConfig) (errs []error) {
+	if strings.ToLower(dc.RegistrarName) == "none" {
+		return
+	}
 	if dc.AutoDNSSEC == "on" {
 		for providerName := range dc.DNSProviderNames {
 			if dc.RegistrarName != providerName {


### PR DESCRIPTION
* The AutoDNSSEC validation should be a warning, not an error
* Disable the warning if the provider's name is "NONE".