### PR TITLE
TESTING: add integration test for no trailing dot in nameservers

### DIFF
--- a/integrationTest/integration_test.go
+++ b/integrationTest/integration_test.go
@@ -319,6 +319,14 @@ func runTests(t *testing.T, prv providers.DNSServiceProvider, domainName string,
 
 	}
 
+	// Issue https://github.com/StackExchange/dnscontrol/issues/491
+	t.Run("No trailing dot in nameserver", func(t *testing.T) {
+		for _, nameserver := range dc.Nameservers {
+			if strings.HasSuffix(nameserver.Name, ".") {
+				t.Errorf("Provider returned nameserver with trailing dot: %s (See issue https://github.com/StackExchange/dnscontrol/issues/491, TL;DR: use models.ToNameserversStripTD in GetNameservers)", nameserver)
+			}
+		}
+	})
 }
 
 func TestDualProviders(t *testing.T) {


### PR DESCRIPTION
<!--
Before you submit a pull request, please make sure you've run the following commands from the root directory.

go vet ./...
go fmt ./...
go generate ./...
go mod tidy
!-->

As suggested in https://github.com/StackExchange/dnscontrol/pull/2301#pullrequestreview-1408080979 this PR is adding an integration test for checking that dnscontrol providers remove any trailing dot from nameservers as returned by the respective dns provider (https://github.com/StackExchange/dnscontrol/issues/491).

_The next time all maintainers run the tests we might see a few remaining providers fix their handling of nameservers. The test failure message points them right at the solution._

Closes https://github.com/StackExchange/dnscontrol/issues/2307
