### PR TITLE
CLOUDFLARE: Fix another redirect bug

### DIFF
--- a/providers/cloudflare/singleredirect.go
+++ b/providers/cloudflare/singleredirect.go
@@ -149,7 +149,7 @@ func makeRuleFromPattern(pattern, replacement string, temporary bool) (string, s
 		expr = fmt.Sprintf(`concat("https://%s", http.request.uri.path)`, rhost)
 
 	} else if strings.Count(host, `*`) == 1 && strings.Count(path, `*`) == 1 &&
-		strings.Count(replacement, `$`) == 1 && strings.HasPrefix(rpath, `/$2`) {
+		strings.Count(replacement, `$`) == 1 && strings.HasSuffix(rpath, `/$2`) {
 		// https://careers.stackoverflow.com/$2
 		expr = fmt.Sprintf(`concat("https://%s", http.request.uri.path)`, rhost)
 


### PR DESCRIPTION
<!--
## Before submiting a pull request

Please make sure you've run the following commands from the root directory.

go vet ./...
go fmt ./...
go generate ./...
go mod tidy

## Release changelog section

Help keep the release changelog clear by pre-naming the proper section in the GitHub pull request title.

Some examples:
* CICD: Add required GHA permissions for goreleaser
* DOCS: Fixed providers with "contributor support" table
* ROUTE53: Allow R53_ALIAS records to enable target health evaluation

More examples/context can be found in the file .goreleaser.yml under the 'build' > 'changelog' key.
!-->
