### PR TITLE
CICD: Bugfix: Changes introduced while tagging new releases cause git problems

### DIFF
--- a/documentation/release-engineering.md
+++ b/documentation/release-engineering.md
@@ -24,7 +24,7 @@ git commit -a -m "Update generated files for $VERSION"
 ```shell
 export VERSION=v4.2.0
 git tag -m "Release $VERSION" -a $VERSION
-git push origin --tags
+git push origin HEAD --tags
 ```
 
 Soon after


### PR DESCRIPTION
* Correct the `git push` statement used in producing releases.  