### PR TITLE
CICD: GoReleaser snapshot property deprecation

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -150,7 +150,7 @@ docker_manifests:
 checksum:
   name_template: 'checksums.txt'
 snapshot:
-  name_template: "{{ incpatch .Version }}-next"
+  version_template: "{{ incpatch .Version }}-next"
 
 release:
   draft: true


### PR DESCRIPTION
Fixes https://github.com/StackExchange/dnscontrol/issues/3129

```shell
goreleaser check
```

**Before**

```shell
  • checking                                 path=.goreleaser.yml
  • DEPRECATED:  snapshot.name_template  should not be used anymore, check https://goreleaser.com/deprecations#snapshotnametemplate for more info
  • .goreleaser.yml                                  error=configuration is valid, but uses deprecated properties
  ⨯ command failed                                   error=1 out of 1 configuration file(s) have issues
```

**After**

```shell
  • checking                                 path=.goreleaser.yml
  • 1 configuration file(s) validated
  • thanks for using goreleaser!
```