### PR TITLE
LOOPIA: Ban Null MX

### DIFF
--- a/providers/loopia/auditrecords.go
+++ b/providers/loopia/auditrecords.go
@@ -17,6 +17,8 @@ func AuditRecords(records []*models.RecordConfig) []error {
 	//Loopias TXT length limit appears to be 450 octets
 	a.Add("TXT", TxtHasSegmentLen450orLonger)
 
+	a.Add("MX", rejectif.MxNull) // Last verified 2023-03-23
+
 	return a.Audit(records)
 }
 


### PR DESCRIPTION
`Record pointing to @` test passes fine, however.