### PR TITLE
dnscontrol get-zones --help typo fix

### DIFF
--- a/commands/getZones.go
+++ b/commands/getZones.go
@@ -70,7 +70,7 @@ EXAMPLES:
    dnscontrol get-zones gmain GANDI_V5 example.com other.com
    dnscontrol get-zones cfmain CLOUDFLAREAPI all
    dnscontrol get-zones --format=tsv bind BIND example.com
-   dnscontrol get-zones --format=djs --out=draft.js glcoud GCLOUD example.com`,
+   dnscontrol get-zones --format=djs --out=draft.js gcloud GCLOUD example.com`,
 	}
 }())
 


### PR DESCRIPTION
Fixing a teensy nitpick typo in the get-zones cli help

glcoud -> gcloud


```go
 EXAMPLES:
...
      dnscontrol get-zones --format=djs --out=draft.js glcoud GCLOUD example.com
``` 