### PR TITLE
CLOUDNS: remove TxtLongerThan255

### DIFF
--- a/providers/cloudns/auditrecords.go
+++ b/providers/cloudns/auditrecords.go
@@ -19,8 +19,6 @@ func AuditRecords(records []*models.RecordConfig) []error {
 
 	a.Add("TXT", rejectif.TxtHasDoubleQuotes) // Last verified 2021-03-01
 
-	a.Add("TXT", rejectif.TxtLongerThan255) // Last verified 2021-03-01
-
 	a.Add("SRV", rejectif.SrvHasNullTarget) // Last verified 2023-03-30
 
 	return a.Audit(records)


### PR DESCRIPTION
As mention at https://github.com/StackExchange/dnscontrol/pull/2631#issuecomment-1822884141

All test passed. log: https://pb.esd.cc/scout-child-snow