### PR TITLE
DOCS: Removed the (by GitBook) broken GitHub links

### DIFF
--- a/documentation/writing-providers.md
+++ b/documentation/writing-providers.md
@@ -203,11 +203,11 @@ an automated way to test for this bug.  The manual steps are here in
 
 ## Step 9: Update docs
 
-* Edit [README.md](https://github.com/StackExchange/dnscontrol): Add the provider to the bullet list.
-* Edit [documentation/providers.md](https://github.com/StackExchange/dnscontrol/blob/master/documentation/providers.md): Add the provider to the provider list.
-* Edit [documentation/SUMMARY.md](https://github.com/StackExchange/dnscontrol/blob/master/documentation/SUMMARY.md): Add the provider to the provider list.
+* Edit `README.md`: Add the provider to the bullet list.
+* Edit `documentation/providers.md`: Add the provider to the provider list.
+* Edit `documentation/SUMMARY.md`: Add the provider to the provider list.
 * Create `documentation/providers/PROVIDERNAME.md`: Use one of the other files in that directory as a base.
-* Edit [OWNERS](https://github.com/StackExchange/dnscontrol/blob/master/OWNERS): Add the directory name and your GitHub username.
+* Edit `OWNERS`: Add the directory name and your GitHub username.
 
 ## Step 10: Submit a PR
 


### PR DESCRIPTION
Removed the (by GitBook) broken GitHub links.

**Before**

![before](https://github.com/StackExchange/dnscontrol/assets/1150425/4a8add49-7f77-4f57-ba85-f0855251cca5)

_<https://docs.dnscontrol.org/developer-info/writing-providers#step-9-update-docs>_

**After**

![after](https://github.com/StackExchange/dnscontrol/assets/1150425/915a6fac-2bcb-4c9d-a6a2-0f89b311f1f3)

_<https://docs.dnscontrol.org/~/revisions/pL1ZCo9rR6Pc7fd9s81a/developer-info/writing-providers#step-9-update-docs>_