### PR TITLE
Change Docker to Debian base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
 # syntax = docker/dockerfile:1.4
 
-FROM alpine:3.18.0@sha256:02bb6f428431fbc2809c5d1b41eab5a68350194fb508869a33cb1af4444c9b11 as RUN
+# We're using Debian because that is also the base image for the `golang` images
+FROM debian:11@sha256:432f545c6ba13b79e2681f4cc4858788b0ab099fc1cca799cc0fae4687c69070 AS RUN
 
-#RUN --mount=type=cache,target=/var/cache/apk \
-#    apk update \
-#    && apk add ca-certificates \
-#    && update-ca-certificates
+# Install `ca-certificates` since `debian` does not ship with them
+# and they are required for a few of our supported providers
+RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*
 
 COPY dnscontrol /usr/local/bin/
 


### PR DESCRIPTION
This pull request changes the base image used for Docker from Alpine to Debian to address the issue described in https://github.com/StackExchange/dnscontrol/issues/2422.

The change consists of two lines (and comments):
- The changed base image, now referring to `debian:11` which is the current stable release of Debian.
  - To check the SHA256 I'm proposing in this commit, you can download the latest Debian image yourself using `docker pull debian:11`, and then inspect its digest with `docker inspect --format='{{index .RepoDigests 0}}' debian:11`, and see if it matches with the one mentioned in my commit, assuming they didn't just release a new version which you can check [here](https://hub.docker.com/_/debian/tags?name=latest).

- We explicitly install the [`ca-certificates` package](https://packages.debian.org/bullseye/ca-certificates), which is needed to make providers which use HTTPS work out-of-the-box without throwing CA errors.
  - In the previous Alpine version this was commented out because unlike Debian Alpine actually does already ship with common CA certificates included.
  - The install command and the command before/after it are the way they are to follow the [best practises](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/) from the Docker documentation.

Note that this will be a breaking change for some users of the Docker image, if they depended on the image specifically being based on Alpine. The examples outlined in the DNSControl documentation do not specifically depend on Alpine, so those will continue to work, but if people modified them to make use of Alpine-specific parts of the Docker image it will break. This should probably be added to the release notes.
