### PR TITLE
BUILD: GoReleaser v2.0.0

### DIFF
--- a/.github/workflows/pr_test.yml
+++ b/.github/workflows/pr_test.yml
@@ -54,7 +54,7 @@ jobs:
       id: build_binaries_tagged
       name: Build binaries (if tagged)
       if: github.ref_type == 'tag'
-      uses: goreleaser/goreleaser-action@v5
+      uses: goreleaser/goreleaser-action@v6
       with:
         distribution: goreleaser
         version: latest
@@ -63,7 +63,7 @@ jobs:
       id: build_binaries_not_tagged
       name: Build binaries (not tagged)
       if: github.ref_type != 'tag'
-      uses: goreleaser/goreleaser-action@v5
+      uses: goreleaser/goreleaser-action@v6
       with:
         args: build --snapshot
   integration-test-providers:

--- a/.github/workflows/release_draft.yml
+++ b/.github/workflows/release_draft.yml
@@ -52,7 +52,7 @@ jobs:
     -
       id: release
       name: Goreleaser release
-      uses: goreleaser/goreleaser-action@v5
+      uses: goreleaser/goreleaser-action@v6
       with:
         distribution: goreleaser
         version: latest

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,5 +1,6 @@
 # yaml-language-server: $schema=https://goreleaser.com/static/schema.json
 project_name: dnscontrol
+version: 2
 builds:
   -
     id: build


### PR DESCRIPTION
[GoReleaser v2.0.0](https://github.com/goreleaser/goreleaser/releases/tag/v2.0.0) and [GoReleaser GitHub actions v.6.0.0](https://github.com/goreleaser/goreleaser-action/releases/tag/v6.0.0) are released 🥳 

<details>
    <summary>Upgrading GoReleaser v2.0.0</summary>

> If you keep up with the deprecation notices, it's likely you don't need to do anything.
>
> If you don't, that's fine too! Let's figure it out together! You can start by running the following commands:
>
> ```shell
> goreleaser check # using the latest v1
> rm -rf ./dist/
> grep -iR '\--rm-dist' .
> grep -iR '\--skip-' .
> grep -iR '\--debug' .
> ```
>
> **Extra tip**: You can also look into your last release logs if they are still there, and fix the deprecation warnings based on it.
>
> Fix any occurrences following [this][notices], then, upgrade `goreleaser` to v2 using the method you used to install v1, and run:
>
> ```shell
> goreleaser check # using latest v2
> ```
>
> It should only warn you about the `version` header in the configuration file, which you can fix by adding `version: 2` to it.
>
> Then, you should be ready to use GoReleaser v2! You can build a snapshot with:
>
> ```shell
> goreleaser release --snapshot --clean
> ```

</details>

<https://goreleaser.com/blog/goreleaser-v2/#upgrading>

<details>
    <summary>Upgrading goreleaser/goreleaser-action v6.0.0</summary>

> If you use our [GitHub Action](https://github.com/goreleaser/goreleaser-action), the latest version (v6.0.0) should use `~> v2` by default if your `version` option is either empty or `latest`.

</details>

<https://goreleaser.com/blog/goreleaser-v2/#github-action>

```shell
goreleaser --version
```
```shell
  ____       ____      _
 / ___| ___ |  _ \ ___| | ___  __ _ ___  ___ _ __
| |  _ / _ \| |_) / _ \ |/ _ \/ _` / __|/ _ \ '__|
| |_| | (_) |  _ <  __/ |  __/ (_| \__ \  __/ |
 \____|\___/|_| \_\___|_|\___|\__,_|___/\___|_|
goreleaser: Deliver Go Binaries as fast and easily as possible
https://goreleaser.com

GitVersion:    2.0.0
GitCommit:     f35dcda343ddebf9dae706c8a86aa5915501fa84
GitTreeState:  false
BuildDate:     2024-06-05T00:24:56Z
BuiltBy:       goreleaser
GoVersion:     go1.22.3
Compiler:      gc
ModuleSum:     h1:TxH7v+rYsQ+e4CQDMmdBFnVzxuTbBJRwsLXeCSkOREU=
Platform:      darwin/amd64
```

```shell
goreleaser check
```
```shell
  • checking                                 path=.goreleaser.yml
  • 1 configuration file(s) validated
  • thanks for using goreleaser!
```

```shell
goreleaser release --snapshot --clean
```

<details>
    <summary>GoReleaser release output</summary>


```shell
  • starting release...
  • loading                                          path=.goreleaser.yml
  • skipping announce, publish and validate...
  • loading environment variables
  • getting and validating git state
    • git state                                      commit=8c54c57eda2453bfb477b243e99cf8721c0106c4 branch=build/goreleaser-v2.0.0 current_tag=v4.11.0 previous_tag=v4.10.0 dirty=true
    • pipe skipped                                   reason=disabled during snapshot mode
  • parsing tag
  • setting defaults
  • snapshotting
    • building snapshot...                           version=4.11.1-next
  • running before hooks
    • running                                        hook=go fmt ./...
    • running                                        hook=go mod tidy
    • running                                        hook=go generate ./...
    • took: 5s
  • checking distribution directory
    • cleaning dist
  • setting up metadata
  • storing release metadata
    • writing                                        file=dist/metadata.json
  • loading go mod information
  • build prerequisites
  • writing effective config file
    • writing                                        config=dist/config.yaml
  • building binaries
    • building                                       binary=dist/build_freebsd_arm64/dnscontrol
    • building                                       binary=dist/build_linux_arm64/dnscontrol
    • building                                       binary=dist/build_linux_amd64_v1/dnscontrol
    • building                                       binary=dist/build_windows_arm64/dnscontrol.exe
    • building                                       binary=dist/build_freebsd_amd64_v1/dnscontrol
    • building                                       binary=dist/build_windows_amd64_v1/dnscontrol.exe
    • building                                       binary=dist/build_darwin_arm64/dnscontrol
    • building                                       binary=dist/build_darwin_amd64_v1/dnscontrol
    • took: 29s
  • universal binaries
    • creating from 2 binaries                       id=build binary=dist/build_darwin_all/dnscontrol
  • archives
    • creating                                       archive=dist/dnscontrol_4.11.1-next_darwin_all.tar.gz
    • creating                                       archive=dist/dnscontrol_4.11.1-next_linux_arm64.tar.gz
    • creating                                       archive=dist/dnscontrol_4.11.1-next_windows_arm64.zip
    • creating                                       archive=dist/dnscontrol_4.11.1-next_freebsd_arm64.tar.gz
    • creating                                       archive=dist/dnscontrol_4.11.1-next_windows_amd64.zip
    • creating                                       archive=dist/dnscontrol_4.11.1-next_freebsd_amd64.tar.gz
    • creating                                       archive=dist/dnscontrol_4.11.1-next_linux_amd64.tar.gz
    • took: 8s
  • linux packages
    • creating                                       package=dnscontrol format=rpm arch=amd64v1 file=dist/dnscontrol-4.11.1-next.x86_64.rpm
    • creating                                       package=dnscontrol format=rpm arch=arm64 file=dist/dnscontrol-4.11.1-next.arm64.rpm
    • creating                                       package=dnscontrol format=deb arch=arm64 file=dist/dnscontrol-4.11.1-next.arm64.deb
    • creating                                       package=dnscontrol format=deb arch=amd64v1 file=dist/dnscontrol-4.11.1-next.amd64.deb
    • took: 1s
  • calculating checksums
  • storing artifacts metadata
    • writing                                        file=dist/artifacts.json
  • release succeeded after 44s
  • thanks for using goreleaser!
```

</details>
