### PR TITLE
NSONE: strip dots from nameservers

### DIFF
--- a/providers/ns1/ns1Provider.go
+++ b/providers/ns1/ns1Provider.go
@@ -70,7 +70,7 @@ func (n *nsone) GetNameservers(domain string) ([]*models.Nameserver, error) {
 	if err != nil {
 		return nil, err
 	}
-	return models.ToNameservers(z.DNSServers)
+	return models.ToNameserversStripTD(z.DNSServers)
 }
 
 // GetZoneRecords gets the records of a zone and returns them in RecordConfig format.


### PR DESCRIPTION
Apparently NS1 changed their API, since 2023/03/22 we see 'ERROR: provider code leaves trailing dot on nameserver'.

<!--
Before you submit a pull request, please make sure you've run the following commands from the root directory.

go vet ./...
go fmt ./...
go generate ./...
go mod tidy
!-->

