### PR TITLE
DOCS: Fixed the broken `CAA_BUILDER()` link

### DIFF
--- a/documentation/functions/domain/CAA.md
+++ b/documentation/functions/domain/CAA.md
@@ -38,4 +38,4 @@ D("example.com", REG_MY_PROVIDER, DnsProvider(DSP_MY_PROVIDER),
 ```
 {% endcode %}
 
-DNSControl contains a [`CAA_BUILDER`](../record/CAA_BUILDER.md) which can be used to simply create `CAA()` records for your domains. Instead of creating each CAA record individually, you can simply configure your report mail address, the authorized certificate authorities and the builder cares about the rest.
+DNSControl contains a [`CAA_BUILDER`](CAA_BUILDER.md) which can be used to simply create `CAA()` records for your domains. Instead of creating each CAA record individually, you can simply configure your report mail address, the authorized certificate authorities and the builder cares about the rest.


### PR DESCRIPTION
Fixed the broken (_after the rename from GitHub pull request https://github.com/StackExchange/dnscontrol/pull/2583_) `CAA_BUILDER()` link.

**Before**
[language-reference/domain-modifiers/caa](https://docs.dnscontrol.org/language-reference/domain-modifiers/caa)

**After**
[language-reference/domain-modifiers/caa](https://docs.dnscontrol.org/~/revisions/z3Y43zRdJKPyUAwfCWJB/language-reference/domain-modifiers/caa) (_preview link_)