### PR TITLE
BUG: diff2 flag can not work in both places

### DIFF
--- a/commands/previewPush.go
+++ b/commands/previewPush.go
@@ -68,11 +68,6 @@ func (args *PreviewArgs) flags() []cli.Flag {
 		Destination: &args.Full,
 		Usage:       `Add headings, providers names, notifications of no changes, etc`,
 	})
-	flags = append(flags, &cli.BoolFlag{
-		Name:        "diff2",
-		Destination: &diff2.EnableDiff2,
-		Usage:       `Enable replacement diff algorithm`,
-	})
 	return flags
 }
 


### PR DESCRIPTION
Sadly the flag library we use doesn't support having a global flag that is also a subcommand flag.  Luckily I never wrote an example that used this feature.  

These are the only uses that work (and have been seen in examples)

```
# OLD DIFF:
dnscontrol preview 
dnscontrol --diff2=false preview 
# DIFF2
dnscontrol --diff2 preview 
dnscontrol --diff2=true preview 
```