### PR TITLE
TESTING: Don't skip other tests when test failed

### DIFF
--- a/integrationTest/integration_test.go
+++ b/integrationTest/integration_test.go
@@ -286,14 +286,14 @@ func runTests(t *testing.T, prv providers.DNSServiceProvider, domainName string,
 
 		for _, tst := range group.tests {
 
-// TODO(tlim): This is the old version. It skipped the remaining tc() statements if one failed.
-// The new code continues to test the remaining tc() statements.  Keeping this as a comment
-// in case we ever want to do something similar.
-// https://github.com/StackExchange/dnscontrol/pull/2252#issuecomment-1492204409
-//      makeChanges(t, prv, dc, tst, fmt.Sprintf("%02d:%s", gIdx, group.Desc), true, origConfig)
-//      if t.Failed() {
-//        break
-//      }
+			// TODO(tlim): This is the old version. It skipped the remaining tc() statements if one failed.
+			// The new code continues to test the remaining tc() statements.  Keeping this as a comment
+			// in case we ever want to do something similar.
+			// https://github.com/StackExchange/dnscontrol/pull/2252#issuecomment-1492204409
+			//      makeChanges(t, prv, dc, tst, fmt.Sprintf("%02d:%s", gIdx, group.Desc), true, origConfig)
+			//      if t.Failed() {
+			//        break
+			//      }
 			if ok := makeChanges(t, prv, dc, tst, fmt.Sprintf("%02d:%s", gIdx, group.Desc), true, origConfig); !ok {
 				break
 			}

--- a/integrationTest/integration_test.go
+++ b/integrationTest/integration_test.go
@@ -286,11 +286,10 @@ func runTests(t *testing.T, prv providers.DNSServiceProvider, domainName string,
 
 		for _, tst := range group.tests {
 
-			makeChanges(t, prv, dc, tst, fmt.Sprintf("%02d:%s", gIdx, group.Desc), true, origConfig)
-
-			if t.Failed() {
+			if ok := makeChanges(t, prv, dc, tst, fmt.Sprintf("%02d:%s", gIdx, group.Desc), true, origConfig); !ok {
 				break
 			}
+
 		}
 
 		// Remove all records so next group starts with a clean slate.

--- a/integrationTest/integration_test.go
+++ b/integrationTest/integration_test.go
@@ -286,6 +286,14 @@ func runTests(t *testing.T, prv providers.DNSServiceProvider, domainName string,
 
 		for _, tst := range group.tests {
 
+// TODO(tlim): This is the old version. It skipped the remaining tc() statements if one failed.
+// The new code continues to test the remaining tc() statements.  Keeping this as a comment
+// in case we ever want to do something similar.
+// https://github.com/StackExchange/dnscontrol/pull/2252#issuecomment-1492204409
+//      makeChanges(t, prv, dc, tst, fmt.Sprintf("%02d:%s", gIdx, group.Desc), true, origConfig)
+//      if t.Failed() {
+//        break
+//      }
 			if ok := makeChanges(t, prv, dc, tst, fmt.Sprintf("%02d:%s", gIdx, group.Desc), true, origConfig); !ok {
 				break
 			}


### PR DESCRIPTION
<!--
Before you submit a pull request, please make sure you've run the following commands from the root directory.

go vet ./...
go fmt ./...
go generate ./...
go mod tidy
!-->

When I fix, #2244, another different integration test failed shows up.

It bothers me why the first time only one integration test failed shows up.

Then I found out that when one test case failed, the rest test group only run the first test case, then break out of the for loop.

I see no reason why we break out of the for loop when a test case failed.

Before this PR,

```
# go test -v -verbose -provider CLOUDNS -start 15 -end 16
--- FAIL: TestDNSProviders (4.98s)
    --- FAIL: TestDNSProviders/example.com (4.39s)
        --- PASS: TestDNSProviders/example.com/Clean_Slate:Empty (0.28s)
        --- PASS: TestDNSProviders/example.com/15:NS:NS_for_subdomain (0.76s)
        --- PASS: TestDNSProviders/example.com/15:NS:Dual_NS_for_subdomain (0.75s)
        --- FAIL: TestDNSProviders/example.com/15:NS:NS_Record_pointing_to_@ (0.81s)
        --- PASS: TestDNSProviders/example.com/Post_cleanup:Empty (0.28s)
        --- PASS: TestDNSProviders/example.com/16:complex_TXT:TXT_with_1_single-quote (0.75s)
        --- PASS: TestDNSProviders/example.com/Post_cleanup:Empty#01 (0.48s)
=== RUN   TestDualProviders
    integration_test.go:318: Skipping.  DocDualHost == Cannot
--- SKIP: TestDualProviders (2.10s)
FAIL
exit status 1
FAIL    github.com/StackExchange/dnscontrol/v3/integrationTest  7.085s
```

Apply this PR,

```
# go test -v -verbose -provider CLOUDNS -start 15 -end 16
--- FAIL: TestDNSProviders (4.00s)
    --- FAIL: TestDNSProviders/example.com (3.82s)
        --- PASS: TestDNSProviders/example.com/Clean_Slate:Empty (0.22s)
        --- PASS: TestDNSProviders/example.com/15:NS:NS_for_subdomain (0.56s)
        --- PASS: TestDNSProviders/example.com/15:NS:Dual_NS_for_subdomain (0.56s)
        --- FAIL: TestDNSProviders/example.com/15:NS:NS_Record_pointing_to_@ (0.56s)
        --- PASS: TestDNSProviders/example.com/Post_cleanup:Empty (0.22s)
        --- PASS: TestDNSProviders/example.com/16:complex_TXT:TXT_with_1_single-quote (0.56s)
        --- SKIP: TestDNSProviders/example.com/16:complex_TXT:TXT_with_1_backtick (0.00s)
        --- SKIP: TestDNSProviders/example.com/16:complex_TXT:TXT_with_1_double-quotes (0.00s)
        --- SKIP: TestDNSProviders/example.com/16:complex_TXT:TXT_with_2_double-quotes (0.00s)
        --- PASS: TestDNSProviders/example.com/16:complex_TXT:a_TXT_with_interior_ws (0.67s)
        --- SKIP: TestDNSProviders/example.com/16:complex_TXT:TXT_with_ws_at_end (0.00s)
        --- PASS: TestDNSProviders/example.com/Post_cleanup:Empty#01 (0.34s)
=== RUN   TestDualProviders
    integration_test.go:318: Skipping.  DocDualHost == Cannot
--- SKIP: TestDualProviders (0.26s)
FAIL
exit status 1
FAIL    github.com/StackExchange/dnscontrol/v3/integrationTest  4.270s
```
