### PR TITLE
Linting

### DIFF
--- a/pkg/bindserial/main.go
+++ b/pkg/bindserial/main.go
@@ -6,6 +6,6 @@ package bindserial
 // by isolating it to this file we limit the blast radius of this bad
 // decision.
 
-// ForceBindSerial if non-zero, BIND will generate SOA serial numbers
+// ForcedValue if non-zero, BIND will generate SOA serial numbers
 // using this value.
 var ForcedValue int64

--- a/pkg/diff2/diff2.go
+++ b/pkg/diff2/diff2.go
@@ -187,7 +187,7 @@ func ByZone(existing models.Records, dc *models.DomainConfig, compFunc Comparabl
 	// Only return the messages.  The caller has the list of records needed to build the new zone.
 	instructions, err := byHelper(analyzeByRecord, existing, dc, compFunc)
 	changes := false
-	for i, _ := range instructions {
+	for i := range instructions {
 		//fmt.Printf("DEBUG: ByZone #%d: %v\n", i, ii)
 		if instructions[i].Type != REPORT {
 			changes = true

--- a/pkg/zonerecs/zonerecords.go
+++ b/pkg/zonerecs/zonerecords.go
@@ -38,7 +38,7 @@ func CorrectZoneRecords(driver models.DNSProvider, dc *models.DomainConfig) ([]*
 // corrections that are purely informational. (i.e. `.F` is nil)
 func CountActionable(corrections []*models.Correction) int {
 	count := 0
-	for i, _ := range corrections {
+	for i := range corrections {
 		if corrections[i].F != nil {
 			count++
 		}


### PR DESCRIPTION
```
pkg/bindserial/main.go:9:1: comment on exported var ForcedValue should be of the form "ForcedValue ..." (ST1022)
pkg/diff2/diff2.go:190:9: unnecessary assignment to the blank identifier (S1005)
pkg/zonerecs/zonerecords.go:41:9: unnecessary assignment to the blank identifier (S1005)
```


<!--
Before you submit a pull request, please make sure you've run the following commands from the root directory.

go vet ./...
go fmt ./...
go generate ./...
go mod tidy
!-->

