### PR TITLE
CHORE: Fix golint warnings about stuttering

### DIFF
--- a/pkg/diff2/diff2.go
+++ b/pkg/diff2/diff2.go
@@ -53,6 +53,7 @@ type Change struct {
 	HintRecordSetLen1 bool
 }
 
+// GetType returns the type of a change.
 func (c Change) GetType() dnsgraph.NodeType {
 	if c.Type == REPORT {
 		return dnsgraph.Report
@@ -61,10 +62,12 @@ func (c Change) GetType() dnsgraph.NodeType {
 	return dnsgraph.Change
 }
 
+// GetName returns the FQDN of the host being changed.
 func (c Change) GetName() string {
 	return c.Key.NameFQDN
 }
 
+// GetDependencies returns the depenencies of a change.
 func (c Change) GetDependencies() []dnsgraph.Dependency {
 	var dependencies []dnsgraph.Dependency
 

--- a/pkg/dnsgraph/dependencies.go
+++ b/pkg/dnsgraph/dependencies.go
@@ -1,5 +1,6 @@
 package dnsgraph
 
+// CreateDependencies creates a dependency list from a list of FQDNs and a DepenendyType.
 func CreateDependencies(dependencyFQDNs []string, dependencyType DependencyType) []Dependency {
 	var dependencies []Dependency
 

--- a/pkg/dnsgraph/dnsgraph.go
+++ b/pkg/dnsgraph/dnsgraph.go
@@ -5,18 +5,23 @@ import "github.com/StackExchange/dnscontrol/v4/pkg/dnstree"
 type edgeDirection uint8
 
 const (
+	// IncomingEdge is an edge inbound.
 	IncomingEdge edgeDirection = iota
+	// OutgoingEdge is an edge outbound.
 	OutgoingEdge
 )
 
+// DNSGraphEdge an edge on the graph.
 type DNSGraphEdge[T Graphable] struct {
 	Dependency Dependency
 	Node       *DNSGraphNode[T]
 	Direction  edgeDirection
 }
 
+// DNSGraphEdges a list of edges.
 type DNSGraphEdges[T Graphable] []DNSGraphEdge[T]
 
+// DNSGraphNode a node in the graph.
 type DNSGraphNode[T Graphable] struct {
 	Data  T
 	Edges DNSGraphEdges[T]
@@ -24,11 +29,13 @@ type DNSGraphNode[T Graphable] struct {
 
 type dnsGraphNodes[T Graphable] []*DNSGraphNode[T]
 
+// DNSGraph a graph.
 type DNSGraph[T Graphable] struct {
 	All  dnsGraphNodes[T]
 	Tree *dnstree.DomainTree[dnsGraphNodes[T]]
 }
 
+// CreateGraph returns a graph.
 func CreateGraph[T Graphable](entries []T) *DNSGraph[T] {
 	graph := &DNSGraph[T]{
 		All:  dnsGraphNodes[T]{},
@@ -48,6 +55,7 @@ func CreateGraph[T Graphable](entries []T) *DNSGraph[T] {
 	return graph
 }
 
+// RemoveNode removes a node from a graph.
 func (graph *DNSGraph[T]) RemoveNode(toRemove *DNSGraphNode[T]) {
 	for _, edge := range toRemove.Edges {
 		edge.Node.Edges = edge.Node.Edges.RemoveNode(toRemove)
@@ -62,6 +70,7 @@ func (graph *DNSGraph[T]) RemoveNode(toRemove *DNSGraphNode[T]) {
 	}
 }
 
+// AddNode adds a node to a graph.
 func (graph *DNSGraph[T]) AddNode(data T) {
 	nodes := graph.Tree.Get(data.GetName())
 	node := &DNSGraphNode[T]{
@@ -77,6 +86,7 @@ func (graph *DNSGraph[T]) AddNode(data T) {
 	graph.Tree.Set(data.GetName(), nodes)
 }
 
+// AddEdge adds an edge to a graph.
 func (graph *DNSGraph[T]) AddEdge(sourceNode *DNSGraphNode[T], dependency Dependency) {
 	destinationNodes := graph.Tree.Get(dependency.NameFQDN)
 
@@ -107,6 +117,7 @@ func (graph *DNSGraph[T]) AddEdge(sourceNode *DNSGraphNode[T], dependency Depend
 	}
 }
 
+// RemoveNode removes a node from a graph.
 func (nodes dnsGraphNodes[T]) RemoveNode(toRemove *DNSGraphNode[T]) dnsGraphNodes[T] {
 	var newNodes dnsGraphNodes[T]
 
@@ -119,6 +130,7 @@ func (nodes dnsGraphNodes[T]) RemoveNode(toRemove *DNSGraphNode[T]) dnsGraphNode
 	return newNodes
 }
 
+// RemoveNode removes a node from a graph.
 func (edges DNSGraphEdges[T]) RemoveNode(toRemove *DNSGraphNode[T]) DNSGraphEdges[T] {
 	var newEdges DNSGraphEdges[T]
 
@@ -131,6 +143,7 @@ func (edges DNSGraphEdges[T]) RemoveNode(toRemove *DNSGraphNode[T]) DNSGraphEdge
 	return newEdges
 }
 
+// Contains returns true if a node is in the graph AND is in that direction.
 func (edges DNSGraphEdges[T]) Contains(toFind *DNSGraphNode[T], direction edgeDirection) bool {
 
 	for _, edge := range edges {

--- a/pkg/dnsgraph/graphable.go
+++ b/pkg/dnsgraph/graphable.go
@@ -1,30 +1,39 @@
 package dnsgraph
 
+// NodeType enumerates the node types.
 type NodeType uint8
 
 const (
+	// Change is the type of change.
 	Change NodeType = iota
+	// Report is a Report.
 	Report
 )
 
+// DependencyType enumerates the dependency types.
 type DependencyType uint8
 
 const (
+	// ForwardDependency is a forward dependency.
 	ForwardDependency DependencyType = iota
+	// BackwardDependency is a backwards dependency.
 	BackwardDependency
 )
 
+// Dependency is a dependency.
 type Dependency struct {
 	NameFQDN string
 	Type     DependencyType
 }
 
+// Graphable is an interface for things that can be in a graph.
 type Graphable interface {
 	GetType() NodeType
 	GetName() string
 	GetDependencies() []Dependency
 }
 
+// GetRecordsNamesForGraphables returns names in a graph.
 func GetRecordsNamesForGraphables[T Graphable](graphables []T) []string {
 	var names []string
 

--- a/pkg/dnsgraph/testutils/stubrecords.go
+++ b/pkg/dnsgraph/testutils/stubrecords.go
@@ -2,24 +2,29 @@ package testutils
 
 import "github.com/StackExchange/dnscontrol/v4/pkg/dnsgraph"
 
+// StubRecord stub
 type StubRecord struct {
 	NameFQDN     string
 	Dependencies []dnsgraph.Dependency
 	Type         dnsgraph.NodeType
 }
 
+// GetType stub
 func (record StubRecord) GetType() dnsgraph.NodeType {
 	return record.Type
 }
 
+// GetName stub
 func (record StubRecord) GetName() string {
 	return record.NameFQDN
 }
 
+// GetDependencies stub
 func (record StubRecord) GetDependencies() []dnsgraph.Dependency {
 	return record.Dependencies
 }
 
+// StubRecordsAsGraphable stub
 func StubRecordsAsGraphable(records []StubRecord) []dnsgraph.Graphable {
 	sortableRecords := make([]dnsgraph.Graphable, len(records))
 

--- a/pkg/dnssort/graphsort.go
+++ b/pkg/dnssort/graphsort.go
@@ -49,7 +49,7 @@ func SortUsingGraph[T dnsgraph.Graphable](records []T) SortResult[T] {
 }
 
 type directedSortState[T dnsgraph.Graphable] struct {
-	graph                *dnsgraph.DNSGraph[T]
+	graph                *dnsgraph.Graph[T]
 	sortedRecords        []T
 	unresolvedRecords    []T
 	hasResolvedLastRound bool
@@ -106,7 +106,7 @@ func (sortState *directedSortState[T]) finalize() {
 	}
 }
 
-func hasUnmetDependencies[T dnsgraph.Graphable](node *dnsgraph.DNSGraphNode[T]) bool {
+func hasUnmetDependencies[T dnsgraph.Graphable](node *dnsgraph.Node[T]) bool {
 	for _, edge := range node.Edges {
 		if edge.Dependency.Type == dnsgraph.BackwardDependency && edge.Direction == dnsgraph.IncomingEdge {
 			return true

--- a/pkg/dnssort/result.go
+++ b/pkg/dnssort/result.go
@@ -2,7 +2,10 @@ package dnssort
 
 import "github.com/StackExchange/dnscontrol/v4/pkg/dnsgraph"
 
+// SortResult is the result of a sort function.
 type SortResult[T dnsgraph.Graphable] struct {
-	SortedRecords     []T
+	// SortedRecords is the sorted records.
+	SortedRecords []T
+	// UnresolvedRecords is the records that could not be resolved.
 	UnresolvedRecords []T
 }

--- a/pkg/txtutil/txtcode.go
+++ b/pkg/txtutil/txtcode.go
@@ -36,14 +36,24 @@ func EncodeQuoted(t string) string {
 	return txtEncode(ToChunks(t))
 }
 
+// State denotes the parser state.
 type State int
 
 const (
-	StateStart     State = iota // Looking for a non-space
-	StateUnquoted               // A run of unquoted text
-	StateQuoted                 // Quoted text
-	StateBackslash              // last char was backlash in a quoted string
-	StateWantSpace              // expect space after closing quote
+	// StateStart indicates parser is looking for a non-space
+	StateStart State = iota
+
+	// StateUnquoted indicates parser is in a run of unquoted text
+	StateUnquoted
+
+	// StateQuoted indicates parser is in quoted text
+	StateQuoted
+
+	// StateBackslash indicates the last char was backlash in a quoted string
+	StateBackslash
+
+	// StateWantSpace indicates parser expects a space (the previous token was a closing quote)
+	StateWantSpace
 )
 
 func isRemaining(s string, i, r int) bool {

--- a/providers/gcore/gcoreExtend.go
+++ b/providers/gcore/gcoreExtend.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"path"
@@ -69,7 +69,7 @@ func dnssdkDo(ctx context.Context, c *dnssdk.Client, apiKey string, method, uri 
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode >= http.StatusMultipleChoices {
-		all, _ := ioutil.ReadAll(resp.Body)
+		all, _ := io.ReadAll(resp.Body)
 		e := dnssdk.APIError{
 			StatusCode: resp.StatusCode,
 		}

--- a/providers/mythicbeasts/mythicbeastsProvider.go
+++ b/providers/mythicbeasts/mythicbeastsProvider.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strings"
 
@@ -85,7 +84,7 @@ func (n *mythicBeastsProvider) GetZoneRecords(domain string, meta map[string]str
 		return nil, err
 	}
 	if got, want := resp.StatusCode, 200; got != want {
-		body, _ := ioutil.ReadAll(resp.Body)
+		body, _ := io.ReadAll(resp.Body)
 		return nil, fmt.Errorf("got HTTP %v, want %v: %v", got, want, string(body))
 	}
 	return zoneFileToRecords(resp.Body, domain)
@@ -138,7 +137,7 @@ func (n *mythicBeastsProvider) GetZoneRecordsCorrections(dc *models.DomainConfig
 						return err
 					}
 					if got, want := resp.StatusCode, 200; got != want {
-						body, _ := ioutil.ReadAll(resp.Body)
+						body, _ := io.ReadAll(resp.Body)
 						return fmt.Errorf("got HTTP %v, want %v: %v", got, want, string(body))
 					}
 					return nil

--- a/providers/porkbun/listzones.go
+++ b/providers/porkbun/listzones.go
@@ -1,7 +1,7 @@
 package porkbun
 
-func (client *porkbunProvider) ListZones() ([]string, error) {
-	zones, err := client.listAllDomains()
+func (c *porkbunProvider) ListZones() ([]string, error) {
+	zones, err := c.listAllDomains()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
CC @blackshadev 

Fix these golint warnings:

```
pkg/dnsgraph/dnsgraph.go:15:6: type name will be used as dnsgraph.DNSGraphEdge by other packages, and that stutters; consider calling this Edge
pkg/dnsgraph/dnsgraph.go:22:6: type name will be used as dnsgraph.DNSGraphEdges by other packages, and that stutters; consider calling this Edges
pkg/dnsgraph/dnsgraph.go:25:6: type name will be used as dnsgraph.DNSGraphNode by other packages, and that stutters; consider calling this Node
```

I used VSCode's "rename symbol" which seems to take care of all the right things.  However I'm splitting this out as its own PR in case we need to roll it back.

