### PR TITLE
CI: Release Docker images without the "v"

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -115,7 +115,7 @@ dockers:
     - "--label=org.opencontainers.image.source={{ .GitURL }}"
     - "--platform=linux/arm64"
 docker_manifests:
-  - name_template: "stackexchange/{{.ProjectName}}:v{{ .Version }}"
+  - name_template: "stackexchange/{{.ProjectName}}:{{ .Version }}"
     image_templates:
       - *amd_image
       - *386_image


### PR DESCRIPTION
<!--
Before you submit a pull request, please make sure you've run the following commands from the root directory.

go vet ./...
go fmt ./...
go generate ./...
go mod tidy
!-->

Based on this [conversation](https://github.com/StackExchange/dnscontrol/pull/2363/files#r1197045183) release the Docker images without the "v" in the versions.

<img width="1280" alt="docker-hub" src="https://github.com/StackExchange/dnscontrol/assets/1150425/bbbc4915-1955-41a9-9731-bd8ca00613a0">

_https://hub.docker.com/r/stackexchange/dnscontrol/tags?name=4.0.1_