### PR TITLE
 FEATURE: M365_BUILDER add support for alternative MX hosts

### DIFF
--- a/commands/types/dnscontrol.d.ts
+++ b/commands/types/dnscontrol.d.ts
@@ -1863,7 +1863,7 @@ declare function LOC_BUILDER_STR(opts: { label?: string; str: string; alt?: numb
  *
  * This sets up `MX` records, Autodiscover, and DKIM.
  *
- * ### Advanced example
+ * ### Example with MDM only
  *
  * ```javascript
  * D("example.com", REG_MY_PROVIDER, DnsProvider(DSP_MY_PROVIDER),
@@ -1881,10 +1881,32 @@ declare function LOC_BUILDER_STR(opts: { label?: string; str: string; alt?: numb
  *
  * This sets up Mobile Device Management only.
  *
+ * ### Example with all services and DNSSEC MX
+ *
+ * ```javascript
+ * D("example.com", REG_MY_PROVIDER, DnsProvider(DSP_MY_PROVIDER),
+ *   M365_BUILDER("example.com", {
+ *       mx: true, // Can be omitted as default: true
+ *       mxHost: "o-v1.mx.microsoft", // Override the default mail.protection.outlook.com
+ *       autodiscover: true, // Can be omitted as default: true
+ *       dkim: true, // Can be omitted as default: true
+ *       skypeForBusiness: true,
+ *       mdm: true,
+ *       initialDomain: "example.onmicrosoft.com",
+ *   }),
+ * END);
+ * ```
+ *
+ * This sets up MX (custom), AutoDiscover, DKIM, Skype for Business/Microsoft Teams and Mobile Device Management records.
+ *
+ * Instead of the default MX target ending in `mail.protection.outlook.com`, this example uses `<random-id>.mx.microsoft` which is a DNSSEC signed zone.
+ * `<random-id>` is obtained from Microsoft after [enabling DNSSEC functionality for the domain](https://learn.microsoft.com/purview/how-smtp-dane-works#inbound-smtp-dane-with-dnssec) within Exchange Online.
+ *
  * ### Parameters
  *
  * * `label` The label of the Microsoft 365 domain, useful if it is a subdomain (default: `"@"`)
  * * `mx` Set an `MX` record? (default: `true`)
+ * * `mxHost` Set your MX host for Exchange Online (default: `mail.protection.outlook.com`)
  * * `autodiscover` Set Autodiscover `CNAME` record? (default: `true`)
  * * `dkim` Set DKIM `CNAME` records? (default: `true`)
  * * `skypeForBusiness` Set Skype for Business/Microsoft Teams records? (default: `false`)

--- a/documentation/language-reference/domain-modifiers/M365_BUILDER.md
+++ b/documentation/language-reference/domain-modifiers/M365_BUILDER.md
@@ -66,6 +66,7 @@ This sets up Mobile Device Management only.
 
 * `label` The label of the Microsoft 365 domain, useful if it is a subdomain (default: `"@"`)
 * `mx` Set an `MX` record? (default: `true`)
+* `mxHost` Set your MX host for Exchange Online (default: `mail.protection.outlook.com`)
 * `autodiscover` Set Autodiscover `CNAME` record? (default: `true`)
 * `dkim` Set DKIM `CNAME` records? (default: `true`)
 * `skypeForBusiness` Set Skype for Business/Microsoft Teams records? (default: `false`)

--- a/documentation/language-reference/domain-modifiers/M365_BUILDER.md
+++ b/documentation/language-reference/domain-modifiers/M365_BUILDER.md
@@ -42,7 +42,7 @@ END);
 
 This sets up `MX` records, Autodiscover, and DKIM.
 
-### Advanced example
+### Example with MDM only
 
 {% code title="dnsconfig.js" %}
 ```javascript

--- a/documentation/language-reference/domain-modifiers/M365_BUILDER.md
+++ b/documentation/language-reference/domain-modifiers/M365_BUILDER.md
@@ -62,6 +62,29 @@ END);
 
 This sets up Mobile Device Management only.
 
+### Example with all services and DNSSEC MX
+
+{% code title="dnsconfig.js" %}
+```javascript
+D("example.com", REG_MY_PROVIDER, DnsProvider(DSP_MY_PROVIDER),
+  M365_BUILDER("example.com", {
+      mx: true, // Can be omitted as default: true
+      mxHost: "o-v1.mx.microsoft", // Override the default mail.protection.outlook.com
+      autodiscover: true, // Can be omitted as default: true
+      dkim: true, // Can be omitted as default: true
+      skypeForBusiness: true,
+      mdm: true,
+      initialDomain: "example.onmicrosoft.com",
+  }),
+END);
+```
+{% endcode %}
+
+This sets up MX (custom), AutoDiscover, DKIM, Skype for Business/Microsoft Teams and Mobile Device Management records.
+
+Instead of the default MX target ending in `mail.protection.outlook.com`, this example uses `<random-id>.mx.microsoft` which is a DNSSEC signed zone.
+`<random-id>` is obtained from Microsoft after [enabling DNSSEC functionality for the domain](https://learn.microsoft.com/purview/how-smtp-dane-works#inbound-smtp-dane-with-dnssec) within Exchange Online.
+
 ### Parameters
 
 * `label` The label of the Microsoft 365 domain, useful if it is a subdomain (default: `"@"`)

--- a/documentation/language-reference/domain-modifiers/M365_BUILDER.md
+++ b/documentation/language-reference/domain-modifiers/M365_BUILDER.md
@@ -13,6 +13,7 @@ parameters_object: true
 parameter_types:
   label: string?
   mx: boolean?
+  mxHost: string?
   autodiscover: boolean?
   dkim: boolean?
   skypeForBusiness: boolean?

--- a/pkg/js/helpers.js
+++ b/pkg/js/helpers.js
@@ -1881,21 +1881,12 @@ function M365_BUILDER(name, value) {
 
     // MX host (default: "mail.protection.outlook.com")
     if (!value.mxHost) {
-        value.mx = "mail.protection.outlook.com";
+        value.mx = 'mail.protection.outlook.com';
     }
 
     // MX (default: true)
     if (value.mx) {
-        r.push(
-            MX(
-                value.label,
-                0,
-                value.domainGUID +
-                '.' +
-                value.mxHost +
-                '.'
-            )
-        );
+        r.push(MX(value.label, 0, value.domainGUID + '.' + value.mxHost + '.'));
     }
 
     // Autodiscover (default: true)

--- a/pkg/js/helpers.js
+++ b/pkg/js/helpers.js
@@ -1879,13 +1879,21 @@ function M365_BUILDER(name, value) {
 
     var r = [];
 
+    // MX host (default: "mail.protection.outlook.com")
+    if (!value.mxHost) {
+        value.mx = "mail.protection.outlook.com";
+    }
+
     // MX (default: true)
     if (value.mx) {
         r.push(
             MX(
                 value.label,
                 0,
-                value.domainGUID + '.mail.protection.outlook.com.'
+                value.domainGUID +
+                '.' +
+                value.mxHost +
+                '.'
             )
         );
     }


### PR DESCRIPTION
<!--
## Before submiting a pull request

Please make sure you've run the following commands from the root directory.

go vet ./...
go fmt ./...
go generate ./...
go mod tidy

## Release changelog section

Help keep the release changelog clear by pre-naming the proper section in the GitHub pull request title.

Some examples:
* CICD: Add required GHA permissions for goreleaser
* DOCS: Fixed providers with "contributor support" table
* ROUTE53: Allow R53_ALIAS records to enable target health evaluation

More examples/context can be found in the file .goreleaser.yml under the 'build' > 'changelog' key.
!-->

Closes #3185

Could you review and advise if this approach is the right way?

I've added a new example for `M365_BUILDER`, with all services enabled and using the new `mxHost` parameter to point to an example DNSSEC enabled MX host.