### PR TITLE
INWX: Paginate through Nameserver Records

### DIFF
--- a/documentation/providers/inwx.md
+++ b/documentation/providers/inwx.md
@@ -109,9 +109,3 @@ D("example.com", REG_INWX, DnsProvider(DSP_CF),
 );
 ```
 {% endcode %}
-
-{% hint style="info" %}
-**NOTE**: The INWX provider implementation currently only supports up to 2,147,483,647 domains. If you exceed
-this limit, it is expected that DNSControl will fail to recognize some domains. Should you exceed this
-limit, please [open an issue on GitHub](https://github.com/StackExchange/dnscontrol/issues/new/choose).
-{% endhint %}


### PR DESCRIPTION
Fixes: #2604

This makes [Nameserver.List](https://www.inwx.de/de/help/apidoc/f/ch02s15.html#nameserver.list) requests in batches of 20 until the length of zones equals that reported by the INWX api.

Please review - its been a time since i've done golang :)