### PR TITLE
CICD: Add required GHA permissions for goreleaser

### DIFF
--- a/.github/workflows/draft_release.yml
+++ b/.github/workflows/draft_release.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       packages: write
+      contents: write
+      pull-requests: write
     steps:
 
     - name: Checkout repo


### PR DESCRIPTION
Added the missing permissions required by goreleaser for releases.

Link: https://github.com/StackExchange/dnscontrol/pull/2418 



