### PR TITLE
POWERDNS: Value in test was too long

### DIFF
--- a/integrationTest/integration_test.go
+++ b/integrationTest/integration_test.go
@@ -1602,7 +1602,7 @@ func makeTests() []*TestGroup {
 		testgroup("DHCID",
 			requires(providers.CanUseDHCID),
 			tc("Create DHCID record", dhcid("test", "AAIBY2/AuCccgoJbsaxcQc9TUapptP69lOjxfNuVAA2kjEA=")),
-			tc("Modify DHCID record", dhcid("test", "FOOAAAAAAAAuCccgoJbsaxcQc9TUapptP69lOjxfNuVAA2kjEA=")),
+			tc("Modify DHCID record", dhcid("test", "AAAAAAAAuCccgoJbsaxcQc9TUapptP69lOjxfNuVAA2kjEA=")),
 		),
 
 		testgroup("DNAME",


### PR DESCRIPTION
Sorry @tlimoncelli - shouldn't have relied on just it being valid base64, there's a max length too.
