### PR TITLE
ROUTE53: add R53_EVALUATE_TARGET_HEALTH to documentation summary

### DIFF
--- a/documentation/SUMMARY.md
+++ b/documentation/SUMMARY.md
@@ -90,6 +90,7 @@
     * Service Provider specific
         * Amazon Route 53
             * [R53_ZONE](functions/record/R53_ZONE.md)
+            * [R53_EVALUATE_TARGET_HEALTH](functions/record/R53_EVALUATE_TARGET_HEALTH.md)
 * [Why CNAME/MX/NS targets require a "dot"](why-the-dot.md)
 
 ## Service Providers


### PR DESCRIPTION
This new record modifier wasn't showing up in the documentation. Is there anywhere else that needs to be updated to get this working?