### PR TITLE
DOCS: Fixed LOC_BUILDER_STR filename

### DIFF
--- a/documentation/SUMMARY.md
+++ b/documentation/SUMMARY.md
@@ -81,7 +81,7 @@
     * [LOC_BUILDER_DD](functions/record/LOC_BUILDER_DD.md)
     * [LOC_BUILDER_DMM_STR](functions/record/LOC_BUILDER_DMM_STR.md)
     * [LOC_BUILDER_DMS_STR](functions/record/LOC_BUILDER_DMS_STR.md)
-    * [LOC_BUILDER_STRING](functions/record/LOC_BUILDER_STRING.md)
+    * [LOC_BUILDER_STR](functions/record/LOC_BUILDER_STR.md)
     * [SPF_BUILDER](functions/record/SPF_BUILDER.md)
     * [TTL](functions/record/TTL.md)
     * Service Provider specific


### PR DESCRIPTION
This pull request fixed the broken `LOC_BUILDER_STR({})` link on [LOC](https://docs.dnscontrol.org/language-reference/domain-modifiers/loc). https://github.com/StackExchange/dnscontrol/pull/2188 https://github.com/StackExchange/dnscontrol/pull/2183 cc: @systemcrash 

<!--
Before you submit a pull request, please make sure you've run the following commands from the root directory.

go vet ./...
go fmt ./...
go generate ./...
go mod tidy
!-->
