### PR TITLE
ci: fix release workflow trigger

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,8 @@
 on:
   push:
-    branches:
-    - master
     tags:
-    - /v[0-9]+(\.[0-9]+)*(-.*)*/
+    - v[0-9]+.[0-9]+.[0-9]+
+    - v[0-9]+.[0-9]+.[0-9]+-*
 
 name: release
 jobs:


### PR DESCRIPTION
Release workflow had both branch and tag filters but they are not evaluated as a boolean "and" and will trigger the workflow separately.  Removed push on branch filter and fixed tag filters to trigger on semantic releases.
