### PR TITLE
INWX: Fix PTR test failing/unexpected PTR modify operation

### DIFF
--- a/providers/inwx/inwxProvider.go
+++ b/providers/inwx/inwxProvider.go
@@ -308,7 +308,14 @@ func (api *inwxAPI) GetZoneRecords(domain string, meta map[string]string) (model
 		   Records with empty targets (i.e. records with target ".")
 		   are not allowed.
 		*/
-		if record.Type == "CNAME" || record.Type == "MX" || record.Type == "NS" || record.Type == "SRV" {
+		var rtypeAddDot = map[string]bool{
+			"CNAME": true,
+			"MX":    true,
+			"NS":    true,
+			"SRV":   true,
+			"PTR":   true,
+		}
+		if rtypeAddDot[record.Type] {
 			record.Content = record.Content + "."
 		}
 


### PR DESCRIPTION
Sorry for the delay. Was able to root-cause and fix the failing PTR test.

Running it with today's code:
```
$ go test -v -verbose -timeout 0 -provider INWX -start 28 -end 28
=== RUN   TestDNSProviders
=== RUN   TestDNSProviders/domain.tld
=== RUN   TestDNSProviders/domain.tld/Clean_Slate:Empty
    integration_test.go:244:
        - DELETE PTR 4.domain.tld foo.com. ttl=300
=== RUN   TestDNSProviders/domain.tld/28:PTR:Create_PTR_record
    integration_test.go:244:
        + CREATE PTR 4.domain.tld foo.com. ttl=300
=== RUN   TestDNSProviders/domain.tld/28:PTR:Modify_PTR_record
    integration_test.go:244:
        ± MODIFY PTR 4.domain.tld: (foo.com. ttl=300) -> (bar.com. ttl=300)
=== RUN   TestDNSProviders/domain.tld/Post_cleanup:Empty
    integration_test.go:244:
        - DELETE PTR 4.domain.tld bar.com. ttl=300
--- PASS: TestDNSProviders (8.76s)
    --- PASS: TestDNSProviders/domain.tld (8.32s)
        --- PASS: TestDNSProviders/domain.tld/Clean_Slate:Empty (1.83s)
        --- PASS: TestDNSProviders/domain.tld/28:PTR:Create_PTR_record (2.47s)
        --- PASS: TestDNSProviders/domain.tld/28:PTR:Modify_PTR_record (2.10s)
        --- PASS: TestDNSProviders/domain.tld/Post_cleanup:Empty (1.93s)
=== RUN   TestDualProviders
    integration_test.go:369: Clearing everything
    integration_test.go:376: Adding nameservers from another provider
    integration_test.go:363: #1:
        + CREATE NS domain.tld ns1.example.com. ttl=300
    integration_test.go:363: #2:
        + CREATE NS domain.tld ns2.example.com. ttl=300
    integration_test.go:379: Running again to ensure stability
--- PASS: TestDualProviders (4.44s)
=== RUN   TestNameserverDots
=== RUN   TestNameserverDots/No_trailing_dot_in_nameserver
--- PASS: TestNameserverDots (0.40s)
    --- PASS: TestNameserverDots/No_trailing_dot_in_nameserver (0.00s)
PASS
ok      github.com/StackExchange/dnscontrol/v4/integrationTest  13.605s
```

Hence, fixes #1948.

(P.S.: Would be cool to skip those `TestDualProviders` optionally.)