### PR TITLE
EXOSCALE: finish implementation of zone creation

### DIFF
--- a/providers/exoscale/exoscaleProvider.go
+++ b/providers/exoscale/exoscaleProvider.go
@@ -83,7 +83,10 @@ func init() {
 // EnsureZoneExists creates a zone if it does not exist
 func (c *exoscaleProvider) EnsureZoneExists(domain string) error {
 	_, err := c.findDomainByName(domain)
-
+	if err == ErrDomainNotFound {
+		d := &egoscale.DNSDomain{UnicodeName: &domain}
+		_, err = c.client.CreateDNSDomain(context.Background(), c.apiZone, d)
+	}
 	return err
 }
 


### PR DESCRIPTION
Hi @pierre-emmanuelJ!
While reviewing all the `ZoneCreator` implementations, I noticed that the EXOSCALE provider has an incomplete implementation for `EnsureZoneExists`. This PR is finishing the implementation, but I have no account with them for testing. Would you mind giving this a try and let me know how it goes? Thanks!