### PR TITLE
DOCS: Code examples missing provider constants

### DIFF
--- a/documentation/examples.md
+++ b/documentation/examples.md
@@ -198,6 +198,9 @@ var FASTMAIL_DKIM = function(the_domain){
 We can then use the macros as such:
 {% code title="dnsconfig.js" %}
 ```javascript
+var REG_NONE = NewRegistrar("none");
+var DSP_R53_MAIN = NewDnsProvider("r53_main");
+
 D("example.com", REG_NONE, DnsProvider(DSP_R53_MAIN),
     FASTMAIL_MX,
     FASTMAIL_DKIM("example.com")

--- a/documentation/providers/cloudflareapi.md
+++ b/documentation/providers/cloudflareapi.md
@@ -155,6 +155,9 @@ The following example shows how to set meta variables with and without aliases:
 
 {% code title="dnsconfig.js" %}
 ```javascript
+var REG_NONE = NewRegistrar("none");
+var DSP_CLOUDFLARE = NewDnsProvider("cloudflare");
+
 D("example.tld", REG_NONE, DnsProvider(DSP_CLOUDFLARE),
     A("www1","1.2.3.11", CF_PROXY_ON),        // turn proxy ON.
     A("www2","1.2.3.12", CF_PROXY_OFF),       // default is OFF, this is a no-op.
@@ -205,6 +208,7 @@ The Cloudflare provider can manage "Forwarding URL" Page Rules (redirects) for y
 ```javascript
 // chiphacker.com should redirect to electronics.stackexchange.com
 
+var REG_NONE = NewRegistrar("none");
 var DSP_CLOUDFLARE = NewDnsProvider("cloudflare", {"manage_redirects": true}); // enable manage_redirects
 
 D("chiphacker.com", REG_NONE, DnsProvider(DSP_CLOUDFLARE),
@@ -236,6 +240,7 @@ The Cloudflare provider can manage Worker Routes for your domains. Simply use th
 
 {% code title="dnsconfig.js" %}
 ```javascript
+var REG_NONE = NewRegistrar("none");
 var DSP_CLOUDFLARE = NewDnsProvider("cloudflare", {"manage_workers": true}); // enable managing worker routes
 
 D("foo.com", REG_NONE, DnsProvider(DSP_CLOUDFLARE),

--- a/documentation/providers/desec.md
+++ b/documentation/providers/desec.md
@@ -24,8 +24,8 @@ An example configuration:
 
 {% code title="dnsconfig.js" %}
 ```javascript
-var REG_NONE = NewRegistrar("none");    // No registrar.
-var DSP_DESEC = NewDnsProvider("desec");  // deSEC
+var REG_NONE = NewRegistrar("none");
+var DSP_DESEC = NewDnsProvider("desec");
 
 D("example.tld", REG_NONE, DnsProvider(DSP_DESEC),
     A("test", "1.2.3.4")

--- a/documentation/providers/gcore.md
+++ b/documentation/providers/gcore.md
@@ -24,8 +24,8 @@ An example configuration:
 
 {% code title="dnsconfig.js" %}
 ```javascript
-var REG_NONE = NewRegistrar("none");    // No registrar.
-var DSP_GCORE = NewDnsProvider("gcore");  // Gcore
+var REG_NONE = NewRegistrar("none");
+var DSP_GCORE = NewDnsProvider("gcore");
 
 D("example.tld", REG_NONE, DnsProvider(DSP_GCORE),
     A("test", "1.2.3.4")

--- a/documentation/providers/route53.md
+++ b/documentation/providers/route53.md
@@ -87,8 +87,8 @@ each with different zone IDs specified using [`R53_ZONE()`](../functions/record/
 
 {% code title="dnsconfig.js" %}
 ```javascript
-var DSP_R53 = NewDnsProvider("r53_main");
 var REG_NONE = NewRegistrar("none");
+var DSP_R53 = NewDnsProvider("r53_main");
 
 D('testzone.net!private', REG_NONE,
     DnsProvider(DSP_R53),

--- a/documentation/providers/softlayer.md
+++ b/documentation/providers/softlayer.md
@@ -32,7 +32,7 @@ An example configuration:
 
 {% code title="dnsconfig.js" %}
 ```javascript
-var REG_NONE = NewRegistrar("none"); // no registrar
+var REG_NONE = NewRegistrar("none");
 var DSP_SOFTLAYER = NewDnsProvider("softlayer");
 
 D("example.tld", registrary, DnsProvider(DSP_SOFTLAYER),

--- a/documentation/providers/softlayer.md
+++ b/documentation/providers/softlayer.md
@@ -47,6 +47,9 @@ For compatibility with the pre-generated NAMESERVER fields it's recommended to s
 
 {% code title="dnsconfig.js" %}
 ```javascript
+var REG_NONE = NewRegistrar("none");
+var DSP_SOFTLAYER = NewDnsProvider("softlayer");
+
 D("example.tld", REG_NONE, DnsProvider(SOFTLAYER),
     NAMESERVER_TTL(86400),
 

--- a/documentation/providers/transip.md
+++ b/documentation/providers/transip.md
@@ -47,9 +47,10 @@ An example configuration:
 
 {% code title="dnsconfig.js" %}
 ```javascript
+var REG_NONE = NewRegistrar("none");
 var DSP_TRANSIP = NewDnsProvider("transip");
 
-D("example.tld", REG_DNSIMPLE, DnsProvider(DSP_TRANSIP),
+D("example.tld", REG_NONE, DnsProvider(DSP_TRANSIP),
     A("test", "1.2.3.4")
 );
 ```


### PR DESCRIPTION
<!--
Before you submit a pull request, please make sure you've run the following commands from the root directory.

go vet ./...
go fmt ./...
go generate ./...
go mod tidy
!-->

Provided the `dnsconfig.js` code examples with the missing provider constants. 