### PR TITLE
CICD: Add GHA trigger for PR workflow of master branch

### DIFF
--- a/.github/workflows/pr_test.yml
+++ b/.github/workflows/pr_test.yml
@@ -1,5 +1,11 @@
 name: "PR: Run all tests"
 on:
+  # git push origin master:tlim_testpr --force
+  # will trigger a full PR test on the master branch:
+  # https://github.com/StackExchange/dnscontrol/actions/workflows/pr_test.yml?query=branch%3Atlim_testpr
+  push:
+    branches:
+      - 'tlim_testpr'
   pull_request:
   workflow_dispatch:
 


### PR DESCRIPTION
Trigger the GitHub Actions pull request workflow by branch name `tlim_testpr`. This fixes #2699 and saves you having to create empty (closed) pull requests.

See also:
1. The [Workflow syntax for GitHub Actions](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushbranchestagsbranches-ignoretags-ignore) documentation.
2. The GitHub Actions workflow running action [#7414124200](https://github.com/cafferata/dnscontrol/actions/runs/7414124200) by the branch `tlim_testpr` on my GitHub fork repository.

The GitHub Actions `PR: Run all tests` workflow can be found here:
1. [StackExchange/dnscontrol/actions/workflows/pr_test.yml?query=branch:tlim_testpr](https://github.com/StackExchange/dnscontrol/actions/workflows/pr_test.yml?query=branch%3Atlim_testpr).
    * Fork [cafferata/dnscontrol](https://github.com/cafferata/dnscontrol/actions/workflows/pr_test.yml?query=branch%3Atlim_testpr) example.
2. [StackExchange/dnscontrol/actions/workflows/pr_test.yml?query=event:push](https://github.com/StackExchange/dnscontrol/actions/workflows/pr_test.yml?query=event%3Apush).
    * Fork [cafferata/dnscontrol](https://github.com/cafferata/dnscontrol/actions/workflows/pr_test.yml?query=event%3Apush) example.

What do you think? Could this help you further?