### PR TITLE
CHORE: Resolved unused parameter warnings

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -55,7 +55,7 @@ require (
 	golang.org/x/net v0.21.0
 	golang.org/x/oauth2 v0.17.0
 	google.golang.org/api v0.167.0
-	gopkg.in/ns1/ns1-go.v2 v2.8.0
+	gopkg.in/ns1/ns1-go.v2 v2.7.11
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -575,8 +575,8 @@ gopkg.in/h2non/gock.v1 v1.1.2/go.mod h1:n7UGz/ckNChHiK05rDoiC4MYSunEC/lyaUm2WWaD
 gopkg.in/ini.v1 v1.51.1/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/ini.v1 v1.67.0 h1:Dgnx+6+nfE+IfzjUEISNeydPJh9AXNNsWbGP9KzCsOA=
 gopkg.in/ini.v1 v1.67.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
-gopkg.in/ns1/ns1-go.v2 v2.8.0 h1:oX8QEHCCvnbTSqnSZRRHiGJsgke8eluTtQhNlPpFZBc=
-gopkg.in/ns1/ns1-go.v2 v2.8.0/go.mod h1:pfaU0vECVP7DIOr453z03HXS6dFJpXdNRwOyRzwmPSc=
+gopkg.in/ns1/ns1-go.v2 v2.7.11 h1:fs8fkDjfdWdR2Gg//HO+LHrtC38+Z+xpUs3z4iojsn8=
+gopkg.in/ns1/ns1-go.v2 v2.7.11/go.mod h1:pfaU0vECVP7DIOr453z03HXS6dFJpXdNRwOyRzwmPSc=
 gopkg.in/readline.v1 v1.0.0-20160726135117-62c6fe619375/go.mod h1:lNEQeAhU009zbRxng+XOj5ITVgY24WcbNnQopyfKoYQ=
 gopkg.in/sourcemap.v1 v1.0.5 h1:inv58fC9f9J3TK2Y2R1NPntXEn3/wjWHkonhIUODNTI=
 gopkg.in/sourcemap.v1 v1.0.5/go.mod h1:2RlvNNSMglmRrcvhfuzp4hQHwOtjxlbjX7UPY/GXb78=

--- a/pkg/normalize/validate.go
+++ b/pkg/normalize/validate.go
@@ -103,7 +103,7 @@ func errorRepeat(label, domain string) string {
 	)
 }
 
-func checkLabel(label string, rType string, target, domain string, meta map[string]string) error {
+func checkLabel(label string, rType string, domain string, meta map[string]string) error {
 	if label == "@" {
 		return nil
 	}
@@ -142,7 +142,7 @@ func checkLabel(label string, rType string, target, domain string, meta map[stri
 	return nil
 }
 
-func checkSoa(expire uint32, minttl uint32, refresh uint32, retry uint32, serial uint32, mbox string) error {
+func checkSoa(expire uint32, minttl uint32, refresh uint32, retry uint32, mbox string) error {
 	if expire <= 0 {
 		return fmt.Errorf("SOA Expire must be > 0")
 	}
@@ -213,7 +213,7 @@ func checkTargets(rec *models.RecordConfig, domain string) (errs []error) {
 	case "PTR":
 		check(checkTarget(target))
 	case "SOA":
-		check(checkSoa(rec.SoaExpire, rec.SoaMinttl, rec.SoaRefresh, rec.SoaRetry, rec.SoaSerial, rec.SoaMbox))
+		check(checkSoa(rec.SoaExpire, rec.SoaMinttl, rec.SoaRefresh, rec.SoaRetry, rec.SoaMbox))
 		check(checkTarget(target))
 		if label != "@" {
 			check(fmt.Errorf("SOA record is only valid for bare domain"))
@@ -373,7 +373,7 @@ func ValidateAndNormalizeConfig(config *models.DNSConfig) (errs []error) {
 			if err := validateRecordTypes(rec, domain.Name, pTypes); err != nil {
 				errs = append(errs, err)
 			}
-			if err := checkLabel(rec.GetLabel(), rec.Type, rec.GetTargetField(), domain.Name, rec.Metadata); err != nil {
+			if err := checkLabel(rec.GetLabel(), rec.Type, domain.Name, rec.Metadata); err != nil {
 				errs = append(errs, err)
 			}
 

--- a/pkg/normalize/validate_test.go
+++ b/pkg/normalize/validate_test.go
@@ -41,35 +41,34 @@ func TestCheckSoa(t *testing.T) {
 		minttl  uint32
 		refresh uint32
 		retry   uint32
-		serial  uint32
 		mbox    string
 	}{
 		// Expire
-		{false, 123, 123, 123, 123, 123, "foo.bar.com."},
-		{true, 0, 123, 123, 123, 123, "foo.bar.com."},
+		{false, 123, 123, 123, 123, "foo.bar.com."},
+		{true, 0, 123, 123, 123, "foo.bar.com."},
 		// MinTTL
-		{false, 123, 123, 123, 123, 123, "foo.bar.com."},
-		{true, 123, 0, 123, 123, 123, "foo.bar.com."},
+		{false, 123, 123, 123, 123, "foo.bar.com."},
+		{true, 123, 0, 123, 123, "foo.bar.com."},
 		// Refresh
-		{false, 123, 123, 123, 123, 123, "foo.bar.com."},
-		{true, 123, 123, 0, 123, 123, "foo.bar.com."},
+		{false, 123, 123, 123, 123, "foo.bar.com."},
+		{true, 123, 123, 0, 123, "foo.bar.com."},
 		// Retry
-		{false, 123, 123, 123, 123, 123, "foo.bar.com."},
-		{true, 123, 123, 123, 0, 123, "foo.bar.com."},
+		{false, 123, 123, 123, 123, "foo.bar.com."},
+		{true, 123, 123, 123, 0, "foo.bar.com."},
 		// Serial
-		{false, 123, 123, 123, 123, 123, "foo.bar.com."},
-		{false, 123, 123, 123, 123, 0, "foo.bar.com."},
+		{false, 123, 123, 123, 123, "foo.bar.com."},
+		{false, 123, 123, 123, 123, "foo.bar.com."},
 		// MBox
-		{true, 123, 123, 123, 123, 123, ""},
-		{true, 123, 123, 123, 123, 123, "foo@bar.com."},
-		{false, 123, 123, 123, 123, 123, "foo.bar.com."},
+		{true, 123, 123, 123, 123, ""},
+		{true, 123, 123, 123, 123, "foo@bar.com."},
+		{false, 123, 123, 123, 123, "foo.bar.com."},
 	}
 
 	for _, test := range tests {
-		experiment := fmt.Sprintf("%d %d %d %d %d %s", test.expire, test.minttl, test.refresh,
-			test.retry, test.serial, test.mbox)
+		experiment := fmt.Sprintf("%d %d %d %d %s", test.expire, test.minttl, test.refresh,
+			test.retry, test.mbox)
 		t.Run(experiment, func(t *testing.T) {
-			err := checkSoa(test.expire, test.minttl, test.refresh, test.retry, test.serial, test.mbox)
+			err := checkSoa(test.expire, test.minttl, test.refresh, test.retry, test.mbox)
 			checkError(t, err, test.isError, experiment)
 		})
 	}
@@ -102,7 +101,7 @@ func TestCheckLabel(t *testing.T) {
 			if test.hasSkipMeta {
 				meta["skip_fqdn_check"] = "true"
 			}
-			err := checkLabel(test.label, test.rType, test.target, "foo.tld", meta)
+			err := checkLabel(test.label, test.rType, "foo.tld", meta)
 			if err != nil && !test.isError {
 				t.Errorf("%02d: Expected no error but got %s", i, err)
 			}

--- a/providers/akamaiedgedns/akamaiEdgeDnsService.go
+++ b/providers/akamaiedgedns/akamaiEdgeDnsService.go
@@ -186,7 +186,7 @@ func getAuthorities(contractID string) ([]string, error) {
 }
 
 // rcToRs converts DNSControl RecordConfig records to an AkamaiEdgeDNS recordset.
-func rcToRs(records []*models.RecordConfig, zonename string) (*dnsv2.RecordBody, error) {
+func rcToRs(records []*models.RecordConfig) (*dnsv2.RecordBody, error) {
 	if len(records) == 0 {
 		return nil, fmt.Errorf("no records to replace")
 	}
@@ -206,7 +206,7 @@ func rcToRs(records []*models.RecordConfig, zonename string) (*dnsv2.RecordBody,
 
 // createRecordset creates a new AkamaiEdgeDNS recordset in the zone.
 func createRecordset(records []*models.RecordConfig, zonename string) error {
-	akaRecord, err := rcToRs(records, zonename)
+	akaRecord, err := rcToRs(records)
 	if err != nil {
 		return err
 	}
@@ -220,7 +220,7 @@ func createRecordset(records []*models.RecordConfig, zonename string) error {
 
 // replaceRecordset replaces an existing AkamaiEdgeDNS recordset in the zone.
 func replaceRecordset(records []*models.RecordConfig, zonename string) error {
-	akaRecord, err := rcToRs(records, zonename)
+	akaRecord, err := rcToRs(records)
 	if err != nil {
 		return err
 	}
@@ -234,7 +234,7 @@ func replaceRecordset(records []*models.RecordConfig, zonename string) error {
 
 // deleteRecordset deletes an existing AkamaiEdgeDNS recordset in the zone.
 func deleteRecordset(records []*models.RecordConfig, zonename string) error {
-	akaRecord, err := rcToRs(records, zonename)
+	akaRecord, err := rcToRs(records)
 	if err != nil {
 		return err
 	}

--- a/providers/azuredns/azureDnsProvider.go
+++ b/providers/azuredns/azureDnsProvider.go
@@ -223,7 +223,7 @@ func (a *azurednsProvider) GetZoneRecordsCorrections(dc *models.DomainConfig, ex
 			corrections = append(corrections, &models.Correction{
 				Msg: msgs,
 				F: func() error {
-					return a.recordDelete(dcn, chaKey, change.Old)
+					return a.recordDelete(dcn, chaKey)
 				},
 			})
 		default:
@@ -271,7 +271,7 @@ retry:
 	return err
 }
 
-func (a *azurednsProvider) recordDelete(zoneName string, reckey models.RecordKey, recs models.Records) error {
+func (a *azurednsProvider) recordDelete(zoneName string, reckey models.RecordKey) error {
 
 	shortName := strings.TrimSuffix(reckey.NameFQDN, "."+zoneName)
 	if shortName == zoneName {

--- a/providers/azureprivatedns/azurePrivateDnsProvider.go
+++ b/providers/azureprivatedns/azurePrivateDnsProvider.go
@@ -211,7 +211,7 @@ func (a *azurednsProvider) GetZoneRecordsCorrections(dc *models.DomainConfig, ex
 			corrections = append(corrections, &models.Correction{
 				Msg: msgs,
 				F: func() error {
-					return a.recordDelete(dcn, chaKey, change.Old)
+					return a.recordDelete(dcn, chaKey)
 				},
 			})
 		default:
@@ -259,7 +259,7 @@ retry:
 	return err
 }
 
-func (a *azurednsProvider) recordDelete(zoneName string, reckey models.RecordKey, recs models.Records) error {
+func (a *azurednsProvider) recordDelete(zoneName string, reckey models.RecordKey) error {
 
 	shortName := strings.TrimSuffix(reckey.NameFQDN, "."+zoneName)
 	if shortName == zoneName {

--- a/providers/cscglobal/dns.go
+++ b/providers/cscglobal/dns.go
@@ -92,15 +92,15 @@ func (client *providerClient) GetZoneRecordsCorrections(dc *models.DomainConfig,
 	var edits []zoneResourceRecordEdit
 	var descriptions []string
 	for _, del := range dels {
-		edits = append(edits, makePurge(dc.Name, del))
+		edits = append(edits, makePurge(del))
 		descriptions = append(descriptions, del.String())
 	}
 	for _, cre := range creates {
-		edits = append(edits, makeAdd(dc.Name, cre))
+		edits = append(edits, makeAdd(cre))
 		descriptions = append(descriptions, cre.String())
 	}
 	for _, m := range modifications {
-		edits = append(edits, makeEdit(dc.Name, m))
+		edits = append(edits, makeEdit(m))
 		descriptions = append(descriptions, m.String())
 	}
 	if len(edits) > 0 {
@@ -126,7 +126,7 @@ func (client *providerClient) GetZoneRecordsCorrections(dc *models.DomainConfig,
 	return corrections, nil
 }
 
-func makePurge(domainname string, cor diff.Correlation) zoneResourceRecordEdit {
+func makePurge(cor diff.Correlation) zoneResourceRecordEdit {
 	var existingTarget string
 
 	switch cor.Existing.Type {
@@ -152,7 +152,7 @@ func makePurge(domainname string, cor diff.Correlation) zoneResourceRecordEdit {
 	return zer
 }
 
-func makeAdd(domainname string, cre diff.Correlation) zoneResourceRecordEdit {
+func makeAdd(cre diff.Correlation) zoneResourceRecordEdit {
 	rec := cre.Desired
 
 	var recTarget string
@@ -192,7 +192,7 @@ func makeAdd(domainname string, cre diff.Correlation) zoneResourceRecordEdit {
 	return zer
 }
 
-func makeEdit(domainname string, m diff.Correlation) zoneResourceRecordEdit {
+func makeEdit(m diff.Correlation) zoneResourceRecordEdit {
 	old, rec := m.Existing, m.Desired
 	// TODO: Assert that old.Type == rec.Type
 	// TODO: Assert that old.Name == rec.Name

--- a/providers/desec/convert.go
+++ b/providers/desec/convert.go
@@ -35,7 +35,7 @@ func nativeToRecords(n resourceRecord, origin string) (rcs []*models.RecordConfi
 	return rcs
 }
 
-func recordsToNative(rcs []*models.RecordConfig, origin string) []resourceRecord {
+func recordsToNative(rcs []*models.RecordConfig) []resourceRecord {
 	// Take a list of RecordConfig and return an equivalent list of resourceRecord.
 	// deSEC requires one resourceRecord for each label:key tuple, therefore we
 	// might collapse many RecordConfig into one resourceRecord.

--- a/providers/desec/desecProvider.go
+++ b/providers/desec/desecProvider.go
@@ -198,7 +198,7 @@ func (c *desecProvider) GetZoneRecordsCorrections(dc *models.DomainConfig, exist
 			}
 		} else {
 			//it must be an update or create, both can be done with the same api call.
-			ns := recordsToNative(desiredRecords[label], dc.Name)
+			ns := recordsToNative(desiredRecords[label])
 			if len(ns) > 1 {
 				panic("we got more than one resource record to create / modify")
 			}

--- a/providers/digitalocean/digitaloceanProvider.go
+++ b/providers/digitalocean/digitaloceanProvider.go
@@ -195,7 +195,7 @@ func (api *digitaloceanProvider) GetZoneRecordsCorrections(dc *models.DomainConf
 		corrections = append(corrections, corr)
 	}
 	for _, m := range toCreate {
-		req := toReq(dc, m.Desired)
+		req := toReq(m.Desired)
 		corr := &models.Correction{
 			Msg: m.String(),
 			F: func() error {
@@ -213,7 +213,7 @@ func (api *digitaloceanProvider) GetZoneRecordsCorrections(dc *models.DomainConf
 	}
 	for _, m := range toModify {
 		id := m.Existing.Original.(*godo.DomainRecord).ID
-		req := toReq(dc, m.Desired)
+		req := toReq(m.Desired)
 		corr := &models.Correction{
 			Msg: fmt.Sprintf("%s, DO ID: %d", m.String(), id),
 			F: func() error {
@@ -304,7 +304,7 @@ func toRc(domain string, r *godo.DomainRecord) *models.RecordConfig {
 	return t
 }
 
-func toReq(dc *models.DomainConfig, rc *models.RecordConfig) *godo.DomainRecordEditRequest {
+func toReq(rc *models.RecordConfig) *godo.DomainRecordEditRequest {
 	name := rc.GetLabel()         // DO wants the short name or "@" for apex.
 	target := rc.GetTargetField() // DO uses the target field only for a single value
 	priority := 0                 // DO uses the same property for MX and SRV priority

--- a/providers/dnsmadeeasy/types.go
+++ b/providers/dnsmadeeasy/types.go
@@ -140,7 +140,7 @@ func toRecordConfig(domain string, record *recordResponseDataEntry) *models.Reco
 	} else if record.Type == "CAA" {
 		value, unquoteErr := strconv.Unquote(record.Value)
 		if unquoteErr != nil {
-			panic(err)
+			panic(unquoteErr)
 		}
 		err = rc.SetTargetCAA(uint8(record.IssuerCritical), record.CaaType, value)
 	} else {

--- a/providers/doh/api.go
+++ b/providers/doh/api.go
@@ -31,6 +31,6 @@ func (c *dohProvider) getNameservers(domain string) ([]string, error) {
 	return ns, nil
 }
 
-func (c *dohProvider) updateNameservers(ns []string, domain string) error {
+func (c *dohProvider) updateNameservers(domain string) error {
 	return fmt.Errorf("DNS-over-HTTPS 'Registrar' is read only, changes must be applied to %s manually", domain)
 }

--- a/providers/doh/dohProvider.go
+++ b/providers/doh/dohProvider.go
@@ -54,7 +54,7 @@ func (c *dohProvider) GetRegistrarCorrections(dc *models.DomainConfig) ([]*model
 		{
 			Msg: fmt.Sprintf("Update nameservers %s -> %s", foundNameservers, expectedNameservers),
 			F: func() error {
-				return c.updateNameservers(expected, dc.Name)
+				return c.updateNameservers(dc.Name)
 			},
 		},
 	}, nil

--- a/providers/hexonet/records.go
+++ b/providers/hexonet/records.go
@@ -85,7 +85,7 @@ func (n *HXClient) GetZoneRecordsCorrections(dc *models.DomainConfig, actual mod
 		changes = true
 		fmt.Fprintln(buf, d)
 		rec := d.Existing.Original.(*HXRecord)
-		params[fmt.Sprintf("DELRR%d", delrridx)] = n.deleteRecordString(rec, dc.Name)
+		params[fmt.Sprintf("DELRR%d", delrridx)] = n.deleteRecordString(rec)
 		delrridx++
 	}
 	for _, chng := range mod {
@@ -93,7 +93,7 @@ func (n *HXClient) GetZoneRecordsCorrections(dc *models.DomainConfig, actual mod
 		fmt.Fprintln(buf, chng)
 		old := chng.Existing.Original.(*HXRecord)
 		new := chng.Desired
-		params[fmt.Sprintf("DELRR%d", delrridx)] = n.deleteRecordString(old, dc.Name)
+		params[fmt.Sprintf("DELRR%d", delrridx)] = n.deleteRecordString(old)
 		newRecordString, err := n.createRecordString(new, dc.Name)
 		if err != nil {
 			return corrections, err
@@ -256,6 +256,6 @@ func (n *HXClient) createRecordString(rc *models.RecordConfig, domain string) (s
 	return str, nil
 }
 
-func (n *HXClient) deleteRecordString(record *HXRecord, domain string) string {
+func (n *HXClient) deleteRecordString(record *HXRecord) string {
 	return record.Raw
 }

--- a/providers/hostingde/hostingdeProvider.go
+++ b/providers/hostingde/hostingdeProvider.go
@@ -178,9 +178,10 @@ func (hp *hostingdeProvider) GetZoneRecordsCorrections(dc *models.DomainConfig, 
 	}
 
 	defaultSoa := &hp.defaultSoa
-	if defaultSoa == nil {
-		defaultSoa = &soaValues{}
-	}
+	// Commented out because this can not happen:
+	// if defaultSoa == nil {
+	// 	defaultSoa = &soaValues{}
+	// }
 
 	newSOA := soaValues{
 		Refresh:     firstNonZero(desiredSoa.SoaRefresh, defaultSoa.Refresh, 86400),

--- a/providers/oracle/oracleProvider.go
+++ b/providers/oracle/oracleProvider.go
@@ -95,7 +95,7 @@ func (o *oracleProvider) EnsureZoneExists(domain string) error {
 	if err == nil {
 		return nil
 	}
-	if err != nil && getResp.RawResponse.StatusCode != 404 {
+	if getResp.RawResponse.StatusCode != 404 {
 		return err
 	}
 

--- a/providers/packetframe/packetframeProvider.go
+++ b/providers/packetframe/packetframeProvider.go
@@ -114,7 +114,7 @@ func (api *packetframeProvider) GetZoneRecordsCorrections(dc *models.DomainConfi
 	corrections := diff.GenerateMessageCorrections(toReport)
 
 	for _, m := range create {
-		req, err := toReq(zone.ID, dc, m.Desired)
+		req, err := toReq(zone.ID, m.Desired)
 		if err != nil {
 			return nil, err
 		}
@@ -150,7 +150,7 @@ func (api *packetframeProvider) GetZoneRecordsCorrections(dc *models.DomainConfi
 			continue
 		}
 
-		req, _ := toReq(zone.ID, dc, m.Desired)
+		req, _ := toReq(zone.ID, m.Desired)
 		req.ID = original.ID
 		corr := &models.Correction{
 			Msg: m.String(),
@@ -165,7 +165,7 @@ func (api *packetframeProvider) GetZoneRecordsCorrections(dc *models.DomainConfi
 	return corrections, nil
 }
 
-func toReq(zoneID string, dc *models.DomainConfig, rc *models.RecordConfig) (*domainRecord, error) {
+func toReq(zoneID string, rc *models.RecordConfig) (*domainRecord, error) {
 	req := &domainRecord{
 		Type:  rc.Type,
 		TTL:   int(rc.TTL),

--- a/providers/rwth/api.go
+++ b/providers/rwth/api.go
@@ -66,7 +66,7 @@ func checkIsLockedSystemRecord(record *models.RecordConfig) error {
 	return nil
 }
 
-func (api *rwthProvider) createRecord(domain string, record *models.RecordConfig) error {
+func (api *rwthProvider) createRecord(record *models.RecordConfig) error {
 	if err := checkIsLockedSystemRecord(record); err != nil {
 		return err
 	}

--- a/providers/rwth/dns.go
+++ b/providers/rwth/dns.go
@@ -43,7 +43,7 @@ func (api *rwthProvider) GetZoneRecordsCorrections(dc *models.DomainConfig, exis
 		des := d.Desired
 		corrections = append(corrections, &models.Correction{
 			Msg: d.String(),
-			F:   func() error { return api.createRecord(dc.Name, des) },
+			F:   func() error { return api.createRecord(des) },
 		})
 	}
 	for _, d := range del {

--- a/providers/vultr/convert_test.go
+++ b/providers/vultr/convert_test.go
@@ -65,7 +65,7 @@ func TestConversion(t *testing.T) {
 			t.Error("Error converting Vultr record", record)
 		}
 
-		converted := toVultrRecord(dc, rc, "0")
+		converted := toVultrRecord(rc, "0")
 
 		if converted.Type != record.Type || converted.Name != record.Name || converted.Data != record.Data || (converted.Priority != record.Priority) || converted.TTL != record.TTL {
 			t.Error("Vultr record conversion mismatch", record, rc, converted)

--- a/providers/vultr/vultrProvider.go
+++ b/providers/vultr/vultrProvider.go
@@ -137,7 +137,7 @@ func (api *vultrProvider) GetZoneRecordsCorrections(dc *models.DomainConfig, cur
 		case diff2.REPORT:
 			corrections = append(corrections, &models.Correction{Msg: change.MsgsJoined})
 		case diff2.CREATE:
-			r := toVultrRecord(dc, change.New[0], "0")
+			r := toVultrRecord(change.New[0], "0")
 			corrections = append(corrections, &models.Correction{
 				Msg: change.Msgs[0],
 				F: func() error {
@@ -146,7 +146,7 @@ func (api *vultrProvider) GetZoneRecordsCorrections(dc *models.DomainConfig, cur
 				},
 			})
 		case diff2.CHANGE:
-			r := toVultrRecord(dc, change.New[0], change.Old[0].Original.(govultr.DomainRecord).ID)
+			r := toVultrRecord(change.New[0], change.Old[0].Original.(govultr.DomainRecord).ID)
 			corrections = append(corrections, &models.Correction{
 				Msg: fmt.Sprintf("%s; Vultr RecordID: %v", change.Msgs[0], r.ID),
 				F: func() error {
@@ -271,7 +271,7 @@ func toRecordConfig(domain string, r govultr.DomainRecord) (*models.RecordConfig
 }
 
 // toVultrRecord converts a RecordConfig converted by toRecordConfig back to a Vultr DomainRecordReq. #rtype_variations
-func toVultrRecord(dc *models.DomainConfig, rc *models.RecordConfig, vultrID string) *govultr.DomainRecord {
+func toVultrRecord(rc *models.RecordConfig, vultrID string) *govultr.DomainRecord {
 	name := rc.GetLabel()
 	// Vultr uses a blank string to represent the apex domain.
 	if name == "@" {


### PR DESCRIPTION
Fixed many linting errors all related to "unused parameters".  There are still some left to fix.

CC'ing various code owners for visibility:

* pkg/normalize @tlimoncelli
* providers/akamaiedgedns @svernick
* providers/azuredns @vatsalyagoel
* providers/azureprivatedns @matthewmgamble
* providers/cscglobal @mikenz
* providers/desec @D3luxee
* providers/digitalocean @Deraen
* providers/dnsmadeeasy @vojtad
* providers/doh @mikenz
* providers/hexonet @KaiSchwarz-cnic
* providers/hostingde @juliusrickert
* providers/oracle @kallsyms
* providers/packetframe @hamptonmoore
* providers/rwth @mistererwin
* providers/vultr @pgaskin
