### PR TITLE
CICD: Revert actions/upload-artifact to 3.1.3 (from 4.0.0)

### DIFF
--- a/.github/workflows/pr_test.yml
+++ b/.github/workflows/pr_test.yml
@@ -29,7 +29,7 @@ jobs:
         gotestsum --junitfile ${TEST_RESULTS}/gotestsum-report.xml -- $PACKAGE_NAMES
     - name: Enforce Go Formatted Code
       run: "[ `go fmt ./... | wc -l` -eq 0 ]"
-    - uses: actions/upload-artifact@v4.0.0
+    - uses: actions/upload-artifact@v3.1.3
       with:
         path: "/tmp/test-results"
 
@@ -200,7 +200,7 @@ jobs:
           echo "Skip test for ${{ matrix.provider }} provider"
         fi
       working-directory: integrationTest
-    - uses: actions/upload-artifact@v4.0.0
+    - uses: actions/upload-artifact@v3.1.3
       with:
         path: "/tmp/test-results"
 #  release:
@@ -229,10 +229,10 @@ jobs:
 #    - name: Install goreleaser
 #      run: go install github.com/goreleaser/goreleaser@latest
 #    - run: goreleaser release
-#    - uses: actions/upload-artifact@v4.0.0
+#    - uses: actions/upload-artifact@v3.1.3
 #      with:
 #        path: dist
-#    - uses: actions/upload-artifact@v4.0.0
+#    - uses: actions/upload-artifact@v3.1.3
 #      with:
 #        path: |-
 #          dist/*.rpm


### PR DESCRIPTION
<!--
## Before submiting a pull request

Please make sure you've run the following commands from the root directory.

go vet ./...
go fmt ./...
go generate ./...
go mod tidy

## Release changelog section

Help keep the release changelog clear by pre-naming the proper section in the GitHub pull request title.

Some examples:
* CICD: Add required GHA permissions for goreleaser
* DOCS: Fixed providers with "contributor support" table
* ROUTE53: Allow R53_ALIAS records to enable target health evaluation

More examples/context can be found in the file .goreleaser.yml under the 'build' > 'changelog' key.
!-->
