### PR TITLE
ci: add goreleaser to release pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
 
 env:
-  cache-key: 1639697695 #Change to force cache reset `pwsh > Get-Date -UFormat %s`; this should match the same key found in the release.yml file
+  cache-key: 1639697695 #Change to force cache reset `pwsh > Get-Date -UFormat %s`
   go-mod-path: /go/pkg/mod
 
 jobs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
 
 env:
-  cache-key: 1639697695 #Change to force cache reset `pwsh > Get-Date -UFormat %s`
+  cache-key: 1639697695 #Change to force cache reset `pwsh > Get-Date -UFormat %s`; this should match the same key found in the release.yml file
   go-mod-path: /go/pkg/mod
 
 jobs:
@@ -118,7 +118,7 @@ jobs:
         GCLOUD_PRIVATEKEY: ${{ secrets.GCLOUD_PRIVATEKEY }}
         GCLOUD_PROJECT: ${{ secrets.GCLOUD_PROJECT }}
         GCLOUD_TYPE: ${{ secrets.GCLOUD_TYPE }}
- 
+
         HEDNS_PASSWORD: ${{ secrets.HEDNS_PASSWORD }}
         HEDNS_TOTP_SECRET: ${{ secrets.HEDNS_TOTP_SECRET }}
         HEDNS_USERNAME: ${{ secrets.HEDNS_USERNAME }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,7 @@
 on:
   push:
     branches:
-    - ci/add-goreleaser
-#    - master
+    - master
     tags:
     - /v[0-9]+(\.[0-9]+)*(-.*)*/
 
@@ -25,91 +24,89 @@ jobs:
 
     - name: Install goreleaser
       run: go install github.com/goreleaser/goreleaser@latest
-#
-#    - name: Goreleaser release
-#      run: goreleaser release
 
-#    - name: Get release
-#      id: get_release
-#      uses: bruceadams/get-release@v1.3.2
-#      env:
-#        GITHUB_TOKEN: ${{ github.token }}
-#
     - name: Build binaries
       run: go run build/build.go
       env:
         CGO_ENABLED: 0
-#
-#    - name: Get release from tag
-#      run: echo ::set-output name=RELEASE_VERSION::$(echo ${GITHUB_REF:11})
-#      id: versioner
-#
-#    - name: Create target directory
-#      run: mkdir -p usr/bin
-#
-#    - name: Copy Linux version to dnscontrol
-#      run: cp dnscontrol-Linux usr/bin/dnscontrol
-#
-#    - name: Bundle RPM
-#      uses: bpicode/github-action-fpm@master
-#      with:
-#        fpm_args: 'usr/'
-#        fpm_opts: '-n dnscontrol -t rpm -s dir -v ${{ steps.versioner.outputs.RELEASE_VERSION }} --license "The MIT License (MIT)" --url "https://dnscontrol.org/" --description "DNSControl: Infrastructure as Code for DNS Zones"'
-#
-#    - name: Bundle DEB
-#      uses: bpicode/github-action-fpm@master
-#      with:
-#        fpm_args: 'usr/'
-#        fpm_opts: '-n dnscontrol -t deb -s dir -v ${{ steps.versioner.outputs.RELEASE_VERSION }} --license "The MIT License (MIT)" --url "https://dnscontrol.org/" --description "DNSControl: Infrastructure as Code for DNS Zones"'
-#
-#    - name: Upload dnscontrol-Darwin
-#      uses: actions/upload-release-asset@v1
-#      env:
-#        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-#      with:
-#        upload_url: ${{ steps.get_release.outputs.upload_url }}
-#        asset_path: ./dnscontrol-Darwin
-#        asset_name: dnscontrol-Darwin
-#        asset_content_type: application/octet-stream
-#
-#    - name: Upload dnscontrol-Linux
-#      uses: actions/upload-release-asset@v1
-#      env:
-#        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-#      with:
-#        upload_url: ${{ steps.get_release.outputs.upload_url }}
-#        asset_path: ./dnscontrol-Linux
-#        asset_name: dnscontrol-Linux
-#        asset_content_type: application/octet-stream
-#
-#    - name: Upload dnscontrol.exe
-#      uses: actions/upload-release-asset@v1
-#      env:
-#        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-#      with:
-#        upload_url: ${{ steps.get_release.outputs.upload_url }}
-#        asset_path: ./dnscontrol.exe
-#        asset_name: dnscontrol.exe
-#        asset_content_type: application/octet-stream
-#
-#    - name: Upload RPM
-#      uses: actions/upload-release-asset@v1
-#      env:
-#        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-#      with:
-#        upload_url: ${{ steps.get_release.outputs.upload_url }}
-#        asset_path: dnscontrol-${{ steps.versioner.outputs.RELEASE_VERSION }}-1.x86_64.rpm
-#        asset_name: dnscontrol-${{ steps.versioner.outputs.RELEASE_VERSION }}-1.x86_64.rpm
-#        asset_content_type: application/x-rpm
-#
-#    - name: Upload DEB
-#      uses: actions/upload-release-asset@v1
-#      env:
-#        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-#      with:
-#        upload_url: ${{ steps.get_release.outputs.upload_url }}
-#        asset_path: dnscontrol_${{ steps.versioner.outputs.RELEASE_VERSION }}_amd64.deb
-#        asset_name: dnscontrol_${{ steps.versioner.outputs.RELEASE_VERSION }}_amd64.deb
-#        asset_content_type: application/vnd.debian.binary-package
-#
-#
+
+    - name: Goreleaser release
+      run: goreleaser release
+
+    - name: Get release from tag
+      run: echo ::set-output name=RELEASE_VERSION::$(echo ${GITHUB_REF:11})
+      id: versioner
+
+    - name: Create target directory
+      run: mkdir -p usr/bin
+
+    - name: Copy Linux version to dnscontrol
+      run: cp dnscontrol-Linux usr/bin/dnscontrol
+
+    - name: Get release
+      id: get_release
+      uses: bruceadams/get-release@v1.3.2
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+
+    - name: Bundle RPM
+      uses: bpicode/github-action-fpm@master
+      with:
+        fpm_args: 'usr/'
+        fpm_opts: '-n dnscontrol -t rpm -s dir -v ${{ steps.versioner.outputs.RELEASE_VERSION }} --license "The MIT License (MIT)" --url "https://dnscontrol.org/" --description "DNSControl: Infrastructure as Code for DNS Zones"'
+
+    - name: Bundle DEB
+      uses: bpicode/github-action-fpm@master
+      with:
+        fpm_args: 'usr/'
+        fpm_opts: '-n dnscontrol -t deb -s dir -v ${{ steps.versioner.outputs.RELEASE_VERSION }} --license "The MIT License (MIT)" --url "https://dnscontrol.org/" --description "DNSControl: Infrastructure as Code for DNS Zones"'
+
+    - name: Upload dnscontrol-Darwin
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.get_release.outputs.upload_url }}
+        asset_path: ./dnscontrol-Darwin
+        asset_name: dnscontrol-Darwin
+        asset_content_type: application/octet-stream
+
+    - name: Upload dnscontrol-Linux
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.get_release.outputs.upload_url }}
+        asset_path: ./dnscontrol-Linux
+        asset_name: dnscontrol-Linux
+        asset_content_type: application/octet-stream
+
+    - name: Upload dnscontrol.exe
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.get_release.outputs.upload_url }}
+        asset_path: ./dnscontrol.exe
+        asset_name: dnscontrol.exe
+        asset_content_type: application/octet-stream
+
+    - name: Upload RPM
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.get_release.outputs.upload_url }}
+        asset_path: dnscontrol-${{ steps.versioner.outputs.RELEASE_VERSION }}-1.x86_64.rpm
+        asset_name: dnscontrol-${{ steps.versioner.outputs.RELEASE_VERSION }}-1.x86_64.rpm
+        asset_content_type: application/x-rpm
+
+    - name: Upload DEB
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.get_release.outputs.upload_url }}
+        asset_path: dnscontrol_${{ steps.versioner.outputs.RELEASE_VERSION }}_amd64.deb
+        asset_name: dnscontrol_${{ steps.versioner.outputs.RELEASE_VERSION }}_amd64.deb
+        asset_content_type: application/vnd.debian.binary-package

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,14 @@
 on:
-  release:
-    types: [published]
+  push:
+    branches:
+    - ci/add-goreleaser
+#    - master
+    tags:
+    - /v[0-9]+(\.[0-9]+)*(-.*)*/
+
+env:
+  cache-key: 1639697695 #Change to force cache reset `pwsh > Get-Date -UFormat %s`; this should match the same key found in the build.yml file
+  go-mod-path: ~/go/pkg/mod
 
 name: release
 jobs:
@@ -8,12 +16,6 @@ jobs:
     name: release
     runs-on: ubuntu-latest
     steps:
-
-    - name: Get release
-      id: get_release
-      uses: bruceadams/get-release@v1.3.2
-      env:
-        GITHUB_TOKEN: ${{ github.token }}
 
     - name: Checkout repo
       uses: actions/checkout@v3
@@ -25,80 +27,100 @@ jobs:
       with:
         go-version: ^1.15
 
+    - name: Install goreleaser
+      run: go install github.com/goreleaser/goreleaser@latest
+#
+#    - name: Goreleaser release
+#      run: goreleaser release
+
+    - name: restore_cache
+      uses: actions/cache@v3.3.1
+      with:
+        key: linux-go-${{ hashFiles('go.sum') }}-${{ env.cache-key }}
+        restore-keys: linux-go-${{ hashFiles('go.sum') }}-${{ env.cache-key }}
+        path: ${{ env.go-mod-path }}
+
+#    - name: Get release
+#      id: get_release
+#      uses: bruceadams/get-release@v1.3.2
+#      env:
+#        GITHUB_TOKEN: ${{ github.token }}
+#
     - name: Build binaries
       run: go run build/build.go
       env:
         CGO_ENABLED: 0
-
-    - name: Get release from tag
-      run: echo ::set-output name=RELEASE_VERSION::$(echo ${GITHUB_REF:11})
-      id: versioner
-
-    - name: Create target directory
-      run: mkdir -p usr/bin
-
-    - name: Copy Linux version to dnscontrol
-      run: cp dnscontrol-Linux usr/bin/dnscontrol
-
-    - name: Bundle RPM
-      uses: bpicode/github-action-fpm@master
-      with:
-        fpm_args: 'usr/'
-        fpm_opts: '-n dnscontrol -t rpm -s dir -v ${{ steps.versioner.outputs.RELEASE_VERSION }} --license "The MIT License (MIT)" --url "https://dnscontrol.org/" --description "DNSControl: Infrastructure as Code for DNS Zones"'
-
-    - name: Bundle DEB
-      uses: bpicode/github-action-fpm@master
-      with:
-        fpm_args: 'usr/'
-        fpm_opts: '-n dnscontrol -t deb -s dir -v ${{ steps.versioner.outputs.RELEASE_VERSION }} --license "The MIT License (MIT)" --url "https://dnscontrol.org/" --description "DNSControl: Infrastructure as Code for DNS Zones"'
-
-    - name: Upload dnscontrol-Darwin
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.get_release.outputs.upload_url }}
-        asset_path: ./dnscontrol-Darwin
-        asset_name: dnscontrol-Darwin
-        asset_content_type: application/octet-stream
-
-    - name: Upload dnscontrol-Linux
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.get_release.outputs.upload_url }}
-        asset_path: ./dnscontrol-Linux
-        asset_name: dnscontrol-Linux
-        asset_content_type: application/octet-stream
-
-    - name: Upload dnscontrol.exe
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.get_release.outputs.upload_url }}
-        asset_path: ./dnscontrol.exe
-        asset_name: dnscontrol.exe
-        asset_content_type: application/octet-stream
-
-    - name: Upload RPM
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.get_release.outputs.upload_url }}
-        asset_path: dnscontrol-${{ steps.versioner.outputs.RELEASE_VERSION }}-1.x86_64.rpm
-        asset_name: dnscontrol-${{ steps.versioner.outputs.RELEASE_VERSION }}-1.x86_64.rpm
-        asset_content_type: application/x-rpm
-
-    - name: Upload DEB
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.get_release.outputs.upload_url }}
-        asset_path: dnscontrol_${{ steps.versioner.outputs.RELEASE_VERSION }}_amd64.deb
-        asset_name: dnscontrol_${{ steps.versioner.outputs.RELEASE_VERSION }}_amd64.deb
-        asset_content_type: application/vnd.debian.binary-package
-
+#
+#    - name: Get release from tag
+#      run: echo ::set-output name=RELEASE_VERSION::$(echo ${GITHUB_REF:11})
+#      id: versioner
+#
+#    - name: Create target directory
+#      run: mkdir -p usr/bin
+#
+#    - name: Copy Linux version to dnscontrol
+#      run: cp dnscontrol-Linux usr/bin/dnscontrol
+#
+#    - name: Bundle RPM
+#      uses: bpicode/github-action-fpm@master
+#      with:
+#        fpm_args: 'usr/'
+#        fpm_opts: '-n dnscontrol -t rpm -s dir -v ${{ steps.versioner.outputs.RELEASE_VERSION }} --license "The MIT License (MIT)" --url "https://dnscontrol.org/" --description "DNSControl: Infrastructure as Code for DNS Zones"'
+#
+#    - name: Bundle DEB
+#      uses: bpicode/github-action-fpm@master
+#      with:
+#        fpm_args: 'usr/'
+#        fpm_opts: '-n dnscontrol -t deb -s dir -v ${{ steps.versioner.outputs.RELEASE_VERSION }} --license "The MIT License (MIT)" --url "https://dnscontrol.org/" --description "DNSControl: Infrastructure as Code for DNS Zones"'
+#
+#    - name: Upload dnscontrol-Darwin
+#      uses: actions/upload-release-asset@v1
+#      env:
+#        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#      with:
+#        upload_url: ${{ steps.get_release.outputs.upload_url }}
+#        asset_path: ./dnscontrol-Darwin
+#        asset_name: dnscontrol-Darwin
+#        asset_content_type: application/octet-stream
+#
+#    - name: Upload dnscontrol-Linux
+#      uses: actions/upload-release-asset@v1
+#      env:
+#        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#      with:
+#        upload_url: ${{ steps.get_release.outputs.upload_url }}
+#        asset_path: ./dnscontrol-Linux
+#        asset_name: dnscontrol-Linux
+#        asset_content_type: application/octet-stream
+#
+#    - name: Upload dnscontrol.exe
+#      uses: actions/upload-release-asset@v1
+#      env:
+#        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#      with:
+#        upload_url: ${{ steps.get_release.outputs.upload_url }}
+#        asset_path: ./dnscontrol.exe
+#        asset_name: dnscontrol.exe
+#        asset_content_type: application/octet-stream
+#
+#    - name: Upload RPM
+#      uses: actions/upload-release-asset@v1
+#      env:
+#        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#      with:
+#        upload_url: ${{ steps.get_release.outputs.upload_url }}
+#        asset_path: dnscontrol-${{ steps.versioner.outputs.RELEASE_VERSION }}-1.x86_64.rpm
+#        asset_name: dnscontrol-${{ steps.versioner.outputs.RELEASE_VERSION }}-1.x86_64.rpm
+#        asset_content_type: application/x-rpm
+#
+#    - name: Upload DEB
+#      uses: actions/upload-release-asset@v1
+#      env:
+#        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#      with:
+#        upload_url: ${{ steps.get_release.outputs.upload_url }}
+#        asset_path: dnscontrol_${{ steps.versioner.outputs.RELEASE_VERSION }}_amd64.deb
+#        asset_name: dnscontrol_${{ steps.versioner.outputs.RELEASE_VERSION }}_amd64.deb
+#        asset_content_type: application/vnd.debian.binary-package
+#
+#

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,10 +6,6 @@ on:
     tags:
     - /v[0-9]+(\.[0-9]+)*(-.*)*/
 
-env:
-  cache-key: 1639697695 #Change to force cache reset `pwsh > Get-Date -UFormat %s`; this should match the same key found in the build.yml file
-  go-mod-path: ~/go/pkg/mod
-
 name: release
 jobs:
   release:
@@ -32,13 +28,6 @@ jobs:
 #
 #    - name: Goreleaser release
 #      run: goreleaser release
-
-    - name: restore_cache
-      uses: actions/cache@v3.3.1
-      with:
-        key: linux-go-${{ hashFiles('go.sum') }}-${{ env.cache-key }}
-        restore-keys: linux-go-${{ hashFiles('go.sum') }}-${{ env.cache-key }}
-        path: ${{ env.go-mod-path }}
 
 #    - name: Get release
 #      id: get_release


### PR DESCRIPTION
Migrate functionality from CCI pipeline to GHA release workflow

* Change release workflow trigger from release published to push with tag filter
* Add goreleaser to GHA release pipeline