### PR TITLE
TRANSIP: Added audit record for a maximum of 1024 TXT-record characters

### DIFF
--- a/providers/transip/auditrecords.go
+++ b/providers/transip/auditrecords.go
@@ -23,5 +23,7 @@ func AuditRecords(records []*models.RecordConfig) []error {
 
 	a.Add("TXT", rejectif.TxtIsEmpty) // Last verified 2023-12-10
 
+	a.Add("TXT", rejectif.TxtLongerThan(1024)) // Last verified 2023-12-15
+
 	return a.Audit(records)
 }


### PR DESCRIPTION
<!--
## Before submiting a pull request

Please make sure you've run the following commands from the root directory.

go vet ./...
go fmt ./...
go generate ./...
go mod tidy

## Release changelog section

Help keep the release changelog clear by pre-naming the proper section in the GitHub pull request title.

Some examples:
* CICD: Add required GHA permissions for goreleaser
* DOCS: Fixed providers with "contributor support" table
* ROUTE53: Allow R53_ALIAS records to enable target health evaluation

More examples/context can be found in the file .goreleaser.yml under the 'build' > 'changelog' key.
!-->

Avoid the TransIP failure https://github.com/StackExchange/dnscontrol/issues/2272#issuecomment-1856454095 by adding an audit record of a maximum of 1024 TXT record characters.
