### PR TITLE
BIND: Allow use in cmode=concurrent

### DIFF
--- a/commands/ppreviewPush.go
+++ b/commands/ppreviewPush.go
@@ -581,7 +581,7 @@ func generatePopulateCorrections(provider *models.DNSProviderInstance, zoneName 
 	}
 
 	return []*models.Correction{{
-		Msg: fmt.Sprintf("Create zone '%s' in the '%s' profile", aceZoneName, provider.Name),
+		Msg: fmt.Sprintf("Ensuring zone %q exists in %q", aceZoneName, provider.Name),
 		F:   func() error { return creator.EnsureZoneExists(aceZoneName) },
 	}}
 }
@@ -604,7 +604,10 @@ func generateDelegationCorrections(zone *models.DomainConfig, providers []*model
 	nameservers.AddNSRecords(zone)
 
 	if len(zone.Nameservers) == 0 && zone.Metadata["no_ns"] != "true" {
-		return []*models.Correction{{Msg: fmt.Sprintf("No nameservers declared for domain %q; skipping registrar. Add {no_ns:'true'} to force", zone.Name)}}, 0
+		return []*models.Correction{{Msg: fmt.Sprintf("Skipping registrar %q: No nameservers declared for domain %q. Add {no_ns:'true'} to force",
+			zone.RegistrarName,
+			zone.Name,
+		)}}, 0
 	}
 
 	corrections, err := zone.RegistrarInstance.Driver.GetRegistrarCorrections(zone)

--- a/documentation/providers.md
+++ b/documentation/providers.md
@@ -19,7 +19,7 @@ If a feature is definitively not supported for whatever reason, we would also li
 | [`AXFRDDNS`](provider/axfrddns.md) | ❌ | ✅ | ❌ | ❌ | ❔ | ✅ | ✅ | ✅ | ❔ | ✅ | ✅ | ❔ | ✅ | ✅ | ✅ | ✅ | ❔ | ✅ | ❔ | ❔ | ❌ | ❌ | ❌ |
 | [`AZURE_DNS`](provider/azure_dns.md) | ✅ | ✅ | ❌ | ✅ | ❌ | ✅ | ❔ | ❔ | ❌ | ❌ | ✅ | ❔ | ✅ | ❌ | ❔ | ❌ | ❔ | ❔ | ❔ | ❔ | ✅ | ✅ | ✅ |
 | [`AZURE_PRIVATE_DNS`](provider/azure_private_dns.md) | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❔ | ❔ | ❌ | ❌ | ✅ | ❔ | ✅ | ❌ | ❔ | ❌ | ❔ | ❔ | ❔ | ❔ | ✅ | ✅ | ✅ |
-| [`BIND`](provider/bind.md) | ✅ | ✅ | ❌ | ❌ | ❔ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| [`BIND`](provider/bind.md) | ✅ | ✅ | ❌ | ✅ | ❔ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | [`BUNNY_DNS`](provider/bunny_dns.md) | ❌ | ✅ | ❌ | ❌ | ✅ | ✅ | ❌ | ❔ | ❌ | ❌ | ✅ | ❌ | ✅ | ❌ | ❔ | ❌ | ❌ | ❌ | ❔ | ❔ | ❌ | ✅ | ✅ |
 | [`CLOUDFLAREAPI`](provider/cloudflareapi.md) | ✅ | ✅ | ❌ | ✅ | ✅ | ✅ | ❔ | ✅ | ❌ | ✅ | ✅ | ❔ | ✅ | ✅ | ✅ | ✅ | ❔ | ❔ | ❔ | ❌ | ❌ | ✅ | ✅ |
 | [`CLOUDNS`](provider/cloudns.md) | ❌ | ✅ | ❌ | ✅ | ✅ | ✅ | ✅ | ❔ | ✅ | ❔ | ✅ | ❔ | ✅ | ✅ | ❔ | ✅ | ❔ | ❔ | ✅ | ❔ | ❔ | ✅ | ✅ |

--- a/providers/bind/bindProvider.go
+++ b/providers/bind/bindProvider.go
@@ -35,7 +35,7 @@ var features = providers.DocumentationNotes{
 	// See providers/capabilities.go for the entire list of capabilities.
 	providers.CanAutoDNSSEC:          providers.Can("Just writes out a comment indicating DNSSEC was requested"),
 	providers.CanGetZones:            providers.Can(),
-	providers.CanConcur:              providers.Cannot(),
+	providers.CanConcur:              providers.Can(),
 	providers.CanUseCAA:              providers.Can(),
 	providers.CanUseDHCID:            providers.Can(),
 	providers.CanUseDNAME:            providers.Can(),
@@ -126,8 +126,6 @@ type bindProvider struct {
 	nameservers    []*models.Nameserver
 	directory      string
 	filenameformat string
-	//zonefile       string // Where the zone data is e texpected
-	//zoneFileFound  bool   // Did the zonefile exist?
 }
 
 // GetNameservers returns the nameservers for a domain.
@@ -184,18 +182,14 @@ func (c *bindProvider) GetZoneRecords(domain string, meta map[string]string) (mo
 	content, err := os.ReadFile(zonefile)
 	if os.IsNotExist(err) {
 		// If the file doesn't exist, that's not an error. Just informational.
-		//c.zoneFileFound = false
 		fmt.Fprintf(os.Stderr, "File does not yet exist: %q (will create)\n", zonefile)
 		return nil, nil
 	}
 	if err != nil {
 		return nil, fmt.Errorf("can't open %s: %w", zonefile, err)
 	}
-	//c.zoneFileFound = true
 
-	zonefileName := zonefile
-
-	return ParseZoneContents(string(content), domain, zonefileName)
+	return ParseZoneContents(string(content), domain, zonefile)
 }
 
 // ParseZoneContents parses a string as a BIND zone and returns the records.
@@ -215,6 +209,10 @@ func ParseZoneContents(content string, zoneName string, zonefileName string) (mo
 		return nil, fmt.Errorf("error while parsing '%v': %w", zonefileName, err)
 	}
 	return foundRecords, nil
+}
+
+func (n *bindProvider) EnsureZoneExists(_ string) error {
+	return nil
 }
 
 // GetZoneRecordsCorrections returns a list of corrections that will turn existing records into dc.Records.

--- a/providers/bind/bindProvider.go
+++ b/providers/bind/bindProvider.go
@@ -127,7 +127,7 @@ type bindProvider struct {
 	directory      string
 	filenameformat string
 	zonefile       string // Where the zone data is e texpected
-	zoneFileFound  bool   // Did the zonefile exist?
+	//zoneFileFound  bool   // Did the zonefile exist?
 }
 
 // GetNameservers returns the nameservers for a domain.
@@ -183,14 +183,14 @@ func (c *bindProvider) GetZoneRecords(domain string, meta map[string]string) (mo
 	content, err := os.ReadFile(c.zonefile)
 	if os.IsNotExist(err) {
 		// If the file doesn't exist, that's not an error. Just informational.
-		c.zoneFileFound = false
+		//c.zoneFileFound = false
 		fmt.Fprintf(os.Stderr, "File does not yet exist: %q (will create)\n", c.zonefile)
 		return nil, nil
 	}
 	if err != nil {
 		return nil, fmt.Errorf("can't open %s: %w", c.zonefile, err)
 	}
-	c.zoneFileFound = true
+	//c.zoneFileFound = true
 
 	zonefileName := c.zonefile
 


### PR DESCRIPTION
Fixes https://github.com/StackExchange/dnscontrol/issues/3252

* BIND: Enable cmode=concurrent
* BIND: Calculate the zone's filename any time it is needed rather than trying to store it for later use.
  * bindProvider.zoneFileFound: Remove. This is written to but never read.
  * bindProvider.zonefile: Remove. This is cached but always regenerated. Cache wasn't threadsafe.
* BIND: Implement ZoneCreator so that when BIND is your registrar (which it shouldn't be), at least you get reasonable messages.
* BIND: Improve messages around ensuring zones exist
