### PR TITLE
NEW FEATURE: Added "push --report" flag which generates JSON report of changes made

### DIFF
--- a/commands/previewPush.go
+++ b/commands/previewPush.go
@@ -47,10 +47,10 @@ type PreviewArgs struct {
 }
 
 type ReportItem struct {
-	Domain      string
-	Corrections int
-	Provider    string
-	Registrar   string
+	Domain      string `json:"domain"`
+	Corrections int    `json:"corrections"`
+	Provider    string `json:"provider"`
+	Registrar   string `json:"registrar"`
 }
 
 func (args *PreviewArgs) flags() []cli.Flag {
@@ -296,7 +296,7 @@ func run(args PreviewArgs, push bool, interactive bool, out printer.CLI, report 
 		return fmt.Errorf("there are pending changes")
 	}
 	if report != nil {
-		f, err := os.OpenFile(*report, os.O_CREATE|os.O_WRONLY, 0644)
+		f, err := os.OpenFile(*report, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
 		if err != nil {
 			return err
 		}

--- a/commands/previewPush.go
+++ b/commands/previewPush.go
@@ -49,8 +49,8 @@ type PreviewArgs struct {
 type ReportItem struct {
 	Domain      string `json:"domain"`
 	Corrections int    `json:"corrections"`
-	Provider    string `json:"provider"`
-	Registrar   string `json:"registrar"`
+	Provider    string `json:"provider,omitempty"`
+	Registrar   string `json:"registrar,omitempty"`
 }
 
 func (args *PreviewArgs) flags() []cli.Flag {
@@ -250,7 +250,6 @@ func run(args PreviewArgs, push bool, interactive bool, out printer.CLI, report 
 					Domain:      domain.Name,
 					Corrections: len(corrections),
 					Provider:    provider.Name,
-					Registrar:   domain.RegistrarName,
 				})
 				anyErrors = printOrRunCorrections(domain.Name, provider.Name, corrections, out, push, interactive, notifier) || anyErrors
 			}
@@ -276,7 +275,6 @@ func run(args PreviewArgs, push bool, interactive bool, out printer.CLI, report 
 			reportItems = append(reportItems, ReportItem{
 				Domain:      domain.Name,
 				Corrections: len(corrections),
-				Provider:    domain.RegistrarName,
 				Registrar:   domain.RegistrarName,
 			})
 			anyErrors = printOrRunCorrections(domain.Name, domain.RegistrarName, corrections, out, push, interactive, notifier) || anyErrors

--- a/commands/previewPush.go
+++ b/commands/previewPush.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"strings"
@@ -43,6 +44,13 @@ type PreviewArgs struct {
 	WarnChanges bool
 	NoPopulate  bool
 	Full        bool
+}
+
+type ReportItem struct {
+	Domain      string
+	Corrections int
+	Provider    string
+	Registrar   string
 }
 
 func (args *PreviewArgs) flags() []cli.Flag {
@@ -93,6 +101,7 @@ var _ = cmd(catMain, func() *cli.Command {
 type PushArgs struct {
 	PreviewArgs
 	Interactive bool
+	Report      string
 }
 
 func (args *PushArgs) flags() []cli.Flag {
@@ -102,21 +111,26 @@ func (args *PushArgs) flags() []cli.Flag {
 		Destination: &args.Interactive,
 		Usage:       "Interactive. Confirm or Exclude each correction before they run",
 	})
+	flags = append(flags, &cli.StringFlag{
+		Name:        "report",
+		Destination: &args.Report,
+		Usage:       `Generate a machine-parseable report of performed corrections.`,
+	})
 	return flags
 }
 
 // Preview implements the preview subcommand.
 func Preview(args PreviewArgs) error {
-	return run(args, false, false, printer.DefaultPrinter)
+	return run(args, false, false, printer.DefaultPrinter, nil)
 }
 
 // Push implements the push subcommand.
 func Push(args PushArgs) error {
-	return run(args.PreviewArgs, true, args.Interactive, printer.DefaultPrinter)
+	return run(args.PreviewArgs, true, args.Interactive, printer.DefaultPrinter, &args.Report)
 }
 
 // run is the main routine common to preview/push
-func run(args PreviewArgs, push bool, interactive bool, out printer.CLI) error {
+func run(args PreviewArgs, push bool, interactive bool, out printer.CLI, report *string) error {
 	// TODO: make truly CLI independent. Perhaps return results on a channel as they occur
 
 	// This is a hack until we have the new printer replacement.
@@ -151,7 +165,7 @@ func run(args PreviewArgs, push bool, interactive bool, out printer.CLI) error {
 	// create a WaitGroup with the length of domains for the anonymous functions (later goroutines) to wait for
 	var wg sync.WaitGroup
 	wg.Add(len(cfg.Domains))
-
+	var reportItems []ReportItem
 	// For each domain in dnsconfig.js...
 	for _, domain := range cfg.Domains {
 		// Run preview or push operations per domain as anonymous function, in preparation for the later use of goroutines.
@@ -232,6 +246,12 @@ func run(args PreviewArgs, push bool, interactive bool, out printer.CLI) error {
 				totalCorrections += len(corrections)
 				// When diff1 goes away, the call to printReports() should be moved to HERE.
 				//printReports(domain.Name, provider.Name, reports, out, push, notifier)
+				reportItems = append(reportItems, ReportItem{
+					Domain:      domain.Name,
+					Corrections: len(corrections),
+					Provider:    provider.Name,
+					Registrar:   domain.RegistrarName,
+				})
 				anyErrors = printOrRunCorrections(domain.Name, provider.Name, corrections, out, push, interactive, notifier) || anyErrors
 			}
 
@@ -253,6 +273,12 @@ func run(args PreviewArgs, push bool, interactive bool, out printer.CLI) error {
 				return
 			}
 			totalCorrections += len(corrections)
+			reportItems = append(reportItems, ReportItem{
+				Domain:      domain.Name,
+				Corrections: len(corrections),
+				Provider:    domain.RegistrarName,
+				Registrar:   domain.RegistrarName,
+			})
 			anyErrors = printOrRunCorrections(domain.Name, domain.RegistrarName, corrections, out, push, interactive, notifier) || anyErrors
 		}(domain)
 	}
@@ -268,6 +294,20 @@ func run(args PreviewArgs, push bool, interactive bool, out printer.CLI) error {
 	}
 	if totalCorrections != 0 && args.WarnChanges {
 		return fmt.Errorf("there are pending changes")
+	}
+	if report != nil {
+		f, err := os.OpenFile(*report, os.O_CREATE|os.O_WRONLY, 0644)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+		b, err := json.MarshalIndent(reportItems, "", "  ")
+		if err != nil {
+			return err
+		}
+		if _, err := f.Write(b); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/documentation/SUMMARY.md
+++ b/documentation/SUMMARY.md
@@ -154,6 +154,7 @@
 * [Nameservers and Delegations](nameservers.md)
 * [Notifications](notifications.md)
 * [Useful code tricks](code-tricks.md)
+* [JSON Reports](json-reports.md)
 
 ## Developer info
 

--- a/documentation/json-reports.md
+++ b/documentation/json-reports.md
@@ -1,0 +1,34 @@
+# JSON Reports
+
+DNSControl has build in functionality to generate a machine-parseable report after pushing changes. This report is JSON formated and contains the zonename, the provider or registrar name and the amount of performed changes.
+
+## Usage
+
+To enable the report option you must use the `push` operation in combination with the `--report <filename>` option. This generates the json file.
+
+{% code title="report.json" %}
+```json
+[
+  {
+    "domain": "private.example.com",
+    "corrections": 10,
+    "provider": "bind"
+  },
+  {
+    "domain": "private.example.com",
+    "corrections": 0,
+    "registrar": "none"
+  },
+  {
+    "domain": "admin.example.com",
+    "corrections": 5,
+    "provider": "bind"
+  },
+  {
+    "domain": "admin.example.com",
+    "corrections": 0,
+    "registrar": "none"
+  }
+]
+```
+{% endcode %}


### PR DESCRIPTION
We want to execute some actions after running dnscontrol. To reduce the amount of actions and improve the speed this PR adds a report option that generates a JSON file containing the Domain, the amount of performed actions and the Provider/Registrar. 

Afterwards we can parse the json and identify the domains that were changed and ignore those that kept unchanged. 