### PR TITLE
CHORE: Add runtime dependencies for container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,13 @@
 
 FROM alpine:3.18.0@sha256:02bb6f428431fbc2809c5d1b41eab5a68350194fb508869a33cb1af4444c9b11 as RUN
 
-#RUN --mount=type=cache,target=/var/cache/apk \
-#    apk update \
-#    && apk add ca-certificates \
-#    && update-ca-certificates
+# Add runtime dependencies
+# - tzdata: Go time required external dependency eg: TRANSIP and possibly others
+# - ca-certificates: Needed for https to work properly
+RUN --mount=type=cache,target=/var/cache/apk \
+    apk update \
+    && apk add tzdata ca-certificates \
+    && update-ca-certificates
 
 COPY dnscontrol /usr/local/bin/
 


### PR DESCRIPTION
Add the required runtime dependencies for running dnscontrol in a container.

* tzdata - Go time required external dependency. See: #2422
* ca-certificates - Required for HTTPS to work out-of-the-box without throwing CA errors

Fixes: #2422
Link: #2429