### PR TITLE
HETZNER: fix nameserver trailing dots

### DIFF
--- a/providers/hetzner/hetznerProvider.go
+++ b/providers/hetzner/hetznerProvider.go
@@ -149,11 +149,8 @@ func (api *hetznerProvider) GetNameservers(domain string) ([]*models.Nameserver,
 	if err != nil {
 		return nil, err
 	}
-	nameserver := make([]*models.Nameserver, len(z.NameServers))
-	for i, s := range z.NameServers {
-		nameserver[i] = &models.Nameserver{Name: s}
-	}
-	return nameserver, nil
+
+	return models.ToNameserversStripTD(z.NameServers)
 }
 
 // GetZoneRecords gets the records of a zone and returns them in RecordConfig format.


### PR DESCRIPTION
As per https://github.com/StackExchange/dnscontrol/issues/491#issuecomment-1529072560 hetzner started being affected by the trailing dots on nameservers thing.

My config stopped reporting this error with the change, not sure if you wanted a specific test for this situation to be added.

cc @das7pad as currently listed hetzner maintainer

