### PR TITLE
BUG: GetTargetCombined should not double-escape TXT records

### DIFF
--- a/models/target.go
+++ b/models/target.go
@@ -61,6 +61,8 @@ func (rc *RecordConfig) GetTargetCombined() string {
 
 	if rc.Type == "SOA" {
 		return fmt.Sprintf("%s %v %d %d %d %d %d", rc.target, rc.SoaMbox, rc.SoaSerial, rc.SoaRefresh, rc.SoaRetry, rc.SoaExpire, rc.SoaMinttl)
+	} else if rc.Type == "TXT" {
+		return rc.target // It is already zoneFileQuoted()
 	}
 
 	return rc.zoneFileQuoted()


### PR DESCRIPTION
<!--
Before you submit a pull request, please make sure you've run the following commands from the root directory.

go vet ./...
go fmt ./...
go generate ./...
go mod tidy
!-->

