### PR TITLE
AXFRDDNS: Avoid appending dot if TSIG key ID already has a dot suffix

### DIFF
--- a/providers/axfrddns/axfrddnsProvider.go
+++ b/providers/axfrddns/axfrddnsProvider.go
@@ -212,7 +212,11 @@ func readKey(raw string, kind string) (*Key, error) {
 	if err != nil {
 		return nil, fmt.Errorf("cannot decode Base64 secret (%s) in AXFRDDNS.TSIG", kind)
 	}
-	return &Key{algo: algo, id: arr[1] + ".", secret: arr[2]}, nil
+	id := arr[1]
+	if !strings.HasSuffix(id, ".") {
+		id += "."
+	}
+	return &Key{algo: algo, id: id, secret: arr[2]}, nil
 }
 
 // GetNameservers returns the nameservers for a domain.


### PR DESCRIPTION
AXFRDDNS provider will append a `.` to TSIG key ID no matter if there's already an existing one.

If the key ID provided by user already has a dot suffix, a general `bad rdata` error will be shown without few meaningful clue for troubleshooting.