### PR TITLE
DOCS: Fix CAA_BUILDER  parameter types (issuewild type should be string[])

### DIFF
--- a/commands/types/dnscontrol.d.ts
+++ b/commands/types/dnscontrol.d.ts
@@ -411,7 +411,7 @@ declare function CAA(name: string, tag: "issue" | "issuewild" | "iodef", value: 
  *
  * @see https://docs.dnscontrol.org/language-reference/domain-modifiers/caa_builder
  */
-declare function CAA_BUILDER(opts: { label?: string; iodef: string; iodef_critical?: boolean; issue: string[]; issuewild: string }): DomainModifier;
+declare function CAA_BUILDER(opts: { label?: string; iodef: string; iodef_critical?: boolean; issue: string[]; issuewild: string[] }): DomainModifier;
 
 /**
  * `CF_REDIRECT` uses Cloudflare-specific features ("Forwarding URL" Page Rules) to


### PR DESCRIPTION
The typescript definition file uses the _string_ type for **issuewild** in **CAA_BUILDER**, but it should be _string[]_ as noted in the [documentation](https://docs.dnscontrol.org/language-reference/domain-modifiers/caa_builder)