### PR TITLE
NS1 Fix URLFWD implementation by being more consistent

### DIFF
--- a/integrationTest/integration_test.go
+++ b/integrationTest/integration_test.go
@@ -645,8 +645,8 @@ func tlsa(name string, usage, selector, matchingtype uint8, target string) *mode
 	return r
 }
 
-func urlfwd(name, target string) *models.RecordConfig {
-	return makeRec(name, target, "URLFWD")
+func ns1_urlfwd(name, target string) *models.RecordConfig {
+	return makeRec(name, target, "NS1_URLFWD")
 }
 
 func clear(items ...interface{}) *TestCase {
@@ -1678,8 +1678,8 @@ func makeTests(t *testing.T) []*TestGroup {
 
 		testgroup("NS1_URLFWD tests",
 			only("NS1"),
-			tc("Add a urlfwd", urlfwd("urlfwd1", "/ http://example.com 302 2 0")),
-			tc("Update a urlfwd", urlfwd("urlfwd1", "/ http://example.org 301 2 0")),
+			tc("Add a urlfwd", ns1_urlfwd("urlfwd1", "/ http://example.com 302 2 0")),
+			tc("Update a urlfwd", ns1_urlfwd("urlfwd1", "/ http://example.org 301 2 0")),
 		),
 
 		//// IGNORE* features

--- a/pkg/normalize/validate.go
+++ b/pkg/normalize/validate.go
@@ -206,7 +206,7 @@ func checkTargets(rec *models.RecordConfig, domain string) (errs []error) {
 		if label == "@" {
 			check(fmt.Errorf("cannot create NS record for bare domain. Use NAMESERVER instead"))
 		}
-	case "URLFWD":
+	case "NS1_URLFWD":
 		if len(strings.Fields(target)) != 5 {
 			check(fmt.Errorf("record should follow format: \"from to redirectType pathForwardingMode queryForwarding\""))
 		}

--- a/pkg/normalize/validate_test.go
+++ b/pkg/normalize/validate_test.go
@@ -198,25 +198,25 @@ func TestNSAtRoot(t *testing.T) {
 	}
 }
 
-func TestURLFWDValid(t *testing.T) {
-	rec := &models.RecordConfig{Type: "URLFWD"}
+func TestNS1URLFWDValid(t *testing.T) {
+	rec := &models.RecordConfig{Type: "NS1_URLFWD"}
 	rec.SetLabel("test1", "foo.com")
 	rec.SetTarget("/ http://example.com 302 2 0")
 
 	errs := checkTargets(rec, "foo.com")
 	if len(errs) > 0 {
-		t.Error("Expect no error with valid URLFWD target")
+		t.Error("Expect no error with valid NS1_URLFWD target")
 	}
 }
 
-func TestURLFWDInvalid(t *testing.T) {
-	rec := &models.RecordConfig{Type: "URLFWD"}
+func TestNS1URLFWDInvalid(t *testing.T) {
+	rec := &models.RecordConfig{Type: "NS1_URLFWD"}
 	rec.SetLabel("test2", "foo.com")
 	rec.SetTarget("/ http://example.com 302 2")
 
 	errs := checkTargets(rec, "foo.com")
 	if len(errs) == 0 {
-		t.Error("Expect error with invalid URLFWD target")
+		t.Error("Expect error with invalid NS1_URLFWD target")
 	}
 }
 


### PR DESCRIPTION
URLFWD isn't a real record type. There's no need to maintain both a "virtual" type and an alias type when there's a single implementation.

Discussed in #2319. 