### PR TITLE
Byteplus DNS: initial support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -93,6 +93,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sts v1.28.8 // indirect
 	github.com/aws/smithy-go v1.20.2 // indirect
 	github.com/boombuler/barcode v1.0.1 // indirect
+	github.com/byteplus-sdk/byteplus-sdk-golang v1.0.23 // indirect
 	github.com/cenkalti/backoff v2.2.1+incompatible // indirect
 	github.com/cenkalti/backoff/v3 v3.0.0 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.4 // indirect

--- a/go.mod
+++ b/go.mod
@@ -61,6 +61,7 @@ require (
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.11.1
 	github.com/G-Core/gcore-dns-sdk-go v0.2.9
+	github.com/byteplus-sdk/byteplus-sdk-golang v1.0.23
 	github.com/fatih/color v1.17.0
 	github.com/fbiville/markdown-table-formatter v0.3.0
 	github.com/google/go-cmp v0.6.0
@@ -93,7 +94,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sts v1.28.8 // indirect
 	github.com/aws/smithy-go v1.20.2 // indirect
 	github.com/boombuler/barcode v1.0.1 // indirect
-	github.com/byteplus-sdk/byteplus-sdk-golang v1.0.23 // indirect
 	github.com/cenkalti/backoff v2.2.1+incompatible // indirect
 	github.com/cenkalti/backoff/v3 v3.0.0 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -41,6 +41,7 @@ github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo
 github.com/andybalholm/cascadia v1.3.2 h1:3Xi6Dw5lHF15JtdcmAHD3i1+T8plmv7BQ/nsViSLyss=
 github.com/andybalholm/cascadia v1.3.2/go.mod h1:7gtRlve5FxPPgIgX36uWBX58OdBsSS6lUvCFb+h7KvU=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
+github.com/avast/retry-go v3.0.0+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=
 github.com/aws/aws-sdk-go-v2 v1.26.2 h1:OTRAL8EPdNoOdiq5SUhCaHhVPBU2wxAUe5uwasoJGRM=
 github.com/aws/aws-sdk-go-v2 v1.26.2/go.mod h1:ffIFB97e2yNsv4aTSGkqtHnppsIJzw7G7BReUZ3jCXM=
 github.com/aws/aws-sdk-go-v2/config v1.27.14 h1:QOg8Ud53rrmdjBHX080AaYUBhG2ER28kP/yjE7afF/0=
@@ -79,6 +80,8 @@ github.com/billputer/go-namecheap v0.0.0-20210108011502-994a912fb7f9/go.mod h1:b
 github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
 github.com/boombuler/barcode v1.0.1 h1:NDBbPmhS+EqABEs5Kg3n/5ZNjy73Pz7SIV+KCeqyXcs=
 github.com/boombuler/barcode v1.0.1/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
+github.com/byteplus-sdk/byteplus-sdk-golang v1.0.23 h1:rKzSG6h9izXXnOjClBGBOLSp7iKV/H2zEZMgi0FJkjY=
+github.com/byteplus-sdk/byteplus-sdk-golang v1.0.23/go.mod h1:7iCaE+dR9EycrJU0GQyMhptbInLbQhsKXiDKDjNi8Vs=
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/cenkalti/backoff/v3 v3.0.0 h1:ske+9nBpD9qZsTBoF41nW5L+AIuFBKMeze18XQ3eG1c=
@@ -203,6 +206,7 @@ github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaU
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/enterprise-certificate-proxy v0.3.2 h1:Vie5ybvEvT75RniqhfFxPRy3Bf7vr3h0cechB90XaQs=
@@ -384,6 +388,7 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/transip/gotransip/v6 v6.24.0 h1:QaHgRT3ikpMCXr8Ntojiced/W4izd9ra9PNE/i+7qTE=
@@ -559,6 +564,7 @@ google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlba
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
+google.golang.org/protobuf v1.30.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 google.golang.org/protobuf v1.34.1 h1:9ddQBjfCyZPOHPUiPxpYESBLc+T8P3E+Vo4IbKZgFWg=
 google.golang.org/protobuf v1.34.1/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/integrationTest/providers.json
+++ b/integrationTest/providers.json
@@ -288,5 +288,10 @@
     "TYPE": "VULTR",
     "domain": "$VULTR_DOMAIN",
     "token": "$VULTR_TOKEN"
+  },
+  "BYTEPLUS": {
+    "ak": "$BYTEPLUS_ACCESS_KEY",
+    "sk": "$BYTEPLUS_SECRET_KEY",
+    "domain": "$BYTEPLUS_DOMAIN"
   }
 }

--- a/pkg/rejectif/mx.go
+++ b/pkg/rejectif/mx.go
@@ -16,3 +16,11 @@ func MxNull(rc *models.RecordConfig) error {
 	}
 	return nil
 }
+
+// MxPriorityMoreThan100 reject MX record that have priority/preference >= 100
+func MxPriorityMoreThan100(rc *models.RecordConfig) error {
+	if rc.MxPreference >= 100 {
+		return fmt.Errorf("mx preference/priority is over 100")
+	}
+	return nil
+}

--- a/providers/_all/all.go
+++ b/providers/_all/all.go
@@ -10,6 +10,7 @@ import (
 	_ "github.com/StackExchange/dnscontrol/v4/providers/azureprivatedns"
 	_ "github.com/StackExchange/dnscontrol/v4/providers/bind"
 	_ "github.com/StackExchange/dnscontrol/v4/providers/bunnydns"
+	_ "github.com/StackExchange/dnscontrol/v4/providers/byteplus"
 	_ "github.com/StackExchange/dnscontrol/v4/providers/cloudflare"
 	_ "github.com/StackExchange/dnscontrol/v4/providers/cloudns"
 	_ "github.com/StackExchange/dnscontrol/v4/providers/cscglobal"

--- a/providers/byteplus/auditrecords.go
+++ b/providers/byteplus/auditrecords.go
@@ -11,8 +11,12 @@ import (
 func AuditRecords(records []*models.RecordConfig) []error {
 	a := rejectif.Auditor{}
 
+	a.Add("TXT", rejectif.TxtIsEmpty)
 	a.Add("TXT", rejectif.TxtHasDoubleQuotes)
+	a.Add("TXT", rejectif.TxtHasSingleQuotes)
+	a.Add("TXT", rejectif.TxtHasUnpairedDoubleQuotes)
 	a.Add("MX", rejectif.MxNull)
+	a.Add("MX", rejectif.MxPriorityMoreThan100)
 	a.Add("SRV", rejectif.SrvHasNullTarget)
 	a.Add("CAA", rejectif.CaaTargetContainsWhitespace)
 

--- a/providers/byteplus/auditrecords.go
+++ b/providers/byteplus/auditrecords.go
@@ -1,0 +1,20 @@
+package byteplus
+
+import (
+	"github.com/StackExchange/dnscontrol/v4/models"
+	"github.com/StackExchange/dnscontrol/v4/pkg/rejectif"
+)
+
+// AuditRecords returns a list of errors corresponding to the records
+// that aren't supported by this provider.  If all records are
+// supported, an empty list is returned.
+func AuditRecords(records []*models.RecordConfig) []error {
+	a := rejectif.Auditor{}
+
+	a.Add("TXT", rejectif.TxtHasDoubleQuotes)
+	a.Add("MX", rejectif.MxNull)
+	a.Add("SRV", rejectif.SrvHasNullTarget)
+	a.Add("CAA", rejectif.CaaTargetContainsWhitespace)
+
+	return a.Audit(records)
+}

--- a/providers/byteplus/byteplusProvider.go
+++ b/providers/byteplus/byteplusProvider.go
@@ -1,0 +1,374 @@
+package byteplus
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+
+	byteplus "github.com/byteplus-sdk/byteplus-sdk-golang/service/dns"
+
+	"github.com/StackExchange/dnscontrol/v4/models"
+	"github.com/StackExchange/dnscontrol/v4/pkg/diff"
+	"github.com/StackExchange/dnscontrol/v4/pkg/printer"
+	"github.com/StackExchange/dnscontrol/v4/providers"
+)
+
+// ErrDomainNotFound error indicates domain name is not managed by Exoscale.
+var ErrDomainNotFound = errors.New("domain not found")
+
+type byteplusProvider struct {
+	client *byteplus.Client
+}
+
+type MyStruct struct {
+	DomainID *string
+}
+
+// NewByteplus creates a new Byteplus DNS provider.
+func NewByteplus(m map[string]string, metadata json.RawMessage) (providers.DNSServiceProvider, error) {
+	ak, sk := m["ak"], m["sk"]
+
+	client := byteplus.InitDNSBytePlusClient()
+	client.SetAccessKey(ak)
+	client.SetSecretKey(sk)
+
+	provider := byteplusProvider{client: client}
+
+	return &provider, nil
+}
+
+var features = providers.DocumentationNotes{
+	// The default for unlisted capabilities is 'Cannot'.
+	// See providers/capabilities.go for the entire list of capabilities.
+	providers.CanGetZones:            providers.Can(),
+	providers.CanConcur:              providers.Cannot(),
+	providers.CanUseAlias:            providers.Cannot(),
+	providers.CanUseCAA:              providers.Can(),
+	providers.CanUseLOC:              providers.Cannot(),
+	providers.CanUsePTR:              providers.Cannot(),
+	providers.CanUseSRV:              providers.Can(),
+	providers.CanUseTLSA:             providers.Cannot(),
+	providers.DocCreateDomains:       providers.Cannot(),
+	providers.DocDualHost:            providers.Cannot(),
+	providers.DocOfficiallySupported: providers.Cannot(),
+}
+
+func init() {
+	fns := providers.DspFuncs{
+		Initializer:   NewByteplus,
+		RecordAuditor: AuditRecords,
+	}
+	providers.RegisterDomainServiceProviderType("BYTEPLUS", fns, features)
+}
+
+// EnsureZoneExists creates a zone if it does not exist
+func (c *byteplusProvider) EnsureZoneExists(domain string) error {
+	_, err := c.findDomainByName(domain)
+
+	return err
+}
+
+// GetNameservers returns the nameservers for domain.
+func (c *byteplusProvider) GetNameservers(domain string) ([]*models.Nameserver, error) {
+	return nil, nil
+}
+
+// GetZoneRecords gets the records of a zone and returns them in RecordConfig format.
+func (c *byteplusProvider) GetZoneRecords(domainName string, meta map[string]string) (models.Records, error) {
+	//dc.Punycode()
+
+	domain, err := c.findDomainByName(domainName)
+	if err != nil {
+		return nil, err
+	}
+	domainID := *domain.ZID
+
+	//byteplus package issue
+	domainIDStr := strconv.Itoa(int(domainID))
+
+	// Create the struct, setting the pointer to the string
+	myStruct := MyStruct{
+		DomainID: &domainIDStr, // Take the address of domainIDStr
+	}
+
+	ctx := context.Background()
+	records, err := c.client.ListRecords(ctx, &byteplus.ListRecordsRequest{ZID: myStruct.DomainID})
+	if err != nil {
+		return nil, err
+	}
+
+	existingRecords := make([]*models.RecordConfig, 0, len(records.Records))
+	for _, r := range records.Records {
+		if r.RecordID == nil {
+			continue
+		}
+
+		recordID := *r.RecordID
+
+		record, err := c.client.QueryRecord(ctx, &byteplus.QueryRecordRequest{RecordID: &recordID})
+		if err != nil {
+			return nil, err
+		}
+
+		// nil pointers are not expected, but just to be on the safe side...
+		var rtype, rcontent, rname string
+		if record.Type == nil {
+			continue
+		}
+		rtype = *record.Type
+		if record.Value != nil {
+			rcontent = *record.Value
+		}
+		if record.Host != nil {
+			rname = *record.Host
+		}
+
+		if rtype == "SOA" || rtype == "NS" {
+			continue
+		}
+		if rname == "" {
+			t := "@"
+			record.Host = &t
+		}
+		if rtype == "CNAME" || rtype == "MX" || rtype == "ALIAS" || rtype == "SRV" {
+			t := rcontent + "."
+			// for SRV records we need to aditionally prefix target with priority, which API handles as separate field.
+			if rtype == "SRV" && record.Weight != nil {
+				t = fmt.Sprintf("%d %s", *record.Weight, t)
+			}
+			rcontent = t
+		}
+		// byteplus adds these odd txt records that mirror the alias records.
+		// they seem to manage them on deletes and things, so we'll just pretend they don't exist
+		if rtype == "TXT" && strings.HasPrefix(rcontent, "ALIAS for ") {
+			continue
+		}
+
+		rc := &models.RecordConfig{
+			Original: record,
+		}
+		if record.TTL != nil {
+			rc.TTL = uint32(*record.TTL)
+		}
+		rc.SetLabel(rname, domainName)
+
+		switch rtype {
+		case "ALIAS", "URL":
+			rc.Type = rtype
+			rc.SetTarget(rcontent)
+		case "MX":
+			var prio uint16
+			if record.Weight != nil {
+				prio = uint16(*record.Weight)
+			}
+			err = rc.SetTargetMX(prio, rcontent)
+		default:
+			err = rc.PopulateFromString(rtype, rcontent, domainName)
+		}
+		if err != nil {
+			return nil, fmt.Errorf("unparsable record received from byteplus: %w", err)
+		}
+
+		existingRecords = append(existingRecords, rc)
+	}
+
+	return existingRecords, nil
+}
+
+// GetZoneRecordsCorrections returns a list of corrections that will turn existing records into dc.Records.
+func (c *byteplusProvider) GetZoneRecordsCorrections(dc *models.DomainConfig, existingRecords models.Records) ([]*models.Correction, error) {
+
+	removeOtherNS(dc)
+	domain, err := c.findDomainByName(dc.Name)
+	if err != nil {
+		return nil, err
+	}
+	domainID := domain.ZID
+
+	toReport, create, toDelete, modify, err := diff.NewCompat(dc).IncrementalDiff(existingRecords)
+	if err != nil {
+		return nil, err
+	}
+	// Start corrections with the reports
+	corrections := diff.GenerateMessageCorrections(toReport)
+
+	for _, del := range toDelete {
+		record := del.Existing.Original.(*byteplus.QueryRecordResponse)
+		corrections = append(corrections, &models.Correction{
+			Msg: del.String(),
+			F:   c.deleteRecordFunc(*record.RecordID),
+		})
+	}
+
+	for _, cre := range create {
+		rc := cre.Desired
+		corrections = append(corrections, &models.Correction{
+			Msg: cre.String(),
+			F:   c.createRecordFunc(rc, domainID),
+		})
+	}
+
+	for _, mod := range modify {
+		old := mod.Existing.Original.(*byteplus.QueryRecordResponse)
+		new := mod.Desired
+		corrections = append(corrections, &models.Correction{
+			Msg: mod.String(),
+			F:   c.updateRecordFunc(old, new, domainID),
+		})
+	}
+
+	return corrections, nil
+}
+
+// Returns a function that can be invoked to create a record in a zone.
+func (c *byteplusProvider) createRecordFunc(rc *models.RecordConfig, domainID *int64) func() error {
+	return func() error {
+		target := rc.GetTargetCombined()
+		name := rc.GetLabel()
+		var prio *int64
+
+		if rc.Type == "MX" {
+			target = rc.GetTargetField()
+
+			if rc.MxPreference != 0 {
+				p := int64(rc.MxPreference)
+				prio = &p
+			}
+		}
+
+		if rc.Type == "SRV" {
+			// API wants priority as a separate argument, here we will strip it from combined target.
+			sp := strings.Split(target, " ")
+			target = strings.Join(sp[1:], " ")
+			p, err := strconv.ParseInt(sp[0], 10, 64)
+			if err != nil {
+				return err
+			}
+			prio = &p
+		}
+
+		if rc.Type == "NS" && (name == "@" || name == "") {
+			name = "*"
+		}
+
+		record := byteplus.CreateRecordRequest{
+			Host:   &name,
+			Type:   &rc.Type,
+			Value:  &target,
+			ZID:    domainID,
+			Weight: prio,
+		}
+
+		if rc.TTL != 0 {
+			ttl := int64(rc.TTL)
+			record.TTL = &ttl
+		}
+
+		_, err := c.client.CreateRecord(context.Background(), &record)
+
+		return err
+	}
+}
+
+// Returns a function that can be invoked to delete a record in a zone.
+func (c *byteplusProvider) deleteRecordFunc(recordID string) func() error {
+	return func() error {
+		return c.client.DeleteRecord(context.Background(), &byteplus.DeleteRecordRequest{RecordID: &recordID})
+	}
+}
+
+// Returns a function that can be invoked to update a record in a zone.
+func (c *byteplusProvider) updateRecordFunc(record *byteplus.QueryRecordResponse, rc *models.RecordConfig, domainID *int64) func() error {
+	return func() error {
+		target := rc.GetTargetCombined()
+		name := rc.GetLabel()
+
+		if rc.Type == "MX" {
+			target = rc.GetTargetField()
+
+			if rc.MxPreference != 0 {
+				p := int64(rc.MxPreference)
+				record.Weight = &p
+			}
+		}
+
+		if rc.Type == "SRV" {
+			// API wants priority as separate argument, here we will strip it from combined target.
+			sp := strings.Split(target, " ")
+			target = strings.Join(sp[1:], " ")
+			p, err := strconv.ParseInt(sp[0], 10, 64)
+			if err != nil {
+				return err
+			}
+			record.Weight = &p
+		}
+
+		if rc.Type == "NS" && (name == "@" || name == "") {
+			name = "*"
+		}
+
+		record.Host = &name
+		record.Type = &rc.Type
+		record.Value = &target
+		if rc.TTL != 0 {
+			ttl := int64(rc.TTL)
+			record.TTL = &ttl
+		}
+
+		newRecord := &byteplus.UpdateRecordRequest{
+			Host:     *record.Host,
+			Line:     *record.Line,
+			RecordID: *record.RecordID,
+			TTL:      record.TTL,
+			Type:     record.Type,
+			Value:    record.Value,
+			Weight:   record.Weight,
+		}
+
+		_, err := c.client.UpdateRecord(context.Background(), newRecord)
+
+		return err
+	}
+}
+
+func (c *byteplusProvider) findDomainByName(name string) (*byteplus.TopZoneResponse, error) {
+	domains, err := c.client.ListZones(context.Background(), &byteplus.ListZonesRequest{})
+	if err != nil {
+		return nil, err
+	}
+
+	for _, domain := range domains.Zones {
+		if domain.ZoneName != nil && domain.ZID != nil && *domain.ZoneName == name {
+			return &domain, nil
+		}
+	}
+
+	return nil, ErrDomainNotFound
+}
+
+func defaultNSSUffix(defNS string) bool {
+	return (strings.HasSuffix(defNS, ".byteplus.io.") ||
+		strings.HasSuffix(defNS, ".byteplus.com.") ||
+		strings.HasSuffix(defNS, ".byteplus.net."))
+}
+
+// remove all non-byteplus NS records from our desired state.
+// if any are found, print a warning
+func removeOtherNS(dc *models.DomainConfig) {
+	newList := make([]*models.RecordConfig, 0, len(dc.Records))
+	for _, rec := range dc.Records {
+		if rec.Type == "NS" {
+			// apex NS inside byteplus are expected.
+			if rec.GetLabelFQDN() == dc.Name && defaultNSSUffix(rec.GetTargetField()) {
+				continue
+			}
+			printer.Printf("Warning: byteplus.com(.io, .ch, .net) does not allow NS records to be modified. %s will not be added.\n", rec.GetTargetField())
+			continue
+		}
+		newList = append(newList, rec)
+	}
+	dc.Records = newList
+}

--- a/providers/byteplus/byteplusProvider.go
+++ b/providers/byteplus/byteplusProvider.go
@@ -16,7 +16,7 @@ import (
 	"github.com/StackExchange/dnscontrol/v4/providers"
 )
 
-// ErrDomainNotFound error indicates domain name is not managed by Exoscale.
+// ErrDomainNotFound error indicates domain name is not managed by Byteplus.
 var ErrDomainNotFound = errors.New("domain not found")
 
 type byteplusProvider struct {

--- a/providers/byteplus/byteplusProvider.go
+++ b/providers/byteplus/byteplusProvider.go
@@ -83,7 +83,7 @@ func (c *byteplusProvider) EnsureZoneExists(domain string) error {
 
 // GetNameservers returns the nameservers for a domain.
 func (c *byteplusProvider) GetNameservers(domain string) ([]*models.Nameserver, error) {
-	return models.ToNameservers(defaultNS)
+	return nil, nil
 }
 
 // GetZoneRecords gets the records of a zone and returns them in RecordConfig format.

--- a/providers/byteplus/byteplusProvider.go
+++ b/providers/byteplus/byteplusProvider.go
@@ -350,9 +350,9 @@ func (c *byteplusProvider) findDomainByName(name string) (*byteplus.TopZoneRespo
 }
 
 func defaultNSSUffix(defNS string) bool {
-	return (strings.HasSuffix(defNS, ".byteplus.io.") ||
-		strings.HasSuffix(defNS, ".byteplus.com.") ||
-		strings.HasSuffix(defNS, ".byteplus.net."))
+	return (strings.HasSuffix(defNS, ".byteplusdns.io.") ||
+		strings.HasSuffix(defNS, ".byteplusdns.com.") ||
+		strings.HasSuffix(defNS, ".byteplusdns.net."))
 }
 
 // remove all non-byteplus NS records from our desired state.

--- a/providers/byteplus/byteplusProvider.go
+++ b/providers/byteplus/byteplusProvider.go
@@ -1,3 +1,5 @@
+// byteplus support is done thanks to the authors of exoscale, porkbun, ovh providers!
+
 package byteplus
 
 import (


### PR DESCRIPTION
Byteplus DNS is a product of Byteplus, cloud infrastructure company operated by Tiktok's parent company.

**First time diving to golang, definitely need some experienced help here.** 

It's a mess but basic CRUDs are working. It is failing 21 tests at the moment, with additional details below:

```
1. Record TTL minimum is set by plans. 

Free -> 600s, Professional -> 300s, Enterprise -> 60s, and so on.
Currently, there are no checks for this. It will depend on API response whether the requested TTL is allowed.

2. Inconsistencies in types from Byteplus's Golang SDK

You're going to see ZID, which is the unique identififer for domains. There are cases where ZID is inconsistently defined as string/int64. 

Quick hack was made on GetZoneRecords func.

3. Byteplus not supporting trailing dots on MX records

This caused many failures as Byteplus do not support trailing dots on MX records.

integration_test.go:241: TOP DNS response failed with code 400102: ErrParamInvalid, validation fail: mx value [.] is malformed, requestID:

4. Byteplus not supporting quotes on TXT records

=== RUN   TestDNSProviders/test.net/82:final:final
    integration_test.go:236: 
        + CREATE TXT final.test.net "TestDNSProviders was successful!" ttl=300
    integration_test.go:241: TOP DNS response failed with code 400102: ErrParamInvalid, validation fail: txt value contains non support character["], requestID:
```

Full test report: https://gist.github.com/morpig/c013db4ae7203154cad968f87716ca9e

Would like to credit authors who wrote the Exoscale integration. thank you
