### PR TITLE
DOCS: [get-zones] Removed old reference to `convertzone`

### DIFF
--- a/documentation/get-zones.md
+++ b/documentation/get-zones.md
@@ -1,4 +1,4 @@
-# get-zones (was "convertzone")
+# get-zones
 
 DNSControl has a stand-alone utility that will contact a provider,
 download the records of one or more zones, and output them to a file


### PR DESCRIPTION
Removed the old reference to `convertzone` within the '[get-zones](https://docs.dnscontrol.org/commands/get-zones)' page.