### PR TITLE
CLOUDFLARE: Update docs WRT domain creation

### DIFF
--- a/documentation/providers/cloudflareapi.md
+++ b/documentation/providers/cloudflareapi.md
@@ -197,8 +197,7 @@ D("example2.tld", REG_NONE, DnsProvider(DSP_CLOUDFLARE),
 
 ## New domains
 If a domain does not exist in your Cloudflare account, DNSControl
-will *not* automatically add it. You'll need to do that via the
-control panel manually or via the `dnscontrol create-domains` command.
+will automatically add it when `dnscontrol push` is executed.
 
 
 ## Redirects


### PR DESCRIPTION
Previously it was stated that DNSControl would not create a new domain in Cloudflare unless `dnscontrol create-domains` was executed. That subcommand has now been deprecated and is part of `dnscontrol push`

**Note:** `go vet, go fmt, etc.` were not ran since this is only modifying the documentation and not the code itself.