### PR TITLE
DOCS: Add fmtjson and "get co main" to releng docs

### DIFF
--- a/documentation/release-engineering.md
+++ b/documentation/release-engineering.md
@@ -10,6 +10,7 @@ Please change the version number as appropriate.  Substitute (for example)
 ## Step 0. Update dependencies
 
 ```shell
+git checkout main
 git checkout -b update_deps
 go install github.com/oligot/go-mod-upgrade@latest
 go-mod-upgrade
@@ -23,6 +24,7 @@ git commit -a -m "CHORE: Update dependencies"
 git checkout main
 git pull
 go fmt ./...
+bin/fmtjson $(find . -type f -name \*.json -print)
 go generate ./...
 go mod tidy
 git status
@@ -32,7 +34,7 @@ There should be no modified files. If there are, check them in then start over f
 
 ```
 git checkout -b gogenerate
-git commit -a -m "Update generated files for $VERSION"
+git commit -a -m "Update generated files"
 ```
 
 ## Step 2. Tag the commit in main that you want to release


### PR DESCRIPTION
# Issue

Release engineering docs should clarify that they
should start in "main".  Also add fmtjson instructions.

# Resolution

Added as requested.

<!--
## Before submiting a pull request

Please make sure you've run the following commands from the root directory.

go vet ./...
go fmt ./...
go generate ./...
go mod tidy

## Release changelog section

Help keep the release changelog clear by pre-naming the proper section in the GitHub pull request title.

Some examples:
* CICD: Add required GHA permissions for goreleaser
* DOCS: Fixed providers with "contributor support" table
* ROUTE53: Allow R53_ALIAS records to enable target health evaluation

More examples/context can be found in the file .goreleaser.yml under the 'build' > 'changelog' key.
!-->
