### PR TITLE
FEATURE: `CAA_BUILDER()` with `TTL()` support

### DIFF
--- a/commands/types/dnscontrol.d.ts
+++ b/commands/types/dnscontrol.d.ts
@@ -456,10 +456,11 @@ declare function CAA(name: string, tag: "issue" | "issuewild" | "iodef", value: 
  * * `issue_critical:` This can be `true` or `false`. If enabled and CA does not support this record, then certificate issue will be refused. (Optional. Default: `false`)
  * * `issuewild:` An array of CAs which are allowed to issue wildcard certificates. (Can be simply `"none"` to refuse issuing wildcard certificates for all CAs)
  * * `issuewild_critical:` This can be `true` or `false`. If enabled and CA does not support this record, then certificate issue will be refused. (Optional. Default: `false`)
+ * * `ttl:` Input for `TTL` method (optional)
  *
  * @see https://docs.dnscontrol.org/language-reference/domain-modifiers/caa_builder
  */
-declare function CAA_BUILDER(opts: { label?: string; iodef: string; iodef_critical?: boolean; issue: string[]; issue_critical?: boolean; issuewild: string[]; issuewild_critical?: boolean }): DomainModifier;
+declare function CAA_BUILDER(opts: { label?: string; iodef: string; iodef_critical?: boolean; issue: string[]; issue_critical?: boolean; issuewild: string[]; issuewild_critical?: boolean; ttl?: Duration }): DomainModifier;
 
 /**
  * `CF_REDIRECT` uses Cloudflare-specific features ("Forwarding URL" Page Rules) to

--- a/documentation/language-reference/domain-modifiers/CAA_BUILDER.md
+++ b/documentation/language-reference/domain-modifiers/CAA_BUILDER.md
@@ -8,6 +8,7 @@ parameters:
   - issue_critical
   - issuewild
   - issuewild_critical
+  - ttl
 parameters_object: true
 parameter_types:
   label: string?
@@ -17,6 +18,7 @@ parameter_types:
   issue_critical: boolean?
   issuewild: string[]
   issuewild_critical: boolean?
+  ttl: Duration?
 ---
 
 DNSControl contains a `CAA_BUILDER` which can be used to simply create
@@ -114,3 +116,4 @@ which in turns yield the following records:
 * `issue_critical:` This can be `true` or `false`. If enabled and CA does not support this record, then certificate issue will be refused. (Optional. Default: `false`)
 * `issuewild:` An array of CAs which are allowed to issue wildcard certificates. (Can be simply `"none"` to refuse issuing wildcard certificates for all CAs)
 * `issuewild_critical:` This can be `true` or `false`. If enabled and CA does not support this record, then certificate issue will be refused. (Optional. Default: `false`)
+* `ttl:` Input for `TTL` method (optional)

--- a/pkg/js/helpers.js
+++ b/pkg/js/helpers.js
@@ -1503,6 +1503,7 @@ function SPF_BUILDER(value) {
 // iodef_critical: Boolean if sending report is required/critical. If not supported, certificate should be refused. (optional)
 // issue: List of CAs which are allowed to issue certificates for the domain (creates one record for each).
 // issuewild: Allowed CAs which can issue wildcard certificates for this domain. (creates one record for each)
+// ttl: The time for TTL, integer or string. (default: not defined, using DefaultTTL)
 
 function CAA_BUILDER(value) {
     if (!value.label) {
@@ -1522,13 +1523,19 @@ function CAA_BUILDER(value) {
         throw 'CAA_BUILDER requires at least one entry at issue or issuewild';
     }
 
+    var CAA_TTL = function () {};
+    if (value.ttl) {
+        CAA_TTL = TTL(value.ttl);
+    }
     r = []; // The list of records to return.
 
     if (value.iodef) {
         if (value.iodef_critical) {
-            r.push(CAA(value.label, 'iodef', value.iodef, CAA_CRITICAL));
+            r.push(
+                CAA(value.label, 'iodef', value.iodef, CAA_CRITICAL, CAA_TTL)
+            );
         } else {
-            r.push(CAA(value.label, 'iodef', value.iodef));
+            r.push(CAA(value.label, 'iodef', value.iodef, CAA_TTL));
         }
     }
 
@@ -1538,7 +1545,7 @@ function CAA_BUILDER(value) {
             flag = CAA_CRITICAL;
         }
         for (var i = 0, len = value.issue.length; i < len; i++)
-            r.push(CAA(value.label, 'issue', value.issue[i], flag));
+            r.push(CAA(value.label, 'issue', value.issue[i], flag, CAA_TTL));
     }
 
     if (value.issuewild) {
@@ -1547,7 +1554,9 @@ function CAA_BUILDER(value) {
             flag = CAA_CRITICAL;
         }
         for (var i = 0, len = value.issuewild.length; i < len; i++)
-            r.push(CAA(value.label, 'issuewild', value.issuewild[i], flag));
+            r.push(
+                CAA(value.label, 'issuewild', value.issuewild[i], flag, CAA_TTL)
+            );
     }
 
     return r;


### PR DESCRIPTION
The domain modifier [`CAA_BUILDER()`](https://docs.dnscontrol.org/~/revisions/zxXPLS8rJfg9iKM0hYbP/language-reference/domain-modifiers/caa_builder) with record modifier [`TTL()`](https://docs.dnscontrol.org/language-reference/record-modifiers/ttl) support.

**`dnsconfig.js` before/after**

```javascript
DEFAULTS(
    DefaultTTL('1d')
)
```

```diff
D('jcid.nl',
    PROVIDER_NONE,
    DnsProvider(PROVIDER_TRANSIP),
    CAA_BUILDER({
        label: '@',
        iodef: 'mailto:info@jcid.nl',
        iodef_critical: true,
        issue: [
            'letsencrypt.org',
            'sectigo.com',
        ],
        issue_critical: true,
        issuewild: 'none',
        issuewild_critical: true,
+       ttl: TTL('1h'),
    }),
```

```shell
dnscontrol preview --domains jcid.nl --dev
```
```shell
******************** Domain: jcid.nl
8 corrections (transip)
#1: [1/2] delete: ± MODIFY-TTL jcid.nl CAA 128 iodef "mailto:info@jcid.nl" ttl=(86400->300)
± MODIFY-TTL jcid.nl CAA 128 issue "letsencrypt.org" ttl=(86400->300)
± MODIFY-TTL jcid.nl CAA 128 issue "sectigo.com" ttl=(86400->300)
± MODIFY-TTL jcid.nl CAA 128 issuewild ";" ttl=(86400->300)
#2: [1/2] delete: ± MODIFY-TTL jcid.nl CAA 128 iodef "mailto:info@jcid.nl" ttl=(86400->300)
± MODIFY-TTL jcid.nl CAA 128 issue "letsencrypt.org" ttl=(86400->300)
± MODIFY-TTL jcid.nl CAA 128 issue "sectigo.com" ttl=(86400->300)
± MODIFY-TTL jcid.nl CAA 128 issuewild ";" ttl=(86400->300)
#3: [1/2] delete: ± MODIFY-TTL jcid.nl CAA 128 iodef "mailto:info@jcid.nl" ttl=(86400->300)
± MODIFY-TTL jcid.nl CAA 128 issue "letsencrypt.org" ttl=(86400->300)
± MODIFY-TTL jcid.nl CAA 128 issue "sectigo.com" ttl=(86400->300)
± MODIFY-TTL jcid.nl CAA 128 issuewild ";" ttl=(86400->300)
#4: [1/2] delete: ± MODIFY-TTL jcid.nl CAA 128 iodef "mailto:info@jcid.nl" ttl=(86400->300)
± MODIFY-TTL jcid.nl CAA 128 issue "letsencrypt.org" ttl=(86400->300)
± MODIFY-TTL jcid.nl CAA 128 issue "sectigo.com" ttl=(86400->300)
± MODIFY-TTL jcid.nl CAA 128 issuewild ";" ttl=(86400->300)
#5: [2/2] create: ± MODIFY-TTL jcid.nl CAA 128 iodef "mailto:info@jcid.nl" ttl=(86400->300)
± MODIFY-TTL jcid.nl CAA 128 issue "letsencrypt.org" ttl=(86400->300)
± MODIFY-TTL jcid.nl CAA 128 issue "sectigo.com" ttl=(86400->300)
± MODIFY-TTL jcid.nl CAA 128 issuewild ";" ttl=(86400->300)
#6: [2/2] create: ± MODIFY-TTL jcid.nl CAA 128 iodef "mailto:info@jcid.nl" ttl=(86400->300)
± MODIFY-TTL jcid.nl CAA 128 issue "letsencrypt.org" ttl=(86400->300)
± MODIFY-TTL jcid.nl CAA 128 issue "sectigo.com" ttl=(86400->300)
± MODIFY-TTL jcid.nl CAA 128 issuewild ";" ttl=(86400->300)
#7: [2/2] create: ± MODIFY-TTL jcid.nl CAA 128 iodef "mailto:info@jcid.nl" ttl=(86400->300)
± MODIFY-TTL jcid.nl CAA 128 issue "letsencrypt.org" ttl=(86400->300)
± MODIFY-TTL jcid.nl CAA 128 issue "sectigo.com" ttl=(86400->300)
± MODIFY-TTL jcid.nl CAA 128 issuewild ";" ttl=(86400->300)
#8: [2/2] create: ± MODIFY-TTL jcid.nl CAA 128 iodef "mailto:info@jcid.nl" ttl=(86400->300)
± MODIFY-TTL jcid.nl CAA 128 issue "letsencrypt.org" ttl=(86400->300)
± MODIFY-TTL jcid.nl CAA 128 issue "sectigo.com" ttl=(86400->300)
± MODIFY-TTL jcid.nl CAA 128 issuewild ";" ttl=(86400->300)
Done. 8 corrections.
```

Fixes https://github.com/StackExchange/dnscontrol/issues/2977.