### PR TITLE
HEDNS: Fix support for LOC records

### DIFF
--- a/providers/hedns/hednsProvider.go
+++ b/providers/hedns/hednsProvider.go
@@ -361,7 +361,7 @@ func (c *hednsProvider) GetZoneRecords(domain string) (models.Records, error) {
 		}
 
 		// Ignore record types that dnscontrol does not support
-		if rc.Type == "HINFO" || rc.Type == "AFSDB" || rc.Type == "RP" || rc.Type == "LOC" {
+		if rc.Type == "HINFO" || rc.Type == "AFSDB" || rc.Type == "RP" {
 			return true
 		}
 


### PR DESCRIPTION
This fixes support for LOC records which until were erroneously indicated as supported, despite not working correctly. With this fix, the changes in https://github.com/StackExchange/dnscontrol/issues/2214 all pass correctly for the HEDNS provider.

