### PR TITLE
DOCS: Add commands for pre-generated shell completions

### DIFF
--- a/documentation/getting-started.md
+++ b/documentation/getting-started.md
@@ -60,16 +60,19 @@ Shell completion is available for `zsh` and `bash`.
 
 ### zsh
 
+Enable the required completion in zsh. A good tutorial for this is available at [The Valuable Dev](https://thevaluable.dev/zsh-completion-guide-examples/) <sup>[[archived](https://web.archive.org/web/20231015083946/https://thevaluable.dev/zsh-completion-guide-examples/)]</sup>.
+
 Add `eval "$(dnscontrol shell-completion zsh)"` to your `~/.zshrc` file.
 
-This requires completion to be enabled in zsh. A good tutorial for this is available at
-[The Valuable Dev](https://thevaluable.dev/zsh-completion-guide-examples/) <sup>[[archived](https://web.archive.org/web/20231015083946/https://thevaluable.dev/zsh-completion-guide-examples/)]</sup>.
+Or run `dnscontrol shell-completion zsh > /usr/share/zsh/site-functions/_dnscontrol"`.
 
 ### bash
 
+Install the required `bash-completion` package. See [scop/bash-completion](https://github.com/scop/bash-completion/) for instructions.
+
 Add `eval "$(dnscontrol shell-completion bash)"` to your `~/.bashrc` file.
 
-This requires the `bash-completion` package to be installed. See [scop/bash-completion](https://github.com/scop/bash-completion/) for instructions.
+Or run `dnscontrol shell-completion bash > /usr/share/bash-completion/completions/dnscontrol`.
 
 ## 2. Create a place for the config files
 

--- a/documentation/getting-started.md
+++ b/documentation/getting-started.md
@@ -57,18 +57,18 @@ If these don't work, more info is in [#805](https://github.com/StackExchange/dns
 ## 1.1. Shell Completion
 
 Shell completion is available for `zsh` and `bash`.
+It works out of the box if zsh completion is set up. A good tutorial for this is available at [The Valuable Dev](https://thevaluable.dev/zsh-completion-guide-examples/) <sup>[[archived](https://web.archive.org/web/20231015083946/https://thevaluable.dev/zsh-completion-guide-examples/)]</sup>.
+For bash install the required `bash-completion` package. See [scop/bash-completion](https://github.com/scop/bash-completion/) for instructions.
+
+If shell completion is not availiable the completion can be installed manually:
 
 ### zsh
-
-Enable the required completion in zsh. A good tutorial for this is available at [The Valuable Dev](https://thevaluable.dev/zsh-completion-guide-examples/) <sup>[[archived](https://web.archive.org/web/20231015083946/https://thevaluable.dev/zsh-completion-guide-examples/)]</sup>.
 
 Add `eval "$(dnscontrol shell-completion zsh)"` to your `~/.zshrc` file.
 
 Or run `dnscontrol shell-completion zsh > /usr/share/zsh/site-functions/_dnscontrol"`.
 
 ### bash
-
-Install the required `bash-completion` package. See [scop/bash-completion](https://github.com/scop/bash-completion/) for instructions.
 
 Add `eval "$(dnscontrol shell-completion bash)"` to your `~/.bashrc` file.
 


### PR DESCRIPTION
I have added a few words to the documentation to pre-generate the files for shell completion as well. 

@whi-tw wrote something to this topic: https://github.com/StackExchange/dnscontrol/pull/2449#issuecomment-1600825604

> The benefit of not packaging the files is that they can be updated and people will likely automatically start using them without any messing around with local files.

I cant entirely agree with that. A manual change must be done with the existing instructions. This may be possible. But it is not convenient. I cant manually set a completion command for every tool on my system. 

I want to install a tool. And as soon as the tool and the zsh/bash completion are installed, it should work.

A way for pre-generating and packaging is therefore important.

