### PR TITLE
DOCS: Deprecated get-certs command

### DIFF
--- a/commands/getCerts.go
+++ b/commands/getCerts.go
@@ -19,7 +19,7 @@ var _ = cmd(catUtils, func() *cli.Command {
 	var args GetCertsArgs
 	return &cli.Command{
 		Name:  "get-certs",
-		Usage: "Issue certificates via Let's Encrypt",
+		Usage: "DEPRECATED: Issue certificates via Let's Encrypt",
 		Action: func(c *cli.Context) error {
 			return exit(GetCerts(args))
 		},


### PR DESCRIPTION
<!--
Before you submit a pull request, please make sure you've run the following commands from the root directory.

go vet ./...
go fmt ./...
go generate ./...
go mod tidy
!-->

By testing shell completion https://github.com/StackExchange/dnscontrol/pull/2449 I found that the command `create-domains` contains a `DEPRECATED:` prefix and `get-certs` does not.

https://github.com/StackExchange/dnscontrol/blob/5ae231030eaf32a99b80cc91abae4577d9ee4ccc/commands/createDomains.go#L15

```shell
dnscontrol
```
```diff
NAME:
   dnscontrol - dnscontrol is a compiler and DSL for managing dns zones

USAGE:
   dnscontrol [global options] command [command options] [arguments...]

COMMANDS:
   help, h  Shows a list of commands or help for one command
   main:
     preview  read live configuration and identify changes to be made, without applying them
     push     identify changes to be made, and perform them
   debug:
     check     Check and validate dnsconfig.js. Output to stdout.  Do not access providers.
     print-ir  Output intermediate representation (IR) after running validation and normalization logic.
     version   Print version information
   utility:
     check-creds          Do a small operation to verify credentials (stand-alone)
     create-domains       DEPRECATED: Ensures that all domains in your configuration are activated at their Domain Service Provider (This does not purchase the domain or otherwise interact with Registrars.)
     fmt                  [BETA] Format and prettify a given file
-    get-certs            Issue certificates via Let's Encrypt
+    get-certs            DEPRECATED: Issue certificates via Let's Encrypt
     get-zones, get-zone  gets a zone from a provider (stand-alone)
     write-types          [BETA] Write a TypeScript declaration file in the current directory

GLOBAL OPTIONS:
   -v                 Enable detailed logging (default: false)
   --allow-fetch      Enable JS fetch(), dangerous on untrusted code! (default: false)
   --diff2            Enable replacement diff algorithm (default: true)
   --disableordering  Disables the dns ordering part of the diff2 package (default: false)
   --no-colors        Disable colors (default: false)
   --help, -h         show help
```

```shell
dnscontrol get-certs --help
```
```diff
NAME:
-   dnscontrol get-certs - Issue certificates via Let's Encrypt
+   dnscontrol get-certs - DEPRECATED: Issue certificates via Let's Encrypt

USAGE:
   dnscontrol get-certs [command options] [arguments...]
```

After configuring shell completion https://github.com/StackExchange/dnscontrol/pull/2449:

```shell
./dnscontrol TAB
```
```diff
check                     -- Check and validate dnsconfig.js. Output to stdout.  Do not access providers.
check-creds               -- Do a small operation to verify credentials (stand-alone)
create-domains            -- DEPRECATED: Ensures that all domains in your configuration are activated at their Domain Service Provider (This does not purchas
fmt                       -- [BETA] Format and prettify a given file
-get-certs                -- Issue certificates via Let's Encrypt
+get-certs                -- DEPRECATED: Issue certificates via Let's Encrypt
get-zones       get-zone  -- gets a zone from a provider (stand-alone)
help            h         -- Shows a list of commands or help for one command
preview                   -- read live configuration and identify changes to be made, without applying them
print-ir                  -- Output intermediate representation (IR) after running validation and normalization logic.
push                      -- identify changes to be made, and perform them
version                   -- Print version information
write-types               -- [BETA] Write a TypeScript declaration file in the current directory
```
