### PR TITLE
DOCS: Update Cloudflare permission to "Single Redirect"

### DIFF
--- a/documentation/provider/cloudflareapi.md
+++ b/documentation/provider/cloudflareapi.md
@@ -64,7 +64,7 @@ DNSControl requires the token to have the following permissions:
 * Editing Page Rules?
   * Add: Edit Page Rules (`Zone → Page Rules → Edit`)
 * Creating Redirects?
-  * Add: Edit Dynamic Redirect (`Zone → Dynamic Redirect → Edit`)
+  * Add: Edit Single Redirect (`Zone → Single Redirect → Edit`)
 * Managing Cloudflare Workers? (if `manage_workers`: set to `true` or `CF_WORKER_ROUTE()` is in use.)
   * Add: Edit Worker Scripts (`Account → Workers Scripts → Edit`)
   * Add: Edit Worker Scripts (`Zone → Workers Routes → Edit`)


### PR DESCRIPTION
<!--
## Before submiting a pull request

Please make sure you've run the following commands from the root directory.

go vet ./...
go fmt ./...
go generate ./...
go mod tidy

## Release changelog section

Help keep the release changelog clear by pre-naming the proper section in the GitHub pull request title.

Some examples:
* CICD: Add required GHA permissions for goreleaser
* DOCS: Fixed providers with "contributor support" table
* ROUTE53: Allow R53_ALIAS records to enable target health evaluation

More examples/context can be found in the file .goreleaser.yml under the 'build' > 'changelog' key.
!-->

Below is a screenshot showing the new permission name:

<img width="801" alt="Screenshot 2024-09-22 at 21 43 07" src="https://github.com/user-attachments/assets/864c39c8-1f5e-49d4-9ace-fd2c8d4ca371">