### PR TITLE
DOCS: Release improvements

### DIFF
--- a/documentation/release-engineering.md
+++ b/documentation/release-engineering.md
@@ -7,10 +7,16 @@ GitHub Actions (GHA) will do most of the work for you. You will need to edit the
 Please change the version number as appropriate.  Substitute (for example)
 `v4.2.0` any place you see `$VERSION` in this doc.
 
-## Step 0. Update dependencies
+## Prepare the git repository
 
 ```shell
 git checkout main
+git pull
+```
+
+## Step 0. Update dependencies
+
+```shell
 git checkout -b update_deps
 go install github.com/oligot/go-mod-upgrade@latest
 go-mod-upgrade
@@ -21,8 +27,6 @@ git commit -a -m "CHORE: Update dependencies"
 ## Step 1. Rebuild generated files
 
 ```shell
-git checkout main
-git pull
 go fmt ./...
 bin/fmtjson $(find . -type f -name \*.json -print)
 go generate ./...
@@ -32,7 +36,7 @@ git status
 
 There should be no modified files. If there are, check them in then start over from the beginning:
 
-```
+```shell
 git checkout -b gogenerate
 git commit -a -m "Update generated files"
 ```


### PR DESCRIPTION
Thanks for pointing this out! As you mentioned https://github.com/StackExchange/dnscontrol/pull/3301:

> “Release engineering docs should clarify that they should start in main. Also add fmtjson instructions.”

Initially, the docs did clarify that releases should start in main. However, this changed when `Step 0` was added via https://github.com/StackExchange/dnscontrol/pull/3265.

To resolve this, I suggest moving the duplicate instructions into a “Prepare the Git Repository” section to streamline the process and avoid redundancy. You can check the current state of the docs in the preview here: [Release Engineering Docs Preview](https://docs.dnscontrol.org/~/revisions/VD64bb6k0kj9TcNrp3Cc/release/release-engineering).

Let me know if that works for you, or if you have any other suggestions!