### PR TITLE
another try

### DIFF
--- a/commands/previewPush.go
+++ b/commands/previewPush.go
@@ -23,17 +23,17 @@ import (
 	"golang.org/x/exp/slices"
 )
 
-var _ = cmd(catMain, func() *cli.Command {
-	var args PreviewArgs
-	return &cli.Command{
-		Name:  "preview",
-		Usage: "read live configuration and identify changes to be made, without applying them",
-		Action: func(ctx *cli.Context) error {
-			return exit(Preview(args))
-		},
-		Flags: args.flags(),
-	}
-}())
+// var _ = cmd(catMain, func() *cli.Command {
+// 	var args PPreviewArgs
+// 	return &cli.Command{
+// 		Name:  "preview",
+// 		Usage: "read live configuration and identify changes to be made, without applying them",
+// 		Action: func(ctx *cli.Context) error {
+// 			return exit(Preview(args))
+// 		},
+// 		Flags: args.flags(),
+// 	}
+// }())
 
 // PreviewArgs contains all data/flags needed to run preview, independently of CLI
 type PreviewArgs struct {
@@ -101,17 +101,17 @@ func (args *PreviewArgs) flags() []cli.Flag {
 	return flags
 }
 
-var _ = cmd(catMain, func() *cli.Command {
-	var args PushArgs
-	return &cli.Command{
-		Name:  "push",
-		Usage: "identify changes to be made, and perform them",
-		Action: func(ctx *cli.Context) error {
-			return exit(Push(args))
-		},
-		Flags: args.flags(),
-	}
-}())
+// var _ = cmd(catMain, func() *cli.Command {
+// 	var args PPushArgs
+// 	return &cli.Command{
+// 		Name:  "push",
+// 		Usage: "identify changes to be made, and perform them",
+// 		Action: func(ctx *cli.Context) error {
+// 			return exit(Push(args))
+// 		},
+// 		Flags: args.flags(),
+// 	}
+// }())
 
 // PushArgs contains all data/flags needed to run push, independently of CLI
 type PushArgs struct {
@@ -130,19 +130,21 @@ func (args *PushArgs) flags() []cli.Flag {
 }
 
 // Preview implements the preview subcommand.
-func Preview(args PreviewArgs) error {
+func Preview(args PPreviewArgs) error {
+	fmt.Fprintf(os.Stderr, "DEBUG: OLD PREVIEW\n")
 	return run(args, false, false, printer.DefaultPrinter, &args.Report)
 }
 
 // Push implements the push subcommand.
-func Push(args PushArgs) error {
-	return run(args.PreviewArgs, true, args.Interactive, printer.DefaultPrinter, &args.Report)
+func Push(args PPushArgs) error {
+	fmt.Fprintf(os.Stderr, "DEBUG: OLD PUSH\n")
+	return run(args.PPreviewArgs, true, args.Interactive, printer.DefaultPrinter, &args.Report)
 }
 
 var obsoleteDiff2FlagUsed = false
 
 // run is the main routine common to preview/push
-func run(args PreviewArgs, push bool, interactive bool, out printer.CLI, report *string) error {
+func run(args PPreviewArgs, push bool, interactive bool, out printer.CLI, report *string) error {
 	// TODO: make truly CLI independent. Perhaps return results on a channel as they occur
 
 	// This is a hack until we have the new printer replacement.


### PR DESCRIPTION
CC @cafferata 

Here's the output so far...

```
========== preview --cmode=legacy
WARN: In v4.14 --cmode will default to "concurrent". Please test and report any bugs ASAP. See https://docs.dnscontrol.org/commands/preview-push
DEBUG: OLD PREVIEW

========== preview --cmode=concurrent
WARN: NO WARNING NEEDED (remove this before merge)
DEBUG: NEW PREVIEW cmode="concurrent"

========== preview --cmode=none
WARN: NO WARNING NEEDED (remove this before merge)
DEBUG: NEW PREVIEW cmode="none"

========== preview --cmode=all
WARN: NO WARNING NEEDED (remove this before merge)
DEBUG: NEW PREVIEW cmode="all"

========== push --cmode=legacy
WARN: In v4.14 --cmode will default to "concurrent". Please test and report any bugs ASAP. See https://docs.dnscontrol.org/commands/preview-push
DEBUG: OLD PUSH

========== push --cmode=concurrent
WARN: NO WARNING NEEDED (remove this before merge)
DEBUG: NEW PUSH cmode="concurrent"

========== push --cmode=none
WARN: NO WARNING NEEDED (remove this before merge)
DEBUG: NEW PUSH cmode="none"

========== push --cmode=all
WARN: NO WARNING NEEDED (remove this before merge)
DEBUG: NEW PUSH cmode="all"

========== ppreview --cmode=legacy
WARN: ppreview is going away in v4.16 or later. Use "preview --cmode=legacy" instead.
DEBUG: OLD PREVIEW

========== ppreview --cmode=concurrent
WARN: ppreview is going away in v4.16 or later. Use "preview --cmode=concurrent" instead.
DEBUG: NEW PREVIEW cmode="concurrent"

========== ppreview --cmode=none
WARN: ppreview is going away in v4.16 or later. Use "preview --cmode=none" instead.
DEBUG: NEW PREVIEW cmode="none"

========== ppreview --cmode=all
WARN: ppreview is going away in v4.16 or later. Use "preview --cmode=all" instead.
DEBUG: NEW PREVIEW cmode="all"

========== ppush --cmode=legacy
WARN: ppush is going away in v4.16 or later. Use "push --cmode=legacy" instead.
DEBUG: OLD PUSH

========== ppush --cmode=concurrent
WARN: ppush is going away in v4.16 or later. Use "push --cmode=concurrent" instead.
DEBUG: NEW PUSH cmode="concurrent"

========== ppush --cmode=none
WARN: ppush is going away in v4.16 or later. Use "push --cmode=none" instead.
DEBUG: NEW PUSH cmode="none"

========== ppush --cmode=all
WARN: ppush is going away in v4.16 or later. Use "push --cmode=all" instead.
DEBUG: NEW PUSH cmode="all"
```

Not sure how much I like the text so far.