### PR TITLE
TRANSIP: Audit records verified

### DIFF
--- a/providers/transip/auditrecords.go
+++ b/providers/transip/auditrecords.go
@@ -25,5 +25,7 @@ func AuditRecords(records []*models.RecordConfig) []error {
 
 	a.Add("TXT", rejectif.TxtLongerThan(1024)) // Last verified 2023-12-15
 
+	a.Add("TXT", rejectif.TxtHasTrailingSpace) // Last verified 2024-01-11
+
 	return a.Audit(records)
 }

--- a/providers/transip/auditrecords.go
+++ b/providers/transip/auditrecords.go
@@ -11,6 +11,8 @@ import (
 func AuditRecords(records []*models.RecordConfig) []error {
 	a := rejectif.Auditor{}
 
+	a.Add("ALIAS", rejectif.LabelNotApex) // Last verified 2024-01-11
+
 	a.Add("MX", rejectif.MxNull) // Last verified 2023-12-04
 
 	a.Add("TXT", rejectif.TxtHasBackticks) // Last verified 2023-12-04

--- a/providers/transip/auditrecords.go
+++ b/providers/transip/auditrecords.go
@@ -15,15 +15,15 @@ func AuditRecords(records []*models.RecordConfig) []error {
 
 	a.Add("MX", rejectif.MxNull) // Last verified 2023-12-04
 
-	a.Add("TXT", rejectif.TxtHasBackticks) // Last verified 2023-12-04
+	a.Add("TXT", rejectif.TxtHasBackticks) // Last verified 2024-01-11
 
-	a.Add("TXT", rejectif.TxtHasBackslash) // Last verified 2023-12-04
+	a.Add("TXT", rejectif.TxtHasBackslash) // Last verified 2024-01-11
 
-	a.Add("TXT", rejectif.TxtStartsOrEndsWithSpaces) // Last verified 2023-12-10
+	a.Add("TXT", rejectif.TxtStartsOrEndsWithSpaces) // Last verified 2024-01-11
 
-	a.Add("TXT", rejectif.TxtIsEmpty) // Last verified 2023-12-10
+	a.Add("TXT", rejectif.TxtIsEmpty) // Last verified 2024-01-11
 
-	a.Add("TXT", rejectif.TxtLongerThan(1024)) // Last verified 2023-12-15
+	a.Add("TXT", rejectif.TxtLongerThan(1024)) // Last verified 2024-01-11
 
 	a.Add("TXT", rejectif.TxtHasTrailingSpace) // Last verified 2024-01-11
 

--- a/providers/transip/auditrecords.go
+++ b/providers/transip/auditrecords.go
@@ -17,8 +17,6 @@ func AuditRecords(records []*models.RecordConfig) []error {
 
 	a.Add("TXT", rejectif.TxtHasBackticks) // Last verified 2023-12-04
 
-	a.Add("TXT", rejectif.TxtHasDoubleQuotes) // Last verified 2023-12-04
-
 	a.Add("TXT", rejectif.TxtHasBackslash) // Last verified 2023-12-04
 
 	a.Add("TXT", rejectif.TxtStartsOrEndsWithSpaces) // Last verified 2023-12-10


### PR DESCRIPTION
Verified the audit records against the TransIP API.

```javascript
D(
  'dnscontrol.nl',
  NewRegistrar('none'),
  DnsProvider(NewDnsProvider('transip', '-')),

  // ALIAS: Failure
  // ALIAS('LabelNotApex', 'LabelNotApex.com.')

  // TXT: Failure
  // TXT('TxtHasBackticks', '`')
  // TXT('TxtHasBackslash', "\\")
  // TXT('TxtHasTrailingSpace', ' ')
  // TXT('TxtStartsOrEndsWithSpaces', ' test')
  // TXT('TxtIsEmpty', '')

  // TXT: Success
  // TXT('TxtHasDoubleQuotes', '"test"')
  // TXT('TxtHasSemicolon', ';'),
  // TXT('TxtHasSingleQuotes', "'")
  // TXT('TxtHasUnpairedDoubleQuotes', '" test')

  // CAA: Success
  // CAA('CaaTargetContainsWhitespace', 'iodef', ' mailto:info@jcid.nl ')
  // CAA('CaaTargetHasSemicolon', 'issue', 'letsencrypt.org; policy=ev')
);
```

<details>
    <summary>For completeness/archive purpose my testing steps/output</summary>

I ran a local DNSControl build with a modified `providers/transip/auditrecords.go`.

```go
package transip

import (
	"github.com/StackExchange/dnscontrol/v4/models"
	"github.com/StackExchange/dnscontrol/v4/pkg/rejectif"
)

// AuditRecords returns a list of errors corresponding to the records
// that aren't supported by this provider.  If all records are
// supported, an empty list is returned.
func AuditRecords(records []*models.RecordConfig) []error {
	a := rejectif.Auditor{}
	a.Add("MX", rejectif.MxNull) // Last verified 2023-12-04
	return a.Audit(records)
}
```
```shell
go build
```

```shell
./dnscontrol push --domains dnscontrol.nl
```

### `LabelNotApex`

```shell
******************** Domain: dnscontrol.nl
1 correction (transip)
#1: + CREATE labelnotapex.dnscontrol.nl ALIAS LabelNotApex.com. ttl=300
FAILURE! Alias must be an @ record.: labelnotapex 300 ALIAS LabelNotApex.com.
Done. 1 corrections.
completed with errors
```

### `TxtHasBackticks`

```shell
******************** Domain: dnscontrol.nl
1 correction (transip)
#1: + CREATE txthasbackticks.dnscontrol.nl TXT "`" ttl=300
FAILURE! the content of a TXT record cannot contain invalid characters: txthasbackticks 300 TXT `
Done. 1 corrections.
completed with errors
```

### `TxtHasBackslash`

```shell
******************** Domain: dnscontrol.nl
1 correction (transip)
#1: + CREATE txthasbackslash.dnscontrol.nl TXT "\\" ttl=300
FAILURE! the content of a TXT record cannot contain invalid characters: txthasbackslash 300 TXT \
Done. 1 corrections.
completed with errors
```

### `TxtHasTrailingSpace`

```shell
******************** Domain: dnscontrol.nl
1 correction (transip)
#1: + CREATE txthastrailingspace.dnscontrol.nl TXT " " ttl=300
FAILURE! whitespace at the end or start of the content of a record is not allowed: txthastrailingspace 300 TXT
Done. 1 corrections.
completed with errors
```

### `TxtStartsOrEndsWithSpaces`

```shell
******************** Domain: dnscontrol.nl
1 correction (transip)
#1: + CREATE txtstartsorendswithspaces.dnscontrol.nl TXT " test" ttl=300
FAILURE! whitespace at the end or start of the content of a record is not allowed: txtstartsorendswithspaces 300 TXT  test
Done. 1 corrections.
completed with errors
```

### `TxtIsEmpty`

```shell
******************** Domain: dnscontrol.nl
1 correction (transip)
#1: + CREATE txtisempty.dnscontrol.nl TXT "" ttl=300
FAILURE! record content cannot be empty: txtisempty 300 TXT
Done. 1 corrections.
completed with errors
```

</details>

_cc: Maintainer TransIP: @blackshadev_
