### PR TITLE
TEST: Add flag to skip DualProvider tests if needed

### DIFF
--- a/integrationTest/integration_test.go
+++ b/integrationTest/integration_test.go
@@ -27,6 +27,7 @@ var endIdx = flag.Int("end", -1, "Test index to stop after")
 var verbose = flag.Bool("verbose", false, "Print corrections as you run them")
 var printElapsed = flag.Bool("elapsed", false, "Print elapsed time for each testgroup")
 var enableCFWorkers = flag.Bool("cfworkers", true, "Set false to disable CF worker tests")
+var skipDualProvTest = flag.Bool("skipdualprovtest", false, "Add parameter to disable TestDualProviders tests")
 
 func init() {
 	testing.Init()
@@ -336,6 +337,10 @@ func runTests(t *testing.T, prv providers.DNSServiceProvider, domainName string,
 }
 
 func TestDualProviders(t *testing.T) {
+	if *skipDualProvTest {
+		t.Skip("Skipping.  DualProvidersTest disabled.")
+		return
+	}
 	p, domain, _, _ := getProvider(t)
 	if p == nil {
 		return


### PR DESCRIPTION
This adds optional parameter `-skipdualprovtest` to disable the DualProvider tests on every run, if needed or not. The `FAIL` can be ignored because this changes are based of the master branch without my recent INWX PTR fix.

```
$ go test -v -verbose -timeout 0 -provider INWX -start 28 -end 28 -skipdualprovtest
=== RUN   TestDNSProviders
=== RUN   TestDNSProviders/domain.tld
=== RUN   TestDNSProviders/domain.tld/Clean_Slate:Empty
=== RUN   TestDNSProviders/domain.tld/28:PTR:Create_PTR_record
    integration_test.go:245:
        + CREATE PTR 4.domain.tld foo.com. ttl=300
[...]
=== RUN   TestDualProviders
    integration_test.go:341: Skipping.  DualProvidersTest disabled.
--- SKIP: TestDualProviders (0.00s)
=== RUN   TestNameserverDots
=== RUN   TestNameserverDots/No_trailing_dot_in_nameserver
--- PASS: TestNameserverDots (0.38s)
    --- PASS: TestNameserverDots/No_trailing_dot_in_nameserver (0.00s)
FAIL
exit status 1
FAIL    github.com/StackExchange/dnscontrol/v4/integrationTest  5.213s
```