### PR TITLE
BUG: --full outputs an extra newline when skipping providers

### DIFF
--- a/pkg/printer/printer.go
+++ b/pkg/printer/printer.go
@@ -129,7 +129,7 @@ func (c ConsolePrinter) EndCorrection(err error) {
 func (c ConsolePrinter) StartDNSProvider(provider string, skip bool) {
 	lbl := ""
 	if skip {
-		lbl = " (skipping)\n"
+		lbl = " (skipping)"
 	}
 	if !SkinnyReport {
 		fmt.Fprintf(c.Writer, "----- DNS Provider: %s...%s\n", provider, lbl)
@@ -140,7 +140,7 @@ func (c ConsolePrinter) StartDNSProvider(provider string, skip bool) {
 func (c ConsolePrinter) StartRegistrar(provider string, skip bool) {
 	lbl := ""
 	if skip {
-		lbl = " (skipping)\n"
+		lbl = " (skipping)"
 	}
 	if !SkinnyReport {
 		fmt.Fprintf(c.Writer, "----- Registrar: %s...%s\n", provider, lbl)


### PR DESCRIPTION
OLD:

```
$ dnscontrol preview --full --providers gandi_v5_tal --domains everythingsysadmin.com
******************** Domain: everythingsysadmin.com
----- Getting nameservers from: cloudflare_tal
----- DNS Provider: cloudflare_tal... (skipping)

----- Registrar: gandi_v5_tal...
0 corrections (gandi_v5_tal)
Done. 0 corrections.
%
```

NEW:

```
$ dnscontrol preview --full --providers gandi_v5_tal --domains everythingsysadmin.com
******************** Domain: everythingsysadmin.com
----- Getting nameservers from: cloudflare_tal
----- DNS Provider: cloudflare_tal... (skipping)
----- Registrar: gandi_v5_tal...
0 corrections (gandi_v5_tal)
Done. 0 corrections.
$
```