### PR TITLE
DOCS: [REVCOMPAT] Fixed broken URL's

### DIFF
--- a/documentation/opinions.md
+++ b/documentation/opinions.md
@@ -198,7 +198,7 @@ universally.
 Originally DNSControl implemented RFC 2317.
 
 In v5.0 we will adopt RFC 4183 as the default.  A new function,
-[REVCOMPAT()](functions/global/REVCOMPAT.md), will be provided to enable backwards compatibility.
+[REVCOMPAT()](language-reference/top-level-functions/REVCOMPAT.md), will be provided to enable backwards compatibility.
 v4.x users can use the function to adopt the new behavior early.
 
-See [REVCOMPAT()](functions/global/REVCOMPAT.md) for details.
+See [REVCOMPAT()](language-reference/top-level-functions/REVCOMPAT.md) for details.


### PR DESCRIPTION
Fixed the two broken `REVCOMPAT()` URL's. The two GitHub pull requests below have crossed each other.

1. https://github.com/StackExchange/dnscontrol/pull/2879#event-12347683302
2. https://github.com/StackExchange/dnscontrol/pull/2905#event-12411320354

> @tlimoncelli merged commit https://github.com/StackExchange/dnscontrol/commit/1d96981e117e23419b04d5a15d3aa7da733d51ce into main [on Apr 3](https://github.com/StackExchange/dnscontrol/pull/2879#event-12347683302)

@cafferata commented [on Apr 9](https://github.com/StackExchange/dnscontrol/pull/2905#issuecomment-2045814364)
> Just applied a rebase on main. Ready for review/merge. 👍