### PR TITLE
DOCS: MacPorts removed

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -175,12 +175,6 @@ release:
     brew install dnscontrol
     ```
 
-    ##### Install with [MacPorts](https://www.macports.org)
-
-    ```shell
-    sudo port install dnscontrol
-    ```
-
     ##### Using with [Docker](https://www.docker.com)
 
     You can use the Docker image from [Docker hub](https://hub.docker.com/r/stackexchange/dnscontrol/) or [GitHub Container Registry](https://github.com/stackexchange/dnscontrol/pkgs/container/dnscontrol).
@@ -207,12 +201,6 @@ release:
 
     ```shell
     brew upgrade dnscontrol
-    ```
-
-    ##### Install with [MacPorts](https://www.macports.org)
-
-    ```shell
-    sudo port upgrade dnscontrol
     ```
 
     Alternatively, you can grab the latest binary (or the apt/rpm/deb package) from this page.

--- a/documentation/getting-started.md
+++ b/documentation/getting-started.md
@@ -13,14 +13,6 @@ On macOS (or Linux) you can install it using [Homebrew](https://brew.sh).
 brew install dnscontrol
 ```
 
-### MacPorts
-
-Alternatively on macOS you can install it using [MacPorts](https://www.macports.org).
-
-```shell
-sudo port install dnscontrol
-```
-
 ### Docker
 
 You can use DNSControl locally using the Docker image from [Docker hub](https://hub.docker.com/r/stackexchange/dnscontrol/) or [GitHub Container Registry](https://github.com/stackexchange/dnscontrol/pkgs/container/dnscontrol) and the command below.


### PR DESCRIPTION
Removed the MacPorts references from [Getting started > Overview](https://docs.dnscontrol.org/~/revisions/vsyVZNAyLKpMu56eHflN/getting-started/getting-started).

Fixes https://github.com/StackExchange/dnscontrol/issues/3021.
