### PR TITLE
Provide a cmd switch for disabling colors

### DIFF
--- a/commands/commands.go
+++ b/commands/commands.go
@@ -12,6 +12,8 @@ import (
 	"github.com/StackExchange/dnscontrol/v4/pkg/js"
 	"github.com/StackExchange/dnscontrol/v4/pkg/printer"
 	"github.com/urfave/cli/v2"
+
+	"github.com/fatih/color"
 )
 
 // categories of commands
@@ -67,6 +69,12 @@ func Run(v string) int {
 			Usage:       "Enable replacement diff algorithm",
 			Destination: &diff2.EnableDiff2,
 			Value:       true,
+		},
+		&cli.BoolFlag{
+			Name:        "no-colors",
+			Usage:       "Disable colors",
+			Destination: &color.NoColor,
+			Value:       false,
 		},
 	}
 	sort.Sort(cli.CommandsByName(commands))


### PR DESCRIPTION
... called `--no-colors`.

Fixes #2499

<!--
Before you submit a pull request, please make sure you've run the following commands from the root directory.

go vet ./...
go fmt ./...
go generate ./...
go mod tidy
!-->

