### PR TITLE
DOCS: Rename build filenames

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # DNSControl
 
-[![StackExchange/dnscontrol/build](https://github.com/StackExchange/dnscontrol/actions/workflows/build.yml/badge.svg)](https://github.com/StackExchange/dnscontrol/actions/workflows/build.yml)
+[![StackExchange/dnscontrol/build](https://github.com/StackExchange/dnscontrol/actions/workflows/pr_test.yml/badge.svg)](https://github.com/StackExchange/dnscontrol/actions/workflows/pr_test.yml)
 [![Gitter chat](https://badges.gitter.im/dnscontrol/Lobby.png)](https://gitter.im/dnscontrol/Lobby)
 [![Google Group](https://img.shields.io/badge/google%20group-chat-green.svg)](https://groups.google.com/forum/#!forum/dnscontrol-discuss)
 [![PkgGoDev](https://pkg.go.dev/badge/github.com/StackExchange/dnscontrol)](https://pkg.go.dev/github.com/StackExchange/dnscontrol/v4)

--- a/documentation/byo-secrets.md
+++ b/documentation/byo-secrets.md
@@ -62,16 +62,16 @@ Step 1: Create a branch
 
 Create a branch as you normally would to submit a PR to the project.
 
-Step 2: Update `build.yml`
+Step 2: Update `pr_test.yml`
 
-In this branch, edit `.github/workflows/build.yml`:
+In this branch, edit `.github/workflows/pr_test.yml`:
 
 1. In the `integration-test-providers` section, the name of the provider.
 
 Add your provider's name (alphabetically).
 The line looks something like:
 
-{% code title=".github/workflows/build.yml" %}
+{% code title=".github/workflows/pr_test.yml" %}
 ```
         PROVIDERS: "['BIND','HEXONET','AZURE_DNS','CLOUDFLAREAPI','GCLOUD','NAMEDOTCOM','ROUTE53','CLOUDNS','DIGITALOCEAN','GANDI_V5','HEDNS','INWX','NS1','POWERDNS','TRANSIP']"
 ```
@@ -83,7 +83,7 @@ Add it to the `env` section of `integrtests-diff2`.
 
 For example, the entry for BIND looks like:
 
-{% code title=".github/workflows/build.yml" %}
+{% code title=".github/workflows/pr_test.yml" %}
 ```
         BIND_DOMAIN: ${{ vars.BIND_DOMAIN }}
 ```
@@ -95,7 +95,7 @@ If there are other env variables (for example, for an API key), add that as a "s
 
 For example, the entry for CLOUDFLAREAPI looks like this:
 
-{% code title=".github/workflows/build.yml" %}
+{% code title=".github/workflows/pr_test.yml" %}
 ```
         CLOUDFLAREAPI_ACCOUNTID: ${{ secrets.CLOUDFLAREAPI_ACCOUNTID }}
         CLOUDFLAREAPI_TOKEN: ${{ secrets.CLOUDFLAREAPI_TOKEN }}

--- a/documentation/release-engineering.md
+++ b/documentation/release-engineering.md
@@ -130,7 +130,7 @@ find * -name \*.bak -delete
 GHA is configured to run an integration test for any provider listed in the "provider" list. However the test is skipped if the `*_DOMAIN` variable is not set. For example, the Google Cloud provider integration test is only run if `GCLOUD_DOMAIN` is set.
 
 * Q: Where is the list of providers to run integration tests on?
-* A: In `.github/workflows/build.yml`: (1) the "PROVIDERS" list, (2) the `integrtests-diff2` section.
+* A: In `.github/workflows/pr_test.yml`: (1) the "PROVIDERS" list, (2) the `integrtests-diff2` section.
 
 * Q: Where are non-secret environment variables stored?
 * A: GHA calls them "Variables". Update them here: https://github.com/StackExchange/dnscontrol/settings/variables/actions
@@ -140,7 +140,7 @@ GHA is configured to run an integration test for any provider listed in the "pro
 
 ### How do I add a single new integration test?
 
-1. Edit `.github/workflows/build.yml`
+1. Edit `.github/workflows/pr_test.yml`
 2. Add the `FOO_DOMAIN` variable name of the provider to the "PROVIDERS" list.
 3. Set the `FOO_DOMAIN` variables in GHA via https://github.com/StackExchange/dnscontrol/settings/variables/actions
 4. All other variables should be stored as secrets (for consistency).  Add them to the `integrtests-diff2` section.


### PR DESCRIPTION
Fixed the broken GitHub workflow status badge and the documentation after rename build filenames https://github.com/StackExchange/dnscontrol/pull/2593.