### PR TITLE
HETZNER: provider maintenance

### DIFF
--- a/documentation/providers.md
+++ b/documentation/providers.md
@@ -34,7 +34,7 @@ If a feature is definitively not supported for whatever reason, we would also li
 | [`GCLOUD`](providers/gcloud.md) | ✅ | ✅ | ❌ | ✅ | ✅ | ❔ | ❌ | ❔ | ✅ | ❔ | ✅ | ✅ | ✅ | ❔ | ✅ | ✅ | ✅ | ✅ |
 | [`GCORE`](providers/gcore.md) | ❌ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❔ | ✅ | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ | ✅ |
 | [`HEDNS`](providers/hedns.md) | ❌ | ✅ | ❌ | ✅ | ✅ | ❌ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | ❌ | ❌ | ✅ | ✅ | ✅ | ✅ |
-| [`HETZNER`](providers/hetzner.md) | ❌ | ✅ | ❌ | ❌ | ✅ | ❔ | ❌ | ❔ | ❌ | ❔ | ✅ | ❌ | ✅ | ❌ | ✅ | ✅ | ✅ | ✅ |
+| [`HETZNER`](providers/hetzner.md) | ❌ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | [`HEXONET`](providers/hexonet.md) | ❌ | ✅ | ✅ | ❌ | ✅ | ❔ | ❔ | ❔ | ✅ | ❔ | ✅ | ❔ | ✅ | ❔ | ✅ | ✅ | ✅ | ❔ |
 | [`HOSTINGDE`](providers/hostingde.md) | ❌ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | [`INTERNETBS`](providers/internetbs.md) | ❌ | ❌ | ✅ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❌ | ✅ | ❔ |

--- a/integrationTest/providers.json
+++ b/integrationTest/providers.json
@@ -132,9 +132,7 @@
   "HETZNER": {
     "TYPE": "HETZNER",
     "api_key": "$HETZNER_API_KEY",
-    "domain": "$HETZNER_DOMAIN",
-    "optimize_for_rate_limit_quota": "Hour",
-    "start_with_default_rate_limit": "true"
+    "domain": "$HETZNER_DOMAIN"
   },
   "HEXONET": {
     "TYPE": "HEXONET",

--- a/providers/hetzner/api.go
+++ b/providers/hetzner/api.go
@@ -254,17 +254,19 @@ func (api *hetznerProvider) request(endpoint string, method string, request inte
 			continue
 		}
 
-		defer cleanupResponseBody()
 		if !statusOK(resp.StatusCode) {
 			data, _ := io.ReadAll(resp.Body)
 			printer.Printf(string(data))
+			cleanupResponseBody()
 			return fmt.Errorf("bad status code from HETZNER: %d not 200", resp.StatusCode)
 		}
 		if target == nil {
+			cleanupResponseBody()
 			return nil
 		}
-		decoder := json.NewDecoder(resp.Body)
-		return decoder.Decode(target)
+		err = json.NewDecoder(resp.Body).Decode(target)
+		cleanupResponseBody()
+		return err
 	}
 }
 

--- a/providers/hetzner/auditrecords.go
+++ b/providers/hetzner/auditrecords.go
@@ -11,7 +11,7 @@ import (
 func AuditRecords(records []*models.RecordConfig) []error {
 	a := rejectif.Auditor{}
 
-	a.Add("CAA", rejectif.CaaTargetContainsWhitespace) // Last verified xxxx-xx-xx
+	a.Add("CAA", rejectif.CaaTargetContainsWhitespace) // Last verified 2023-04-01
 
 	return a.Audit(records)
 }

--- a/providers/hetzner/hetznerProvider.go
+++ b/providers/hetzner/hetznerProvider.go
@@ -177,7 +177,10 @@ func (api *hetznerProvider) GetZoneRecords(domain string) (models.Records, error
 	}
 	existingRecords := make([]*models.RecordConfig, len(records))
 	for i := range records {
-		existingRecords[i] = toRecordConfig(domain, &records[i])
+		existingRecords[i], err = toRecordConfig(domain, &records[i])
+		if err != nil {
+			return nil, err
+		}
 	}
 	return existingRecords, nil
 }

--- a/providers/hetzner/hetznerProvider.go
+++ b/providers/hetzner/hetznerProvider.go
@@ -37,29 +37,14 @@ func init() {
 
 // New creates a new API handle.
 func New(settings map[string]string, _ json.RawMessage) (providers.DNSServiceProvider, error) {
-	if settings["api_key"] == "" {
+	apiKey := settings["api_key"]
+	if apiKey == "" {
 		return nil, fmt.Errorf("missing HETZNER api_key")
 	}
 
-	api := &hetznerProvider{}
-
-	api.apiKey = settings["api_key"]
-
-	if settings["rate_limited"] == "true" {
-		// backwards compatibility
-		settings["start_with_default_rate_limit"] = "true"
-	}
-	if settings["start_with_default_rate_limit"] == "true" {
-		api.startRateLimited()
-	}
-
-	quota := settings["optimize_for_rate_limit_quota"]
-	err := api.requestRateLimiter.setOptimizeForRateLimitQuota(quota)
-	if err != nil {
-		return nil, fmt.Errorf("unexpected value for optimize_for_rate_limit_quota: %w", err)
-	}
-
-	return api, nil
+	return &hetznerProvider{
+		apiKey: apiKey,
+	}, nil
 }
 
 // EnsureZoneExists creates a zone if it does not exist

--- a/providers/hetzner/hetznerProvider.go
+++ b/providers/hetzner/hetznerProvider.go
@@ -13,12 +13,16 @@ import (
 )
 
 var features = providers.DocumentationNotes{
+	providers.CanAutoDNSSEC:          providers.Cannot(),
 	providers.CanGetZones:            providers.Can(),
 	providers.CanUseAlias:            providers.Cannot(),
 	providers.CanUseCAA:              providers.Can(),
-	providers.CanUseDS:               providers.Cannot(),
+	providers.CanUseDS:               providers.Can(),
+	providers.CanUseDSForChildren:    providers.Cannot(),
 	providers.CanUseLOC:              providers.Cannot(),
+	providers.CanUseNAPTR:            providers.Cannot(),
 	providers.CanUsePTR:              providers.Cannot(),
+	providers.CanUseSOA:              providers.Cannot(),
 	providers.CanUseSRV:              providers.Can(),
 	providers.CanUseSSHFP:            providers.Cannot(),
 	providers.CanUseTLSA:             providers.Can(),

--- a/providers/hetzner/types.go
+++ b/providers/hetzner/types.go
@@ -85,8 +85,8 @@ func fromRecordConfig(in *models.RecordConfig, zone *zone) *record {
 	return record
 }
 
-func toRecordConfig(domain string, record *record) *models.RecordConfig {
-	rc := &models.RecordConfig{
+func toRecordConfig(domain string, record *record) (*models.RecordConfig, error) {
+	rc := models.RecordConfig{
 		Type:     record.Type,
 		TTL:      *record.TTL,
 		Original: record,
@@ -100,8 +100,5 @@ func toRecordConfig(domain string, record *record) *models.RecordConfig {
 		// Per RFC 1035 spaces outside quoted values are irrelevant.
 		value = strings.TrimRight(value, " ")
 	}
-
-	_ = rc.PopulateFromString(record.Type, value, domain)
-
-	return rc
+	return &rc, rc.PopulateFromString(record.Type, value, domain)
 }

--- a/providers/hetzner/types.go
+++ b/providers/hetzner/types.go
@@ -14,14 +14,6 @@ type bulkUpdateRecordsRequest struct {
 	Records []record `json:"records"`
 }
 
-type createRecordRequest struct {
-	Name   string `json:"name"`
-	TTL    uint32 `json:"ttl"`
-	Type   string `json:"type"`
-	Value  string `json:"value"`
-	ZoneID string `json:"zone_id"`
-}
-
 type createZoneRequest struct {
 	Name string `json:"name"`
 }
@@ -76,6 +68,7 @@ func fromRecordConfig(in *models.RecordConfig, zone *zone) *record {
 		//  suite of integrations tests.
 		// The HETZNER validation does not provide helpful error messages.
 		// {"error":{"message":"422 Unprocessable Entity: missing: ; ","code":422}}
+		// Last checked: 2023-04-01
 		valueNotQuoted := in.TxtStrings[0]
 		if len(valueNotQuoted) == 254 || len(valueNotQuoted) == 255 {
 			record.Value = valueNotQuoted
@@ -96,6 +89,7 @@ func toRecordConfig(domain string, record *record) (*models.RecordConfig, error)
 	value := record.Value
 	// HACK: Hetzner is inserting a trailing space after multiple, quoted values.
 	// NOTE: The actual DNS answer does not contain the space.
+	// Last checked: 2023-04-01
 	if record.Type == "TXT" && len(value) > 0 && value[len(value)-1] == ' ' {
 		// Per RFC 1035 spaces outside quoted values are irrelevant.
 		value = strings.TrimRight(value, " ")

--- a/providers/hetzner/types.go
+++ b/providers/hetzner/types.go
@@ -16,7 +16,7 @@ type bulkUpdateRecordsRequest struct {
 
 type createRecordRequest struct {
 	Name   string `json:"name"`
-	TTL    int    `json:"ttl"`
+	TTL    uint32 `json:"ttl"`
 	Type   string `json:"type"`
 	Value  string `json:"value"`
 	ZoneID string `json:"zone_id"`
@@ -45,28 +45,27 @@ type getAllZonesResponse struct {
 }
 
 type record struct {
-	ID     string `json:"id"`
-	Name   string `json:"name"`
-	TTL    *int   `json:"ttl"`
-	Type   string `json:"type"`
-	Value  string `json:"value"`
-	ZoneID string `json:"zone_id"`
+	ID     string  `json:"id"`
+	Name   string  `json:"name"`
+	TTL    *uint32 `json:"ttl"`
+	Type   string  `json:"type"`
+	Value  string  `json:"value"`
+	ZoneID string  `json:"zone_id"`
 }
 
 type zone struct {
 	ID          string   `json:"id"`
 	Name        string   `json:"name"`
 	NameServers []string `json:"ns"`
-	TTL         int      `json:"ttl"`
+	TTL         uint32   `json:"ttl"`
 }
 
 func fromRecordConfig(in *models.RecordConfig, zone *zone) *record {
-	ttl := int(in.TTL)
 	record := &record{
 		Name:   in.GetLabel(),
 		Type:   in.Type,
 		Value:  in.GetTargetCombined(),
-		TTL:    &ttl,
+		TTL:    &in.TTL,
 		ZoneID: zone.ID,
 	}
 
@@ -89,7 +88,7 @@ func fromRecordConfig(in *models.RecordConfig, zone *zone) *record {
 func toRecordConfig(domain string, record *record) *models.RecordConfig {
 	rc := &models.RecordConfig{
 		Type:     record.Type,
-		TTL:      uint32(*record.TTL),
+		TTL:      *record.TTL,
 		Original: record,
 	}
 	rc.SetLabel(record.Name, domain)


### PR DESCRIPTION
This PR includes a rework for the rate-limiting following API changes. The integration tests complete in about 4min now -- down from 12min. All the settings options were removed.

I restored a few TXT integration tests that were commented out in #2128, they validate the hacks that were added via https://github.com/StackExchange/dnscontrol/pull/1069 (the hacks are still needed, just tested). It might be worth adding a comment to the tests that they are useful for the HETZNER provider. WDYT?
Per the comments in https://github.com/StackExchange/dnscontrol/issues/598#issuecomment-587713630 I did not restore the zero width TXT test-case.
Let me know if you want the test changes separated into a separate PR.

I've updated the compatibility map with the latest state of the API. The tests for DS children fail partially, I left them disabled for now.

There are a few more commits with code cleanup/renaming/pre-allocation for slices and maps/pointer usage.

All the changes merge cleanly into https://github.com/StackExchange/dnscontrol/pull/2120, but they can land ahead of https://github.com/StackExchange/dnscontrol/pull/2120 already.
The integration tests pass for both diff modes (PR HEAD and merged with https://github.com/StackExchange/dnscontrol/pull/2120 plus `-diff2`).