### PR TITLE
CICD: release needs stringer

### DIFF
--- a/.github/workflows/release_draft.yml
+++ b/.github/workflows/release_draft.yml
@@ -44,6 +44,11 @@ jobs:
       with:
         go-version: ^1.21
 
+# Stringer is needed because .goreleaser includes "go generate ./..."
+    - name: Install stringer
+      run: |
+        go install golang.org/x/tools/cmd/stringer@latest
+
 # For some reason goreleaser isn't correctly setting the version
 # string used by "dnscontrol version".  Therefore, we're forcing the
 # string using the GORELEASER_CURRENT_TAG feature.


### PR DESCRIPTION
<!--
## Before submiting a pull request

Please make sure you've run the following commands from the root directory.

go vet ./...
go fmt ./...
go generate ./...
go mod tidy

## Release changelog section

Help keep the release changelog clear by pre-naming the proper section in the GitHub pull request title.

Some examples:
* CICD: Add required GHA permissions for goreleaser
* DOCS: Fixed providers with "contributor support" table
* ROUTE53: Allow R53_ALIAS records to enable target health evaluation

More examples/context can be found in the file .goreleaser.yml under the 'build' > 'changelog' key.
!-->
