### PR TITLE
TEST BRANCH: Clean-up records after TestDualProviders

### DIFF
--- a/integrationTest/integration_test.go
+++ b/integrationTest/integration_test.go
@@ -374,7 +374,7 @@ func TestDualProviders(t *testing.T) {
 	nslist, _ := models.ToNameservers([]string{"ns1.example.com", "ns2.example.com"})
 	dc.Nameservers = append(dc.Nameservers, nslist...)
 	nameservers.AddNSRecords(dc)
-	t.Log("Adding nameservers from another provider")
+	t.Log("Adding test nameservers")
 	run()
 	// run again to make sure no corrections
 	t.Log("Running again to ensure stability")
@@ -392,6 +392,20 @@ func TestDualProviders(t *testing.T) {
 		}
 		t.FailNow()
 	}
+
+	t.Log("Removing test nameservers")
+	dc.Records = []*models.RecordConfig{}
+	n := 0
+	for _, ns := range dc.Nameservers {
+		if ns.Name == "ns1.example.com" || ns.Name == "ns2.example.com" {
+			continue
+		}
+		dc.Nameservers[n] = ns
+		n++
+	}
+	dc.Nameservers = dc.Nameservers[:n]
+	nameservers.AddNSRecords(dc)
+	run()
 }
 
 func TestNameserverDots(t *testing.T) {


### PR DESCRIPTION
<!--
## Before submiting a pull request

Please make sure you've run the following commands from the root directory.

go vet ./...
go fmt ./...
go generate ./...
go mod tidy

## Release changelog section

Help keep the release changelog clear by pre-naming the proper section in the GitHub pull request title.

Some examples:
* CICD: Add required GHA permissions for goreleaser
* DOCS: Fixed providers with "contributor support" table
* ROUTE53: Allow R53_ALIAS records to enable target health evaluation

More examples/context can be found in the file .goreleaser.yml under the 'build' > 'changelog' key.
!-->
