### PR TITLE
DOCS: Getting started installation options summary

### DIFF
--- a/documentation/getting-started.md
+++ b/documentation/getting-started.md
@@ -5,6 +5,11 @@
 
 Choose one of the following installation methods:
 
+1. [Homebrew](#homebrew)
+2. [Docker](#docker)
+3. [GitHub binaries](#binaries)
+4. [GitHub source](#source)
+
 ### Homebrew
 
 On macOS (or Linux) you can install it using [Homebrew](https://brew.sh).


### PR DESCRIPTION
Added a summary of the possible installation within the getting started installation.

See [getting-started/getting-started#id-1.-install-the-software](https://docs.dnscontrol.org/~/revisions/4HyJq7gA37dkWWpZV6au/getting-started/getting-started#id-1.-install-the-software)