### PR TITLE
HEXONET: Adopt version 4.0.0 of the rtldev-middleware-go-sdk

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/route53domains v1.23.6
 	github.com/babolivier/go-doh-client v0.0.0-20201028162107-a76cff4cb8b6
 	github.com/billputer/go-namecheap v0.0.0-20210108011502-994a912fb7f9
-	github.com/centralnicgroup-opensource/rtldev-middleware-go-sdk/v3 v3.5.6
+	github.com/centralnicgroup-opensource/rtldev-middleware-go-sdk/v4 v4.0.3
 	github.com/cloudflare/cloudflare-go v0.95.0
 	github.com/digitalocean/godo v1.115.0
 	github.com/ditashi/jsbeautifier-go v0.0.0-20141206144643-2520a8026a9c

--- a/go.sum
+++ b/go.sum
@@ -84,8 +84,8 @@ github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QH
 github.com/cenkalti/backoff/v3 v3.0.0 h1:ske+9nBpD9qZsTBoF41nW5L+AIuFBKMeze18XQ3eG1c=
 github.com/cenkalti/backoff/v3 v3.0.0/go.mod h1:cIeZDE3IrqwwJl6VUwCN6trj1oXrTS4rc0ij+ULvLYs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/centralnicgroup-opensource/rtldev-middleware-go-sdk/v3 v3.5.6 h1:NwzyMBDEihBaPYlsguXbiraAofgFL0dIokr7haRptng=
-github.com/centralnicgroup-opensource/rtldev-middleware-go-sdk/v3 v3.5.6/go.mod h1:AuVFPx7rRMTT6MstyP2eWwinthewLFWv+zbaoQ3A+fY=
+github.com/centralnicgroup-opensource/rtldev-middleware-go-sdk/v4 v4.0.3 h1:R6bNU7iZz+aPTrZM1zcpJnWOtfTJUgykyWz5hBs/isk=
+github.com/centralnicgroup-opensource/rtldev-middleware-go-sdk/v4 v4.0.3/go.mod h1:LgG44oKLMQN53wrIotY6mM1mjA9VOhGQd//lzAIF46A=
 github.com/chzyer/logex v1.2.1/go.mod h1:JLbx6lG2kDbNRFnfkgvh4eRJRPX1QCoOIWomwysCBrQ=
 github.com/chzyer/test v1.0.0/go.mod h1:2JlltgoNkt4TW/z9V/IzDdFaMTM2JPIi26O1pF38GC8=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=

--- a/providers/hexonet/error.go
+++ b/providers/hexonet/error.go
@@ -3,7 +3,7 @@ package hexonet
 import (
 	"fmt"
 
-	"github.com/centralnicgroup-opensource/rtldev-middleware-go-sdk/v3/response"
+	"github.com/centralnicgroup-opensource/rtldev-middleware-go-sdk/v4/response"
 )
 
 // GetHXApiError returns an error including API error code and error description.

--- a/providers/hexonet/hexonetProvider.go
+++ b/providers/hexonet/hexonetProvider.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 
 	"github.com/StackExchange/dnscontrol/v4/providers"
-	hxcl "github.com/centralnicgroup-opensource/rtldev-middleware-go-sdk/v3/apiclient"
+	hxcl "github.com/centralnicgroup-opensource/rtldev-middleware-go-sdk/v4/apiclient"
 )
 
 // GoReleaser: version


### PR DESCRIPTION
Version **4.0.0** of the `rtldev-middleware-go-sdk` includes bug fixes, performance improvements, and significant restructuring. Notable changes include:

- **Bug Fixes:**
    - Replaced the IDN translator.
    - Improved library structure to avoid import cycles and address linter issues.
    - Merged the response class with the response template and added a response translator.
    - Reviewed and patched failing tests related to the response template manager.

- **Performance Improvements:**
    - Deprecated the API IDN conversion.
    - Integrated the GOLang IDN library with tests.

- **BREAKING CHANGES:**
    - The response class has undergone significant restructuring to bring the library to the next Golang level and ensure future safety.