### PR TITLE
DOCS: add reference tag for TypeScript server to recognise the type definitions

### DIFF
--- a/documentation/typescript.md
+++ b/documentation/typescript.md
@@ -38,6 +38,7 @@ Add this comment to the top of your `dnsconfig.js` file:
 
 {% code title="dnsconfig.js" %}
 ```javascript
+/// <reference path="types-dnscontrol.d.ts" />
 // @ts-check
 ```
 {% endcode %}

--- a/documentation/typescript.md
+++ b/documentation/typescript.md
@@ -38,8 +38,8 @@ Add this comment to the top of your `dnsconfig.js` file:
 
 {% code title="dnsconfig.js" %}
 ```javascript
-/// <reference path="types-dnscontrol.d.ts" />
 // @ts-check
+/// <reference path="types-dnscontrol.d.ts" />
 ```
 {% endcode %}
 

--- a/documentation/typescript.md
+++ b/documentation/typescript.md
@@ -34,7 +34,7 @@ for the version of DNSControl you are using.
 At this point some features (autocomplete) will work. However to get the full experience, including
 type checking (i.e. red squiggly underlines when you misuse APIs), there is one more step.
 
-Add this comment to the top of your `dnsconfig.js` file:
+Add these comments to the top of your `dnsconfig.js` file:
 
 {% code title="dnsconfig.js" %}
 ```javascript


### PR DESCRIPTION
Per #2263 :) This will help reduce confusion on TypeScript setup.