### PR TITLE
DOCS: Disabling colors via environment variable

### DIFF
--- a/documentation/colors.md
+++ b/documentation/colors.md
@@ -15,6 +15,8 @@ codes.
 In order to do so, a global `--no-colors` command option is provided, which when
 set `--no-colors=true`, will disable colors globally.
 
+Alternatively, a `NO_COLOR` environment variable set to any non-empty string will disable color output.
+
 ## (Force) Enable colors
 
 If color support is not correctly detected, providing `--no-colors=false` would


### PR DESCRIPTION
dnscontrol uses fatih/color package which respects the NO_COLOR standard

https://github.com/fatih/color?tab=readme-ov-file#disableenable-color

https://no-color.org

This change touches only docs, no code, so no code testing was performed.