### PR TITLE
DOCS: Rackspace Cloud DNS provider request

### DIFF
--- a/documentation/provider/index.md
+++ b/documentation/provider/index.md
@@ -173,6 +173,7 @@ code to support this provider, we'd be glad to help in any way.
 * [Infoblox DNS](https://github.com/StackExchange/dnscontrol/issues/1077) (#1077)
 * [Joker.com](https://github.com/StackExchange/dnscontrol/issues/854) (#854)
 * [Plesk](https://github.com/StackExchange/dnscontrol/issues/2261) (#2261)
+* [Rackspace Cloud DNS](https://github.com/StackExchange/dnscontrol/issues/2980) (#2980)
 * [RcodeZero](https://github.com/StackExchange/dnscontrol/issues/884) (#884)
 * [SynergyWholesale](https://github.com/StackExchange/dnscontrol/issues/1605) (#1605)
 * [UltraDNS by Neustar / CSCGlobal](https://github.com/StackExchange/dnscontrol/issues/1533) (#1533)


### PR DESCRIPTION
The Rackspace Cloud DNS provider request has been included in the documentation.

Closes https://github.com/StackExchange/dnscontrol/issues/2980