### PR TITLE
DYNADOT: correct example in docs

### DIFF
--- a/documentation/providers/dynadot.md
+++ b/documentation/providers/dynadot.md
@@ -10,7 +10,7 @@ Example:
 {% code title="creds.json" %}
 ```json
 {
-  "easyname": {
+  "dynadot": {
     "TYPE": "DYNADOT",
     "key": "API Key",
   }


### PR DESCRIPTION
I based the Dynadot provider documentation on the Easyname docs and missed one occurrence of easyname.

Sorry about that!