### PR TITLE
GCORE: enable ALIAS records

### DIFF
--- a/providers/gcore/gcoreProvider.go
+++ b/providers/gcore/gcoreProvider.go
@@ -43,7 +43,7 @@ func NewGCore(m map[string]string, metadata json.RawMessage) (providers.DNSServi
 var features = providers.DocumentationNotes{
 	providers.CanAutoDNSSEC:          providers.Cannot(),
 	providers.CanGetZones:            providers.Can(),
-	providers.CanUseAlias:            providers.Cannot(),
+	providers.CanUseAlias:            providers.Can(),
 	providers.CanUseCAA:              providers.Can(),
 	providers.CanUseDS:               providers.Cannot(),
 	providers.CanUseLOC:              providers.Cannot(),
@@ -135,6 +135,13 @@ func (c *gcoreProvider) GetZoneRecordsCorrections(dc *models.DomainConfig, exist
 	var corrections []*models.Correction
 	var deletions []*models.Correction
 	var reports []*models.Correction
+
+	// Gcore auto uses ALIAS for apex zone CNAME records, just like CloudFlare
+	for _, rec := range dc.Records {
+		if rec.Type == "ALIAS" {
+			rec.Type = "CNAME"
+		}
+	}
 
 	changes, err := diff2.ByRecordSet(existing, dc, nil)
 	if err != nil {


### PR DESCRIPTION
<!--
## Before submiting a pull request

Please make sure you've run the following commands from the root directory.

go vet ./...
go fmt ./...
go generate ./...
go mod tidy

## Release changelog section

Help keep the release changelog clear by pre-naming the proper section in the GitHub pull request title.

Some examples:
* CICD: Add required GHA permissions for goreleaser
* DOCS: Fixed providers with "contributor support" table
* ROUTE53: Allow R53_ALIAS records to enable target health evaluation

More examples/context can be found in the file .goreleaser.yml under the 'build' > 'changelog' key.
!-->

GCore DNS supports ALIAS record at apex zone level by automatic CNAME flattening: https://gcore.com/docs/dns/dns-records/specify-cname-at-root

Enable ALIAS records for GCORE provider, and transform ALIAS records into CNAME just like CLOUDFLARE provider.