### PR TITLE
NS1: revert #2295 (nameserver "trailing dot" issue)

### DIFF
--- a/providers/ns1/ns1Provider.go
+++ b/providers/ns1/ns1Provider.go
@@ -85,7 +85,7 @@ func (n *nsone) GetNameservers(domain string) ([]*models.Nameserver, error) {
 			nservers = append(nservers, ns)
 		}
 	}
-	return models.ToNameserversStripTD(nservers)
+	return models.ToNameservers(nservers)
 }
 
 // GetZoneRecords gets the records of a zone and returns them in RecordConfig format.


### PR DESCRIPTION
Fixes https://github.com/StackExchange/dnscontrol/issues/2317
Fixes https://github.com/StackExchange/dnscontrol/issues/2319