### PR TITLE
GCLOUD: Fix issue on creating/deleting/updating TXT records

### DIFF
--- a/models/record.go
+++ b/models/record.go
@@ -536,6 +536,17 @@ func (recs Records) GetByType(typeName string) Records {
 	return results
 }
 
+// GetByKey returns the records that match RecordKey.
+func (recs Records) GetByKey(key RecordKey) Records {
+	results := Records{}
+	for _, rec := range recs {
+		if rec.Key() == key {
+			results = append(results, rec)
+		}
+	}
+	return results
+}
+
 // GroupedByKey returns a map of keys to records.
 func (recs Records) GroupedByKey() map[RecordKey]Records {
 	groups := map[RecordKey]Records{}

--- a/models/record.go
+++ b/models/record.go
@@ -536,17 +536,6 @@ func (recs Records) GetByType(typeName string) Records {
 	return results
 }
 
-// GetByKey returns the records that match RecordKey.
-func (recs Records) GetByKey(key RecordKey) Records {
-	results := Records{}
-	for _, rec := range recs {
-		if rec.Key() == key {
-			results = append(results, rec)
-		}
-	}
-	return results
-}
-
 // GroupedByKey returns a map of keys to records.
 func (recs Records) GroupedByKey() map[RecordKey]Records {
 	groups := map[RecordKey]Records{}

--- a/providers/gcloud/gcloudProvider.go
+++ b/providers/gcloud/gcloudProvider.go
@@ -271,11 +271,15 @@ func (g *gcloudProvider) GetZoneRecordsCorrections(dc *models.DomainConfig, exis
 		case diff2.CHANGE:
 			newMsgs = change.Msgs
 			newAdds = mkRRSs(n, ty, change.New)
-			newDels = mkRRSs(n, ty, change.Old)
+			// When deleting in GCLOUD order of elements matters, so lets take original old value
+			origOld := existingRecords.GetByKey(change.Key)
+			newDels = mkRRSs(n, ty, origOld)
 		case diff2.DELETE:
 			newMsgs = change.Msgs
 			newAdds = nil
-			newDels = mkRRSs(n, ty, change.Old)
+			// When deleting in GCLOUD order of elements matters, so lets take original old value
+			origOld := existingRecords.GetByKey(change.Key)
+			newDels = mkRRSs(n, ty, origOld)
 		default:
 			return nil, fmt.Errorf("GCLOUD unhandled change.TYPE %s", change.Type)
 		}


### PR DESCRIPTION
Fixes the issue with updating/deleting TXT (maybe others too) record types from GCLOUD.
```
#1: + CREATE domain.com TXT "some_value" ttl=3600
FAILURE! runChange error: googleapi: Error 412: Precondition not met for 'entity.change.deletions[domain.com.][TXT]', conditionNotMet
```

Under the hood DNS had TXT resources that was not sorted and `diff2.ByRecordSet` returns changes that have sorted values so we tried to send request with proper values but sorted differently, and seems like google is picky about ordering.
Maybe it was possible to pass `compFunc` but I didnt get how to do that..
Taking the original records was way easier, and should always return proper order.

Easiest reproduction case.
Add any TXT record with entries not sorted alphabetically (manually), and do any change/delete via dnscontrol.
