### PR TITLE
CLOUDFLARE: Fixed bug: Zone not populated with records if domain was created in the same run

### DIFF
--- a/providers/cloudflare/cloudflareProvider.go
+++ b/providers/cloudflare/cloudflareProvider.go
@@ -823,6 +823,7 @@ func (c *cloudflareProvider) EnsureZoneExists(domain string) error {
 	var id string
 	id, err := c.createZone(domain)
 	printer.Printf("Added zone for %s to Cloudflare account: %s\n", domain, id)
+	c.domainIndex = nil // clear the index to let the following functions get a fresh list with nameservers etc..
 	return err
 }
 


### PR DESCRIPTION
Reset the `domainIndex` after the domain has been created at Cloudflare so that the following functions can fetch a new list of nameservers.

This fixes https://github.com/StackExchange/dnscontrol/issues/2652
