### PR TITLE
ORACLE: Do not warn about TTL for sub domain NS records

### DIFF
--- a/providers/oracle/oracleProvider.go
+++ b/providers/oracle/oracleProvider.go
@@ -228,7 +228,7 @@ func (o *oracleProvider) GetZoneRecordsCorrections(dc *models.DomainConfig, exis
 			continue
 		}
 
-		if rec.TTL != 86400 {
+		if rec.GetLabel() == "@" && rec.TTL != 86400 {
 			printer.Warnf("Oracle Cloud forces TTL=86400 for NS records. Ignoring configured TTL of %d for %s\n", rec.TTL, recNS)
 			rec.TTL = 86400
 		}


### PR DESCRIPTION
Fix for #3176

Will only warn about TTL reset to 86400 for domain own NS records, not for subdomains
