### PR TITLE
M365_BUILDER: Support second level domains, fix domainGUID Generation

### DIFF
--- a/pkg/js/helpers.js
+++ b/pkg/js/helpers.js
@@ -1850,7 +1850,7 @@ function M365_BUILDER(name, value) {
             );
         }
 
-        value.domainGUID = name.replace('.', '-');
+        value.domainGUID = name.replace(/\./g, '-');
     }
 
     if (value.dkim && !value.initialDomain) {


### PR DESCRIPTION
Update M365_BUILDER to use a global match regex

<!--
## Release changelog section
Other changes and improvements: Update M365_BUILDER to use a global match regex

!-->
