### PR TITLE
Update goreleaser providers regexp

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -25,7 +25,7 @@ changelog:
       regexp: "(?i)^.*(major|new provider|feature)[(\\w)]*:+.*$"
       order: 1
     - title: 'Provider-specific changes:'
-      regexp: "(?i)((akamaiedge|autodns|axfrd|azure_dns|bind|cloudflare|cloudflareapi_old|cloudns|cscglobal|desec|digitalocean|dnsimple|dnsmadeeasy|domainnameshop|exoscale|gandi_v5|gcloud|hedns|hetzner|hexonet|hostingde|inwx|linode|msdns|namecheap|namedotcom|netcup|ns1|oracle|ovh|packetframe|powerdns|route53|softlayer|transip|vultr).*:)+.*"
+      regexp: "(?i)((akamaiedge|autodns|axfrd|azure|bind|cloudflare|cloudflareapi_old|cloudns|cscglobal|desec|digitalocean|dnsimple|dnsmadeeasy|doh|domainnameshop|easyname|exoscale|gandi|gcloud|gcore|hedns|hetzner|hexonet|hostingde|inwx|linode|loopia|luadns|msdns|namecheap|namedotcom|netcup|netlify|ns1|opensrs|oracle|ovh|packetframe|porkbun|powerdns|route53|rwth|softlayer|transip|vultr).*:)+.*"
       order: 2
     - title: 'Deprecation warnings:'
       regexp: "(?i)^.*Deprecate[(\\w)]*:+.*$"

--- a/documentation/writing-providers.md
+++ b/documentation/writing-providers.md
@@ -283,7 +283,12 @@ for tips about managing modules and checking for outdated
 dependencies.
 
 
-## Step 14: Check your work
+## Step 14: Modify the release regexp
+
+In the repo root, open `.goreleaser.yml` and add the provider to `Provider-specific changes` regexp.
+
+
+## Step 15: Check your work
 
 Here are some last-minute things to check before you submit your PR.
 
@@ -293,7 +298,7 @@ Here are some last-minute things to check before you submit your PR.
 4. Re-run the integration test one last time (See [Step 7](#step-7-integration-test))
 5. Re-read the [maintainer's responsibilities](providers.md) bullet list.  By submitting a provider you agree to maintain it, respond to bugs, perioidically re-run the integration test to verify nothing has broken, and if we don't hear from you for 2 months we may disable the provider.
 
-## Step 15: After the PR is merged
+## Step 16: After the PR is merged
 
 1. Remove the "provider-request" label from the PR.
 2. Verify that [documentation/providers.md](providers.md) no longer shows the provider as "requested"


### PR DESCRIPTION
Are changelogs still produced/needed?

This could potentially be automated by enforcing a 'subject' line in commit texts, that goes e.g.

thingprovider: added flibbonacci decorator

Although I don't seem to see any PR commit message text included. 