### PR TITLE
DOCS: Added the missing provider `OpenSRS` page

### DIFF
--- a/documentation/SUMMARY.md
+++ b/documentation/SUMMARY.md
@@ -132,6 +132,7 @@
     * [Netcup](providers/netcup.md)
     * [Netlify](providers/netlify.md)
     * [NS1](providers/ns1.md)
+    * [OpenSRS](providers/opensrs.md)
     * [Oracle Cloud](providers/oracle.md)
     * [OVH](providers/ovh.md)
     * [Packetframe](providers/packetframe.md)

--- a/documentation/providers/opensrs.md
+++ b/documentation/providers/opensrs.md
@@ -1,0 +1,19 @@
+## Configuration
+
+To use this provider, add an entry to `creds.json` with `TYPE` set to `OpenSRS`
+along with your OpenSRS credentials.
+
+## Usage
+
+An example configuration:
+
+{% code title="dnsconfig.js" %}
+```javascript
+var REG_NONE = NewRegistrar("none");
+var DSP_OPENSRS = NewDnsProvider("opensrs");
+
+D("example.com", REG_NONE, DnsProvider(DSP_OPENSRS),
+    A("test", "1.2.3.4")
+);
+```
+{% endcode %}


### PR DESCRIPTION
<!--
Before you submit a pull request, please make sure you've run the following commands from the root directory.

go vet ./...
go fmt ./...
go generate ./...
go mod tidy
!-->

Added the missing provider OpenSRS page so that there is no 404 error and/or GitHub redirect occurs.
_https://docs.dnscontrol.org/~/revisions/zj4vNIIhrMcRjkGVoL3J/service-providers/providers/opensrs_

cc: @philhug would you, as maintainer of this provider, like to further supplement this page with the missing provider details? This includes the provider variables, the method of authorization and/or obtaining an API token. Thanks! 🙏 