### PR TITLE
AZURE_PRIVATE_DNS: Enable building this provider by default

### DIFF
--- a/providers/_all/all.go
+++ b/providers/_all/all.go
@@ -6,6 +6,7 @@ import (
 	_ "github.com/StackExchange/dnscontrol/v4/providers/akamaiedgedns"
 	_ "github.com/StackExchange/dnscontrol/v4/providers/autodns"
 	_ "github.com/StackExchange/dnscontrol/v4/providers/axfrddns"
+	_ "github.com/StackExchange/dnscontrol/v4/providers/azure_private_dns"
 	_ "github.com/StackExchange/dnscontrol/v4/providers/azuredns"
 	_ "github.com/StackExchange/dnscontrol/v4/providers/bind"
 	_ "github.com/StackExchange/dnscontrol/v4/providers/cloudflare"


### PR DESCRIPTION
Discovered that by default on the master branch (and the current releases) that the AZURE_PRIVATE_DNS module wasn't getting built by default.  Adding it back to all.go so that it gets included by default.
