### PR TITLE
AKAMAIEDGEDNS: new maintainer: Ed Lynes

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,4 +1,4 @@
-providers/akamaiedgedns @cdornin
+providers/akamaiedgedns @edglynes
 providers/autodns @arnoschoon
 providers/axfrddns @hnrgrgr
 providers/azuredns @vatsalyagoel

--- a/documentation/providers.md
+++ b/documentation/providers.md
@@ -110,7 +110,7 @@ Providers in this category and their maintainers are:
 |Name|Maintainer|
 |---|---|
 |[`AZURE_PRIVATE_DNS`](provider/azure_private_dns.md)|@matthewmgamble|
-|[`AKAMAIEDGEDNS`](provider/akamaiedgedns.md)|@cdornin|
+|[`AKAMAIEDGEDNS`](provider/akamaiedgedns.md)|@edglynes|
 |[`AXFRDDNS`](provider/axfrddns.md)|@hnrgrgr|
 |[`BUNNY_DNS`](provider/bunny_dns.md)|@ppmathis|
 |[`CLOUDFLAREAPI`](provider/cloudflareapi.md)|@tresni|


### PR DESCRIPTION
The new AKAMAIEDGEDNS maintainer is Ed Lynes (edglynes).