### PR TITLE
feat(import_transform): skip records with import_transform_skip set

### DIFF
--- a/documentation/language-reference/domain-modifiers/IMPORT_TRANSFORM.md
+++ b/documentation/language-reference/domain-modifiers/IMPORT_TRANSFORM.md
@@ -12,8 +12,13 @@ ts_ignore: true
 Don't use this feature. It was added for a very specific situation at Stack Overflow.
 {% endhint %}
 
-`IMPORT_TRANSFORM` adds to the domain all the records from another
+`IMPORT_TRANSFORM` adds to the domain the records from another
 domain, after making certain transformations and resetting the TTL.
+
+Not all records are copied and transformed:
+* The record must be a A or CNAME.
+* Records are skipped if they have a metadata key `import_transform_skip` (any non-null value).
+* Records are skipped if a record of the same label and type already exist in the destination domain.
 
 Example:
 
@@ -46,10 +51,17 @@ Here's how you'd implement this in DNSControl:
 
 {% code title="dnsconfig.js" %}
 ```javascript
-var TRANSFORM_INT = [
+// Transforms that use newBase:
+var TRANSFORM_CF = [
     // RANGE_START, RANGE_END, NEW_BASE
     { low: "1.2.3.10", high: "1.2.3.20", newBase: "123.123.123.100" },  //   .10 to .20 rewritten as 123.123.123.100+IP
     { low: "2.4.6.80", high: "2.4.6.90", newBase: "123.123.123.200" },  //   Another rule, just to show that you can have many.
+]
+// Transforms that use newIP
+var TRANSFORM_FSTLY = [
+    // RANGE_START, RANGE_END, NEW_BASE
+    { low: "1.2.3.10", high: "1.2.3.10", newIP: "123.123.123.100" },  //   .10 is rewritten as 123.123.123.100
+    { low: "2.4.6.20", high: "2.4.6.20", newIP: "123.123.123.200" },  //   .20 is rewritten as 123.123.123.200
 ]
 
 D("foo.com", REG_MY_PROVIDER, DnsProvider(DSP_MY_PROVIDER),
@@ -61,12 +73,28 @@ END);
 
 D("bar.com", REG_MY_PROVIDER, DnsProvider(DSP_MY_PROVIDER),
   A("www","123.123.123.123"),
-  IMPORT_TRANSFORM(TRANSFORM_INT, "foo.com", 300),
+  IMPORT_TRANSFORM(TRANSFORM_CF, "foo.com", 300),
+END);
+
+D("baz.com", REG_MY_PROVIDER, DnsProvider(DSP_MY_PROVIDER),
+  A("www","123.123.123.123"),
+  IMPORT_TRANSFORM(TRANSFORM_FSTLY, "foo.com", 300),
 END);
 ```
 {% endcode %}
 
-Transform rules are: RANGE_START, RANGE_END, NEW_BASE.  NEW_BASE may be:
+Transform rules are: `RANGE_START`, `RANGE_END`, `NEW_BASE` or `NEW_IP`.
+
+Only one of `newBase` and `newBase` may be specified. If both are non-null the behavior is undefined.
+
+`NEW_BASE` works as follows:
 
 * An IP address.  Rebase the IP address on this IP address. Extract the host part of the /24 and add it to the "new base" address.
 * A list of IP addresses. For each A record, inject an A record for each item in the list: `newBase: ["1.2.3.100", "2.4.6.8.100"]` would produce 2 records for each A record.
+* For CNAMEs, the `.internal` is appended to the end of the target.
+
+`NEW_IP` works as follows:
+
+* An IP address.  Change the IP address of the A record to this IP address. If there are multiple A records at this label, only one A record is generated.
+* A list of IP addresses. Not supported.
+* For CNAMEs, the `.internal` is appended to the end of the target. (same as `NEW_BASE`)

--- a/documentation/language-reference/domain-modifiers/IMPORT_TRANSFORM.md
+++ b/documentation/language-reference/domain-modifiers/IMPORT_TRANSFORM.md
@@ -16,9 +16,9 @@ Don't use this feature. It was added for a very specific situation at Stack Over
 domain, after making certain transformations and resetting the TTL.
 
 Not all records are copied and transformed:
-* The record must be a A or CNAME.
+* The record must be type A or CNAME.
+* Records are skipped if a record of the same label+type already exist in the destination domain.
 * Records are skipped if they have a metadata key `import_transform_skip` (any non-null value).
-* Records are skipped if a record of the same label and type already exist in the destination domain.
 
 Example:
 

--- a/documentation/language-reference/domain-modifiers/IMPORT_TRANSFORM_STRIP.md
+++ b/documentation/language-reference/domain-modifiers/IMPORT_TRANSFORM_STRIP.md
@@ -23,7 +23,7 @@ For CNAMEs, the `suffixstrip` is stripped from the beginning (prefix) of the tar
 
 For example, if the domain is `com.extra` and the label is `foo.com`,
 `IMPORT_TRANSFORM` would generate a label `foo.com.com.extra`.
-`IMPORT_TRANSFORM_STRIP(... , '.com')` would generate
+`IMPORT_TRANSFORM_STRIP(... , 'com')` would generate
 the label `foo.com.extra` instead.
 
 In the case of a CNAME, if the target is `foo.com.`, the new target would be `foo.com.extra`.

--- a/documentation/language-reference/domain-modifiers/IMPORT_TRANSFORM_STRIP.md
+++ b/documentation/language-reference/domain-modifiers/IMPORT_TRANSFORM_STRIP.md
@@ -25,4 +25,5 @@ For example, if the domain is `com.extra` and the label is `foo.com`,
 `IMPORT_TRANSFORM` would generate a label `foo.com.com.extra`.
 `IMPORT_TRANSFORM_STRIP(... , '.com')` would generate
 the label `foo.com.extra` instead.
-A CNAME's target would be `foo.com.extra`.
+
+In the case of a CNAME, if the target is `foo.com.`, the new target would be `foo.com.extra`.

--- a/pkg/normalize/validate.go
+++ b/pkg/normalize/validate.go
@@ -277,6 +277,11 @@ func importTransform(srcDomain, dstDomain *models.DomainConfig,
 	// 4. For As, change the target as described the transforms.
 
 	for _, rec := range srcDomain.Records {
+		// If this record is marked to be skipped, skip it.
+		if rec.Metadata["import_transform_skip"] != "" {
+			continue
+		}
+		// If the dstDomain already has a record with this type+label, skip it.
 		if dstDomain.Records.HasRecordTypeName(rec.Type, rec.GetLabelFQDN()) {
 			continue
 		}


### PR DESCRIPTION
Problem:
* IMPORT_TRANSFORM/IMPORT_TRANSFORM_STRIP need to be able to skip certain records.

Solution:
* With this PR, if the metadata for a record includes "import_transform_skip" (any value), that record is skipped