### PR TITLE
DOCS: Providers: Fixed the broken absolute link

### DIFF
--- a/documentation/providers.md
+++ b/documentation/providers.md
@@ -168,7 +168,7 @@ code to support this provider, we'd be glad to help in any way.
 
 #### Q: Why are the above GitHub issues marked "closed"?
 
-A: Following [the bug triage process](/developer-info/bug-triage), the request
+A: Following [the bug triage process](bug-triage.md), the request
 is closed once it is added to this list. If someone chooses to implement the
 provider, they re-open the issue.
 


### PR DESCRIPTION
Fixed the broken absolute link on de [Provider](https://docs.dnscontrol.org/service-providers/providers#q-why-are-the-above-github-issues-marked-closed) > [Requested providers](https://docs.dnscontrol.org/service-providers/providers#requested-providers) section. This improvement passed the [previous review](https://github.com/StackExchange/dnscontrol/pull/2269/files#diff-f49f8c191a562999338f9b4e93db36244e5315e8eb6daced32c61f8eb635cfb9R181).

**Before**

_<https://docs.dnscontrol.org/service-providers/providers#q-why-are-the-above-github-issues-marked-closed>_

**After**

_<https://docs.dnscontrol.org/~/revisions/ZMt4acDFLrTK0XhR2xjQ/service-providers/providers#q-why-are-the-above-github-issues-marked-closed>_