### PR TITLE
CSCGLOBAL: Be less noisy about rate limit delays

### DIFF
--- a/providers/cscglobal/api.go
+++ b/providers/cscglobal/api.go
@@ -647,7 +647,7 @@ func (client *providerClient) geturl(url string) ([]byte, error) {
 	// Default CSCGlobal rate limit is twenty requests per second
 	var backoff = time.Second
 
-	const maxBackoff = time.Second * 15
+	const maxBackoff = time.Second * 25
 
 retry:
 	resp, err := hclient.Do(req)
@@ -666,9 +666,9 @@ retry:
 
 		if string(bodyString) == "Requests exceeded API Rate limit." {
 			// a simple exponential back-off with a 3-minute max.
-			if backoff > 10 {
+			if backoff > (time.Second * 10) {
 				// With this provider backups seem to be pretty common. Only
-				// announce it when the problem gets really bad.
+				// announce it for long delays.
 				printer.Printf("Delaying %v due to ratelimit (CSCGLOBAL)\n", backoff)
 			}
 			time.Sleep(backoff)


### PR DESCRIPTION
<!--
## Before submiting a pull request

Please make sure you've run the following commands from the root directory.

go vet ./...
go fmt ./...
go generate ./...
go mod tidy

## Release changelog section

Help keep the release changelog clear by pre-naming the proper section in the GitHub pull request title.

Some examples:
* CICD: Add required GHA permissions for goreleaser
* DOCS: Fixed providers with "contributor support" table
* ROUTE53: Allow R53_ALIAS records to enable target health evaluation

More examples/context can be found in the file .goreleaser.yml under the 'build' > 'changelog' key.
!-->
