### PR TITLE
DOCS: Document daily update limits

### DIFF
--- a/documentation/providers/desec.md
+++ b/documentation/providers/desec.md
@@ -36,3 +36,10 @@ D("example.com", REG_NONE, DnsProvider(DSP_DESEC),
 ## Activation
 DNSControl depends on a deSEC account auth token.
 This token can be obtained by [logging in via the deSEC API](https://desec.readthedocs.io/en/latest/auth/account.html#log-in).
+
+{% hint style="warning" %}
+deSEC enforces a daily limit of 300 RRset creation/deletion/modification per
+domain. As a result, large changes may have to be done over the course of a few
+days.  The integration test suite can not be run in one session.
+{% endhint %} 
+

--- a/documentation/providers/desec.md
+++ b/documentation/providers/desec.md
@@ -39,7 +39,8 @@ This token can be obtained by [logging in via the deSEC API](https://desec.readt
 
 {% hint style="warning" %}
 deSEC enforces a daily limit of 300 RRset creation/deletion/modification per
-domain. As a result, large changes may have to be done over the course of a few
-days.  The integration test suite can not be run in one session.
+domain. Large changes may have to be done over the course of a few days.  The
+integration test suite can not be run in a single session. See
+[https://desec.readthedocs.io/en/latest/rate-limits.html#api-request-throttling](https://desec.readthedocs.io/en/latest/rate-limits.html#api-request-throttling)
 {% endhint %} 
 

--- a/integrationTest/integration_test.go
+++ b/integrationTest/integration_test.go
@@ -1314,6 +1314,7 @@ func makeTests(t *testing.T) []*TestGroup {
 				"AZURE_DNS",     // Removed because it is too slow
 				"CLOUDFLAREAPI", // Infinite pagesize but due to slow speed, skipping.
 				"DIGITALOCEAN",  // No paging. Why bother?
+				"DESEC",         // Skip due to daily update limits.
 				//"CSCGLOBAL",     // Doesn't page. Works fine.  Due to the slow API we skip.
 				"GANDI_V5",   // Their API is so damn slow. We'll add it back as needed.
 				"HEDNS",      // Doesn't page. Works fine.  Due to the slow API we skip.
@@ -1334,6 +1335,7 @@ func makeTests(t *testing.T) []*TestGroup {
 				//"AZURE_DNS",     // Removed because it is too slow
 				//"CLOUDFLAREAPI", // Infinite pagesize but due to slow speed, skipping.
 				//"CSCGLOBAL",     // Doesn't page. Works fine.  Due to the slow API we skip.
+				//"DESEC",         // Skip due to daily update limits.
 				//"GANDI_V5",      // Their API is so damn slow. We'll add it back as needed.
 				//"MSDNS",         // No paging done. No need to test.
 				"GCLOUD",
@@ -1350,6 +1352,7 @@ func makeTests(t *testing.T) []*TestGroup {
 				//"AZURE_DNS",     // Currently failing. See https://github.com/StackExchange/dnscontrol/issues/770
 				//"CLOUDFLAREAPI", // Fails with >1000 corrections. See https://github.com/StackExchange/dnscontrol/issues/1440
 				//"CSCGLOBAL",     // Doesn't page. Works fine.  Due to the slow API we skip.
+				//"DESEC",         // Skip due to daily update limits.
 				//"GANDI_V5",      // Their API is so damn slow. We'll add it back as needed.
 				//"HEDNS",         // No paging done. No need to test.
 				//"MSDNS",         // No paging done. No need to test.


### PR DESCRIPTION
* Update deSEC to include the 300 updates per day per domain limit
* Remove deSEC from certain tests that would exceed limits