### PR TITLE
AXFRDDNS: Canonicalize key name as per RFC 2845 3.4.2

### DIFF
--- a/providers/axfrddns/axfrddnsProvider.go
+++ b/providers/axfrddns/axfrddnsProvider.go
@@ -216,10 +216,7 @@ func readKey(raw string, kind string) (*Key, error) {
 	if err != nil {
 		return nil, fmt.Errorf("cannot decode Base64 secret (%s) in AXFRDDNS.TSIG", kind)
 	}
-	id := arr[1]
-	if !strings.HasSuffix(id, ".") {
-		id += "."
-	}
+	id := dns.CanonicalName(arr[1])
 	return &Key{algo: algo, id: id, secret: arr[2]}, nil
 }
 


### PR DESCRIPTION
Hi,

In the AXFRDDNS provider, it appears we can use a key like: `hmac-sha256:MyTsIgKey:Base64EncodedSecret=`

But the key name (here `MyTsIgKey`) is not canonicalized, however it is required by the [RFC 2845](https://datatracker.ietf.org/doc/html/rfc2845#page-7).

This PR calls `CanonicalName`, which also adds a leading `.` if it is missing.