### PR TITLE
NS1: update ns1 for new txt handling

### DIFF
--- a/providers/ns1/auditrecords.go
+++ b/providers/ns1/auditrecords.go
@@ -11,7 +11,7 @@ import (
 func AuditRecords(records []*models.RecordConfig) []error {
 	a := rejectif.Auditor{}
 
-	a.Add("TXT", rejectif.TxtLongerThan255)
+	a.Add("TXT", rejectif.TxtIsEmpty)
 
 	return a.Audit(records)
 }

--- a/providers/ns1/ns1Provider.go
+++ b/providers/ns1/ns1Provider.go
@@ -302,7 +302,7 @@ func buildRecord(recs models.Records, domain string, id string) *dns.Record {
 		if r.Type == "MX" {
 			rec.AddAnswer(&dns.Answer{Rdata: strings.Fields(fmt.Sprintf("%d %v", r.MxPreference, r.GetTargetField()))})
 		} else if r.Type == "TXT" {
-			rec.AddAnswer(&dns.Answer{Rdata: r.GetTargetTXTSegmented()})
+			rec.AddAnswer(&dns.Answer{Rdata: []string{r.GetTargetField()}})
 		} else if r.Type == "CAA" {
 			rec.AddAnswer(&dns.Answer{
 				Rdata: []string{

--- a/providers/ns1/ns1Provider.go
+++ b/providers/ns1/ns1Provider.go
@@ -302,7 +302,7 @@ func buildRecord(recs models.Records, domain string, id string) *dns.Record {
 		if r.Type == "MX" {
 			rec.AddAnswer(&dns.Answer{Rdata: strings.Fields(fmt.Sprintf("%d %v", r.MxPreference, r.GetTargetField()))})
 		} else if r.Type == "TXT" {
-			rec.AddAnswer(&dns.Answer{Rdata: []string{r.GetTargetField()}})
+			rec.AddAnswer(&dns.Answer{Rdata: []string{r.GetTargetTXTJoined()}})
 		} else if r.Type == "CAA" {
 			rec.AddAnswer(&dns.Answer{
 				Rdata: []string{


### PR DESCRIPTION
* update auditrecords for succeeding tests
  * multiple segments not needed anymore. This was there to cover an edge case of a user setting segments in the dnsconfig file
  * strings can be longer than 255 octets, but not 0.
* update ns1 txt handling. No need for segmenting anymore, ns1 api handles this transparently.

<!--
Before you submit a pull request, please make sure you've run the following commands from the root directory.

go vet ./...
go fmt ./...
go generate ./...
go mod tidy
!-->

