### PR TITLE
GitHub: Added contact links

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,6 @@
 ---
 name: Bug report
-about: Create a report to help us improve
+about: Create a report to help us improve.
 title: ''
 labels: ''
 assignees: ''

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: I have a question or need support
+    url: https://docs.dnscontrol.org/
+    about: We use GitHub for tracking bugs, check our website for resources on getting help.
+  - name: I'm unsure where to go
+    url: https://groups.google.com/g/dnscontrol-discuss
+    about: If you are unsure where to go, then joining our mailing list is recommended; Just ask!

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,6 +1,6 @@
 ---
 name: Feature request
-about: Suggest an idea for this project
+about: Suggest an idea for this project.
 title: ''
 labels: ''
 assignees: ''


### PR DESCRIPTION
I've add two [contact links](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#configuring-the-template-chooser) when creating an GitHub issue:

1. [Documentation](https://docs.dnscontrol.org/)
2. [Mailing list](https://groups.google.com/g/dnscontrol-discuss)

![](https://github.com/StackExchange/dnscontrol/assets/1150425/97fe0733-3feb-4076-93ae-00b8a4418dce|width=750px)

_Text is based on the [Get Involved](https://docs.dnscontrol.org/#get-involved) paragraph._

An live example can be found at: https://github.com/cafferata/dnscontrol/issues/new/choose


