### PR TITLE
deSEC: API rejects empty updates caused by IGNORE() of all records

### DIFF
--- a/integrationTest/integration_test.go
+++ b/integrationTest/integration_test.go
@@ -2115,6 +2115,9 @@ func makeTests(t *testing.T) []*TestGroup {
 
 		// https://github.com/StackExchange/dnscontrol/issues/2822
 		// Don't send empty updates.
+		// A carefully constructed IGNORE() can ignore all the
+		// changes. This resulted in the deSEC provider generating an
+		// empty upsert, which the API rejected.
 		testgroup("IGNORE everything b2822",
 			tc("Create some records",
 				a("dyndns-city1", "91.42.1.1"),

--- a/integrationTest/integration_test.go
+++ b/integrationTest/integration_test.go
@@ -2113,6 +2113,25 @@ func makeTests(t *testing.T) []*TestGroup {
 			).ExpectNoChanges(),
 		),
 
+		// https://github.com/StackExchange/dnscontrol/issues/2822
+		// Don't send empty updates.
+		testgroup("IGNORE everything b2822",
+			tc("Create some records",
+				a("dyndns-city1", "91.42.1.1"),
+				a("dyndns-city2", "91.42.1.2"),
+				aaaa("dyndns-city1", "2003:dd:d7ff::fe71:ce77"),
+				aaaa("dyndns-city2", "2003:dd:d7ff::fe71:ce78"),
+			),
+			tc("ignore them all",
+				a("dyndns-city1", "91.42.1.1"),
+				a("dyndns-city2", "91.42.1.2"),
+				aaaa("dyndns-city1", "2003:dd:d7ff::fe71:ce77"),
+				aaaa("dyndns-city2", "2003:dd:d7ff::fe71:ce78"),
+				ignore("dyndns-city1", "A,AAAA", ""),
+				ignore("dyndns-city2", "A,AAAA", ""),
+			).ExpectNoChanges().UnsafeIgnore(),
+		),
+
 		testgroup("structured TXT",
 			only("OVH"),
 			tc("Create TXT",

--- a/providers/desec/desecProvider.go
+++ b/providers/desec/desecProvider.go
@@ -213,19 +213,23 @@ func (c *desecProvider) GetZoneRecordsCorrections(dc *models.DomainConfig, exist
 			}
 		}
 	}
-	msg := fmt.Sprintf("Changes:\n%s", buf)
-	corrections = append(corrections,
-		&models.Correction{
-			Msg: msg,
-			F: func() error {
-				rc := rrs
-				err := c.upsertRR(rc, dc.Name)
-				if err != nil {
-					return err
-				}
-				return nil
-			},
-		})
+
+	// If there are changes, upsert them.
+	if len(rrs) > 0 {
+		msg := fmt.Sprintf("Changes:\n%s", buf)
+		corrections = append(corrections,
+			&models.Correction{
+				Msg: msg,
+				F: func() error {
+					rc := rrs
+					err := c.upsertRR(rc, dc.Name)
+					if err != nil {
+						return err
+					}
+					return nil
+				},
+			})
+	}
 
 	// NB(tlim): This sort is just to make updates look pretty. It is
 	// cosmetic.  The risk here is that there may be some updates that


### PR DESCRIPTION
Fixes https://github.com/StackExchange/dnscontrol/issues/2822

* Add integration test to demonstrate the issue
* Don't create an upsert if there is nothing changing