### PR TITLE
GANDI: Adopt new Gandi v5 auth changes

### DIFF
--- a/documentation/provider/gandi_v5.md
+++ b/documentation/provider/gandi_v5.md
@@ -4,6 +4,8 @@ migrated to the new LiveDNS API, which should be all domains.
 
 * API Documentation: https://api.gandi.net/docs
 * API Endpoint: https://api.gandi.net/
+* Sandbox API Documentation: https://api.sandbox.gandi.net/docs/
+* Sandbox API Endpoint: https://api.sandbox.gandi.net/
 
 ## Configuration
 
@@ -13,6 +15,8 @@ along with other settings:
 * (mandatory, string) your Gandi.net access credentials (see below) - one of:
   * `token`: Personal Access Token (PAT)
   * `apikey` API Key (deprecated)
+* `apiurl`: (optional, string) the endpoint of the API. When empty or absent the production
+endpoint is used (default) ; you can use it to select the Sandbox API Endpoint instead.
 * `sharing_id`: (optional, string) let you scope to a specific organization. When empty or absent
 calls are not scoped to a specific organization.
 
@@ -130,3 +134,6 @@ organization or no organization.  The solution is to set `sharing_id` in
 
 ### Debugging
 Set `GANDI_V5_DEBUG` environment variable to a [boolean-compatible](https://pkg.go.dev/strconv#ParseBool) value to dump all API calls made by this provider.
+
+### Testing
+Set `apiurl` key to the endpoint url for the sandbox (https://api.sandbox.gandi.net/), along with corresponding `token` (or (deprecated) `apikey`) created in this sandbox environment (Cf https://api.sandbox.gandi.net/docs/sandbox/) to make all API calls against Gandi sandbox environment.

--- a/documentation/provider/gandi_v5.md
+++ b/documentation/provider/gandi_v5.md
@@ -1,9 +1,6 @@
 `GANDI_V5` uses the v5 API and can act as a registrar provider
 or a DNS provider. It is only able to work with domains
 migrated to the new LiveDNS API, which should be all domains.
-API keys are assigned to particular users.  Go to User Settings,
-"Manage the user account and security settings", the "Security"
-tab, then regenerate the "Production API key".
 
 * API Documentation: https://api.gandi.net/docs
 * API Endpoint: https://api.gandi.net/
@@ -11,9 +8,20 @@ tab, then regenerate the "Production API key".
 ## Configuration
 
 To use this provider, add an entry to `creds.json` with `TYPE` set to `GANDI_V5`
-along your Gandi.net API key. The [sharing_id](https://api.gandi.net/docs/reference/) is optional.
+along with other settings:
 
-The `sharing_id` selects between different organizations which your account is
+* (mandatory, string) your Gandi.net access credentials (see below) - one of:
+  * `token`: Personal Access Token (PAT)
+  * `apikey` API Key (deprecated)
+* `sharing_id`: (optional, string) let you scope to a specific organization. When empty or absent
+calls are not scoped to a specific organization.
+
+When both `token` and `apikey` are defined, the priority is given to `token` which will
+be used for API communication (as if `apikey` was not set).
+See [the Authentication section](#authentication) for details on obtaining these credentials.
+
+
+The [sharing_id](https://api.gandi.net/docs/reference/#Sharing-ID) selects between different organizations which your account is
 a member of; to manage domains in multiple organizations, you can use multiple
 `creds.json` entries.
 
@@ -33,12 +41,31 @@ Example:
 {
   "gandi": {
     "TYPE": "GANDI_V5",
-    "apikey": "your-gandi-key",
+    "token": "your-gandi-personal-access-token",
     "sharing_id": "your-sharing_id"
   }
 }
 ```
 {% endcode %}
+
+## Authentication
+
+(Cf [official documentation of the API](https://api.gandi.net/docs/authentication/)
+The **Personal Access Token** (PAT) is configured in the [Account Settings of the
+Gandi Admin application](https://admin.gandi.net/organizations/account/pat), then
+click on "Create a token" button.
+Choose an organisation (if your account happens to have multiple ones).
+Then, choose a name (limited to 42 chars), an expiration date.
+You can choose to limit the scope to a select number of products (domain names).
+Finally, choose the permissions : the needed one is "Manage domain name technical configurations"
+(in French: "Gérer la configuration technique des domaines"), which automatically
+implies "See and renew domain names" (in French: "Voir et renouveler les domaines").
+You then have only one (1) chance to copy and save the token somewhere.
+
+The **API Key** is the previous (deprecated) mechanism used to do api calls.
+To generate or delete your API key, go to User Settings,
+"Manage the user account and security settings", the "Authentication options"
+tab, then regenerate the "Production API key" under "Developer access"
 
 ## Metadata
 This provider does not recognize any special metadata fields unique to Gandi.
@@ -80,7 +107,7 @@ If a domain does not exist in your Gandi account, DNSControl will *not* automati
 Error getting corrections: 401: The server could not verify that you authorized to access the document you requested. Either you supplied the wrong credentials (e.g., bad api key), or your access token has expired
 ```
 
-This is the error you'll see if your `apikey` in `creds.json` is wrong or invalid.
+This is the error you'll see if your `token` (or (deprecated) `apikey`) in `creds.json` is wrong or invalid.
 
 #### Domain does not exist in profile
 

--- a/documentation/provider/gandi_v5.md
+++ b/documentation/provider/gandi_v5.md
@@ -124,3 +124,9 @@ If a `dnscontrol get-zones --format=nameonly CredId - all` returns nothing,
 this is usually because your `creds.json`  information is pointing at an empty
 organization or no organization.  The solution is to set `sharing_id` in
 `creds.json`.
+
+
+## Development
+
+### Debugging
+Set `GANDI_V5_DEBUG` environment variable to a [boolean-compatible](https://pkg.go.dev/strconv#ParseBool) value to dump all API calls made by this provider.

--- a/integrationTest/providers.json
+++ b/integrationTest/providers.json
@@ -112,7 +112,8 @@
   "GANDI_V5": {
     "TYPE": "GANDI_V5",
     "apikey": "$GANDI_V5_APIKEY",
-    "domain": "$GANDI_V5_DOMAIN"
+    "domain": "$GANDI_V5_DOMAIN",
+    "token": "$GANDI_V5_TOKEN"
   },
   "GCLOUD": {
     "TYPE": "GCLOUD",

--- a/providers/gandiv5/gandi_v5Provider.go
+++ b/providers/gandiv5/gandi_v5Provider.go
@@ -76,6 +76,7 @@ type gandiv5Provider struct {
 	token     string
 	sharingid string
 	debug     bool
+	apiurl    string
 }
 
 // newDsp generates a DNS Service Provider client handle.
@@ -97,6 +98,7 @@ func newHelper(m map[string]string, _ json.RawMessage) (*gandiv5Provider, error)
 		return nil, fmt.Errorf("missing Gandi personal access token (or apikey - deprecated)")
 	}
 	api.sharingid = m["sharing_id"]
+	api.apiurl = m["apiurl"]
 	debug, err := strconv.ParseBool(os.Getenv("GANDI_V5_DEBUG"))
 	if err == nil {
 		api.debug = debug
@@ -115,6 +117,7 @@ func newLiveDNSClient(client *gandiv5Provider) *livedns.LiveDNS {
 		PersonalAccessToken: client.token,
 		SharingID:           client.sharingid,
 		Debug:               client.debug,
+		APIURL:              client.apiurl,
 	})
 	return g
 }


### PR DESCRIPTION
This PR handles the new default auth mechanism for GANDI_V5 API (`token`) now that the [`apikey` is officialy deprecated](https://news.gandi.net/en/2023/09/pat-jetons-acces-personnels-api-gandi/).  
The change should be transparent for existing users still using the `apikey` entry.  
Other changes to `creds.json` include:
* introducing `apiurl` setting to control then endpoint and allowing to use the sandbox endpoint
* introducing `dryrun` setting to allow DryRun use of certain API verbs (untested)

Please note that I had no success creating a domain in the sandbox environment, thus was not able to validate that everything was working as expected there. However, the API calls are (of course) properly sent to `apiurl` and the authentication works there.
(notifying maintainer: @TomOnTime @tlimoncelli)