### PR TITLE
BUGFIX: push not running concurrently

### DIFF
--- a/commands/ppreviewPush.go
+++ b/commands/ppreviewPush.go
@@ -213,7 +213,7 @@ func PPreview(args PPreviewArgs) error {
 
 // PPush implements the push subcommand.
 func PPush(args PPushArgs) error {
-	return run(args.PPreviewArgs, true, args.Interactive, printer.DefaultPrinter, &args.Report)
+	return prun(args.PPreviewArgs, true, args.Interactive, printer.DefaultPrinter, args.Report)
 }
 
 var pobsoleteDiff2FlagUsed = false


### PR DESCRIPTION
Issue:

while "preview --cmode=concurrent" triggers the concurrent code, "push --cmode=concurrent" does not.

Resolution:

Call the correct damn function.