### PR TITLE
ci: hardcode container tag gover in pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container:
-      image: golang:${{ vars.GOVER }}
+      image: golang:1.18
     env:
       TEST_RESULTS: "/tmp/test-results"
     steps:
@@ -70,7 +70,7 @@ jobs:
     needs: integration-test-providers
     runs-on: ubuntu-latest
     container:
-      image: golang:${{ vars.GOVER }}
+      image: golang:1.18
       env:
         TEST_RESULTS: "/tmp/test-results"
         GOTESTSUM_FORMAT: testname
@@ -171,7 +171,7 @@ jobs:
     if: github.ref != 'refs/heads/master' && github.ref != 'refs/heads/main'
     runs-on: ubuntu-latest
     container:
-      image: golang:${{ vars.GOVER }}
+      image: golang:1.18
     needs:
     - integration-test-providers
     - integrtests-diff1


### PR DESCRIPTION
Hardcoded the gover image tag in pipeline to allow for easier PR integration from forked repos.  Unfortunately, GHA does not allow env context on the image (only github, inputs, vars, needs, strategy, and matrix)

This should allow PRs from forked repos to succeed in building the project without the need to set their own project variable with the GO version image tag.