### PR TITLE
DESEC: populate zone cache after creating zone

### DIFF
--- a/providers/desec/protocol.go
+++ b/providers/desec/protocol.go
@@ -262,6 +262,11 @@ func (c *desecProvider) createDomain(domain string) error {
 	}
 	printer.Printf("To enable DNSSEC validation for your domain, make sure to convey the DS record(s) to your registrar:\n")
 	printer.Printf("%+q", dm.Keys)
+	c.domainIndexLock.Lock()
+	defer c.domainIndexLock.Unlock()
+	if c.domainIndex != nil {
+		c.domainIndex[domain] = dm.MinimumTTL
+	}
 	return nil
 }
 


### PR DESCRIPTION
Hi @D3luxee!
While reviewing all the `ZoneCreator` implementations, I noticed that the DESEC provider has an incomplete caching implementation for zones. The provider is populating the cache once on first access. Any zones that are created will not be readable in the same life-cycle of dnscontrol. This PR is populating the zone cache after creating a zone. Would you mind giving this a try and let me know how it goes? Thanks!

Part of https://github.com/StackExchange/dnscontrol/issues/3007