### PR TITLE
INWX: Updated docs for limit up to 2,147,483,647 domains

### DIFF
--- a/documentation/providers/inwx.md
+++ b/documentation/providers/inwx.md
@@ -5,7 +5,7 @@ INWX.de is a Berlin-based domain registrar.
 To use this provider, add an entry to `creds.json` with `TYPE` set to `INWX`
 along with your INWX username and password.
 
-Example:
+**Example:**
 
 {% code title="creds.json" %}
 ```json
@@ -19,18 +19,19 @@ Example:
 ```
 {% endcode %}
 
-### Two factor authentication
+### Two-factor authentication
 
-INWX supports two factor authentication via TOTP and does not allow TOTP codes to be reused. This means that you will only be able to log into your INWX account once every 30 seconds.
+INWX supports two-factor authentication via TOTP and does not allow TOTP codes to be reused. This means that you will only be able to log into your INWX account once every 30 seconds.
+
 You will hit this limitation in the following two scenarios:
 
 * You run DNSControl twice very quickly (to e.g. first use preview and then push). Waiting for 30 seconds to pass between these two invocations will work fine though.
-* You use INWX as both the registrar and the DNS provider. In this case, DNSControl will try to login twice too quickly and the second login will fail because a TOTP code will be reused. The only way to support this configuration is to use a INWX account without two factor authentication.
+* You use INWX as both the registrar and the DNS provider. In this case, DNSControl will try to login twice too quickly and the second login will fail because a TOTP code will be reused. The only way to support this configuration is to use a INWX account without two-factor authentication.
 
-If you cannot work around these two limitation it is possible to contact the INWX support to request a sub-account for API access only without two factor authentication.
-See issue [issue 848](https://github.com/StackExchange/dnscontrol/issues/848#issuecomment-692288859) for details.
+If you cannot work around these two limitation it is possible to create and manage sub-account - with specific permission sets - dedicated for API access with two-factor
+authentication disabled. This is possible at [inwx.de/en/account](https://www.inwx.de/en/account).
 
-If two factor authentication has been enabled you will also need to provide a valid TOTP number.
+If two-factor authentication has been enabled you will also need to provide a valid TOTP number.
 This can also be done via an environment variable:
 
 {% code title="creds.json" %}
@@ -53,11 +54,11 @@ INWX_TOTP=12345 dnscontrol preview
 ```
 
 It is also possible to directly provide the shared TOTP secret using the key "totp-key" in `creds.json`.
-This secret is only shown once when two factor authentication is enabled and you'll have to make sure to write it down then.
+This secret is only shown once when two-factor authentication is enabled and you'll have to make sure to write it down then.
 
 **Important Notes**:
 * Anyone with access to this `creds.json` file will have *full* access to your INWX account and will be able to transfer and/or delete your domains
-* Storing the shared secret together with the password weakens two factor authentication because both factors are stored in a single place.
+* Storing the shared secret together with the password weakens two-factor authentication because both factors are stored in a single place.
 
 {% code title="creds.json" %}
 ```json
@@ -73,8 +74,7 @@ This secret is only shown once when two factor authentication is enabled and you
 {% endcode %}
 
 ### Sandbox
-You can optionally also specify sandbox with a value of 1 to
-redirect all requests to the sandbox API instead:
+You can optionally also specify sandbox with a value of 1 to redirect all requests to the sandbox API instead:
 
 {% code title="creds.json" %}
 ```json
@@ -89,13 +89,10 @@ redirect all requests to the sandbox API instead:
 ```
 {% endcode %}
 
-If sandbox is omitted or set to any other value the production
-API will be used.
-
+If sandbox is omitted or set to any other value the production API will be used.
 
 ## Metadata
-This provider does not recognize any special metadata fields unique to
-INWX.
+This provider does not recognize any special metadata fields unique to INWX.
 
 ## Usage
 An example `dnsconfig.js` configuration file
@@ -112,3 +109,7 @@ D("example.com", REG_INWX, DnsProvider(DSP_CF),
 );
 ```
 {% endcode %}
+
+**Note**: The INWX provider implementation currently only supports up to 2,147,483,647 domains. If you exceed
+this limit, it is expected that dnscontrol will fail to recognize some domains. Should you exceed this
+limit, please open an issue on GitHub.


### PR DESCRIPTION
As requested in https://github.com/StackExchange/dnscontrol/issues/2512#issuecomment-1741285970 I have updated the documentation. Also added note regarding the new accounts feature and spelling "two-factor", which I find more accurate.

![image](https://github.com/StackExchange/dnscontrol/assets/2029878/4f36c26b-c36a-410b-b32c-84180e370ce6)
![image](https://github.com/StackExchange/dnscontrol/assets/2029878/6c6aebc4-bbec-4ff2-88d0-7f93ad58a3de)
