### PR TITLE
DNSimple: Remove CAA Whitespace in Target restriction

### DIFF
--- a/documentation/providers/dnsimple.md
+++ b/documentation/providers/dnsimple.md
@@ -45,16 +45,4 @@ DNSControl depends on a DNSimple account access token.
 
 ## Caveats
 
-### CAA
-
-As of July 2022, the DNSimple DNS does not accept spaces in CAA records. Putting spaces in the record will result in a 400 Validation Failed error.
-
-```text
-0 issue "letsencrypt.org; validationmethods=dns-01; accounturi=https://acme-v02.api.letsencrypt.org/acme/acct/1234"
-```
-
-Removing the spaces will work.
-```text
-0 issue "letsencrypt.org;validationmethods=dns-01;accounturi=https://acme-v02.api.letsencrypt.org/acme/acct/1234"
-```
-
+None at this time

--- a/providers/dnsimple/auditrecords.go
+++ b/providers/dnsimple/auditrecords.go
@@ -14,7 +14,6 @@ func AuditRecords(records []*models.RecordConfig) []error {
 	a.Add("MX", rejectif.MxNull) // Last verified 2023-03
 
 	a.Add("TXT", rejectif.TxtHasMultipleSegments) // Last verified 2023-03
-	// TODO(onlyhavecans) we can support this, but it needs more work
 
 	a.Add("TXT", rejectif.TxtHasTrailingSpace) // Last verified 2023-03
 

--- a/providers/dnsimple/auditrecords.go
+++ b/providers/dnsimple/auditrecords.go
@@ -11,18 +11,16 @@ import (
 func AuditRecords(records []*models.RecordConfig) []error {
 	a := rejectif.Auditor{}
 
-	a.Add("CAA", rejectif.CaaTargetContainsWhitespace) // Last verified xxxx-xx-xx
+	a.Add("MX", rejectif.MxNull) // Last verified 2023-03
 
-	a.Add("MX", rejectif.MxNull) // Last verified 2020-12-28
+	a.Add("TXT", rejectif.TxtHasMultipleSegments) // Last verified 2023-03
+	// TODO(onlyhavecans) we can support this, but it needs more work
 
-	a.Add("TXT", rejectif.TxtHasMultipleSegments) // Last verified 2022-07
-	//TODO(onlyhavecans) I think we can support multiple strings.
+	a.Add("TXT", rejectif.TxtHasTrailingSpace) // Last verified 2023-03
 
-	a.Add("TXT", rejectif.TxtHasTrailingSpace) // Last verified 2022-07
+	a.Add("TXT", rejectif.TxtHasUnpairedDoubleQuotes) // Last verified 2023-03
 
-	a.Add("TXT", rejectif.TxtHasUnpairedDoubleQuotes) // Last verified 2022-07
-
-	a.Add("TXT", rejectif.TxtIsEmpty) // Last verified 2022-07
+	a.Add("TXT", rejectif.TxtIsEmpty) // Last verified 2023-03
 
 	return a.Audit(records)
 }


### PR DESCRIPTION
DNSimple has updated how their validators work and fixed the inability to handle whitespace in CAA target records.

I also verified that all the other audits are still required and updated their comments.