### PR TITLE
BUG: Register an error if EnzureZoneExists fails

### DIFF
--- a/commands/previewPush.go
+++ b/commands/previewPush.go
@@ -211,6 +211,7 @@ func run(args PreviewArgs, push bool, interactive bool, out printer.CLI, report 
 						// this is the actual push, ensure domain exists at DSP
 						if err := creator.EnsureZoneExists(domain.Name); err != nil {
 							out.Warnf("Error creating domain: %s\n", err)
+							anyErrors = true
 							continue // continue with next provider, as we couldn't create this one
 						}
 					}


### PR DESCRIPTION
If EnsureZoneExists fails for any of the configured providers, keep emitting a warning, but also register an error so that any CI/CD-driven workflow gets to know about this via the relevant message and exit code.

Fixes #2627 

<!--
## Before submiting a pull request

Please make sure you've run the following commands from the root directory.

go vet ./...
go fmt ./...
go generate ./...
go mod tidy

## Release changelog section

Help keep the release changelog clear by pre-naming the proper section in the GitHub pull request title.

Some examples:
* CICD: Add required GHA permissions for goreleaser
* DOCS: Fixed providers with "contributor support" table
* ROUTE53: Allow R53_ALIAS records to enable target health evaluation

More examples/context can be found in the file .goreleaser.yml under the 'build' > 'changelog' key.
!-->
