### PR TITLE
NS1: Ignore RRSets of type REDIRECT

### DIFF
--- a/providers/ns1/ns1Provider.go
+++ b/providers/ns1/ns1Provider.go
@@ -390,6 +390,14 @@ func convert(zr *dns.ZoneRecord, domain string) ([]*models.RecordConfig, error) 
 			if err := rec.SetTargetCAAStrings(xAns[0], xAns[1], xAns[2]); err != nil {
 				return nil, fmt.Errorf("unparsable %s record received from ns1: %w", rtype, err)
 			}
+		case "REDIRECT":
+			// NS1 returns REDIRECTs as records, but there is only one and dummy answer:
+			// "NS1 MANAGED RECORD"
+			// Redirects are managed via a different API endpoint https://api.nsone.net/v1/redirect
+			// It also involves cert management
+			// We may simpply ignore REDIRECTs for now until we support it
+			printer.Warnf("NS1_REDIRECT is NOT supported by dnscontrol and all existing redirects are ignored.\n")
+			continue
 		default:
 			if err := rec.PopulateFromString(rtype, ans, domain); err != nil {
 				return nil, fmt.Errorf("unparsable record received from ns1: %w", err)


### PR DESCRIPTION
NS1 replaces URLFWD with REDIRECTs. The latter supports HTTPS, which is nice, but it is not a 'real' DNS Record from the configuration point of view. To create a redirect, there is a separate API Endpoint. Creating a redirect may also involve Certificate management, if a user wants HTTPS support.
However, NS1 returns names, for which there is a redirect configured in n.Zones.Get(), with a stub answers section 'NS1 MANAGED RECORD'. RRType of REDIRECT confuses dnscontrol, and entire sync fails.

This commit ignores REDIRECTs coming from NS1 API.

<!--
## Before submiting a pull request

Please make sure you've run the following commands from the root directory.

go vet ./...
go fmt ./...
go generate ./...
go mod tidy

## Release changelog section

Help keep the release changelog clear by pre-naming the proper section in the GitHub pull request title.

Some examples:
* CICD: Add required GHA permissions for goreleaser
* DOCS: Fixed providers with "contributor support" table
* ROUTE53: Allow R53_ALIAS records to enable target health evaluation

More examples/context can be found in the file .goreleaser.yml under the 'build' > 'changelog' key.
!-->
