### PR TITLE
CHORE: Clarify TXT string limits

### DIFF
--- a/pkg/rejectif/txt.go
+++ b/pkg/rejectif/txt.go
@@ -74,12 +74,14 @@ func TxtLongerThan255(rc *models.RecordConfig) error {
 	return nil
 }
 
-func TxtLongerThan(rc *models.RecordConfig, l int) func(rc *models.RecordConfig) error {
-
+// TxtLongerThan returns a function that audits TXT records for length
+// greater than maxLength.
+func TxtLongerThan(maxLength int) func(rc *models.RecordConfig) error {
 	return func(rc *models.RecordConfig) error {
-		le := l
-		if len(rc.GetTargetTXTJoined()) > l)
-		return fmt.Errorf("TXT records longer than xx octets (chars)")
-	}
+		m := maxLength
+		if len(rc.GetTargetTXTJoined()) > m {
+			return fmt.Errorf("TXT records longer than %d octets (chars)", m)
+		}
+		return nil
 	}
 }

--- a/pkg/rejectif/txt.go
+++ b/pkg/rejectif/txt.go
@@ -73,3 +73,13 @@ func TxtLongerThan255(rc *models.RecordConfig) error {
 	}
 	return nil
 }
+
+func TxtLongerThan(rc *models.RecordConfig, l int) func(rc *models.RecordConfig) error {
+
+	return func(rc *models.RecordConfig) error {
+		le := l
+		if len(rc.GetTargetTXTJoined()) > l)
+		return fmt.Errorf("TXT records longer than xx octets (chars)")
+	}
+	}
+}

--- a/providers/cscglobal/auditrecords.go
+++ b/providers/cscglobal/auditrecords.go
@@ -21,8 +21,6 @@ func AuditRecords(records []*models.RecordConfig) []error {
 
 	a.Add("TXT", rejectif.TxtIsEmpty) // Last verified 2023-12-03
 
-	//a.Add("TXT", rejectif.TxtLongerThan255) // Last verified 2022-06-10
-
 	return a.Audit(records)
 }
 

--- a/providers/digitalocean/auditrecords.go
+++ b/providers/digitalocean/auditrecords.go
@@ -17,11 +17,12 @@ func AuditRecords(records []*models.RecordConfig) []error {
 
 	a.Add("MX", rejectif.MxNull) // Last verified 2020-12-28
 
-	a.Add("TXT", MaxLengthDO) // Last verified 2021-03-01
+	//a.Add("TXT", MaxLengthDO) // Last verified 2021-03-01
+	a.Add("TXT", rejectif.TxtLongerThan(511)) // Last verified 2021-03-01
 
 	a.Add("TXT", rejectif.TxtHasBackslash) // Last verified 2023-11-11
 
-	a.Add("TXT", rejectif.TxtHasDoubleQuotes) // Last verified 2021-03-01
+	//a.Add("TXT", rejectif.TxtHasDoubleQuotes) // Last verified 2021-03-01
 	// Double-quotes not permitted in TXT strings. I have a hunch that
 	// this is due to a broken parser on the DO side.
 

--- a/providers/digitalocean/auditrecords.go
+++ b/providers/digitalocean/auditrecords.go
@@ -17,14 +17,9 @@ func AuditRecords(records []*models.RecordConfig) []error {
 
 	a.Add("MX", rejectif.MxNull) // Last verified 2020-12-28
 
-	//a.Add("TXT", MaxLengthDO) // Last verified 2021-03-01
-	a.Add("TXT", rejectif.TxtLongerThan(511)) // Last verified 2021-03-01
+	a.Add("TXT", MaxLengthDO) // Last verified 2021-03-01
 
 	a.Add("TXT", rejectif.TxtHasBackslash) // Last verified 2023-11-11
-
-	//a.Add("TXT", rejectif.TxtHasDoubleQuotes) // Last verified 2021-03-01
-	// Double-quotes not permitted in TXT strings. I have a hunch that
-	// this is due to a broken parser on the DO side.
 
 	a.Add("TXT", rejectif.TxtIsEmpty) // Last verified 2023-11-11
 

--- a/providers/loopia/auditrecords.go
+++ b/providers/loopia/auditrecords.go
@@ -1,8 +1,6 @@
 package loopia
 
 import (
-	"fmt"
-
 	"github.com/StackExchange/dnscontrol/v4/models"
 	"github.com/StackExchange/dnscontrol/v4/pkg/rejectif"
 )
@@ -15,20 +13,10 @@ func AuditRecords(records []*models.RecordConfig) []error {
 
 	a.Add("TXT", rejectif.TxtIsEmpty) // Last verified 2023-03-10: Loopia returns 404
 
-	//Loopias TXT length limit appears to be 450 octets
-	a.Add("TXT", TxtHasSegmentLen450orLonger)
+	// Loopias TXT length limit appears to be 450 octets
+	a.Add("TXT", rejectif.TxtLongerThan(450)) // Last verified 2023-03-10
 
 	a.Add("MX", rejectif.MxNull) // Last verified 2023-03-23
 
 	return a.Audit(records)
-}
-
-// TxtHasSegmentLen450orLonger audits TXT records for strings that are >450 octets.
-func TxtHasSegmentLen450orLonger(rc *models.RecordConfig) error {
-	for _, txt := range rc.GetTargetTXTSegmented() {
-		if len(txt) > 450 {
-			return fmt.Errorf("%q txtstring length > 450", rc.GetLabel())
-		}
-	}
-	return nil
 }

--- a/providers/msdns/auditrecords.go
+++ b/providers/msdns/auditrecords.go
@@ -19,7 +19,7 @@ func AuditRecords(records []*models.RecordConfig) []error {
 
 	a.Add("TXT", rejectif.TxtHasDoubleQuotes) // Last verified 2023-02-02
 
-	a.Add("TXT", rejectif.TxtLongerThan255) // Last verified 2023-02-02
+	a.Add("TXT", rejectif.TxtLongerThan(255)) // Last verified 2023-02-02
 
 	a.Add("TXT", rejectif.TxtHasSingleQuotes) // Last verified 2023-02-02
 


### PR DESCRIPTION
Fix TXT length checking.

* CSCGLOBAL: Remove artificial 255-octet length limit on TXT records.
* DIGITALOCEAN: Remove artificial restriction on double-quotes in TXT records
