### PR TITLE
DNSIMPLE: enable Null MX records

### DIFF
--- a/providers/dnsimple/auditrecords.go
+++ b/providers/dnsimple/auditrecords.go
@@ -11,7 +11,7 @@ import (
 func AuditRecords(records []*models.RecordConfig) []error {
 	a := rejectif.Auditor{}
 
-	a.Add("MX", rejectif.MxNull) // Last verified 2023-03
+	// DNSimple sent email 2024-05-16 announcing that they now support Null MX records.
 
 	a.Add("TXT", rejectif.TxtLongerThan(1000)) // Last verified 2023-12
 

--- a/providers/dnsimple/dnsimpleProvider.go
+++ b/providers/dnsimple/dnsimpleProvider.go
@@ -95,7 +95,9 @@ func (c *dnsimpleProvider) GetZoneRecords(domain string, meta map[string]string)
 			r.Name = "@"
 		}
 
-		if r.Type == "CNAME" || r.Type == "MX" || r.Type == "ALIAS" || r.Type == "NS" {
+		if r.Type == "CNAME" || r.Type == "ALIAS" || r.Type == "NS" {
+			r.Content += "."
+		} else if r.Type == "MX" && r.Content != "." {
 			r.Content += "."
 		}
 


### PR DESCRIPTION
DNSimple sent out an announcement 2024-05-16 that they now support Null MX records.