### PR TITLE
CICD: Also push container images to GitHub Container Registry (ghcr.io)

### DIFF
--- a/.github/workflows/draft_release.yml
+++ b/.github/workflows/draft_release.yml
@@ -9,6 +9,8 @@ jobs:
   draft_release:
     name: draft release
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
     steps:
 
     - name: Checkout repo
@@ -21,6 +23,13 @@ jobs:
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
+
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v2
+      with:
+        registry: ghcr.io
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Set up Go
       uses: actions/setup-go@v4

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -71,6 +71,7 @@ nfpms:
 dockers:
   - image_templates:
     - &amd_image "stackexchange/{{.ProjectName}}:{{ .Version }}-amd64"
+    - &amd_image_ghcr "ghcr.io/stackexchange/{{.ProjectName}}:{{ .Version }}-amd64"
     goos: linux
     goarch: amd64
     use: buildx
@@ -86,6 +87,7 @@ dockers:
     - "--platform=linux/amd64"
   - image_templates:
     - &386_image "stackexchange/{{.ProjectName}}:{{ .Version }}-386"
+    - &386_image_ghcr "ghcr.io/stackexchange/{{.ProjectName}}:{{ .Version }}-386"
     goos: linux
     goarch: '386'
     use: buildx
@@ -101,6 +103,7 @@ dockers:
     - "--platform=linux/i386"
   - image_templates:
     - &arm_image "stackexchange/{{.ProjectName}}:{{ .Version }}-arm64"
+    - &arm_image_ghcr "ghcr.io/stackexchange/{{.ProjectName}}:{{ .Version }}-arm64"
     goos: linux
     goarch: arm64
     use: buildx
@@ -120,12 +123,23 @@ docker_manifests:
       - *amd_image
       - *386_image
       - *arm_image
+  - name_template: "ghcr.io/stackexchange/{{.ProjectName}}:{{ .Version }}"
+    image_templates:
+      - *amd_image_ghcr
+      - *386_image_ghcr
+      - *arm_image_ghcr
   - name_template: "stackexchange/{{.ProjectName}}:latest"
     skip_push: auto
     image_templates:
       - *amd_image
       - *386_image
       - *arm_image
+  - name_template: "ghcr.io/stackexchange/{{.ProjectName}}:latest"
+    skip_push: auto
+    image_templates:
+      - *amd_image_ghcr
+      - *386_image_ghcr
+      - *arm_image_ghcr
 checksum:
   name_template: 'checksums.txt'
 snapshot:


### PR DESCRIPTION
This adds the support to also push container images to GitHub Container Registry (ghcr.io)

The goreleaser code change have been briefly tested here ([minor changes to disable other builds](https://github.com/Firefishy/dnscontrol/commit/bc0c066aa18d9e1a3b4d643c5e22b22dd6f752ac)): https://github.com/Firefishy/dnscontrol/actions/runs/5153372408/jobs/9280525081 (👍 docker build/push worked, push GH release failed) and the GitHub container images are published here: https://github.com/Firefishy/dnscontrol/pkgs/container/dnscontrol

