### PR TITLE
Change "push -i" prompt text from "Y/n" to "y/N" to match reality

### DIFF
--- a/pkg/printer/printer.go
+++ b/pkg/printer/printer.go
@@ -97,7 +97,7 @@ func (c ConsolePrinter) PrintReport(i int, correction *models.Correction) {
 
 // PromptToRun prompts the user to see if they want to execute a correction.
 func (c ConsolePrinter) PromptToRun() bool {
-	fmt.Fprint(c.Writer, "Run? (Y/n): ")
+	fmt.Fprint(c.Writer, "Run? (y/N): ")
 	txt, err := c.Reader.ReadString('\n')
 	run := true
 	if err != nil {


### PR DESCRIPTION
Per https://askubuntu.com/questions/322600/do-you-want-to-continuey-n-why-the-upper-case , the convention is that the uppercase character is the default.

PromptToRun() defaults to false, so let's prompt with "y/N".

<!--
Before you submit a pull request, please make sure you've run the following commands from the root directory.

go vet ./...
go fmt ./...
go generate ./...
go mod tidy
!-->

