### PR TITLE
HEXONET: Remove duplicate code

### DIFF
--- a/providers/hexonet/records.go
+++ b/providers/hexonet/records.go
@@ -60,10 +60,10 @@ func (n *HXClient) GetZoneRecords(domain string) (models.Records, error) {
 // GetZoneRecordsCorrections returns a list of corrections that will turn existing records into dc.Records.
 func (n *HXClient) GetZoneRecordsCorrections(dc *models.DomainConfig, actual models.Records) ([]*models.Correction, error) {
 
-	actual, err := n.GetZoneRecords(dc.Name)
-	if err != nil {
-		return nil, err
-	}
+	//	actual, err := n.GetZoneRecords(dc.Name)
+	//	if err != nil {
+	//		return nil, err
+	//	}
 
 	//checkNSModifications(dc)
 


### PR DESCRIPTION
```
$ staticcheck ./...
providers/hexonet/records.go:61:71: argument actual is overwritten before first use (SA4009)
	providers/hexonet/records.go:63:2: assignment to actual
```
