### PR TITLE
ns1: replace ToNameservers with ToNameserversStripTD

### DIFF
--- a/providers/ns1/ns1Provider.go
+++ b/providers/ns1/ns1Provider.go
@@ -85,7 +85,7 @@ func (n *nsone) GetNameservers(domain string) ([]*models.Nameserver, error) {
 			nservers = append(nservers, ns)
 		}
 	}
-	return models.ToNameservers(nservers)
+	return models.ToNameserversStripTD(nservers)
 }
 
 // GetZoneRecords gets the records of a zone and returns them in RecordConfig format.


### PR DESCRIPTION
This is untested, for some reason I haven't been able to build a local docker container.

I got the `provider code leaves trailing dot on nameserver` error and looking at the code suggested the attached fix.

