### PR TITLE
CICD: Add nullMX tests

### DIFF
--- a/integrationTest/integration_test.go
+++ b/integrationTest/integration_test.go
@@ -1035,12 +1035,37 @@ func makeTests(t *testing.T) []*TestGroup {
 			),
 		),
 
-		testgroup("MX",
+		testgroup("ApexMX",
 			tc("Record pointing to @",
 				mx("foo", 8, "**current-domain**"),
 				a("@", "1.2.3.4"),
 			),
-			tc("Null MX", mx("@", 0, ".")), // RFC 7505
+		),
+
+		// RFC 7505 NullMX
+		testgroup("NullMX",
+			tc("create",
+				mx("nmx", 0, "."), // Install a Null MX.
+			),
+			tc("unnull",
+				mx("nmx", 9, "www.example.com."), // Change to regular MX.
+			),
+			tc("renull",
+				mx("nmx", 0, "."), // Change back to Null MX.
+			),
+		),
+
+		// RFC 7505 NullMX at Apex
+		testgroup("NullMXApex",
+			tc("create",
+				mx("@", 0, "."), // Install a Null MX.
+			),
+			tc("unnull",
+				mx("@", 8, "**current-domain**"), // Change to regular MX.
+			),
+			tc("renull",
+				mx("@", 0, "."), // Change back to Null MX.
+			),
 		),
 
 		testgroup("NS",

--- a/integrationTest/integration_test.go
+++ b/integrationTest/integration_test.go
@@ -1050,7 +1050,7 @@ func makeTests(t *testing.T) []*TestGroup {
 			tc("unnull", // Change to regular MX.
 				a("nmx", "1.2.3.9"),
 				a("www", "1.2.3.3"),
-				mx("nmx", 9, "**current-domain**"),
+				mx("nmx", 9, "wmx.**current-domain**"),
 				mx("nmx", 3, "www.**current-domain**"),
 			),
 			tc("renull", // Change back to Null MX.

--- a/integrationTest/integration_test.go
+++ b/integrationTest/integration_test.go
@@ -1043,13 +1043,42 @@ func makeTests(t *testing.T) []*TestGroup {
 		),
 
 		// RFC 7505 NullMX
+		/*
+			$ go test -v -verbose -provider TRANSIP -start 16 -end 17
+			=== RUN   TestDNSProviders
+			=== RUN   TestDNSProviders/dnscontrol.nl
+			=== RUN   TestDNSProviders/dnscontrol.nl/Clean_Slate:Empty
+			=== RUN   TestDNSProviders/dnscontrol.nl/16:NullMX:create
+			    integration_test.go:225: ***SKIPPED(PROVIDER DOES NOT SUPPORT '[mx has null target]' ::"16:NullMX")
+			=== RUN   TestDNSProviders/dnscontrol.nl/16:NullMX:unnull
+			    integration_test.go:247:
+			        + CREATE nmx.dnscontrol.nl A 1.2.3.9 ttl=300
+			    integration_test.go:247:
+			        + CREATE www.dnscontrol.nl A 1.2.3.3 ttl=300
+			    integration_test.go:247:
+			        + CREATE nmx.dnscontrol.nl MX 3 www.dnscontrol.nl. ttl=300
+			        + CREATE nmx.dnscontrol.nl MX 9 wmx.dnscontrol.nl. ttl=300
+			    integration_test.go:252: A hostname for a CNAME, NS, MX or SRV record was not found (external hostnames need a trailing dot, eg. "example.com."): nmx 300 MX 9 wmx.dnscontrol.nl.
+			=== RUN   TestDNSProviders/dnscontrol.nl/17:NullMXApex_***SKIPPED(excluded_by_not("TRANSIP"))***:Empty
+			    integration_test.go:247:
+			        - DELETE nmx.dnscontrol.nl A 1.2.3.9 ttl=300
+			    integration_test.go:247:
+			        - DELETE nmx.dnscontrol.nl MX 3 www.dnscontrol.nl. ttl=300
+			    integration_test.go:247:
+			        - DELETE www.dnscontrol.nl A 1.2.3.3 ttl=300
+			--- FAIL: TestDNSProviders (21.15s)
+			    --- FAIL: TestDNSProviders/dnscontrol.nl (21.15s)
+			        --- PASS: TestDNSProviders/dnscontrol.nl/Clean_Slate:Empty (0.37s)
+			        --- SKIP: TestDNSProviders/dnscontrol.nl/16:NullMX:create (0.00s)
+			        --- FAIL: TestDNSProviders/dnscontrol.nl/16:NullMX:unnull (9.44s)
+		*/
 		testgroup("NullMX",
 			not(
 				"TRANSIP", // Fails with odd error message.
 			),
 			tc("create", // Install a Null MX.
-				a("nmx", "1.2.3.9"),
-				a("www", "1.2.3.3"),
+				a("nmx", "1.2.3.9"), // Install this so it is ready for the next tc()
+				a("www", "1.2.3.3"), // Install this so it is ready for the next tc()
 				mx("nmx", 0, "."),
 			),
 			tc("unnull", // Change to regular MX.
@@ -1066,9 +1095,11 @@ func makeTests(t *testing.T) []*TestGroup {
 		// RFC 7505 NullMX at Apex
 		testgroup("NullMXApex",
 			not(
-				"TRANSIP", // Fails with odd error message.
+				"TRANSIP", // TRANSIP is slow and doesn't support NullMX. Skip to save time.
 			),
 			tc("create", // Install a Null MX.
+				a("nmx", "1.2.3.9"), // Install this so it is ready for the next tc()
+				a("www", "1.2.3.3"), // Install this so it is ready for the next tc()
 				mx("@", 0, "."),
 			),
 			tc("unnull", // Change to regular MX.

--- a/integrationTest/integration_test.go
+++ b/integrationTest/integration_test.go
@@ -1048,17 +1048,19 @@ func makeTests(t *testing.T) []*TestGroup {
 				"TRANSIP", // TRANSIP is slow and doesn't support NullMX. Skip to save time.
 			),
 			tc("create", // Install a Null MX.
-				a("nmx", "1.2.3.9"), // Install this so it is ready for the next tc()
-				a("www", "1.2.3.3"), // Install this so it is ready for the next tc()
+				a("nmx", "1.2.3.3"), // Install this so it is ready for the next tc()
+				a("www", "1.2.3.9"), // Install this so it is ready for the next tc()
 				mx("nmx", 0, "."),
 			),
 			tc("unnull", // Change to regular MX.
-				a("www", "1.2.3.3"),
-				a("nmx", "1.2.3.9"),
-				mx("nmx", 9, "nmx.**current-domain**"),
-				mx("nmx", 3, "www.**current-domain**"),
+				a("nmx", "1.2.3.3"),
+				a("www", "1.2.3.9"),
+				mx("nmx", 3, "nmx.**current-domain**"),
+				mx("nmx", 9, "www.**current-domain**"),
 			),
 			tc("renull", // Change back to Null MX.
+				a("nmx", "1.2.3.3"),
+				a("www", "1.2.3.9"),
 				mx("nmx", 0, "."),
 			),
 		),
@@ -1069,17 +1071,19 @@ func makeTests(t *testing.T) []*TestGroup {
 				"TRANSIP", // TRANSIP is slow and doesn't support NullMX. Skip to save time.
 			),
 			tc("create", // Install a Null MX.
-				a("nmx", "1.2.3.9"), // Install this so it is ready for the next tc()
-				a("www", "1.2.3.3"), // Install this so it is ready for the next tc()
+				a("@", "1.2.3.2"),   // Install this so it is ready for the next tc()
+				a("www", "1.2.3.8"), // Install this so it is ready for the next tc()
 				mx("@", 0, "."),
 			),
 			tc("unnull", // Change to regular MX.
-				a("@", "1.2.3.4"),
+				a("@", "1.2.3.2"),
 				a("www", "1.2.3.8"),
-				mx("@", 8, "**current-domain**"),
-				mx("@", 4, "www.**current-domain**"),
+				mx("@", 2, "**current-domain**"),
+				mx("@", 8, "www.**current-domain**"),
 			),
 			tc("renull", // Change back to Null MX.
+				a("@", "1.2.3.2"),
+				a("www", "1.2.3.8"),
 				mx("@", 0, "."),
 			),
 		),

--- a/integrationTest/integration_test.go
+++ b/integrationTest/integration_test.go
@@ -1044,12 +1044,17 @@ func makeTests(t *testing.T) []*TestGroup {
 
 		// RFC 7505 NullMX
 		testgroup("NullMX",
+			not(
+				"TRANSIP", // Fails with odd error message.
+			),
 			tc("create", // Install a Null MX.
+				a("nmx", "1.2.3.9"),
+				a("www", "1.2.3.3"),
 				mx("nmx", 0, "."),
 			),
 			tc("unnull", // Change to regular MX.
-				a("nmx", "1.2.3.9"),
 				a("www", "1.2.3.3"),
+				a("nmx", "1.2.3.9"),
 				mx("nmx", 9, "wmx.**current-domain**"),
 				mx("nmx", 3, "www.**current-domain**"),
 			),
@@ -1060,6 +1065,9 @@ func makeTests(t *testing.T) []*TestGroup {
 
 		// RFC 7505 NullMX at Apex
 		testgroup("NullMXApex",
+			not(
+				"TRANSIP", // Fails with odd error message.
+			),
 			tc("create", // Install a Null MX.
 				mx("@", 0, "."),
 			),
@@ -1071,6 +1079,30 @@ func makeTests(t *testing.T) []*TestGroup {
 			),
 			tc("renull", // Change back to Null MX.
 				mx("@", 0, "."),
+			),
+		),
+
+		// Make TransIP fail in a weird way.
+		/*
+			=== RUN   TestDNSProviders/dnscontrol.nl/18:NullMX:unnull
+			  integration_test.go:247:
+			      + CREATE nmx.dnscontrol.nl A 1.2.3.9 ttl=300
+			  integration_test.go:247:
+			      + CREATE www.dnscontrol.nl A 1.2.3.3 ttl=300
+			  integration_test.go:247:
+			      + CREATE nmx.dnscontrol.nl MX 3 www.dnscontrol.nl. ttl=300
+			      + CREATE nmx.dnscontrol.nl MX 9 wmx.dnscontrol.nl. ttl=300
+			  integration_test.go:252: A hostname for a CNAME, NS, MX or SRV record was not found (external hostnames need a trailing dot, eg. "example.com."): nmx 300 MX 9 wmx.dnscontrol.nl.
+		*/
+		testgroup("TIPfail1",
+			only(
+				"TRANSIP", // Fails with odd error message.
+			),
+			tc("step1", // Change to regular MX.
+				//a("www", "1.2.3.3"),
+				a("nmx", "1.2.3.9"),
+				mx("nmx", 9, "wmx.**current-domain**"),
+				mx("nmx", 3, "www.**current-domain**"),
 			),
 		),
 

--- a/integrationTest/integration_test.go
+++ b/integrationTest/integration_test.go
@@ -1044,27 +1044,33 @@ func makeTests(t *testing.T) []*TestGroup {
 
 		// RFC 7505 NullMX
 		testgroup("NullMX",
-			tc("create",
-				mx("nmx", 0, "."), // Install a Null MX.
+			tc("create", // Install a Null MX.
+				mx("nmx", 0, "."),
 			),
-			tc("unnull",
-				mx("nmx", 9, "www.example.com."), // Change to regular MX.
+			tc("unnull", // Change to regular MX.
+				a("nmx", "1.2.3.9"),
+				a("www", "1.2.3.3"),
+				mx("nmx", 9, "**current-domain**"),
+				mx("nmx", 3, "www.**current-domain**"),
 			),
-			tc("renull",
-				mx("nmx", 0, "."), // Change back to Null MX.
+			tc("renull", // Change back to Null MX.
+				mx("nmx", 0, "."),
 			),
 		),
 
 		// RFC 7505 NullMX at Apex
 		testgroup("NullMXApex",
-			tc("create",
-				mx("@", 0, "."), // Install a Null MX.
+			tc("create", // Install a Null MX.
+				mx("@", 0, "."),
 			),
-			tc("unnull",
-				mx("@", 8, "**current-domain**"), // Change to regular MX.
+			tc("unnull", // Change to regular MX.
+				a("@", "1.2.3.4"),
+				a("www", "1.2.3.8"),
+				mx("@", 8, "**current-domain**"),
+				mx("@", 4, "www.**current-domain**"),
 			),
-			tc("renull",
-				mx("@", 0, "."), // Change back to Null MX.
+			tc("renull", // Change back to Null MX.
+				mx("@", 0, "."),
 			),
 		),
 

--- a/integrationTest/integration_test.go
+++ b/integrationTest/integration_test.go
@@ -1043,38 +1043,9 @@ func makeTests(t *testing.T) []*TestGroup {
 		),
 
 		// RFC 7505 NullMX
-		/*
-			$ go test -v -verbose -provider TRANSIP -start 16 -end 17
-			=== RUN   TestDNSProviders
-			=== RUN   TestDNSProviders/dnscontrol.nl
-			=== RUN   TestDNSProviders/dnscontrol.nl/Clean_Slate:Empty
-			=== RUN   TestDNSProviders/dnscontrol.nl/16:NullMX:create
-			    integration_test.go:225: ***SKIPPED(PROVIDER DOES NOT SUPPORT '[mx has null target]' ::"16:NullMX")
-			=== RUN   TestDNSProviders/dnscontrol.nl/16:NullMX:unnull
-			    integration_test.go:247:
-			        + CREATE nmx.dnscontrol.nl A 1.2.3.9 ttl=300
-			    integration_test.go:247:
-			        + CREATE www.dnscontrol.nl A 1.2.3.3 ttl=300
-			    integration_test.go:247:
-			        + CREATE nmx.dnscontrol.nl MX 3 www.dnscontrol.nl. ttl=300
-			        + CREATE nmx.dnscontrol.nl MX 9 wmx.dnscontrol.nl. ttl=300
-			    integration_test.go:252: A hostname for a CNAME, NS, MX or SRV record was not found (external hostnames need a trailing dot, eg. "example.com."): nmx 300 MX 9 wmx.dnscontrol.nl.
-			=== RUN   TestDNSProviders/dnscontrol.nl/17:NullMXApex_***SKIPPED(excluded_by_not("TRANSIP"))***:Empty
-			    integration_test.go:247:
-			        - DELETE nmx.dnscontrol.nl A 1.2.3.9 ttl=300
-			    integration_test.go:247:
-			        - DELETE nmx.dnscontrol.nl MX 3 www.dnscontrol.nl. ttl=300
-			    integration_test.go:247:
-			        - DELETE www.dnscontrol.nl A 1.2.3.3 ttl=300
-			--- FAIL: TestDNSProviders (21.15s)
-			    --- FAIL: TestDNSProviders/dnscontrol.nl (21.15s)
-			        --- PASS: TestDNSProviders/dnscontrol.nl/Clean_Slate:Empty (0.37s)
-			        --- SKIP: TestDNSProviders/dnscontrol.nl/16:NullMX:create (0.00s)
-			        --- FAIL: TestDNSProviders/dnscontrol.nl/16:NullMX:unnull (9.44s)
-		*/
 		testgroup("NullMX",
 			not(
-				"TRANSIP", // Fails with odd error message.
+				"TRANSIP", // TRANSIP is slow and doesn't support NullMX. Skip to save time.
 			),
 			tc("create", // Install a Null MX.
 				a("nmx", "1.2.3.9"), // Install this so it is ready for the next tc()
@@ -1084,7 +1055,7 @@ func makeTests(t *testing.T) []*TestGroup {
 			tc("unnull", // Change to regular MX.
 				a("www", "1.2.3.3"),
 				a("nmx", "1.2.3.9"),
-				mx("nmx", 9, "wmx.**current-domain**"),
+				mx("nmx", 9, "nmx.**current-domain**"),
 				mx("nmx", 3, "www.**current-domain**"),
 			),
 			tc("renull", // Change back to Null MX.

--- a/integrationTest/integration_test.go
+++ b/integrationTest/integration_test.go
@@ -1082,30 +1082,6 @@ func makeTests(t *testing.T) []*TestGroup {
 			),
 		),
 
-		// Make TransIP fail in a weird way.
-		/*
-			=== RUN   TestDNSProviders/dnscontrol.nl/18:NullMX:unnull
-			  integration_test.go:247:
-			      + CREATE nmx.dnscontrol.nl A 1.2.3.9 ttl=300
-			  integration_test.go:247:
-			      + CREATE www.dnscontrol.nl A 1.2.3.3 ttl=300
-			  integration_test.go:247:
-			      + CREATE nmx.dnscontrol.nl MX 3 www.dnscontrol.nl. ttl=300
-			      + CREATE nmx.dnscontrol.nl MX 9 wmx.dnscontrol.nl. ttl=300
-			  integration_test.go:252: A hostname for a CNAME, NS, MX or SRV record was not found (external hostnames need a trailing dot, eg. "example.com."): nmx 300 MX 9 wmx.dnscontrol.nl.
-		*/
-		testgroup("TIPfail1",
-			only(
-				"TRANSIP", // Fails with odd error message.
-			),
-			tc("step1", // Change to regular MX.
-				//a("www", "1.2.3.3"),
-				a("nmx", "1.2.3.9"),
-				mx("nmx", 9, "wmx.**current-domain**"),
-				mx("nmx", 3, "www.**current-domain**"),
-			),
-		),
-
 		testgroup("NS",
 			not(
 				"DNSIMPLE", // Does not support NS records nor subdomains.


### PR DESCRIPTION
We found a bug with one provider when converting from multiple MX records to a single Null MX.  Adding integration tests to detect this situation and prevent regressions.