### PR TITLE
GCORE: add DNSSEC support

### DIFF
--- a/documentation/providers.md
+++ b/documentation/providers.md
@@ -35,7 +35,7 @@ If a feature is definitively not supported for whatever reason, we would also li
 | [`EXOSCALE`](providers/exoscale.md) | ❌ | ✅ | ❌ | ❌ | ✅ | ✅ | ❔ | ❌ | ❔ | ✅ | ❔ | ✅ | ❔ | ❌ | ❔ | ❔ | ❌ | ❌ | ❔ |
 | [`GANDI_V5`](providers/gandi_v5.md) | ❌ | ✅ | ✅ | ❌ | ✅ | ✅ | ❔ | ❌ | ❔ | ✅ | ❔ | ✅ | ✅ | ✅ | ❌ | ❔ | ❔ | ❌ | ✅ |
 | [`GCLOUD`](providers/gcloud.md) | ✅ | ✅ | ❌ | ✅ | ✅ | ✅ | ❔ | ❌ | ❔ | ✅ | ❔ | ✅ | ✅ | ✅ | ❔ | ❔ | ✅ | ✅ | ✅ |
-| [`GCORE`](providers/gcore.md) | ❌ | ✅ | ❌ | ❌ | ✅ | ✅ | ❌ | ❌ | ❌ | ✅ | ❔ | ✅ | ❌ | ❌ | ❌ | ❔ | ✅ | ✅ | ✅ |
+| [`GCORE`](providers/gcore.md) | ❌ | ✅ | ❌ | ❌ | ✅ | ✅ | ✅ | ❌ | ❌ | ✅ | ❔ | ✅ | ❌ | ❌ | ❌ | ❔ | ✅ | ✅ | ✅ |
 | [`HEDNS`](providers/hedns.md) | ❌ | ✅ | ❌ | ❌ | ✅ | ✅ | ❌ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | ❌ | ❌ | ❔ | ✅ | ✅ | ✅ |
 | [`HETZNER`](providers/hetzner.md) | ❌ | ✅ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ | ✅ | ❔ | ✅ | ✅ | ✅ |
 | [`HEXONET`](providers/hexonet.md) | ❌ | ✅ | ✅ | ❌ | ❌ | ✅ | ❔ | ❔ | ❔ | ✅ | ❔ | ✅ | ❔ | ✅ | ❔ | ❔ | ✅ | ✅ | ❔ |

--- a/providers/gcore/gcoreExtend.go
+++ b/providers/gcore/gcoreExtend.go
@@ -13,6 +13,14 @@ import (
 	dnssdk "github.com/G-Core/gcore-dns-sdk-go"
 )
 
+type gcoreZone struct {
+	DNSSECEnabled bool `json:"dnssec_enabled"`
+}
+
+type gcoreDNSSECRequest struct {
+	Enabled bool `json:"enabled"`
+}
+
 type gcoreRRSets struct {
 	RRSets []gcoreRRSetExtended `json:"rrsets"`
 }
@@ -102,4 +110,30 @@ func (c *gcoreProvider) dnssdkRRSets(domain string) (gcoreRRSets, error) {
 	}
 
 	return result, nil
+}
+
+func (c *gcoreProvider) dnssdkGetDNSSEC(domain string) (bool, error) {
+	var result gcoreZone
+	url := fmt.Sprintf("/v2/zones/%s", domain)
+
+	err := dnssdkDo(c.ctx, c.provider, c.apiKey, http.MethodGet, url, nil, &result)
+	if err != nil {
+		return false, err
+	}
+
+	return result.DNSSECEnabled, nil
+}
+
+func (c *gcoreProvider) dnssdkSetDNSSEC(domain string, enabled bool) error {
+	var request gcoreDNSSECRequest
+	request.Enabled = enabled
+
+	url := fmt.Sprintf("/v2/zones/%s/dnssec", domain)
+
+	err := dnssdkDo(c.ctx, c.provider, c.apiKey, http.MethodPatch, url, request, nil)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }


### PR DESCRIPTION
<!--
## Before submiting a pull request

Please make sure you've run the following commands from the root directory.

go vet ./...
go fmt ./...
go generate ./...
go mod tidy

## Release changelog section

Help keep the release changelog clear by pre-naming the proper section in the GitHub pull request title.

Some examples:
* CICD: Add required GHA permissions for goreleaser
* DOCS: Fixed providers with "contributor support" table
* ROUTE53: Allow R53_ALIAS records to enable target health evaluation

More examples/context can be found in the file .goreleaser.yml under the 'build' > 'changelog' key.
!-->

Gcore DNS recently added support for DNSSEC: https://gcore.com/news/dnssec-open-beta/

Add `AUTODNSSEC_ON/OFF` support for Gcore provider, following their API doc: https://gcore.com/docs/dns/getting-started-with-dnssec

Manually tested and passed integration test.