### PR TITLE
DOCS: Fix `R53_` broken links

### DIFF
--- a/documentation/SUMMARY.md
+++ b/documentation/SUMMARY.md
@@ -90,7 +90,7 @@
     * Service Provider specific
         * Amazon Route 53
             * [R53_ZONE](functions/record/R53_ZONE.md)
-            * [R53_EVALUATE_TARGET_HEALTH](functions/record/R53_EVALUATE_TARGET_HEALTH.md)
+            * [R53_EVALUATE_TARGET_HEALTH](functions/record/R53\_EVALUATE\_TARGET\_HEALTH.md)
 * [Why CNAME/MX/NS targets require a "dot"](why-the-dot.md)
 
 ## Service Providers

--- a/documentation/functions/domain/R53_ALIAS.md
+++ b/documentation/functions/domain/R53_ALIAS.md
@@ -39,7 +39,7 @@ The zone id can be found depending on the target type:
 * _S3 bucket_ (configured as website): specify the hosted zone ID for the region that you created the bucket in. You can find it in [the List of regions and hosted Zone IDs](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region)
 * _Another Route 53 record_: you can either specify the correct zone id or do not specify anything and DNSControl will figure out the right zone id. (Note: Route53 alias can't reference a record in a different zone).
 
-Target health evaluation can be enabled with the [`R53_EVALUATE_TARGET_HEALTH`](../record/R53_EVALUATE_TARGET_HEALTH.md) record modifier.
+Target health evaluation can be enabled with the [`R53_EVALUATE_TARGET_HEALTH`](../record/R53\_EVALUATE\_TARGET\_HEALTH.md) record modifier.
 
 {% code title="dnsconfig.js" %}
 ```javascript


### PR DESCRIPTION
@jonathanbouvier [commented](https://github.com/StackExchange/dnscontrol/pull/2659#issuecomment-1833834072)

> The link to R53_EVALUATE_TARGET_HEALTH on [R53_ALIAS](https://docs.dnscontrol.org/language-reference/domain-modifiers/service-provider-specific/amazon-route-53/r53_alias) is pointing to https://github.com/StackExchange/dnscontrol/blob/master/documentation/functions/record/R53_EVALUATE_TARGET_HEALTH.md instead of https://docs.dnscontrol.org/language-reference/record-modifiers/service-provider-specific/amazon-route-53/r53_evaluate_target_health
> 
> Any ideas what might be going wrong there?

I fixed the `R53_` broken links by adding a backslash in the file names. See the preview URL:
_https://docs.dnscontrol.org/~/revisions/SMhInsWkrPeuva4GWfmr/language-reference/domain-modifiers/service-provider-specific/amazon-route-53/r53_alias_

_PS. I've never understood when this is necessary. I'm going after it. The question has been submitted to the GitBook support department._