### PR TITLE
Revert "FEATURE: parallel preview/push is now default (#3132)"

### DIFF
--- a/commands/ppreviewPush.go
+++ b/commands/ppreviewPush.go
@@ -31,9 +31,8 @@ type zoneCache struct {
 var _ = cmd(catMain, func() *cli.Command {
 	var args PPreviewArgs
 	return &cli.Command{
-		Name:    "preview",
-		Aliases: []string{"ppreview"},
-		Usage:   "read live configuration and identify changes to be made, without applying them",
+		Name:  "ppreview",
+		Usage: "read live configuration and identify changes to be made, without applying them",
 		Action: func(ctx *cli.Context) error {
 			return exit(PPreview(args))
 		},
@@ -123,9 +122,8 @@ func (args *PPreviewArgs) flags() []cli.Flag {
 var _ = cmd(catMain, func() *cli.Command {
 	var args PPushArgs
 	return &cli.Command{
-		Name:    "push",
-		Aliases: []string{"ppush"},
-		Usage:   "identify changes to be made, and perform them",
+		Name:  "ppush",
+		Usage: "identify changes to be made, and perform them",
 		Action: func(ctx *cli.Context) error {
 			return exit(PPush(args))
 		},

--- a/commands/previewPush.go
+++ b/commands/previewPush.go
@@ -26,7 +26,7 @@ import (
 var _ = cmd(catMain, func() *cli.Command {
 	var args PreviewArgs
 	return &cli.Command{
-		Name:  "oldpreview",
+		Name:  "preview",
 		Usage: "read live configuration and identify changes to be made, without applying them",
 		Action: func(ctx *cli.Context) error {
 			return exit(Preview(args))
@@ -98,7 +98,7 @@ func (args *PreviewArgs) flags() []cli.Flag {
 var _ = cmd(catMain, func() *cli.Command {
 	var args PushArgs
 	return &cli.Command{
-		Name:  "oldpush",
+		Name:  "push",
 		Usage: "identify changes to be made, and perform them",
 		Action: func(ctx *cli.Context) error {
 			return exit(Push(args))


### PR DESCRIPTION
This reverts commit 0f08087978462f52b1051dd961af5200380ad329.

<!--
## Before submiting a pull request

Please make sure you've run the following commands from the root directory.

go vet ./...
go fmt ./...
go generate ./...
go mod tidy

## Release changelog section

Help keep the release changelog clear by pre-naming the proper section in the GitHub pull request title.

Some examples:
* CICD: Add required GHA permissions for goreleaser
* DOCS: Fixed providers with "contributor support" table
* ROUTE53: Allow R53_ALIAS records to enable target health evaluation

More examples/context can be found in the file .goreleaser.yml under the 'build' > 'changelog' key.
!-->
