### PR TITLE
FEATURE: enable --report for preview (not just push)

### DIFF
--- a/commands/ppreviewPush.go
+++ b/commands/ppreviewPush.go
@@ -120,7 +120,7 @@ func (args *PPreviewArgs) flags() []cli.Flag {
 	flags = append(flags, &cli.StringFlag{
 		Name:        "report",
 		Destination: &args.Report,
-		Usage:       `Generate a machine-parseable report of performed corrections.`,
+		Usage:       `Generate a machine-parseable report of corrections.`,
 	})
 	return flags
 }

--- a/commands/ppreviewPush.go
+++ b/commands/ppreviewPush.go
@@ -155,7 +155,7 @@ func (args *PPushArgs) flags() []cli.Flag {
 
 // PPreview implements the preview subcommand.
 func PPreview(args PPreviewArgs) error {
-	return prun(args, false, false, printer.DefaultPrinter, "")
+	return prun(args, false, false, printer.DefaultPrinter, args.Report)
 }
 
 // PPush implements the push subcommand.

--- a/commands/ppreviewPush.go
+++ b/commands/ppreviewPush.go
@@ -50,6 +50,7 @@ type PPreviewArgs struct {
 	ConcurMode  string
 	NoPopulate  bool
 	DePopulate  bool
+	Report      string
 	Full        bool
 }
 
@@ -116,6 +117,11 @@ func (args *PPreviewArgs) flags() []cli.Flag {
 		Destination: &bindserial.ForcedValue,
 		Usage:       `Force BIND serial numbers to this value (for reproducibility)`,
 	})
+	flags = append(flags, &cli.StringFlag{
+		Name:        "report",
+		Destination: &args.Report,
+		Usage:       `Generate a machine-parseable report of performed corrections.`,
+	})
 	return flags
 }
 
@@ -135,7 +141,6 @@ var _ = cmd(catMain, func() *cli.Command {
 type PPushArgs struct {
 	PPreviewArgs
 	Interactive bool
-	Report      string
 }
 
 func (args *PPushArgs) flags() []cli.Flag {
@@ -144,11 +149,6 @@ func (args *PPushArgs) flags() []cli.Flag {
 		Name:        "i",
 		Destination: &args.Interactive,
 		Usage:       "Interactive. Confirm or Exclude each correction before they run",
-	})
-	flags = append(flags, &cli.StringFlag{
-		Name:        "report",
-		Destination: &args.Report,
-		Usage:       `Generate a machine-parseable report of performed corrections.`,
 	})
 	return flags
 }

--- a/commands/previewPush.go
+++ b/commands/previewPush.go
@@ -131,7 +131,7 @@ func (args *PushArgs) flags() []cli.Flag {
 
 // Preview implements the preview subcommand.
 func Preview(args PreviewArgs) error {
-	return run(args, false, false, printer.DefaultPrinter, nil)
+	return run(args, false, false, printer.DefaultPrinter, &args.Report)
 }
 
 // Push implements the push subcommand.

--- a/commands/previewPush.go
+++ b/commands/previewPush.go
@@ -44,6 +44,7 @@ type PreviewArgs struct {
 	WarnChanges bool
 	NoPopulate  bool
 	Full        bool
+	Report      string
 }
 
 // ReportItem is a record of corrections for a particular domain/provider/registrar.
@@ -92,6 +93,11 @@ func (args *PreviewArgs) flags() []cli.Flag {
 		Destination: &bindserial.ForcedValue,
 		Usage:       `Force BIND serial numbers to this value (for reproducibility)`,
 	})
+	flags = append(flags, &cli.StringFlag{
+		Name:        "report",
+		Destination: &args.Report,
+		Usage:       `Generate a machine-parseable report of performed corrections.`,
+	})
 	return flags
 }
 
@@ -111,7 +117,6 @@ var _ = cmd(catMain, func() *cli.Command {
 type PushArgs struct {
 	PreviewArgs
 	Interactive bool
-	Report      string
 }
 
 func (args *PushArgs) flags() []cli.Flag {
@@ -120,11 +125,6 @@ func (args *PushArgs) flags() []cli.Flag {
 		Name:        "i",
 		Destination: &args.Interactive,
 		Usage:       "Interactive. Confirm or Exclude each correction before they run",
-	})
-	flags = append(flags, &cli.StringFlag{
-		Name:        "report",
-		Destination: &args.Report,
-		Usage:       `Generate a machine-parseable report of performed corrections.`,
 	})
 	return flags
 }

--- a/commands/previewPush.go
+++ b/commands/previewPush.go
@@ -96,7 +96,7 @@ func (args *PreviewArgs) flags() []cli.Flag {
 	flags = append(flags, &cli.StringFlag{
 		Name:        "report",
 		Destination: &args.Report,
-		Usage:       `Generate a machine-parseable report of performed corrections.`,
+		Usage:       `Generate a machine-parseable report of corrections counts.`,
 	})
 	return flags
 }

--- a/documentation/json-reports.md
+++ b/documentation/json-reports.md
@@ -6,8 +6,8 @@ The report is JSON formated and contains the zonename, the provider or
 registrar name, and the number of changes.
 
 To generate the report, add the `--report <filename>` option to a preview or
-push command (this includes `preview`, `ppreview`, `oldpreview`, `push`,
-`ppush`, `oldpush`).
+push command (this includes `preview`, `ppreview`, `push`,
+`ppush`).
 
 
 The report lists the changes that would be (preview) or are (push) attempted,

--- a/documentation/json-reports.md
+++ b/documentation/json-reports.md
@@ -1,10 +1,21 @@
 # JSON Reports
 
-DNSControl has build in functionality to generate a machine-parseable report after pushing changes. This report is JSON formated and contains the zonename, the provider or registrar name and the amount of performed changes.
+DNSControl can generate a machine-parseable report of changes.
 
-## Usage
+The report is JSON formated and contains the zonename, the provider or
+registrar name, and the number of changes.
 
-To enable the report option you must use the `push` operation in combination with the `--report <filename>` option. This generates the json file.
+To generate the report, add the `--report <filename>` option to a preview or
+push command (this includes `preview`, `ppreview`, `oldpreview`, `push`,
+`ppush`, `oldpush`).
+
+
+The report lists the changes that would be (preview) or are (push) attempted,
+whether they are successful or not.
+
+If a fatal error happens during the run, no report is generated.
+
+## Sample output.
 
 {% code title="report.json" %}
 ```json

--- a/documentation/json-reports.md
+++ b/documentation/json-reports.md
@@ -15,7 +15,7 @@ whether they are successful or not.
 
 If a fatal error happens during the run, no report is generated.
 
-## Sample output.
+## Sample output
 
 {% code title="report.json" %}
 ```json

--- a/documentation/preview-push.md
+++ b/documentation/preview-push.md
@@ -26,7 +26,7 @@ OPTIONS:
    --no-populate                                              Use this flag to not auto-create non-existing zones at the provider (default: false)
    --full                                                     Add headings, providers names, notifications of no changes, etc (default: false)
    --bindserial value                                         Force BIND serial numbers to this value (for reproducibility) (default: 0)
-   --report value                                             (push) Generate a JSON-formatted report of the number of changes made.
+   --report value                                             Generate a JSON-formatted report of the number of changes.
    --help, -h                                                 show help
 ```
 
@@ -92,9 +92,9 @@ OPTIONS:
     generally used for reproducibility in testing pipelines.
 
 * `--report name`
-  * (`push` only!)  Generate a machine-parseable report of
-    performed corrections in the file named `name`. If no name is specified, no
-    report is generated.
+  * Write a machine-parseable report of
+    corrections to the file named `name`. If no name is specified, no
+    report is generated. See [JSON Reports](../advanced-features/json-reports.md)
 
 ## ppreview/ppush
 

--- a/documentation/preview-push.md
+++ b/documentation/preview-push.md
@@ -94,7 +94,7 @@ OPTIONS:
 * `--report name`
   * Write a machine-parseable report of
     corrections to the file named `name`. If no name is specified, no
-    report is generated. See [JSON Reports](../advanced-features/json-reports.md)
+    report is generated. See [JSON Reports](json-reports.md)
 
 ## ppreview/ppush
 


### PR DESCRIPTION
Fixes https://github.com/StackExchange/dnscontrol/issues/3148

* --report can now be used on preview/ppreview, not just push/ppush
* The help message is changed to be more accurate. It is no longer a report of corrections that were performed, but a report of corrections.
* Docs updated