### PR TITLE
GCLOUD: Fix missing length in make()

### DIFF
--- a/providers/gcloud/gcloudProvider.go
+++ b/providers/gcloud/gcloudProvider.go
@@ -475,7 +475,7 @@ func (g *gcloudProvider) EnsureZoneExists(domain string) error {
 		mz.Name = strings.Replace(mz.Name, "zone-", "zone-"+g.Visibility+"-", 1)
 	}
 	if g.Networks != nil {
-		mzn := make([]*gdns.ManagedZonePrivateVisibilityConfigNetwork, len(g.Networks))
+		mzn := make([]*gdns.ManagedZonePrivateVisibilityConfigNetwork, 0, len(g.Networks))
 		printer.Printf("for network(s) ")
 		for _, v := range g.Networks {
 			printer.Printf("%s ", v)


### PR DESCRIPTION
Fixes https://github.com/StackExchange/dnscontrol/issues/2981

A makezero linter found this typo.