### PR TITLE
NS1: Remove tests for NS1_URLFWD

### DIFF
--- a/integrationTest/integration_test.go
+++ b/integrationTest/integration_test.go
@@ -779,10 +779,6 @@ func tlsa(name string, usage, selector, matchingtype uint8, target string) *mode
 	return r
 }
 
-func ns1Urlfwd(name, target string) *models.RecordConfig {
-	return makeRec(name, target, "NS1_URLFWD")
-}
-
 func porkbunUrlfwd(name, target, t, includePath, wildcard string) *models.RecordConfig {
 	r := makeRec(name, target, "PORKBUN_URLFWD")
 	r.Metadata = make(map[string]string)
@@ -2078,14 +2074,6 @@ func makeTests() []*TestGroup {
 				cfWorkerRoute("msn.**current-domain-no-trailing**/*", "dnscontrol_integrationtest_msnbc"),
 				cfWorkerRoute("api.**current-domain-no-trailing**/cnn/*", "dnscontrol_integrationtest_cnn"),
 			),
-		),
-
-		// NS1 features
-
-		testgroup("NS1_URLFWD tests",
-			only("NS1"),
-			tc("Add a urlfwd", ns1Urlfwd("urlfwd1", "/ http://example.com 302 2 0")),
-			tc("Update a urlfwd", ns1Urlfwd("urlfwd1", "/ http://example.org 301 2 0")),
 		),
 
 		//// IGNORE* features


### PR DESCRIPTION
CC @costasd 

Remove tests for NS1's URLFWD record. It is no longer supported.

```
=== FAIL: integrationTest TestDNSProviders/***integration.io/72:NS1_URLFWD_tests:Add_a_urlfwd (0.12s)
    integration_test.go:248: 
        + CREATE urlfwd1.***integration.io NS1_URLFWD / http://example.com/ 302 2 0 ttl=300
WARNING: NS1_URLFWD is deprecated and may stop working anytime now. Please avoid such records going forward.
    integration_test.go:253: PUT https://api.nsone.net/v1/zones/***integration.io/urlfwd1.***integration.io/URLFWD: 410 create record of URLFWD type is permanently disabled
        --- FAIL: TestDNSProviders/***integration.io/72:NS1_URLFWD_tests:Add_a_urlfwd (0.12s)
```