### PR TITLE
CLOUDFLARE: Bugfix for Redirect, correct typo in error message.

### DIFF
--- a/providers/cloudflare/singleredirect.go
+++ b/providers/cloudflare/singleredirect.go
@@ -149,7 +149,7 @@ func makeRuleFromPattern(pattern, replacement string, temporary bool) (string, s
 		expr = fmt.Sprintf(`concat("https://%s", http.request.uri.path)`, rhost)
 
 	} else if strings.Count(host, `*`) == 1 && strings.Count(path, `*`) == 1 &&
-		strings.Count(replacement, `$`) == 1 && rpath == `/$2` {
+		strings.Count(replacement, `$`) == 1 && strings.HasPrefix(rpath, `/$2`) {
 		// https://careers.stackoverflow.com/$2
 		expr = fmt.Sprintf(`concat("https://%s", http.request.uri.path)`, rhost)
 
@@ -165,7 +165,7 @@ func makeRuleFromPattern(pattern, replacement string, temporary bool) (string, s
 		return "", "", fmt.Errorf("conversion not implemented for pattern: %s", origPattern)
 	}
 	if expr == "" {
-		return "", "", fmt.Errorf("conversion not implemented for replacemennt: %s", origReplacement)
+		return "", "", fmt.Errorf("conversion not implemented for replacement: %s", origReplacement)
 	}
 
 	return matcher, expr, nil


### PR DESCRIPTION
## Release changelog section

CLOUDFLARE: Fix bug where a $2 redirect did not match any exiting single redirect rules
CLOUDFLARE: Correct error message typo