### PR TITLE
CLOUDNS: fix two integration test failed

### DIFF
--- a/providers/cloudns/auditrecords.go
+++ b/providers/cloudns/auditrecords.go
@@ -21,5 +21,7 @@ func AuditRecords(records []*models.RecordConfig) []error {
 
 	a.Add("TXT", rejectif.TxtHasMultipleSegments) // Last verified 2021-03-01
 
+	a.Add("SRV", rejectif.SrvHasNullTarget) // Last verified 2023-03-30
+
 	return a.Audit(records)
 }

--- a/providers/cloudns/cloudnsProvider.go
+++ b/providers/cloudns/cloudnsProvider.go
@@ -136,7 +136,11 @@ func (c *cloudnsProvider) GetDomainCorrections(dc *models.DomainConfig) ([]*mode
 		}
 	}
 
-	var createCorrections []*models.Correction
+	var (
+		createCorrections         []*models.Correction
+		createARecordCorrections  []*models.Correction
+		createNSRecordCorrections []*models.Correction
+	)
 	for _, m := range create {
 		req, err := toReq(m.Desired)
 		if err != nil {
@@ -155,15 +159,20 @@ func (c *cloudnsProvider) GetDomainCorrections(dc *models.DomainConfig) ([]*mode
 				return c.createRecord(domainID, req)
 			},
 		}
-		// at ClouDNS, we MUST have a NS for a DS
-		// So, when creating, we must create the NS first, otherwise creating the DS throws an error
-		if m.Desired.Type == "NS" {
-			// type NS is prepended - so executed first
-			createCorrections = append([]*models.Correction{corr}, createCorrections...)
-		} else {
+		// A & AAAA need to be created before NS #2244
+		// NS need to be created before DS #1018
+		// or else errors will be thrown
+		switch m.Desired.Type {
+		case "A", "AAAA":
+			createARecordCorrections = append(createARecordCorrections, corr)
+		case "NS":
+			createNSRecordCorrections = append(createNSRecordCorrections, corr)
+		default:
 			createCorrections = append(createCorrections, corr)
 		}
 	}
+	corrections = append(corrections, createARecordCorrections...)
+	corrections = append(corrections, createNSRecordCorrections...)
 	corrections = append(corrections, createCorrections...)
 
 	for _, m := range modify {


### PR DESCRIPTION
<!--
Before you submit a pull request, please make sure you've run the following commands from the root directory.

go vet ./...
go fmt ./...
go generate ./...
go mod tidy
!-->

1. Fix record creation order

Creation Order
A & AAAA > NS > else

close #2244

2. Skip SRV Null Target test

```
=== RUN   TestDNSProviders/example.com/30:SRV:Null_Target
    integration_test.go:223:
        + CREATE SRV _sip._tcp.example.com 15 65 75 . ttl=300
    integration_test.go:227: failed create record (ClouDNS): ClouDNS API error: This is not a domain name. URL:api.cloudns.net/dns/add-record.json?auth-id=**REDACTED**&auth-password=**REDACTED**&domain-name=example.com&host=_sip._tcp&port=75&priority=15&record=.&record-type=SRV&sub-auth-id=&ttl=300&weight=65
```