### PR TITLE
Loopia: now passes test: 18:testByRecordSet

### DIFF
--- a/providers/loopia/convert.go
+++ b/providers/loopia/convert.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/StackExchange/dnscontrol/v3/models"
+	"github.com/miekg/dns/dnsutil"
 )
 
 // nativeToRecord takes a DNS record from Loopia and returns a native RecordConfig struct.
@@ -24,7 +25,8 @@ func nativeToRecord(zr zoneRecord, origin string, subdomain string) (rc *models.
 	case "CAA":
 		err = rc.SetTargetCAAString(record.Rdata)
 	case "MX":
-		err = rc.SetTargetMX(record.Priority, record.Rdata)
+		// See dnscontrol issue #2218
+		err = rc.SetTargetMX(record.Priority, dnsutil.AddOrigin(record.Rdata, origin)+".")
 	case "NAPTR":
 		err = rc.SetTargetNAPTRString(record.Rdata)
 	case "TXT":


### PR DESCRIPTION
See issue #2218 

```text
=== RUN   TestDNSProviders
=== RUN   TestDNSProviders/example.com
=== RUN   TestDNSProviders/example.com/Clean_Slate:Empty
    integration_test.go:223:
        records affected by deletion of subdomain *.example.com
        - DELETE A *.example.com 194.9.94.85 ttl=3600
        - DELETE A *.example.com 194.9.94.86 ttl=3600
    integration_test.go:223:
        records affected by deletion of subdomain www.example.com
        - DELETE A www.example.com 194.9.94.85 ttl=3600
        - DELETE A www.example.com 194.9.94.86 ttl=3600
    integration_test.go:223:
        - DELETE A example.com 194.9.94.85 ttl=3600
    integration_test.go:223:
        - DELETE A example.com 194.9.94.86 ttl=3600
    integration_test.go:223:
        ± MODIFY NS example.com: (ns2.loopia.se. ttl=3600) -> (ns2.loopia.se. ttl=300)
    integration_test.go:223:
        ± MODIFY NS example.com: (ns1.loopia.se. ttl=3600) -> (ns1.loopia.se. ttl=300)
=== RUN   TestDNSProviders/example.com/18:testByRecordSet:initial
    integration_test.go:223:
        + CREATE A bar.example.com 1.2.3.4 ttl=300
    integration_test.go:223:
        + CREATE A foo.example.com 2.3.4.5 ttl=300
    integration_test.go:223:
        + CREATE A foo.example.com 3.4.5.6 ttl=300
    integration_test.go:223:
        + CREATE MX foo.example.com 10 foo.example.com. ttl=300
    integration_test.go:223:
        + CREATE MX foo.example.com 20 bar.example.com. ttl=300
=== RUN   TestDNSProviders/example.com/18:testByRecordSet:changeOne
    integration_test.go:223:
        ± MODIFY A foo.example.com: (3.4.5.6 ttl=300) -> (8.8.8.8 ttl=300)
=== RUN   TestDNSProviders/example.com/18:testByRecordSet:deleteOne
    integration_test.go:223:
        - DELETE A foo.example.com 8.8.8.8 ttl=300
=== RUN   TestDNSProviders/example.com/18:testByRecordSet:addOne
    integration_test.go:223:
        + CREATE A foo.example.com 8.8.8.8 ttl=300
=== RUN   TestDNSProviders/example.com/Post_cleanup:Empty
    integration_test.go:223:
        records affected by deletion of subdomain bar.example.com
        - DELETE A bar.example.com 1.2.3.4 ttl=300
    integration_test.go:223:
        records affected by deletion of subdomain foo.example.com
        - DELETE A foo.example.com 2.3.4.5 ttl=300
        - DELETE A foo.example.com 8.8.8.8 ttl=300
        - DELETE MX foo.example.com 10 foo.example.com. ttl=300
        - DELETE MX foo.example.com 20 bar.example.com. ttl=300
--- PASS: TestDNSProviders (69.53s)
    --- PASS: TestDNSProviders/example.com (69.53s)
        --- PASS: TestDNSProviders/example.com/Clean_Slate:Empty (12.86s)
        --- PASS: TestDNSProviders/example.com/18:testByRecordSet:initial (14.11s)
        --- PASS: TestDNSProviders/example.com/18:testByRecordSet:changeOne (11.39s)
        --- PASS: TestDNSProviders/example.com/18:testByRecordSet:deleteOne (11.54s)
        --- PASS: TestDNSProviders/example.com/18:testByRecordSet:addOne (11.44s)
        --- PASS: TestDNSProviders/example.com/Post_cleanup:Empty (7.79s)
```