### PR TITLE
DOCS: Improved docker instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,13 @@ Running `dnscontrol preview` will talk to the providers (here name.com as regist
 
 Running `dnscontrol push` will make those changes with the provider and my dns records will be correctly updated.
 
-See [Getting Started](https://docs.dnscontrol.org/getting-started/getting-started) page on documentation site.
+The easiest way to run DNSControl is to use the Docker container:
+
+```
+docker run --rm -it -v "$(pwd):/dns"  ghcr.io/stackexchange/dnscontrol preview
+```
+
+See [Getting Started](https://docs.dnscontrol.org/getting-started/getting-started) page on documentation site to get started!
 
 ## Benefits
 

--- a/documentation/getting-started.md
+++ b/documentation/getting-started.md
@@ -23,19 +23,10 @@ sudo port install dnscontrol
 
 ### Docker
 
-You can use DNSControl locally using the Docker image from [Docker hub](https://hub.docker.com/r/stackexchange/dnscontrol/) and the command below.
+You can use DNSControl locally using the Docker image from [Docker hub](https://hub.docker.com/r/stackexchange/dnscontrol/)  or [Github Container Registry](https://github.com/stackexchange/dnscontrol/pkgs/container/dnscontrol) and the command below.
 
 ```shell
-docker run --rm \
-  -it \
-  -v $(pwd)/dnsconfig.js:/dns/dnsconfig.js \
-  -v $(pwd)/creds.json:/dns/creds.json \
-  -v $(pwd)/spfcache.updated.json:/dns/spfcache.updated.json \
-  -v $(pwd)/spfcache.json:/dns/spfcache.json \
-  -v $(pwd)/zones/:/dns/zones/ \
-  -u $(id -u ${USER}):$(id -g ${USER}) \
-  stackexchange/dnscontrol \
-  preview
+  docker run --rm -it -v "$(pwd):/dns"  ghcr.io/stackexchange/dnscontrol preview
 ```
 
 ### Binaries


### PR DESCRIPTION
The old example specifies each file DNSControl might want to access, which is brittle.  It also doesn't work for the "fmt" subcommand.

The new example it shorter and works for all subcommands.

<!--
Before you submit a pull request, please make sure you've run the following commands from the root directory.

go vet ./...
go fmt ./...
go generate ./...
go mod tidy
!-->

