### PR TITLE
Update Dockerfile to use Alpine 3.18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax = docker/dockerfile:1.4
 
-FROM alpine:3.17.3@sha256:124c7d2707904eea7431fffe91522a01e5a861a624ee31d03372cc1d138a3126 as RUN
+FROM alpine:3.18.0@sha256:02bb6f428431fbc2809c5d1b41eab5a68350194fb508869a33cb1af4444c9b11 as RUN
 
 #RUN --mount=type=cache,target=/var/cache/apk \
 #    apk update \


### PR DESCRIPTION
Alpine 3.17.3 has a few vulns per Trivy scan.

```
stackexchange/dnscontrol:v3.31.5 (alpine 3.17.3)

Total: 2 (MEDIUM: 2, HIGH: 0, CRITICAL: 0)

┌────────────┬───────────────┬──────────┬───────────────────┬───────────────┬────────────────────────────────────────────────────────────┐
│  Library   │ Vulnerability │ Severity │ Installed Version │ Fixed Version │                           Title                            │
├────────────┼───────────────┼──────────┼───────────────────┼───────────────┼────────────────────────────────────────────────────────────┤
│ libcrypto3 │ CVE-2023-1255 │ MEDIUM   │ 3.0.8-r3          │ 3.0.8-r4      │ Input buffer over-read in AES-XTS implementation on 64 bit │
│            │               │          │                   │               │ ARM                                                        │
│            │               │          │                   │               │ https://avd.aquasec.com/nvd/cve-2023-1255                  │
├────────────┤               │          │                   │               │                                                            │
│ libssl3    │               │          │                   │               │                                                            │
│            │               │          │                   │               │                                                            │
│            │               │          │                   │               │                                                            │
└────────────┴───────────────┴──────────┴───────────────────┴───────────────┴────────────────────────────────────────────────────────────┘
```


