### PR TITLE
inwx: fix fetchNameserverDomains

### DIFF
--- a/providers/inwx/inwxProvider.go
+++ b/providers/inwx/inwxProvider.go
@@ -401,9 +401,7 @@ func (api *inwxAPI) GetRegistrarCorrections(dc *models.DomainConfig) ([]*models.
 
 // fetchNameserverDomains returns the domains configured in INWX nameservers
 func (api *inwxAPI) fetchNameserverDomains() error {
-	request := &goinwx.DomainListRequest{}
-	request.PageLimit = 2147483647 // int32 max value, highest number API accepts
-	info, err := api.client.Domains.List(request)
+	info, err := api.client.Nameservers.List("")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
fetchNameserverDomains was erroneously pulling configured domains from the registrar side of INWX, instead of the DNS serving side.

api.client.Domains     -> Registrar
api.client.Nameservers -> DNS Hosting

Fixes #2541

<!--
Before you submit a pull request, please make sure you've run the following commands from the root directory.

go vet ./...
go fmt ./...
go generate ./...
go mod tidy
!-->

