### PR TITLE
BUG: Ensure report location is not empty

### DIFF
--- a/commands/previewPush.go
+++ b/commands/previewPush.go
@@ -293,7 +293,7 @@ func run(args PreviewArgs, push bool, interactive bool, out printer.CLI, report 
 	if totalCorrections != 0 && args.WarnChanges {
 		return fmt.Errorf("there are pending changes")
 	}
-	if report != nil {
+	if report != nil && *report != "" {
 		f, err := os.OpenFile(*report, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
 		if err != nil {
 			return err


### PR DESCRIPTION
<!--
Before you submit a pull request, please make sure you've run the following commands from the root directory.

go vet ./...
go fmt ./...
go generate ./...
go mod tidy
!-->

`report` is a pointer, `*report` may be empty, currently it will throw an error when `*report` is empty

close #2559