### PR TITLE
DNSMADEEASY: DOCS: Fix provider name from DNS Made Simple to DNS Made Easy

### DIFF
--- a/documentation/SUMMARY.md
+++ b/documentation/SUMMARY.md
@@ -106,7 +106,7 @@
     * [CSC Global](providers/cscglobal.md)
     * [deSEC](providers/desec.md)
     * [DigitalOcean](providers/digitalocean.md)
-    * [DNS Made Simple](providers/dnsmadeeasy.md)
+    * [DNS Made Easy](providers/dnsmadeeasy.md)
     * [DNSimple](providers/dnsimple.md)
     * [DNS-over-HTTPS](providers/dnsoverhttps.md)
     * [DOMAINNAMESHOP](providers/domainnameshop.md)

--- a/providers/dnsmadeeasy/restApi.go
+++ b/providers/dnsmadeeasy/restApi.go
@@ -207,7 +207,7 @@ func (restApi *dnsMadeEasyRestAPI) createRequest(request *apiRequest) (*http.Req
 	return req, nil
 }
 
-// DNS Made Simple only allows 150 request / 5 minutes
+// DNS Made Easy only allows 150 request / 5 minutes
 // backoff is the amount of time to sleep if a "Rate limit exceeded" error is received
 // It is increased up to maxBackoff after each use
 // It is reset after successful request


### PR DESCRIPTION
Fixed incorrect provider name `DNS Made Simple` instead of `DNS Made Easy` in the documentation and some code.