### PR TITLE
NS1: Enable BYO secrets for NS1 in the CI/CD pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -104,6 +104,7 @@ jobs:
         HEDNS_DOMAIN: ${{ vars.HEDNS_DOMAIN }}
         HEXONET_DOMAIN: ${{ vars.HEXONET_DOMAIN }}
         NAMEDOTCOM_DOMAIN: ${{ vars.NAMEDOTCOM_DOMAIN }}
+        NS1_DOMAIN: ${{ vars.NS1_DOMAIN }}
         POWERDNS_DOMAIN: ${{ vars.POWERDNS_DOMAIN }}
         ROUTE53_DOMAIN: ${{ vars.ROUTE53_DOMAIN }}
         TRANSIP_DOMAIN: ${{ vars.TRANSIP_DOMAIN }}
@@ -146,6 +147,8 @@ jobs:
         NAMEDOTCOM_KEY: ${{ secrets.NAMEDOTCOM_KEY }}
         NAMEDOTCOM_URL: ${{ secrets.NAMEDOTCOM_URL }}
         NAMEDOTCOM_USER: ${{ secrets.NAMEDOTCOM_USER }}
+
+        NS1_TOKEN: ${{ secrets.NS1_TOKEN }}
 
         POWERDNS_APIKEY: ${{ secrets.POWERDNS_APIKEY }}
         POWERDNS_APIURL: ${{ secrets.POWERDNS_APIURL }}
@@ -208,6 +211,7 @@ jobs:
       HEDNS_DOMAIN: ${{ vars.HEDNS_DOMAIN }}
       HEXONET_DOMAIN: ${{ vars.HEXONET_DOMAIN }}
       NAMEDOTCOM_DOMAIN: ${{ vars.NAMEDOTCOM_DOMAIN }}
+      NS1_DOMAIN: ${{ vars.NS1_DOMAIN }}
       POWERDNS_DOMAIN: ${{ vars.POWERDNS_DOMAIN }}
       ROUTE53_DOMAIN: ${{ vars.ROUTE53_DOMAIN }}
       TRANSIP_DOMAIN: ${{ vars.TRANSIP_DOMAIN }}
@@ -250,6 +254,8 @@ jobs:
       NAMEDOTCOM_KEY: ${{ secrets.NAMEDOTCOM_KEY }}
       NAMEDOTCOM_URL: ${{ secrets.NAMEDOTCOM_URL }}
       NAMEDOTCOM_USER: ${{ secrets.NAMEDOTCOM_USER }}
+
+      NS1_TOKEN: ${{ secrets.NS1_TOKEN }}
 
       POWERDNS_APIKEY: ${{ secrets.POWERDNS_APIKEY }}
       POWERDNS_APIURL: ${{ secrets.POWERDNS_APIURL }}


### PR DESCRIPTION
Enable NS1 credentials so that we can spawn CI tests with them.

<!--
Before you submit a pull request, please make sure you've run the following commands from the root directory.

go vet ./...
go fmt ./...
go generate ./...
go mod tidy
!-->

