### PR TITLE
DOCS: [GitBook] Remove configuration file

### DIFF
--- a/.gitbook.yaml
+++ b/.gitbook.yaml
@@ -1,1 +1,0 @@
-root: ./documentation/


### PR DESCRIPTION
Removed the GitBook configuration file. Followed up at https://github.com/StackExchange/dnscontrol/pull/2052. This folder structure is guaranteed within GitBook interface.

![Screenshot 2024-01-22 at 20 53 00](https://github.com/StackExchange/dnscontrol/assets/1150425/b8c72f00-dca7-4d5a-a358-8d8f8452ffc8)
