### PR TITLE
POWERDNS: Change DHCID test value to valid base64 code

### DIFF
--- a/integrationTest/integration_test.go
+++ b/integrationTest/integration_test.go
@@ -1602,7 +1602,7 @@ func makeTests() []*TestGroup {
 		testgroup("DHCID",
 			requires(providers.CanUseDHCID),
 			tc("Create DHCID record", dhcid("test", "AAIBY2/AuCccgoJbsaxcQc9TUapptP69lOjxfNuVAA2kjEA=")),
-			tc("Modify DHCID record", dhcid("test", "Test/AuCccgoJbsaxcQc9TUapptP69lOjxfNuVAA2kjEA=")),
+			tc("Modify DHCID record", dhcid("test", "FOOAAAAAAAAuCccgoJbsaxcQc9TUapptP69lOjxfNuVAA2kjEA=")),
 		),
 
 		testgroup("DNAME",


### PR DESCRIPTION
Fixes broken DHCID test for PowerDNS