### PR TITLE
CLOUDFLAREAPI: Allow API debugging to be enabled via env variable

### DIFF
--- a/providers/cloudflare/cloudflareProvider.go
+++ b/providers/cloudflare/cloudflareProvider.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
+	"os"
+	"strconv"
 	"strings"
 
 	"github.com/StackExchange/dnscontrol/v4/models"
@@ -677,6 +679,11 @@ func newCloudflare(m map[string]string, metadata json.RawMessage) (providers.DNS
 	// Check account data if set
 	if m["accountid"] != "" {
 		api.cfClient.AccountID = m["accountid"]
+	}
+
+	debug, err := strconv.ParseBool(os.Getenv("CLOUDFLAREAPI_DEBUG"))
+	if err == nil {
+		api.cfClient.Debug = debug
 	}
 
 	if len(metadata) > 0 {


### PR DESCRIPTION
This change allows the environment variable CLOUDFLAREAPI_DEBUG to be set to enable logging of all the Cloudflare API interactions. Modeled on GANDI_V5_DEBUG in gandi_v5Provider.go.