### PR TITLE
NETLIFY: fix SRV priority and allow apex NS records

### DIFF
--- a/providers/netlify/api.go
+++ b/providers/netlify/api.go
@@ -48,7 +48,7 @@ type dnsRecordCreate struct {
 	Flag     int64  `json:"flag"`
 	Hostname string `json:"hostname,omitempty"`
 	Port     int64  `json:"port,omitempty"`
-	Priority int64  `json:"priority,omitempty"`
+	Priority int64  `json:"priority"`
 	Tag      string `json:"tag,omitempty"`
 	TTL      int64  `json:"ttl,omitempty"`
 	Type     string `json:"type,omitempty"`

--- a/providers/netlify/netlifyProvider.go
+++ b/providers/netlify/netlifyProvider.go
@@ -8,7 +8,6 @@ import (
 	"github.com/StackExchange/dnscontrol/v4/models"
 	"github.com/StackExchange/dnscontrol/v4/pkg/diff"
 	"github.com/StackExchange/dnscontrol/v4/pkg/diff2"
-	"github.com/StackExchange/dnscontrol/v4/pkg/printer"
 	"github.com/StackExchange/dnscontrol/v4/providers"
 	"github.com/miekg/dns"
 )
@@ -144,43 +143,8 @@ func (n *netlifyProvider) GetZoneRecords(domain string, meta map[string]string) 
 	return cleanRecords, nil
 }
 
-// Return true if the string ends in one of Netlify's name server domains
-// False if anything else
-func isNetlifyNameServerDomain(name string) bool {
-	for _, i := range nameServerSuffixes {
-		if strings.HasSuffix(name, i) {
-			return true
-		}
-	}
-	return false
-}
-
-// remove all non-netlify NS records from our desired state.
-// if any are found, print a warning
-func removeOtherApexNS(dc *models.DomainConfig) {
-	newList := make([]*models.RecordConfig, 0, len(dc.Records))
-	for _, rec := range dc.Records {
-		if rec.Type == "NS" {
-			// apex NS inside netlify are expected.
-			// We ignore them, warning as needed.
-			// Child delegations are supported so, we allow non-apex NS records.
-			if rec.GetLabelFQDN() == dc.Name {
-				if !isNetlifyNameServerDomain(rec.GetTargetField()) {
-					printer.Printf("Warning: Netlify does not allow NS records to be modified. %s will not be added.\n", rec.GetTargetField())
-				}
-				continue
-			}
-		}
-		newList = append(newList, rec)
-	}
-	dc.Records = newList
-}
-
 // GetZoneRecordsCorrections returns a list of corrections that will turn existing records into dc.Records.
 func (n *netlifyProvider) GetZoneRecordsCorrections(dc *models.DomainConfig, records models.Records) ([]*models.Correction, error) {
-
-	removeOtherApexNS(dc)
-
 	var corrections []*models.Correction
 	var differ diff.Differ
 	if !diff2.EnableDiff2 {


### PR DESCRIPTION
1. fix SRV priority

In the following case,

```
SRV('_jmap._tcp', 0, 1, 443, 'api.fastmail.com.')
```

with the `omitempty` attr, Netlify will treat priority as unset and put a default value 10 in it

Which will cause DNSControl to try to correct it on every push

```
MODIFY SRV _jmap._tcp.example.com: (10 1 443 api.fastmail.com. ttl=3600) -> (0 1 443 api.fastmail.com. ttl=3600)
```

This PR removes `omitempty` from priority

2. allow apex NS records

Netlify seems to allow changing the apex NS records now, so I remove the limitation.

![image](https://github.com/StackExchange/dnscontrol/assets/4951333/33232240-0651-4333-a6fd-83f300c90d99)
(web dashboard)

![image](https://github.com/StackExchange/dnscontrol/assets/4951333/f81f9992-c13a-4492-952e-51af875d5490)
(dig result)

---

All testes passed.

```
--- PASS: TestDNSProviders (628.04s)
    --- PASS: TestDNSProviders/example.com (628.04s)
        --- PASS: TestDNSProviders/example.com/Clean_Slate:Empty (3.40s)
        --- PASS: TestDNSProviders/example.com/00:A:Create_A (2.39s)
        --- PASS: TestDNSProviders/example.com/00:A:Change_A_target (3.63s)
        --- PASS: TestDNSProviders/example.com/Post_cleanup:Empty (1.58s)
        --- PASS: TestDNSProviders/example.com/01:Apex:Create_A (2.47s)
        --- PASS: TestDNSProviders/example.com/01:Apex:Change_A_target (3.23s)
        --- PASS: TestDNSProviders/example.com/Post_cleanup:Empty#01 (1.79s)
        --- PASS: TestDNSProviders/example.com/02:Protocol-Wildcard:Create_wildcard (3.56s)
        --- PASS: TestDNSProviders/example.com/02:Protocol-Wildcard:Delete_wildcard (2.91s)
        --- PASS: TestDNSProviders/example.com/Post_cleanup:Empty#02 (2.00s)
        --- PASS: TestDNSProviders/example.com/03:CNAME:Create_a_CNAME (3.03s)
        --- PASS: TestDNSProviders/example.com/03:CNAME:Change_CNAME_target (3.22s)
        --- PASS: TestDNSProviders/example.com/Post_cleanup:Empty#03 (1.53s)
        --- PASS: TestDNSProviders/example.com/04:MX:Create_MX (3.91s)
        --- PASS: TestDNSProviders/example.com/04:MX:Change_MX_target (3.28s)
        --- PASS: TestDNSProviders/example.com/04:MX:Change_MX_p (3.40s)
        --- PASS: TestDNSProviders/example.com/Post_cleanup:Empty#04 (1.62s)
        --- PASS: TestDNSProviders/example.com/05:TXT:Create_TXT (2.42s)
        --- PASS: TestDNSProviders/example.com/05:TXT:Change_TXT_target (3.43s)
        --- PASS: TestDNSProviders/example.com/Post_cleanup:Empty#05 (1.59s)
        --- PASS: TestDNSProviders/example.com/06:ManyAtOnce:CreateManyAtLabel (6.49s)
        --- PASS: TestDNSProviders/example.com/06:ManyAtOnce:Empty (3.23s)
        --- PASS: TestDNSProviders/example.com/06:ManyAtOnce:Create_an_A_record (2.58s)
        --- PASS: TestDNSProviders/example.com/06:ManyAtOnce:Add_at_label1 (2.43s)
        --- PASS: TestDNSProviders/example.com/06:ManyAtOnce:Add_at_label2 (4.28s)
        --- PASS: TestDNSProviders/example.com/Post_cleanup:Empty#06 (3.36s)
        --- PASS: TestDNSProviders/example.com/07:manyTypesAtOnce:CreateManyTypesAtLabel (4.04s)
        --- PASS: TestDNSProviders/example.com/07:manyTypesAtOnce:Empty (3.20s)
        --- PASS: TestDNSProviders/example.com/07:manyTypesAtOnce:Create_an_A_record (4.01s)
        --- PASS: TestDNSProviders/example.com/07:manyTypesAtOnce:Add_Type_At_Label (2.66s)
        --- PASS: TestDNSProviders/example.com/07:manyTypesAtOnce:Add_Type_At_Label#01 (2.83s)
        --- PASS: TestDNSProviders/example.com/Post_cleanup:Empty#07 (3.27s)
        --- PASS: TestDNSProviders/example.com/08:Attl:Create_Arc (2.42s)
        --- PASS: TestDNSProviders/example.com/08:Attl:Change_TTL (3.40s)
        --- PASS: TestDNSProviders/example.com/Post_cleanup:Empty#08 (1.59s)
        --- PASS: TestDNSProviders/example.com/09:TTL:Start (4.66s)
        --- PASS: TestDNSProviders/example.com/09:TTL:Change_a_ttl (5.31s)
        --- PASS: TestDNSProviders/example.com/09:TTL:Change_single_target_from_set (3.25s)
        --- PASS: TestDNSProviders/example.com/09:TTL:Change_all_ttls (7.56s)
        --- PASS: TestDNSProviders/example.com/Post_cleanup:Empty#09 (3.20s)
        --- PASS: TestDNSProviders/example.com/10:add_to_label_and_change_orig_ttl:Setup (2.37s)
        --- PASS: TestDNSProviders/example.com/10:add_to_label_and_change_orig_ttl:Add_at_same_label,_new_ttl (5.38s)
        --- PASS: TestDNSProviders/example.com/Post_cleanup:Empty#10 (2.33s)
        --- PASS: TestDNSProviders/example.com/11:TypeChange:Create_A (2.60s)
        --- PASS: TestDNSProviders/example.com/11:TypeChange:Change_to_MX (3.21s)
        --- PASS: TestDNSProviders/example.com/11:TypeChange:Change_back_to_A (3.47s)
        --- PASS: TestDNSProviders/example.com/Post_cleanup:Empty#11 (1.81s)
        --- PASS: TestDNSProviders/example.com/12:TypeChangeHard:Create_a_CNAME (2.63s)
        --- PASS: TestDNSProviders/example.com/12:TypeChangeHard:Change_to_A_record (3.57s)
        --- PASS: TestDNSProviders/example.com/12:TypeChangeHard:Change_back_to_CNAME (3.17s)
        --- PASS: TestDNSProviders/example.com/Post_cleanup:Empty#12 (1.60s)
        --- PASS: TestDNSProviders/example.com/13:CNAME:Record_pointing_to_@ (2.63s)
        --- PASS: TestDNSProviders/example.com/Post_cleanup:Empty#13 (1.59s)
        --- PASS: TestDNSProviders/example.com/14:MX:Record_pointing_to_@ (2.93s)
        --- SKIP: TestDNSProviders/example.com/14:MX:Null_MX (0.00s)
        --- PASS: TestDNSProviders/example.com/Post_cleanup:Empty#14 (1.50s)
        --- PASS: TestDNSProviders/example.com/15:NS:NS_for_subdomain (3.48s)
        --- PASS: TestDNSProviders/example.com/15:NS:Dual_NS_for_subdomain (4.30s)
        --- PASS: TestDNSProviders/example.com/15:NS:NS_Record_pointing_to_@ (6.24s)
        --- PASS: TestDNSProviders/example.com/Post_cleanup:Empty#15 (2.32s)
        --- PASS: TestDNSProviders/example.com/16:complex_TXT:TXT_with_1_single-quote (3.35s)
        --- PASS: TestDNSProviders/example.com/16:complex_TXT:TXT_with_1_backtick (4.51s)
        --- PASS: TestDNSProviders/example.com/16:complex_TXT:TXT_with_1_double-quotes (3.35s)
        --- PASS: TestDNSProviders/example.com/16:complex_TXT:TXT_with_2_double-quotes (3.16s)
        --- PASS: TestDNSProviders/example.com/16:complex_TXT:a_TXT_with_interior_ws (3.21s)
        --- PASS: TestDNSProviders/example.com/16:complex_TXT:TXT_with_ws_at_end (4.09s)
        --- PASS: TestDNSProviders/example.com/Post_cleanup:Empty#16 (1.82s)
        --- PASS: TestDNSProviders/example.com/17:Case_Sensitivity:Create_CAPS (3.48s)
        --- PASS: TestDNSProviders/example.com/17:Case_Sensitivity:Downcase_label (2.66s)
        --- PASS: TestDNSProviders/example.com/17:Case_Sensitivity:Downcase_target (3.64s)
        --- PASS: TestDNSProviders/example.com/17:Case_Sensitivity:Upcase_both (3.28s)
        --- PASS: TestDNSProviders/example.com/Post_cleanup:Empty#17 (2.68s)
        --- PASS: TestDNSProviders/example.com/18:testByLabel:initial (4.44s)
        --- PASS: TestDNSProviders/example.com/18:testByLabel:changeOne (3.37s)
        --- PASS: TestDNSProviders/example.com/18:testByLabel:deleteOne (2.54s)
        --- PASS: TestDNSProviders/example.com/18:testByLabel:addOne (3.84s)
        --- PASS: TestDNSProviders/example.com/Post_cleanup:Empty#18 (2.31s)
        --- PASS: TestDNSProviders/example.com/19:testByRecordSet:initial (6.97s)
        --- PASS: TestDNSProviders/example.com/19:testByRecordSet:changeOne (3.27s)
        --- PASS: TestDNSProviders/example.com/19:testByRecordSet:deleteOne (2.62s)
        --- PASS: TestDNSProviders/example.com/19:testByRecordSet:addOne (2.59s)
        --- PASS: TestDNSProviders/example.com/Post_cleanup:Empty#19 (6.02s)
        --- PASS: TestDNSProviders/example.com/20:IDNA:Internationalized_name (3.53s)
        --- PASS: TestDNSProviders/example.com/20:IDNA:Change_IDN (3.64s)
        --- PASS: TestDNSProviders/example.com/20:IDNA:Internationalized_CNAME_Target (4.35s)
        --- PASS: TestDNSProviders/example.com/Post_cleanup:Empty#20 (1.69s)
        --- PASS: TestDNSProviders/example.com/21:IDNAs_in_CNAME_targets:IDN_CNAME_AND_Target (2.69s)
        --- PASS: TestDNSProviders/example.com/Post_cleanup:Empty#21 (1.82s)
        --- PASS: TestDNSProviders/example.com/22:pager101:99_records (91.51s)
        --- PASS: TestDNSProviders/example.com/22:pager101:100_records (3.91s)
        --- PASS: TestDNSProviders/example.com/22:pager101:101_records (3.35s)
        --- PASS: TestDNSProviders/example.com/Post_cleanup:Empty#22 (78.67s)
        --- PASS: TestDNSProviders/example.com/23:pager601_***SKIPPED(disabled_by_only)***:Empty (1.04s)
        --- PASS: TestDNSProviders/example.com/24:pager1201_***SKIPPED(disabled_by_only)***:Empty (0.83s)
        --- PASS: TestDNSProviders/example.com/25:CAA:CAA_record (2.73s)
        --- PASS: TestDNSProviders/example.com/25:CAA:CAA_change_tag (3.40s)
        --- PASS: TestDNSProviders/example.com/25:CAA:CAA_change_target (3.30s)
        --- PASS: TestDNSProviders/example.com/25:CAA:CAA_change_flag (3.50s)
        --- PASS: TestDNSProviders/example.com/25:CAA:CAA_many_records (3.44s)
        --- PASS: TestDNSProviders/example.com/25:CAA:CAA_whitespace (3.38s)
        --- PASS: TestDNSProviders/example.com/Post_cleanup:Empty#23 (1.86s)
        --- PASS: TestDNSProviders/example.com/26:LOC_***SKIPPED(CanUseLOC_not_supported)***:Empty (0.83s)
        --- PASS: TestDNSProviders/example.com/27:NAPTR_***SKIPPED(CanUseNAPTR_not_supported)***:Empty (0.83s)
        --- PASS: TestDNSProviders/example.com/28:PTR_***SKIPPED(CanUsePTR_not_supported)***:Empty (1.03s)
        --- PASS: TestDNSProviders/example.com/29:SOA_***SKIPPED(CanUseSOA_not_supported)***:Empty (0.85s)
        --- PASS: TestDNSProviders/example.com/30:SRV:SRV_record (3.05s)
        --- PASS: TestDNSProviders/example.com/30:SRV:Second_SRV_record,_same_prio (4.70s)
        --- PASS: TestDNSProviders/example.com/30:SRV:3_SRV (3.69s)
        --- PASS: TestDNSProviders/example.com/30:SRV:Delete_one (4.41s)
        --- PASS: TestDNSProviders/example.com/30:SRV:Change_Target (5.75s)
        --- PASS: TestDNSProviders/example.com/30:SRV:Change_Priority (5.27s)
        --- PASS: TestDNSProviders/example.com/30:SRV:Change_Weight (5.59s)
        --- PASS: TestDNSProviders/example.com/30:SRV:Change_Port (5.30s)
        --- PASS: TestDNSProviders/example.com/30:SRV:Empty (3.55s)
        --- PASS: TestDNSProviders/example.com/30:SRV:Null_Target (3.04s)
        --- PASS: TestDNSProviders/example.com/Post_cleanup:Empty#24 (1.73s)
        --- PASS: TestDNSProviders/example.com/31:SRV:Create_SRV333 (3.01s)
        --- PASS: TestDNSProviders/example.com/31:SRV:Change_TTL999 (3.65s)
        --- PASS: TestDNSProviders/example.com/Post_cleanup:Empty#25 (1.53s)
        --- PASS: TestDNSProviders/example.com/32:SSHFP_***SKIPPED(CanUseSSHFP_not_supported)***:Empty (1.00s)
        --- PASS: TestDNSProviders/example.com/33:TLSA_***SKIPPED(CanUseTLSA_not_supported)***:Empty (0.83s)
        --- PASS: TestDNSProviders/example.com/34:DS_***SKIPPED(CanUseDS_not_supported)***:Empty (0.82s)
        --- PASS: TestDNSProviders/example.com/35:DS_(children_only)_***SKIPPED(CanUseDSForChildren_not_supported)***:Empty (1.03s)
        --- PASS: TestDNSProviders/example.com/36:DS_(children_only)_CLOUDNS_***SKIPPED(CanUseDSForChildren_not_supported)***:Empty (0.82s)
        --- PASS: TestDNSProviders/example.com/37:ALIAS:ALIAS_at_root (2.61s)
        --- PASS: TestDNSProviders/example.com/37:ALIAS:change_it (3.81s)
        --- PASS: TestDNSProviders/example.com/37:ALIAS:ALIAS_at_subdomain (3.39s)
        --- PASS: TestDNSProviders/example.com/37:ALIAS:change_it#01 (3.46s)
        --- PASS: TestDNSProviders/example.com/Post_cleanup:Empty#26 (1.96s)
        --- PASS: TestDNSProviders/example.com/38:AZURE_ALIAS_A_***SKIPPED(CanUseAzureAlias_not_supported)***:Empty (1.23s)
        --- PASS: TestDNSProviders/example.com/39:AZURE_ALIAS_CNAME_***SKIPPED(CanUseAzureAlias_not_supported)***:Empty (0.83s)
        --- PASS: TestDNSProviders/example.com/40:R53_ALIAS2_***SKIPPED(CanUseRoute53Alias_not_supported)***:Empty (0.82s)
        --- PASS: TestDNSProviders/example.com/41:R53_ALIAS_ORDER_***SKIPPED(CanUseRoute53Alias_not_supported)***:Empty (1.04s)
        --- PASS: TestDNSProviders/example.com/42:R53_ALIAS_CNAME_***SKIPPED(CanUseRoute53Alias_not_supported)***:Empty (1.01s)
        --- PASS: TestDNSProviders/example.com/43:R53_ALIAS_Loop_***SKIPPED(CanUseRoute53Alias_not_supported)***:Empty (0.83s)
        --- PASS: TestDNSProviders/example.com/44:R53_alias_pre-existing_***SKIPPED(CanUseRoute53Alias_not_supported)***:Empty (1.01s)
        --- PASS: TestDNSProviders/example.com/45:CF_REDIRECT_***SKIPPED(disabled_by_only)***:Empty (0.82s)
        --- PASS: TestDNSProviders/example.com/46:CF_PROXY_A_create_***SKIPPED(disabled_by_only)***:Empty (0.82s)
        --- PASS: TestDNSProviders/example.com/47:CF_PROXY_A_off_to_X_***SKIPPED(disabled_by_only)***:Empty (1.02s)
        --- PASS: TestDNSProviders/example.com/48:CF_PROXY_A_on_to_X_***SKIPPED(disabled_by_only)***:Empty (1.03s)
        --- PASS: TestDNSProviders/example.com/49:CF_PROXY_A_full1_to_X_***SKIPPED(disabled_by_only)***:Empty (0.81s)
        --- PASS: TestDNSProviders/example.com/50:CF_PROXY_A_full2_to_X_***SKIPPED(disabled_by_only)***:Empty (1.20s)
        --- PASS: TestDNSProviders/example.com/51:CF_PROXY_CNAME_create_***SKIPPED(disabled_by_only)***:Empty (0.81s)
        --- PASS: TestDNSProviders/example.com/52:CF_PROXY_CNAME_off_to_X_***SKIPPED(disabled_by_only)***:Empty (1.02s)
        --- PASS: TestDNSProviders/example.com/53:CF_PROXY_CNAME_on_to_X_***SKIPPED(disabled_by_only)***:Empty (1.02s)
        --- PASS: TestDNSProviders/example.com/54:CF_PROXY_CNAME_full_to_X_***SKIPPED(disabled_by_only)***:Empty (1.06s)
        --- PASS: TestDNSProviders/example.com/55:CF_WORKER_ROUTE_***SKIPPED(disabled_by_only)***:Empty (1.02s)
        --- PASS: TestDNSProviders/example.com/56:NS1_URLFWD_tests_***SKIPPED(disabled_by_only)***:Empty (1.01s)
        --- PASS: TestDNSProviders/example.com/57:IGNORE_main_***SKIPPED(test_for_diff2_only)***:Empty (1.01s)
        --- PASS: TestDNSProviders/example.com/58:IGNORE_apex_***SKIPPED(test_for_diff2_only)***:Empty (0.83s)
        --- PASS: TestDNSProviders/example.com/59:IGNORE_NAME_function_***SKIPPED(test_for_diff2_only)***:Empty (1.21s)
        --- PASS: TestDNSProviders/example.com/60:IGNORE_NAME_apex_***SKIPPED(test_for_diff2_only)***:Empty (0.83s)
        --- PASS: TestDNSProviders/example.com/61:IGNORE_TARGET_function_CNAME:Create_some_records (3.18s)
        --- PASS: TestDNSProviders/example.com/61:IGNORE_TARGET_function_CNAME:ignoring_CNAME=test.foo.com. (1.82s)
        --- PASS: TestDNSProviders/example.com/61:IGNORE_TARGET_function_CNAME:ignoring_CNAME=test.foo.com._and_add (3.36s)
        --- PASS: TestDNSProviders/example.com/Post_cleanup:Empty#27 (3.97s)
        --- PASS: TestDNSProviders/example.com/62:IGNORE_TARGET_function_CNAME*:Create_some_records (5.20s)
        --- PASS: TestDNSProviders/example.com/62:IGNORE_TARGET_function_CNAME*:ignoring_CNAME=test.foo.com. (1.63s)
        --- PASS: TestDNSProviders/example.com/62:IGNORE_TARGET_function_CNAME*:ignoring_CNAME=test.foo.com._and_add (3.17s)
        --- PASS: TestDNSProviders/example.com/Post_cleanup:Empty#28 (4.68s)
        --- PASS: TestDNSProviders/example.com/63:IGNORE_TARGET_function_CNAME**:Create_some_records (5.22s)
        --- PASS: TestDNSProviders/example.com/63:IGNORE_TARGET_function_CNAME**:ignoring_CNAME=test.foo.com. (1.62s)
        --- PASS: TestDNSProviders/example.com/63:IGNORE_TARGET_function_CNAME**:ignoring_CNAME=test.foo.com._and_add (3.61s)
        --- PASS: TestDNSProviders/example.com/Post_cleanup:Empty#29 (4.99s)
        --- PASS: TestDNSProviders/example.com/64:IGNORE_TARGET_b2285_***SKIPPED(test_for_diff2_only)***:Empty (1.03s)
        --- PASS: TestDNSProviders/example.com/65:structured_TXT_***SKIPPED(disabled_by_only)***:Empty (0.80s)
        --- PASS: TestDNSProviders/example.com/66:structured_TXT_as_native_records_***SKIPPED(disabled_by_only)***:Empty (0.84s)
=== RUN   TestDualProviders
    integration_test.go:351:
--- SKIP: TestDualProviders (0.00s)
=== RUN   TestNameserverDots
    integration_test.go:425: Skipping.  DocDualHost == Cannot
--- SKIP: TestNameserverDots (0.28s)
PASS
ok  	github.com/StackExchange/dnscontrol/v4/integrationTest	629.131s
```