### PR TITLE
CNR Provider: Review CI / Docs / Capabilities (add NAPTR, SSHFP)

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -39,7 +39,7 @@ changelog:
       regexp: "(?i)^.*(major|new provider|feature)[(\\w)]*:+.*$"
       order: 1
     - title: 'Provider-specific changes:'
-      regexp: "(?i)((akamaiedge|autodns|axfrd|azure|azure_private_dns|bind|bunnydns|cloudflare|cloudflareapi_old|cloudns|cscglobal|desec|digitalocean|dnsimple|dnsmadeeasy|doh|domainnameshop|dynadot|easyname|exoscale|gandi|gcloud|gcore|hedns|hetzner|hexonet|hostingde|huaweicloud|inwx|linode|loopia|luadns|msdns|mythicbeasts|namecheap|namedotcom|netcup|netlify|ns1|opensrs|oracle|ovh|packetframe|porkbun|powerdns|realtimeregister|route53|rwth|sakuracloud|softlayer|transip|vultr).*:)+.*"
+      regexp: "(?i)((akamaiedge|autodns|axfrd|azure|azure_private_dns|bind|bunnydns|cloudflare|cloudflareapi_old|cloudns|cnr|cscglobal|desec|digitalocean|dnsimple|dnsmadeeasy|doh|domainnameshop|dynadot|easyname|exoscale|gandi|gcloud|gcore|hedns|hetzner|hexonet|hostingde|huaweicloud|inwx|linode|loopia|luadns|msdns|mythicbeasts|namecheap|namedotcom|netcup|netlify|ns1|opensrs|oracle|ovh|packetframe|porkbun|powerdns|realtimeregister|route53|rwth|sakuracloud|softlayer|transip|vultr).*:)+.*"
       order: 2
     - title: 'Documentation:'
       regexp: "(?i)^.*(docs)[(\\w)]*:+.*$"

--- a/documentation/SUMMARY.md
+++ b/documentation/SUMMARY.md
@@ -112,6 +112,7 @@
 * [Azure Private DNS](provider/azure_private_dns.md)
 * [BIND](provider/bind.md)
 * [Bunny DNS](provider/bunny\_dns.md)
+* [CentralNic Reseller (fka RRPproxy)](provider/cnr.md)
 * [Cloudflare](provider/cloudflareapi.md)
 * [ClouDNS](provider/cloudns.md)
 * [CSC Global](provider/cscglobal.md)

--- a/documentation/providers.md
+++ b/documentation/providers.md
@@ -23,7 +23,7 @@ If a feature is definitively not supported for whatever reason, we would also li
 | [`BUNNY_DNS`](provider/bunny_dns.md) | ❌ | ✅ | ❌ | ❌ | ✅ | ✅ | ❌ | ❔ | ❌ | ❌ | ✅ | ❌ | ✅ | ❌ | ❔ | ❌ | ❌ | ❌ | ❔ | ❔ | ❌ | ✅ | ✅ |
 | [`CLOUDFLAREAPI`](provider/cloudflareapi.md) | ✅ | ✅ | ❌ | ✅ | ✅ | ✅ | ❔ | ✅ | ❌ | ✅ | ✅ | ❔ | ✅ | ✅ | ✅ | ✅ | ❔ | ❔ | ❔ | ❌ | ❌ | ✅ | ✅ |
 | [`CLOUDNS`](provider/cloudns.md) | ❌ | ✅ | ❌ | ❌ | ✅ | ✅ | ✅ | ❔ | ✅ | ❔ | ✅ | ❔ | ✅ | ✅ | ❔ | ✅ | ❔ | ❔ | ✅ | ❔ | ❔ | ✅ | ✅ |
-| [`CNR`](provider/cnr.md) | ❌ | ✅ | ✅ | ✅ | ❌ | ✅ | ❔ | ❔ | ❔ | ❔ | ✅ | ❔ | ✅ | ❔ | ❔ | ✅ | ❔ | ❔ | ❔ | ❔ | ✅ | ✅ | ✅ |
+| [`CNR`](provider/cnr.md) | ❌ | ✅ | ✅ | ✅ | ❌ | ✅ | ❔ | ❌ | ❌ | ✅ | ✅ | ❌ | ✅ | ✅ | ❌ | ✅ | ❔ | ❌ | ❌ | ❔ | ✅ | ✅ | ✅ |
 | [`CSCGLOBAL`](provider/cscglobal.md) | ✅ | ✅ | ✅ | ✅ | ❔ | ✅ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ✅ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❌ | ✅ |
 | [`DESEC`](provider/desec.md) | ❌ | ✅ | ❌ | ✅ | ❔ | ✅ | ✅ | ✅ | ❔ | ✅ | ✅ | ❔ | ✅ | ✅ | ✅ | ✅ | ✅ | ❔ | ❔ | ✅ | ❔ | ✅ | ✅ |
 | [`DIGITALOCEAN`](provider/digitalocean.md) | ❌ | ✅ | ❌ | ✅ | ❔ | ✅ | ❔ | ❔ | ❌ | ❔ | ❔ | ❔ | ✅ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ✅ | ✅ |

--- a/documentation/providers.md
+++ b/documentation/providers.md
@@ -118,6 +118,7 @@ Providers in this category and their maintainers are:
 |[`BUNNY_DNS`](provider/bunny_dns.md)|@ppmathis|
 |[`CLOUDFLAREAPI`](provider/cloudflareapi.md)|@tresni|
 |[`CLOUDNS`](provider/cloudns.md)|@pragmaton|
+|[`CNR`](provider/cnr.md)|@KaiSchwarz-cnic|
 |[`CSCGLOBAL`](provider/cscglobal.md)|@Air-New-Zealand|
 |[`DESEC`](provider/desec.md)|@D3luxee|
 |[`DIGITALOCEAN`](provider/digitalocean.md)|@Deraen|
@@ -172,7 +173,6 @@ code to support this provider, we'd be glad to help in any way.
 * [Infoblox DNS](https://github.com/StackExchange/dnscontrol/issues/1077) (#1077)
 * [Joker.com](https://github.com/StackExchange/dnscontrol/issues/854) (#854)
 * [Plesk](https://github.com/StackExchange/dnscontrol/issues/2261) (#2261)
-* [RRPPRoxy](https://github.com/StackExchange/dnscontrol/issues/1656) (#1656)
 * [RcodeZero](https://github.com/StackExchange/dnscontrol/issues/884) (#884)
 * [SynergyWholesale](https://github.com/StackExchange/dnscontrol/issues/1605) (#1605)
 * [UltraDNS by Neustar / CSCGlobal](https://github.com/StackExchange/dnscontrol/issues/1533) (#1533)

--- a/providers/cnr/cnrProvider.go
+++ b/providers/cnr/cnrProvider.go
@@ -27,32 +27,32 @@ var features = providers.DocumentationNotes{
 	// See providers/capabilities.go for the entire list of capabilities.
 	// The default for unlisted capabilities is 'Cannot'.
 	// --- Supported Features ---
-	providers.CanAutoDNSSEC:		  providers.Unimplemented("Ask for this feature."),
+	providers.CanAutoDNSSEC:          providers.Unimplemented("Ask for this feature."),
 	providers.CanConcur:              providers.Can(),
 	providers.CanGetZones:            providers.Can(),
 	providers.DocCreateDomains:       providers.Can(),
 	providers.DocDualHost:            providers.Can(),
 	providers.DocOfficiallySupported: providers.Cannot("Actively maintained provider module."),
 	// --- Supported record types ---
-	providers.CanUseAKAMAICDN: 	      providers.Cannot(), // can only be supported by Akamai EdgeDns provider
-	providers.CanUseAlias:            providers.Cannot("Not supported. You may use CNAME records instead. An Alternative solution is planned."),
-	providers.CanUseAzureAlias:		  providers.Cannot(), // can only be supported by Azure provider
-	providers.CanUseCAA:              providers.Can(),
-	providers.CanUseDHCID:			  providers.Unimplemented(),
-	providers.CanUseDNAME:            providers.Unimplemented(),
-	providers.CanUseDNSKEY:           providers.Unimplemented(),
-	providers.CanUseDS:               providers.Unimplemented(),
-	providers.CanUseDSForChildren:	  providers.Unimplemented(), // CanUseDS implies CanUseDSForChildren
-	providers.CanUseHTTPS:			  providers.Unimplemented(),
-	providers.CanUseLOC:              providers.Unimplemented(),
-	providers.CanUseNAPTR:			  providers.Can(),
-	providers.CanUsePTR:              providers.Can(),
-	providers.CanUseRoute53Alias:	  providers.Cannot(), // can only be supported by AWS Route53 provider
-	providers.CanUseSOA:			  providers.Unimplemented(),
-	providers.CanUseSRV:              providers.Can("SRV records with empty targets are not supported"),
-	providers.CanUseSSHFP:			  providers.Can(),
-	providers.CanUseSVCB:			  providers.Unimplemented(),
-	providers.CanUseTLSA:             providers.Can(),
+	// providers.CanUseAKAMAICDN: 	      providers.Cannot(), // can only be supported by Akamai EdgeDns provider
+	providers.CanUseAlias: providers.Cannot("Not supported. You may use CNAME records instead. An Alternative solution is planned."),
+	// providers.CanUseAzureAlias:		  providers.Cannot(), // can only be supported by Azure provider
+	providers.CanUseCAA:           providers.Can(),
+	providers.CanUseDHCID:         providers.Cannot("Ask for this feature."),
+	providers.CanUseDNAME:         providers.Cannot("Ask for this feature."),
+	providers.CanUseDNSKEY:        providers.Unimplemented("Ask for this feature."),
+	providers.CanUseDS:            providers.Unimplemented("Ask for this feature."),
+	providers.CanUseDSForChildren: providers.Unimplemented("Ask for this feature."), // CanUseDS implies CanUseDSForChildren
+	providers.CanUseHTTPS:         providers.Cannot("Managed via (Query|Add|Modify|Delete)WebFwd API call. Data not accessible via the resource records list. Hard to integrate this into DNSControl by that."),
+	providers.CanUseLOC:           providers.Cannot("Ask for this feature."),
+	providers.CanUseNAPTR:         providers.Can(),
+	providers.CanUsePTR:           providers.Can(),
+	// providers.CanUseRoute53Alias:	  providers.Cannot(), // can only be supported by AWS Route53 provider
+	providers.CanUseSOA:   providers.Cannot("The SOA record is managed on the DNSZone directly. Data only accessible via StatusDNSZone Request, not via the resource records list. Hard to integrate this into DNSControl by that."), // supported by bind, honstingde
+	providers.CanUseSRV:   providers.Can("SRV records with empty targets are not supported"),
+	providers.CanUseSSHFP: providers.Can(),
+	providers.CanUseSVCB:  providers.Cannot("Ask for this feature."),
+	providers.CanUseTLSA:  providers.Can(),
 }
 
 func newProvider(conf map[string]string) (*CNRClient, error) {

--- a/providers/cnr/cnrProvider.go
+++ b/providers/cnr/cnrProvider.go
@@ -50,7 +50,7 @@ var features = providers.DocumentationNotes{
 	providers.CanUseRoute53Alias:	  providers.Cannot(), // can only be supported by AWS Route53 provider
 	providers.CanUseSOA:			  providers.Unimplemented(),
 	providers.CanUseSRV:              providers.Can("SRV records with empty targets are not supported"),
-	providers.CanUseSSHFP:			  providers.Unimplemented(),
+	providers.CanUseSSHFP:			  providers.Can(),
 	providers.CanUseSVCB:			  providers.Unimplemented(),
 	providers.CanUseTLSA:             providers.Can(),
 }

--- a/providers/cnr/cnrProvider.go
+++ b/providers/cnr/cnrProvider.go
@@ -24,19 +24,35 @@ type CNRClient struct {
 }
 
 var features = providers.DocumentationNotes{
-	// The default for unlisted capabilities is 'Cannot'.
 	// See providers/capabilities.go for the entire list of capabilities.
-	providers.CanGetZones:            providers.Can(),
+	// The default for unlisted capabilities is 'Cannot'.
+	// --- Supported Features ---
+	providers.CanAutoDNSSEC:		  providers.Unimplemented("Ask for this feature."),
 	providers.CanConcur:              providers.Can(),
-	providers.CanUseAlias:            providers.Cannot("Not supported. You may use CNAME records instead. An Alternative solution is planned."),
-	providers.CanUseCAA:              providers.Can(),
-	providers.CanUseLOC:              providers.Unimplemented(),
-	providers.CanUsePTR:              providers.Can(),
-	providers.CanUseSRV:              providers.Can("SRV records with empty targets are not supported"),
-	providers.CanUseTLSA:             providers.Can(),
+	providers.CanGetZones:            providers.Can(),
 	providers.DocCreateDomains:       providers.Can(),
 	providers.DocDualHost:            providers.Can(),
 	providers.DocOfficiallySupported: providers.Cannot("Actively maintained provider module."),
+	// --- Supported record types ---
+	providers.CanUseAKAMAICDN: 	      providers.Cannot(), // can only be supported by Akamai EdgeDns provider
+	providers.CanUseAlias:            providers.Cannot("Not supported. You may use CNAME records instead. An Alternative solution is planned."),
+	providers.CanUseAzureAlias:		  providers.Cannot(), // can only be supported by Azure provider
+	providers.CanUseCAA:              providers.Can(),
+	providers.CanUseDHCID:			  providers.Unimplemented(),
+	providers.CanUseDNAME:            providers.Unimplemented(),
+	providers.CanUseDNSKEY:           providers.Unimplemented(),
+	providers.CanUseDS:               providers.Unimplemented(),
+	providers.CanUseDSForChildren:	  providers.Unimplemented(), // CanUseDS implies CanUseDSForChildren
+	providers.CanUseHTTPS:			  providers.Unimplemented(),
+	providers.CanUseLOC:              providers.Unimplemented(),
+	providers.CanUseNAPTR:			  providers.Can(),
+	providers.CanUsePTR:              providers.Can(),
+	providers.CanUseRoute53Alias:	  providers.Cannot(), // can only be supported by AWS Route53 provider
+	providers.CanUseSOA:			  providers.Unimplemented(),
+	providers.CanUseSRV:              providers.Can("SRV records with empty targets are not supported"),
+	providers.CanUseSSHFP:			  providers.Unimplemented(),
+	providers.CanUseSVCB:			  providers.Unimplemented(),
+	providers.CanUseTLSA:             providers.Can(),
 }
 
 func newProvider(conf map[string]string) (*CNRClient, error) {

--- a/providers/cnr/cnrProvider.go
+++ b/providers/cnr/cnrProvider.go
@@ -62,7 +62,7 @@ func newProvider(conf map[string]string) (*CNRClient, error) {
 	}
 	api.client.SetUserAgent("DNSControl", version)
 	api.APILogin, api.APIPassword, api.APIEntity = conf["apilogin"], conf["apipassword"], conf["apientity"]
-	if conf["debugmode"] == "1" {
+	if conf["debugmode"] == "2" {
 		api.client.EnableDebugMode()
 	}
 	if api.APIEntity != "OTE" && api.APIEntity != "LIVE" {

--- a/providers/cnr/records.go
+++ b/providers/cnr/records.go
@@ -293,6 +293,11 @@ func (n *CNRClient) createRecordString(rc *models.RecordConfig, domain string) (
 		if domain == host {
 			host = fmt.Sprintf(`%s.`, host)
 		}
+	case "SSHFP":
+		answer = fmt.Sprintf(`%v %v %s`, rc.SshfpAlgorithm, rc.SshfpFingerprint, rc.GetTargetField())
+		if domain == host {
+			host = fmt.Sprintf(`%s.`, host)
+		}
 	case "NAPTR":
 		answer = fmt.Sprintf(`%v %v "%v" "%v" "%v" %v`, rc.NaptrOrder, rc.NaptrPreference, rc.NaptrFlags, rc.NaptrService, rc.NaptrRegexp, rc.GetTargetField())
 		if domain == host {

--- a/providers/cnr/records.go
+++ b/providers/cnr/records.go
@@ -376,5 +376,5 @@ func isNoPopulate() bool {
 
 // Function to check if debug mode is enabled
 func (n *CNRClient) isDebugOn() bool {
-	return n.conf["debugmode"] == "1"
+	return n.conf["debugmode"] == "1" || n.conf["debugmode"] == "2"
 }

--- a/providers/cnr/records.go
+++ b/providers/cnr/records.go
@@ -195,7 +195,10 @@ func (n *CNRClient) getRecords(domain string) ([]*CNRRecord, error) {
 		if r.GetCode() == 545 {
 			// If dns zone does not exist create a new one automatically
 			if !isNoPopulate() {
-				n.EnsureZoneExists(domain)
+				err := n.EnsureZoneExists(domain)
+				if err != nil {
+					return nil, err
+				}
 			} else {
 				// Return specific error if the zone does not exist
 				return nil, n.GetCNRApiError("Use `dnscontrol create-domains` to create not-existing zone", domain, r)

--- a/providers/cnr/records.go
+++ b/providers/cnr/records.go
@@ -293,6 +293,11 @@ func (n *CNRClient) createRecordString(rc *models.RecordConfig, domain string) (
 		if domain == host {
 			host = fmt.Sprintf(`%s.`, host)
 		}
+	case "NAPTR":
+		answer = fmt.Sprintf(`%v %v "%v" "%v" "%v" %v`, rc.NaptrOrder, rc.NaptrPreference, rc.NaptrFlags, rc.NaptrService, rc.NaptrRegexp, rc.GetTargetField())
+		if domain == host {
+			host = fmt.Sprintf(`%s.`, host)
+		}
 	case "TLSA":
 		answer = fmt.Sprintf(`%v %v %v %s`, rc.TlsaUsage, rc.TlsaSelector, rc.TlsaMatchingType, rc.GetTargetField())
 	case "CAA":


### PR DESCRIPTION
@tlimoncelli I went through all the capabilities and played around with the CentralNic Reseller API. All this is now updated and great that I've been able to identify SSHFP and NAPTR as supported record types.
Finally, I went through the Dev Guide for new Provider Modules and reviewed the missing parts. 

* Reviewed Provider Capabilities
* Added support for NAPTR record
* Added support for SSHFP record
* reviewed documentation
  * cleanup requested providers
  * added CNR to the provider list
* reviewed reported linting issues (golangci-lint)
* fixed go releaser regexp

Integration Tests passed:

```
...
--- PASS: TestDualProviders (4.89s)
=== RUN   TestNameserverDots
No nameservers found
=== RUN   TestNameserverDots/No_trailing_dot_in_nameserver
--- PASS: TestNameserverDots (0.12s)
    --- PASS: TestNameserverDots/No_trailing_dot_in_nameserver (0.00s)
PASS
ok      github.com/StackExchange/dnscontrol/v4/integrationTest  381.239s
```