### PR TITLE
DOCS: Warn that get-certs will be removed without notice

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -161,7 +161,7 @@ release:
     > [!WARNING]
     > - **MSDNS maintainer needed!** Without a new volunteer, this DNS provider will lose support after April 2025. See https://github.com/StackExchange/dnscontrol/issues/2878
     > - **Call for new volunteer maintainers for NAMEDOTCOM and SOFTLAYER.** These providers have no maintainer. Maintainers respond to PRs and fix bugs in a timely manner, and try to stay on top of protocol changes.
-    > - **ACME/Let's Encrypt support is frozen and will be removed without notice between now and April 2025.**  It has been unsupported since December 2022.  If you don't use this feature, do not start. If you do use this feature, migrate ASAP.  See discussion in [issues/1400](https://github.com/StackExchange/dnscontrol/issues/1400)
+    > - **get-certs/ACME support is frozen and will be removed without notice between now and July 2025.** It has been unsupported since December 2022.  If you don't use this feature, do not start. If you do use this feature, migrate ASAP.  See discussion in [issues/1400](https://github.com/StackExchange/dnscontrol/issues/1400)
 
     ## Install
 

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ See [dnscontrol-action](https://github.com/koenrh/dnscontrol-action) or [gacts/i
 
 - **MSDNS maintainer needed!** Without a new volunteer, this DNS provider will lose support after April 2025. See https://github.com/StackExchange/dnscontrol/issues/2878
 - **Call for new volunteer maintainers for NAMEDOTCOM and SOFTLAYER.** These providers have no maintainer. Maintainers respond to PRs and fix bugs in a timely manner, and try to stay on top of protocol changes.
-- **ACME/Let's Encrypt support is frozen and will be removed without notice between now and April 2025.**  It has been unsupported since December 2022.  If you don't use this feature, do not start. If you do use this feature, migrate ASAP.  See discussion in [issues/1400](https://github.com/StackExchange/dnscontrol/issues/1400)
+- **get-certs/ACME support is frozen and will be removed without notice between now and July 2025.** It has been unsupported since December 2022.  If you don't use this feature, do not start. If you do use this feature, migrate ASAP.  See discussion in [issues/1400](https://github.com/StackExchange/dnscontrol/issues/1400)
 
 ## More info at our website
 

--- a/commands/getCerts.go
+++ b/commands/getCerts.go
@@ -24,6 +24,8 @@ var _ = cmd(catUtils, func() *cli.Command {
 			return exit(GetCerts(args))
 		},
 		Flags: args.flags(),
+
+		Hidden: true,
 	}
 }())
 

--- a/documentation/get-certs.md
+++ b/documentation/get-certs.md
@@ -1,7 +1,7 @@
 # *Let's Encrypt* Certificate generation
 
 {% hint style="warning" %}
-**WARNING**: This feature is frozen and will be removed without notice between now and April 2025.
+**WARNING**: This feature is frozen and will be removed without notice between now and July 2025.
 It has been unsupported since December 2022.
 This feature has no maintainer. There are other projects that do a better job. 
 If you do use this feature, please migrate to something else ASAP.

--- a/documentation/get-certs.md
+++ b/documentation/get-certs.md
@@ -1,8 +1,11 @@
 # *Let's Encrypt* Certificate generation
 
 {% hint style="warning" %}
-**WARNING**: This feature
-is frozen and will be removed in early 2023. The "get-certs" command (renews certs via Let's Encrypt) has no maintainer. There are other projects that do a better job. If you don't use this feature, please do not start. If you do use this feature, please plan on migrating to something else. See discussion in [#1400](https://github.com/StackExchange/dnscontrol/issues/1400)
+**WARNING**: This feature is frozen and will be removed without notice between now and April 2025.
+It has been unsupported since December 2022.
+This feature has no maintainer. There are other projects that do a better job. 
+If you do use this feature, please migrate to something else ASAP.
+See discussion in [issues/1400](https://github.com/StackExchange/dnscontrol/issues/1400)
 {% endhint %}
 
 DNSControl will generate/renew Let's Encrypt certificates using DNS


### PR DESCRIPTION
* Make the "get-certs" subcommand hidden.
* Warn that the code may be removed without notice.
* Unify the warning to list July 2025 as the max deadline.