### PR TITLE
HUAWEICLOUD: Document DNSSEC capability and improve docs, reliability

### DIFF
--- a/documentation/provider/huaweicloud.md
+++ b/documentation/provider/huaweicloud.md
@@ -42,7 +42,7 @@ D("example.com", REG_NONE, DnsProvider(DSP_HWCLOUD),
     A("test", "223.5.5.5", {hw_line: "CN"}), // GEODNS
     A("test", "223.6.6.6", {hw_line: "CN", hw_weight: "10"}), // GEODNS with weight
 
-    // this example will create 3 rrsets with the same name "lb"
+    // this example will create 3 rrsets with the same name "rr-lb"
     A("rr-lb", "10.0.0.1", {hw_weight: "10", hw_rrset_key: "lb-zone-a"}),
     A("rr-lb", "10.0.0.2", {hw_weight: "10", hw_rrset_key: "lb-zone-a"}),
     A("rr-lb", "10.0.1.1", {hw_weight: "10", hw_rrset_key: "lb-zone-b"}),
@@ -95,7 +95,7 @@ The minimum permissions required are as follows:
 }
 ```
 
-To determine the `Region` parameter, refer to the [endpoint page of huaweicloud](https://developer.huaweicloud.com/intl/en-us/endpoint?DNS). For example, on the international site, the `Region` name `ap-southeast-1` is known to work.
+To determine the `Region` parameter, refer to the [endpoint page of huaweicloud](https://console-intl.huaweicloud.com/apiexplorer/#/endpoint/DNS). For example, on the international site, the `Region` name `ap-southeast-1` is known to work.
 
 If that doesn't work, log into Huaweicloud's website and open the [API Explorer](https://console-intl.huaweicloud.com/apiexplorer/#/openapi/DNS/debug?api=ListPublicZones), find the `ListPublicZones` API, select a different Region and click Debug to try and find your Region.
 

--- a/documentation/providers.md
+++ b/documentation/providers.md
@@ -40,7 +40,7 @@ If a feature is definitively not supported for whatever reason, we would also li
 | [`HETZNER`](provider/hetzner.md) | ❌ | ✅ | ❌ | ❌ | ❌ | ✅ | ❌ | ❔ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❔ | ✅ | ✅ | ❔ | ❔ | ❔ | ✅ | ✅ | ✅ |
 | [`HEXONET`](provider/hexonet.md) | ❌ | ✅ | ✅ | ❌ | ❌ | ✅ | ❔ | ❔ | ❔ | ❔ | ✅ | ❔ | ✅ | ❔ | ❔ | ✅ | ❔ | ❔ | ❔ | ❔ | ✅ | ✅ | ❔ |
 | [`HOSTINGDE`](provider/hostingde.md) | ❌ | ✅ | ✅ | ❌ | ✅ | ✅ | ✅ | ❔ | ❌ | ❌ | ✅ | ✅ | ✅ | ✅ | ❔ | ✅ | ✅ | ❔ | ❔ | ❔ | ✅ | ✅ | ✅ |
-| [`HUAWEICLOUD`](provider/huaweicloud.md) | ❌ | ✅ | ❌ | ❔ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❔ | ❔ | ❔ | ✅ | ✅ | ✅ |
+| [`HUAWEICLOUD`](provider/huaweicloud.md) | ❌ | ✅ | ❌ | ❔ | ❌ | ✅ | ❔ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❔ | ❔ | ❔ | ✅ | ✅ | ✅ |
 | [`INTERNETBS`](provider/internetbs.md) | ❌ | ❌ | ✅ | ❌ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❌ | ❔ |
 | [`INWX`](provider/inwx.md) | ❌ | ✅ | ✅ | ❌ | ❌ | ✅ | ❔ | ✅ | ❔ | ✅ | ✅ | ❔ | ✅ | ✅ | ✅ | ✅ | ❔ | ❔ | ❔ | ❔ | ✅ | ✅ | ✅ |
 | [`LINODE`](provider/linode.md) | ❌ | ✅ | ❌ | ❌ | ❔ | ✅ | ❔ | ❔ | ❌ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❌ | ❌ | ✅ |

--- a/providers/huaweicloud/convert.go
+++ b/providers/huaweicloud/convert.go
@@ -22,6 +22,7 @@ func getRRSetIDFromRecords(rcs models.Records) []string {
 		}
 		ids = append(ids, *r.Original.(*model.ShowRecordSetByZoneResp).Id)
 	}
+	slices.Sort(ids)
 	return slices.Compact(ids)
 }
 

--- a/providers/huaweicloud/huaweicloudProvider.go
+++ b/providers/huaweicloud/huaweicloudProvider.go
@@ -28,9 +28,9 @@ Info required in `creds.json`:
 
 Record level metadata available:
    - hw_line (refer below Huawei Cloud DNS API documentation for available lines, default "default_view")
-	 					 (https://support.huaweicloud.com/intl/en-us/api-dns/en-us_topic_0085546214.html)
+             (https://support.huaweicloud.com/intl/en-us/api-dns/en-us_topic_0085546214.html)
    - hw_weight (0-1000, default "1")
-	 - hw_rrset_key (default "")
+   - hw_rrset_key (default "")
 
 */
 
@@ -82,7 +82,7 @@ func newHuaweicloud(m map[string]string, metadata json.RawMessage) (providers.DN
 var features = providers.DocumentationNotes{
 	// The default for unlisted capabilities is 'Cannot'.
 	// See providers/capabilities.go for the entire list of capabilities.
-	providers.CanAutoDNSSEC:          providers.Cannot(),
+	providers.CanAutoDNSSEC:          providers.Unimplemented("No public api provided, but can be turned on manually in the console."),
 	providers.CanGetZones:            providers.Can(),
 	providers.CanUseAlias:            providers.Cannot(),
 	providers.CanUseCAA:              providers.Can(),

--- a/providers/huaweicloud/records.go
+++ b/providers/huaweicloud/records.go
@@ -143,9 +143,6 @@ func collectRecordsByLineAndWeightAndKey(records models.Records) map[string]mode
 		weight := rec.Metadata[metaWeight]
 		rrsetKey := rec.Metadata[metaKey]
 		key := weight + "," + line + "," + rrsetKey
-		if _, ok := recordsByLineAndWeight[key]; !ok {
-			recordsByLineAndWeight[key] = models.Records{}
-		}
 		recordsByLineAndWeight[key] = append(recordsByLineAndWeight[key], rec)
 	}
 	return recordsByLineAndWeight


### PR DESCRIPTION
This pr is intended to make 3 changes
- Huawei Cloud supports DNSSEC but doesn't provide a corresponding API, so I've labelled it as Unimplemented.
- Huawei Cloud has changed the link to the document, so I've updated it here.
- Fixed a potential de-duplication bug
