### PR TITLE
BUG: ZSH Autocomplete does not work if installed as a file #2955

### DIFF
--- a/commands/completion-scripts/completion.zsh.gotmpl
+++ b/commands/completion-scripts/completion.zsh.gotmpl
@@ -1,4 +1,4 @@
-#compdef "{{.App.Name}}"
+#compdef {{.App.Name}}
 
 _dnscontrol() {
   local -a opts
@@ -17,4 +17,12 @@ _dnscontrol() {
   fi
 }
 
-compdef "_dnscontrol" "{{.App.Name}}"
+# Run the function the first time we are auto-loaded, otherwise the very first
+# complete wouldn't work in each shell session
+# Otherwise assume we are directly sourced and register the completion
+# (This is done by the #compdef directive in the autoloaded case.)
+if [[ "${zsh_eval_context[-1]}" == "loadautofunc" ]]; then
+  _dnscontrol "$@"
+else
+  compdef "_dnscontrol" "dnscontrol"
+fi


### PR DESCRIPTION
Fixes: #2955

The #compdef directive shouldn't have double-quotes. (https://zsh.sourceforge.io/Doc/Release/Completion-System.html#Autoloaded-files)

We need to execute the function the first time when its loaded as described by https://zsh.sourceforge.io/Doc/Release/Functions.html#Autoloading-Functions

> [If the KSH_AUTOLOAD option is not set] the function body
(with no surrounding `funcname() {...}``) is taken to be the complete contents of the file.
This form allows the file to be used directly as an executable shell script.
>
> If processing of the file results in the function being re-defined, the function itself is not re-executed. To force the shell to perform initialization and then call the function defined, the file should contain initialization code (which will be executed then discarded) in addition to a complete function definition (which will be retained for subsequent calls to the function), and a call to the shell function, including any arguments, at the end.

To keep direct sourcing possible, `zsh_eval_context` is used (https://zsh.sourceforge.io/Doc/Release/Parameters.html#Parameters-Set-By-The-Shell) to detect wether the script is being auto-loaded.
