### PR TITLE
POWERDNS: Add option to set the PowerDNS zone kind

### DIFF
--- a/documentation/providers/powerdns.md
+++ b/documentation/providers/powerdns.md
@@ -29,13 +29,15 @@ Following metadata are available:
         'a.example.com.',
         'b.example.com.'
     ],
-    'dnssec_on_create': false
+    'dnssec_on_create': false,
+    'zone_kind': 'Native',
 }
 ```
 {% endcode %}
 
 - `default_ns` sets the nameserver which are used
 - `dnssec_on_create` specifies if DNSSEC should be enabled when creating zones
+- `zone_kind` is the type that will be used when creating the zone. Can be one of `Native`, `Master` or `Slave`, when not specified it defaults to `Native`. Please see [[PowerDNS documentation](https://doc.powerdns.com/authoritative/modes-of-operation.html) for explanation of the kinds.
 
 ## Usage
 An example configuration:

--- a/documentation/providers/powerdns.md
+++ b/documentation/providers/powerdns.md
@@ -37,7 +37,11 @@ Following metadata are available:
 
 - `default_ns` sets the nameserver which are used
 - `dnssec_on_create` specifies if DNSSEC should be enabled when creating zones
-- `zone_kind` is the type that will be used when creating the zone. Can be one of `Native`, `Master` or `Slave`, when not specified it defaults to `Native`. Please see [[PowerDNS documentation](https://doc.powerdns.com/authoritative/modes-of-operation.html) for explanation of the kinds.
+- `zone_kind` is the type that will be used when creating the zone.
+  <br>Can be one of `Native`, `Master` or `Slave`, when not specified it defaults to `Native`.
+  <br>Please see [PowerDNS documentation](https://doc.powerdns.com/authoritative/modes-of-operation.html) for explanation of the kinds.
+  <br>**Note that these tokens are case-sensitive!**
+
 
 ## Usage
 An example configuration:

--- a/providers/powerdns/dns.go
+++ b/providers/powerdns/dns.go
@@ -86,6 +86,7 @@ func (dsp *powerdnsProvider) EnsureZoneExists(domain string) error {
 		Type:        zones.ZoneTypeZone,
 		DNSSec:      dsp.DNSSecOnCreate,
 		Nameservers: dsp.DefaultNS,
+		Kind:        dsp.ZoneKind,
 	})
 	return err
 }

--- a/providers/powerdns/powerdnsProvider.go
+++ b/providers/powerdns/powerdnsProvider.go
@@ -3,6 +3,7 @@ package powerdns
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/mittwald/go-powerdns/apis/zones"
 
 	"github.com/StackExchange/dnscontrol/v3/models"
 	"github.com/StackExchange/dnscontrol/v3/providers"
@@ -40,8 +41,9 @@ type powerdnsProvider struct {
 	APIKey         string
 	APIUrl         string
 	ServerName     string
-	DefaultNS      []string `json:"default_ns"`
-	DNSSecOnCreate bool     `json:"dnssec_on_create"`
+	DefaultNS      []string       `json:"default_ns"`
+	DNSSecOnCreate bool           `json:"dnssec_on_create"`
+	ZoneKind       zones.ZoneKind `json:"zone_kind"`
 
 	nameservers []*models.Nameserver
 }


### PR DESCRIPTION
This PR adds a option to the PowerDNS provider to set the zone kind when creating a new zone.

If this is not specified in the request, PowerDNS uses `Native`, which results in the zone not being transfered via AXFR/IXFR. `Native` is used to let the storage backend of PDNS handle the replication.

The PR does not break the default behavior, if it is not set, the zone is still created with the `Native` type.

I'm currently waiting for a second tester to test this.