### PR TITLE
CICD: Use GHA concurrency groups to prevent tests from clobbering each other

### DIFF
--- a/.github/workflows/pr_test.yml
+++ b/.github/workflows/pr_test.yml
@@ -171,7 +171,7 @@ jobs:
       TRANSIP_ACCOUNT_NAME: ${{ secrets.TRANSIP_ACCOUNT_NAME }}
       TRANSIP_PRIVATE_KEY: ${{ secrets.TRANSIP_PRIVATE_KEY }}
 
-    concurrency: ${{ matrix.provider }}
+    concurrency:
       group: ${{ github.workflow }}-${{ matrix.provider }}
     strategy:
       fail-fast: false

--- a/.github/workflows/pr_test.yml
+++ b/.github/workflows/pr_test.yml
@@ -94,8 +94,6 @@ jobs:
   integrtests-diff2:
     if: github.ref != 'refs/heads/master' && github.ref != 'refs/heads/main'
     runs-on: ubuntu-latest
-    concurrency:
-      group: ${{ github.workflow }}-${{ matrix.provider }}
     container:
       image: golang:1.21
     needs:
@@ -174,6 +172,7 @@ jobs:
       TRANSIP_PRIVATE_KEY: ${{ secrets.TRANSIP_PRIVATE_KEY }}
 
     concurrency: ${{ matrix.provider }}
+      group: ${{ github.workflow }}-${{ matrix.provider }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/pr_test.yml
+++ b/.github/workflows/pr_test.yml
@@ -94,7 +94,7 @@ jobs:
   integrtests-diff2:
     if: github.ref != 'refs/heads/master' && github.ref != 'refs/heads/main'
     runs-on: ubuntu-latest
-      concurrency:
+    concurrency:
       group: ${{ github.workflow }}-${{ matrix.provider }}
     container:
       image: golang:1.21

--- a/.github/workflows/pr_test.yml
+++ b/.github/workflows/pr_test.yml
@@ -94,6 +94,8 @@ jobs:
   integrtests-diff2:
     if: github.ref != 'refs/heads/master' && github.ref != 'refs/heads/main'
     runs-on: ubuntu-latest
+      concurrency:
+      group: ${{ github.workflow }}-${{ matrix.provider }}
     container:
       image: golang:1.21
     needs:


### PR DESCRIPTION
<!--
Before you submit a pull request, please make sure you've run the following commands from the root directory.

go vet ./...
go fmt ./...
go generate ./...
go mod tidy
!-->

