### PR TITLE
DOCS: Fixed the broken provider `ClouDNS` link in the providers table

### DIFF
--- a/documentation/providers.md
+++ b/documentation/providers.md
@@ -109,7 +109,7 @@ Providers in this category and their maintainers are:
 |[`AKAMAIEDGEDNS`](providers/akamaiedgedns.md)|@svernick|
 |[`AXFRDDNS`](providers/axfrddns.md)|@hnrgrgr|
 |[`CLOUDFLAREAPI`](providers/cloudflareapi.md)|@tresni|
-|[`CLOUDNS`](providers/CLOUDNS.md)|@pragmaton|
+|[`CLOUDNS`](providers/cloudns.md)|@pragmaton|
 |[`CSCGLOBAL`](providers/cscglobal.md)|@Air-New-Zealand|
 |[`DESEC`](providers/desec.md)|@D3luxee|
 |[`DIGITALOCEAN`](providers/digitalocean.md)|@Deraen|


### PR DESCRIPTION
<!--
Before you submit a pull request, please make sure you've run the following commands from the root directory.

go vet ./...
go fmt ./...
go generate ./...
go mod tidy
!-->

Fixed the broken provider `ClouDNS` link in the providers table.

**Before**
_https://docs.dnscontrol.org/service-providers/providers#providers-with-contributor-support_

**After**
_https://docs.dnscontrol.org/~/revisions/IYp46WX59nYUeyg6NErx/service-providers/providers#providers-with-contributor-support_
