### PR TITLE
DOCS: AUTODNSSEC_* improvements

### DIFF
--- a/commands/types/dnscontrol.d.ts
+++ b/commands/types/dnscontrol.d.ts
@@ -247,24 +247,24 @@ declare function AKAMAICDN(name: string, target: string, ...modifiers: RecordMod
 declare function ALIAS(name: string, target: string, ...modifiers: RecordModifier[]): DomainModifier;
 
 /**
- * AUTODNSSEC_OFF tells the provider to disable AutoDNSSEC. It takes no
+ * `AUTODNSSEC_OFF` tells the provider to disable AutoDNSSEC. It takes no
  * parameters.
  *
- * See `AUTODNSSEC_ON` for further details.
+ * See [`AUTODNSSEC_ON`](AUTODNSSEC_ON.md) for further details.
  *
  * @see https://docs.dnscontrol.org/language-reference/domain-modifiers/autodnssec_off
  */
 declare const AUTODNSSEC_OFF: DomainModifier;
 
 /**
- * AUTODNSSEC_ON tells the provider to enable AutoDNSSEC.
+ * `AUTODNSSEC_ON` tells the provider to **enable** AutoDNSSEC.
  *
- * AUTODNSSEC_OFF tells the provider to disable AutoDNSSEC.
+ * [`AUTODNSSEC_OFF`](AUTODNSSEC_OFF.md) tells the provider to **disable** AutoDNSSEC.
  *
  * AutoDNSSEC is a feature where a DNS provider can automatically manage
  * DNSSEC for a domain. Not all providers support this.
  *
- * At this time, AUTODNSSEC_ON takes no parameters.  There is no ability
+ * At this time, `AUTODNSSEC_ON` takes no parameters.  There is no ability
  * to tune what the DNS provider sets, no algorithm choice.  We simply
  * ask that they follow their defaults when enabling a no-fuss DNSSEC
  * data model.

--- a/documentation/language-reference/domain-modifiers/AUTODNSSEC_OFF.md
+++ b/documentation/language-reference/domain-modifiers/AUTODNSSEC_OFF.md
@@ -2,7 +2,7 @@
 name: AUTODNSSEC_OFF
 ---
 
-AUTODNSSEC_OFF tells the provider to disable AutoDNSSEC. It takes no
+`AUTODNSSEC_OFF` tells the provider to disable AutoDNSSEC. It takes no
 parameters.
 
-See `AUTODNSSEC_ON` for further details.
+See [`AUTODNSSEC_ON`](AUTODNSSEC_ON.md) for further details.

--- a/documentation/language-reference/domain-modifiers/AUTODNSSEC_ON.md
+++ b/documentation/language-reference/domain-modifiers/AUTODNSSEC_ON.md
@@ -2,14 +2,14 @@
 name: AUTODNSSEC_ON
 ---
 
-AUTODNSSEC_ON tells the provider to enable AutoDNSSEC.
+`AUTODNSSEC_ON` tells the provider to **enable** AutoDNSSEC.
 
-AUTODNSSEC_OFF tells the provider to disable AutoDNSSEC.
+[`AUTODNSSEC_OFF`](AUTODNSSEC_OFF.md) tells the provider to **disable** AutoDNSSEC.
 
 AutoDNSSEC is a feature where a DNS provider can automatically manage
 DNSSEC for a domain. Not all providers support this.
 
-At this time, AUTODNSSEC_ON takes no parameters.  There is no ability
+At this time, `AUTODNSSEC_ON` takes no parameters.  There is no ability
 to tune what the DNS provider sets, no algorithm choice.  We simply
 ask that they follow their defaults when enabling a no-fuss DNSSEC
 data model.


### PR DESCRIPTION
Minor improvements in the `AUTODNSSEC_*` documentation:

**Before**

1. https://docs.dnscontrol.org/language-reference/domain-modifiers/autodnssec_on
2. https://docs.dnscontrol.org/language-reference/domain-modifiers/autodnssec_off

**After**

1. https://docs.dnscontrol.org/~/revisions/FfooJaEujEGdD2tmvj2H/language-reference/domain-modifiers/autodnssec_on
2. https://docs.dnscontrol.org/~/revisions/FfooJaEujEGdD2tmvj2H/language-reference/domain-modifiers/autodnssec_off
