### PR TITLE
ns1: fix a leftover change from ns1-go update

### DIFF
--- a/providers/ns1/ns1Provider.go
+++ b/providers/ns1/ns1Provider.go
@@ -68,7 +68,7 @@ func newProvider(creds map[string]string, meta json.RawMessage) (providers.DNSSe
 // no explicit sleep is needed, it is implemented in NS1 client's RateLimitStrategy we used
 func (n *nsone) GetZone(domain string) (*dns.Zone, error) {
 	for rtr := 0; ; rtr++ {
-		z, httpResp, err := n.Zones.Get(domain)
+		z, httpResp, err := n.Zones.Get(domain, true)
 		if httpResp.StatusCode == http.StatusTooManyRequests && rtr < CLIENT_RETRIES {
 			continue
 		}


### PR DESCRIPTION
PR #2506 getting merged while #2516 was still in flight introduced another place we needed to fix to make our code work with NS1's updated go API, which wasn't covered.

This changeset covers this as well.

<!--
Before you submit a pull request, please make sure you've run the following commands from the root directory.

go vet ./...
go fmt ./...
go generate ./...
go mod tidy
!-->

