### PR TITLE
DOCS: Fixed providers with "contributor support" table.

### DIFF
--- a/documentation/providers.md
+++ b/documentation/providers.md
@@ -105,7 +105,7 @@ Providers in this category and their maintainers are:
 
 |Name|Maintainer|
 |---|---|
-[[`AZURE_PRIVATE_DNS`](providers/azure_private_dns.md)|@matthewmgamble]
+|[`AZURE_PRIVATE_DNS`](providers/azure_private_dns.md)|@matthewmgamble|
 |[`AKAMAIEDGEDNS`](providers/akamaiedgedns.md)|@svernick|
 |[`AXFRDDNS`](providers/axfrddns.md)|@hnrgrgr|
 |[`CLOUDFLAREAPI`](providers/cloudflareapi.md)|@tresni|


### PR DESCRIPTION
Fixed providers with "contributor support" table.

**Before**

![Screenshot 2023-11-29 at 19 59 15](https://github.com/StackExchange/dnscontrol/assets/1150425/3bc1d4bb-a298-4afc-b4f0-15be4491bcd5)
_https://docs.dnscontrol.org/service-providers/providers#providers-with-contributor-support_

**After**

![Screenshot 2023-11-29 at 20 07 53](https://github.com/StackExchange/dnscontrol/assets/1150425/c3947a4f-a940-463d-ba86-d22913c3a20f)

_https://docs.dnscontrol.org/~/revisions/xp6ldzoScuGcfC9GQfye/service-providers/providers#providers-with-contributor-support_

The origin https://github.com/StackExchange/dnscontrol/pull/2626/commits/4e223aafa0fa19d2100d69d269d791558fc532fe#diff-f49f8c191a562999338f9b4e93db36244e5315e8eb6daced32c61f8eb635cfb9R80