### PR TITLE
ci: split draft release logic into separate workflow

### DIFF
--- a/.github/workflows/draft_release.yml
+++ b/.github/workflows/draft_release.yml
@@ -1,0 +1,36 @@
+on:
+  push:
+    tags:
+    - v[0-9]+.[0-9]+.[0-9]+
+    - v[0-9]+.[0-9]+.[0-9]+-*
+
+name: draft release
+jobs:
+  draft_release:
+    name: draft release
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Checkout repo
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
+    - name: Login to Docker Hub
+      uses: docker/login-action@v2
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
+
+    - name: Set up Go
+      uses: actions/setup-go@v4
+      with:
+        go-version: ^1.15
+
+    - name: Install goreleaser
+      run: go install github.com/goreleaser/goreleaser@latest
+
+    - name: Goreleaser release
+      run: goreleaser release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,6 @@
 on:
-  push:
-    tags:
-    - v[0-9]+.[0-9]+.[0-9]+
-    - v[0-9]+.[0-9]+.[0-9]+-*
+  release:
+    types: [published]
 
 name: release
 jobs:
@@ -11,34 +9,26 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
+    - name: Get release
+      id: get_release
+      uses: bruceadams/get-release@v1.3.2
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+
     - name: Checkout repo
       uses: actions/checkout@v3
       with:
         fetch-depth: 0
-
-    - name: Login to Docker Hub
-      uses: docker/login-action@v2
-      with:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
 
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
         go-version: ^1.15
 
-    - name: Install goreleaser
-      run: go install github.com/goreleaser/goreleaser@latest
-
     - name: Build binaries
       run: go run build/build.go
       env:
         CGO_ENABLED: 0
-
-    - name: Goreleaser release
-      run: goreleaser release
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Get release from tag
       run: echo ::set-output name=RELEASE_VERSION::$(echo ${GITHUB_REF:11})
@@ -49,12 +39,6 @@ jobs:
 
     - name: Copy Linux version to dnscontrol
       run: cp dnscontrol-Linux usr/bin/dnscontrol
-
-#    - name: Get release
-#      id: get_release
-#      uses: bruceadams/get-release@v1.3.2
-#      env:
-#        GITHUB_TOKEN: ${{ github.token }}
 
     - name: Bundle RPM
       uses: bpicode/github-action-fpm@master


### PR DESCRIPTION
goreleaser is configured to create a draft release which should have the release notes [edited](https://docs.dnscontrol.org/release/release-engineering#step-3.-create-the-release-notes) before the GHA release workflow is run (as specified by the trigger `release: types: [published]`.  Consolidated logic after migrating from CCI but logic for drafting the release needs to be split out to maintain overall release workflow.