### PR TITLE
DOCS: Removed comments from `dnsconfig.js` code examples

### DIFF
--- a/documentation/getting-started.md
+++ b/documentation/getting-started.md
@@ -88,12 +88,8 @@ The file looks like:
 
 {% code title="dnsconfig.js" %}
 ```javascript
-// Providers:
-
-var REG_NONE = NewRegistrar('none');    // No registrar.
-var DNS_BIND = NewDnsProvider('bind');  // ISC BIND.
-
-// Domains:
+var REG_NONE = NewRegistrar('none');
+var DNS_BIND = NewDnsProvider('bind');
 
 D('example.com', REG_NONE, DnsProvider(DNS_BIND),
     A('@', '1.2.3.4')

--- a/documentation/providers/hexonet.md
+++ b/documentation/providers/hexonet.md
@@ -73,7 +73,6 @@ You are free to decide if you want to use both of our provider technology or jus
 
 {% code title="dnsconfig.js" %}
 ```javascript
-// Providers:
 var REG_HX = NewRegistrar("hexonet");
 var DSP_HX = NewDnsProvider("hexonet");
 
@@ -86,7 +85,6 @@ DEFAULTS(
     DefaultTTL(3600)
 );
 
-// Domains:
 D("abhoster.com", REG_HX, DnsProvider(DSP_HX),
     NAMESERVER("ns1.ispapi.net"),
     NAMESERVER("ns2.ispapi.net"),

--- a/documentation/providers/loopia.md
+++ b/documentation/providers/loopia.md
@@ -183,7 +183,6 @@ you're not forced to do that (thank god).
 
 {% code title="dnsconfig.js" %}
 ```javascript
-// Providers:
 var REG_LOOPIA = NewRegistrar("loopia");
 var DSP_LOOPIA = NewDnsProvider("loopia");
 
@@ -195,7 +194,6 @@ DEFAULTS(
     DefaultTTL(3600)
 );
 
-// Domains:
 D("example.com", REG_LOOPIA, DnsProvider(DSP_LOOPIA),
     //NAMESERVER("ns1.loopia.se."), //default
     //NAMESERVER("ns2.loopia.se."), //default


### PR DESCRIPTION
<!--
Before you submit a pull request, please make sure you've run the following commands from the root directory.

go vet ./...
go fmt ./...
go generate ./...
go mod tidy
!-->

Only in these three places are comments used in the `dnsconfig.js` code examples. I suggest drawing one line and deleting these comments.