### PR TITLE
AZURE: populate zone cache after creating zone

### DIFF
--- a/providers/azuredns/azureDnsProvider.go
+++ b/providers/azuredns/azureDnsProvider.go
@@ -11,6 +11,7 @@ import (
 	aauth "github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	adns "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/dns/armdns"
 	"github.com/Azure/go-autorest/autorest/to"
+
 	"github.com/StackExchange/dnscontrol/v4/models"
 	"github.com/StackExchange/dnscontrol/v4/pkg/diff2"
 	"github.com/StackExchange/dnscontrol/v4/pkg/printer"
@@ -609,9 +610,10 @@ func (a *azurednsProvider) EnsureZoneExists(domain string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 6000*time.Second)
 	defer cancel()
 
-	_, err := a.zonesClient.CreateOrUpdate(ctx, *a.resourceGroup, domain, adns.Zone{Location: to.StringPtr("global")}, nil)
+	z, err := a.zonesClient.CreateOrUpdate(ctx, *a.resourceGroup, domain, adns.Zone{Location: to.StringPtr("global")}, nil)
 	if err != nil {
 		return err
 	}
+	a.zones[domain] = &z.Zone
 	return nil
 }


### PR DESCRIPTION
Hi @vatsalyagoel!
While reviewing all the `ZoneCreator` implementations, I noticed that the AZURE provider has an incomplete caching implementation for zones. The provider is populating the cache once on startup. Any zones that are created will not readable in the same life-cycle of dnscontrol. This PR is populating the zone cache with any newly created zones for later use. Would you mind giving this a try and let me know how it goes? Thanks!

Part of https://github.com/StackExchange/dnscontrol/issues/3007