### PR TITLE
ci(gorelease): move to github action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,8 +21,6 @@ jobs:
         key: linux-go-${{ hashFiles('go.sum') }}-${{ env.cache-key }}
         restore-keys: linux-go-${{ hashFiles('go.sum') }}-${{ env.cache-key }}
         path: ${{ env.go-mod-path }}
-    - name: Install goreleaser
-      run: go install github.com/goreleaser/goreleaser@latest
     - run: mkdir -p "$TEST_RESULTS"
     - name: Run unit tests
       run: |
@@ -44,15 +42,26 @@ jobs:
         echo "TAG_NAME=$(git config --global --add safe.directory /__w/dnscontrol/dnscontrol ; git describe)" >> $GITHUB_OUTPUT
     - name: Reveal version
       run: echo ${{ steps.version.outputs.TAG_NAME }}
-
-    - name: Build binaries (if tagged)
+    -
+      id: build_binaries_tagged
+      name: Build binaries (if tagged)
       if: github.ref_type == 'tag'
-      run: goreleaser build
+      uses: goreleaser/goreleaser-action@v4
+      with:
+        distribution: goreleaser
+        version: latest
+        args: build
       env:
         GORELEASER_CURRENT_TAG: ${{ steps.version.outputs.TAG_NAME }}
-    - name: Build binaries (not tagged)
+    -
+      id: build_binaries_not_tagged
+      name: Build binaries (not tagged)
       if: github.ref_type != 'tag'
-      run: goreleaser build --snapshot
+      uses: goreleaser/goreleaser-action@v4
+      with:
+        distribution: goreleaser
+        version: latest
+        args: build --snapshot
       env:
         GORELEASER_CURRENT_TAG: ${{ steps.version.outputs.TAG_NAME }}
   integration-test-providers:

--- a/.github/workflows/draft_release.yml
+++ b/.github/workflows/draft_release.yml
@@ -38,9 +38,6 @@ jobs:
       with:
         go-version: ^1.20
 
-    - name: Install goreleaser
-      run: go install github.com/goreleaser/goreleaser@latest
-
 # For some reason goreleaser isn't correctly setting the version
 # string used by "dnscontrol version".  Therefore, we're forcing the
 # string using the GORELEASER_CURRENT_TAG feature.
@@ -53,9 +50,14 @@ jobs:
 
     - name: Reveal version
       run: echo ${{ steps.version.outputs.TAG_NAME }}
-
-    - name: Goreleaser release
-      run: goreleaser release
+    -
+      id: release
+      name: Goreleaser release
+      uses: goreleaser/goreleaser-action@v4
+      with:
+        distribution: goreleaser
+        version: latest
+        args: release
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         GORELEASER_CURRENT_TAG: ${{ steps.version.outputs.TAG_NAME }}


### PR DESCRIPTION
## Issue

Installing gorelease in separate step as part of CI

## Resolution

Utilize existing gorelease github action for build and draft release
