### PR TITLE
DESEC: implement ListZones

### DIFF
--- a/providers/desec/desecProvider.go
+++ b/providers/desec/desecProvider.go
@@ -248,3 +248,12 @@ func (c *desecProvider) GetZoneRecordsCorrections(dc *models.DomainConfig, exist
 
 	return corrections, nil
 }
+
+// ListZones return all the zones in the account
+func (c *desecProvider) ListZones() ([]string, error) {
+	var domains []string
+	for domain := range c.domainIndex {
+		domains = append(domains, domain)
+	}
+	return domains, nil
+}


### PR DESCRIPTION
<!--
Before you submit a pull request, please make sure you've run the following commands from the root directory.

go vet ./...
go fmt ./...
go generate ./...
go mod tidy
!-->

close #2346

the zones list are already loaded in provider initialize, this PR simply load the local cache to implement ListZones

https://github.com/StackExchange/dnscontrol/blob/0edffa198b0a09acdf086cb6fa7026a7aaef628c/providers/desec/protocol.go#L82-L127

```
# dnscontrol get-zones --format=nameonly desec - all
desec.esd.cc
```
