### PR TITLE
BUG: IMPORT_TRANSFORM_STRIP not stripping CNAME targets

### DIFF
--- a/pkg/normalize/validate.go
+++ b/pkg/normalize/validate.go
@@ -238,12 +238,13 @@ func checkTargets(rec *models.RecordConfig, domain string) (errs []error) {
 	return
 }
 
-func transformCNAME(target, oldDomain, newDomain string) string {
+func transformCNAME(target, oldDomain, newDomain, suffixstrip string) string {
 	// Canonicalize. If it isn't a FQDN, add the newDomain.
 	result := dnsutil.AddOrigin(target, oldDomain)
 	if dns.IsFqdn(result) {
 		result = result[:len(result)-1]
 	}
+	result = strings.TrimSuffix(result, suffixstrip)
 	return dnsutil.AddOrigin(result, newDomain) + "."
 }
 
@@ -301,7 +302,7 @@ func importTransform(srcDomain, dstDomain *models.DomainConfig,
 				return err
 			}
 			r.SetLabel(l, dstDomain.Name)
-			r.SetTarget(transformCNAME(r.GetTargetField(), srcDomain.Name, dstDomain.Name))
+			r.SetTarget(transformCNAME(r.GetTargetField(), srcDomain.Name, dstDomain.Name, suffixstrip))
 			dstDomain.Records = append(dstDomain.Records, r)
 		default:
 			// Anything else is ignored.

--- a/pkg/normalize/validate_test.go
+++ b/pkg/normalize/validate_test.go
@@ -174,9 +174,55 @@ func Test_transform_cname(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		actual := transformCNAME(test.experiment, "old.com", "new.com")
+		actual := transformCNAME(test.experiment, "old.com", "new.com", "")
 		if test.expected != actual {
 			t.Errorf("%v: expected (%v) got (%v)\n", test.experiment, test.expected, actual)
+		}
+	}
+}
+
+func Test_transform_cname_strip(t *testing.T) {
+	var tests = []struct {
+		p        []string
+		expected string
+	}{
+		{[]string{"ai.meta.stackexchange.com.", "stackexchange.com", "com.internal", ".com"},
+			"ai.meta.stackexchange.com.internal."},
+		{[]string{"askubuntu.com.", "askubuntu.com", "com.internal", ".com"},
+			"askubuntu.com.internal."},
+		{[]string{"blogoverflow.com.", "stackoverflow.com", "com.internal", ".com"},
+			"blogoverflow.com.internal."},
+		{[]string{"careers.stackoverflow.com.", "stackoverflow.com", "com.internal", ".com"},
+			"careers.stackoverflow.com.internal."},
+		{[]string{"chat.stackexchange.com.", "askubuntu.com", "com.internal", ".com"},
+			"chat.stackexchange.com.internal."},
+		{[]string{"chat.stackexchange.com.", "stackoverflow.com", "com.internal", ".com"},
+			"chat.stackexchange.com.internal."},
+		{[]string{"chat.stackexchange.com.", "superuser.com", "com.internal", ".com"},
+			"chat.stackexchange.com.internal."},
+		{[]string{"sstatic.net.", "sstatic.net", "net.internal", ".net"},
+			"sstatic.net.internal."},
+		{[]string{"stackapps.com.", "stackapps.com", "com.internal", ".com"},
+			"stackapps.com.internal."},
+		{[]string{"stackexchange.com.", "stackexchange.com", "com.internal", ".com"},
+			"stackexchange.com.internal."},
+		{[]string{"stackoverflow.com.", "stackoverflow.com", "com.internal", ".com"},
+			"stackoverflow.com.internal."},
+		{[]string{"superuser.com.", "superuser.com", "com.internal", ".com"},
+			"superuser.com.internal."},
+		{[]string{"teststackoverflow.com.", "teststackoverflow.com", "com.internal", ".com"},
+			"teststackoverflow.com.internal."},
+		{[]string{"webapps.stackexchange.com.", "stackexchange.com", "com.internal", ".com"},
+			"webapps.stackexchange.com.internal."},
+		//
+		{[]string{"sstatic.net.", "sstatic.net", "com.internal", ".com"},
+			"sstatic.net.com.internal."},
+	}
+
+	for _, test := range tests {
+		actual := transformCNAME(test.p[0], test.p[1], test.p[2], test.p[3])
+		if test.expected != actual {
+			t.Errorf("%v: expected (%v) got (%v)\n", test.p, test.expected, actual)
 		}
 	}
 }


### PR DESCRIPTION
<!--
## Before submiting a pull request

Please make sure you've run the following commands from the root directory.

go vet ./...
go fmt ./...
go generate ./...
go mod tidy

## Release changelog section

Help keep the release changelog clear by pre-naming the proper section in the GitHub pull request title.

Some examples:
* CICD: Add required GHA permissions for goreleaser
* DOCS: Fixed providers with "contributor support" table
* ROUTE53: Allow R53_ALIAS records to enable target health evaluation

More examples/context can be found in the file .goreleaser.yml under the 'build' > 'changelog' key.
!-->
