### PR TITLE
TESTING: un-skip TestDualProviders

### DIFF
--- a/integrationTest/integration_test.go
+++ b/integrationTest/integration_test.go
@@ -348,7 +348,6 @@ func runTests(t *testing.T, prv providers.DNSServiceProvider, domainName string,
 }
 
 func TestDualProviders(t *testing.T) {
-	t.Skip()
 	p, domain, _, _ := getProvider(t)
 	if p == nil {
 		return


### PR DESCRIPTION
It looks like the test was accidentally skipped via https://github.com/StackExchange/dnscontrol/pull/2535 / 6c7a920369b29320b5ae8181e7471b46e3f02696.

The integration tests pass with the HETZNER provider on this PRs revision and also when rebased onto #2575 :tada: 