### PR TITLE
CNR: Disable pager101 integration test

### DIFF
--- a/integrationTest/integration_test.go
+++ b/integrationTest/integration_test.go
@@ -1415,6 +1415,7 @@ func makeTests() []*TestGroup {
 				"NS1",        // Free acct only allows 50 records, therefore we skip
 				//"ROUTE53",       // Batches up changes in pages.
 				"TRANSIP", // Doesn't page. Works fine.  Due to the slow API we skip.
+				"CNR",     // Test beaks limits.
 			),
 			tc("99 records", manyA("rec%04d", "1.2.3.4", 99)...),
 			tc("100 records", manyA("rec%04d", "1.2.3.4", 100)...),


### PR DESCRIPTION
Problem:

The pager101 integration test files for CNR.

Solution:

* I suspect our account has a limit in place.
* This test is safe to ignore for most providers as most don't send API results 1 page at a time.
