### PR TITLE
DNSMADEEASY: populate zone cache after creating zone

### DIFF
--- a/providers/dnsmadeeasy/api.go
+++ b/providers/dnsmadeeasy/api.go
@@ -11,7 +11,7 @@ import (
 
 type dnsMadeEasyProvider struct {
 	restAPI *dnsMadeEasyRestAPI
-	domains map[string]multiDomainResponseDataEntry
+	domains map[string]int
 }
 
 func newProvider(apiKey string, secretKey string, sandbox bool, debug bool) *dnsMadeEasyProvider {
@@ -41,7 +41,7 @@ func (api *dnsMadeEasyProvider) loadDomains() error {
 		return nil
 	}
 
-	domains := map[string]multiDomainResponseDataEntry{}
+	domains := map[string]int{}
 
 	res, err := api.restAPI.multiDomainGet()
 	if err != nil {
@@ -53,7 +53,7 @@ func (api *dnsMadeEasyProvider) loadDomains() error {
 			return errors.New("fetching domains from DNSMADEEASY failed: domains with GTD enabled are not supported")
 		}
 
-		domains[domain.Name] = domain
+		domains[domain.Name] = domain.ID
 	}
 
 	api.domains = domains
@@ -71,26 +71,26 @@ func (api *dnsMadeEasyProvider) domainExists(name string) (bool, error) {
 	return ok, nil
 }
 
-func (api *dnsMadeEasyProvider) findDomain(name string) (*multiDomainResponseDataEntry, error) {
+func (api *dnsMadeEasyProvider) findDomainId(name string) (int, error) {
 	if err := api.loadDomains(); err != nil {
-		return nil, err
+		return 0, err
 	}
 
 	domain, ok := api.domains[name]
 	if !ok {
-		return nil, fmt.Errorf("domain not found on this DNSMADEEASY account: %q", name)
+		return 0, fmt.Errorf("domain not found on this DNSMADEEASY account: %q", name)
 	}
 
-	return &domain, nil
+	return domain, nil
 }
 
 func (api *dnsMadeEasyProvider) fetchDomainRecords(domainName string) ([]recordResponseDataEntry, error) {
-	domain, err := api.findDomain(domainName)
+	domainId, err := api.findDomainId(domainName)
 	if err != nil {
 		return nil, err
 	}
 
-	res, err := api.restAPI.recordGet(domain.ID)
+	res, err := api.restAPI.recordGet(domainId)
 	if err != nil {
 		return nil, fmt.Errorf("fetching records failed: %w", err)
 	}
@@ -108,12 +108,12 @@ func (api *dnsMadeEasyProvider) fetchDomainRecords(domainName string) ([]recordR
 }
 
 func (api *dnsMadeEasyProvider) fetchDomainNameServers(domainName string) ([]string, error) {
-	domain, err := api.findDomain(domainName)
+	domainId, err := api.findDomainId(domainName)
 	if err != nil {
 		return nil, err
 	}
 
-	res, err := api.restAPI.singleDomainGet(domain.ID)
+	res, err := api.restAPI.singleDomainGet(domainId)
 	if err != nil {
 		return nil, fmt.Errorf("fetching domain from DNSMADEEASY failed: %w", err)
 	}

--- a/providers/dnsmadeeasy/api.go
+++ b/providers/dnsmadeeasy/api.go
@@ -127,13 +127,12 @@ func (api *dnsMadeEasyProvider) fetchDomainNameServers(domainName string) ([]str
 }
 
 func (api *dnsMadeEasyProvider) createDomain(domain string) error {
-	_, err := api.restAPI.singleDomainCreate(singleDomainRequestData{Name: domain})
+	res, err := api.restAPI.singleDomainCreate(singleDomainRequestData{Name: domain})
 	if err != nil {
 		return err
 	}
 
-	// reset cached domains after adding a new one, they will be refetched when needed
-	api.domains = nil
+	api.domains[domain] = res.ID
 
 	return nil
 }

--- a/providers/dnsmadeeasy/dnsMadeEasyProvider.go
+++ b/providers/dnsmadeeasy/dnsMadeEasyProvider.go
@@ -105,7 +105,7 @@ func New(settings map[string]string, _ json.RawMessage) (providers.DNSServicePro
 
 func (api *dnsMadeEasyProvider) GetZoneRecordsCorrections(dc *models.DomainConfig, existingRecords models.Records) ([]*models.Correction, int, error) {
 	domainName := dc.Name
-	domain, err := api.findDomain(domainName)
+	domainId, err := api.findDomainId(domainName)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -139,7 +139,7 @@ func (api *dnsMadeEasyProvider) GetZoneRecordsCorrections(dc *models.DomainConfi
 		corr := &models.Correction{
 			Msg: strings.Join(deleteDescription, "\n\t"),
 			F: func() error {
-				return api.deleteRecords(domain.ID, deleteRecordIds)
+				return api.deleteRecords(domainId, deleteRecordIds)
 			},
 		}
 		corrections = append(corrections, corr)
@@ -157,7 +157,7 @@ func (api *dnsMadeEasyProvider) GetZoneRecordsCorrections(dc *models.DomainConfi
 		corr := &models.Correction{
 			Msg: strings.Join(createDescription, "\n\t"),
 			F: func() error {
-				return api.createRecords(domain.ID, createRecords)
+				return api.createRecords(domainId, createRecords)
 			},
 		}
 		corrections = append(corrections, corr)
@@ -180,7 +180,7 @@ func (api *dnsMadeEasyProvider) GetZoneRecordsCorrections(dc *models.DomainConfi
 		corr := &models.Correction{
 			Msg: strings.Join(modifyDescription, "\n\t"),
 			F: func() error {
-				return api.updateRecords(domain.ID, modifyRecords)
+				return api.updateRecords(domainId, modifyRecords)
 			},
 		}
 		corrections = append(corrections, corr)

--- a/providers/dnsmadeeasy/restApi.go
+++ b/providers/dnsmadeeasy/restApi.go
@@ -51,7 +51,7 @@ func (restApi *dnsMadeEasyRestAPI) singleDomainGet(domainID int) (*singleDomainR
 	}
 
 	res := &singleDomainResponse{}
-	_, err := restApi.sendRequest(req, &res)
+	_, err := restApi.sendRequest(req, res)
 	if err != nil {
 		return nil, err
 	}
@@ -66,7 +66,7 @@ func (restApi *dnsMadeEasyRestAPI) multiDomainGet() (*multiDomainResponse, error
 	}
 
 	res := &multiDomainResponse{}
-	_, err := restApi.sendRequest(req, &res)
+	_, err := restApi.sendRequest(req, res)
 	if err != nil {
 		return nil, err
 	}
@@ -81,7 +81,7 @@ func (restApi *dnsMadeEasyRestAPI) recordGet(domainID int) (*recordResponse, err
 	}
 
 	res := &recordResponse{}
-	_, err := restApi.sendRequest(req, &res)
+	_, err := restApi.sendRequest(req, res)
 	if err != nil {
 		return nil, err
 	}
@@ -102,7 +102,7 @@ func (restApi *dnsMadeEasyRestAPI) singleDomainCreate(data singleDomainRequestDa
 	}
 
 	res := &singleDomainResponse{}
-	_, err = restApi.sendRequest(req, &res)
+	_, err = restApi.sendRequest(req, res)
 	if err != nil {
 		return nil, err
 	}
@@ -123,7 +123,7 @@ func (restApi *dnsMadeEasyRestAPI) multiRecordCreate(domainID int, data []record
 	}
 
 	res := &[]recordResponseDataEntry{}
-	_, err = restApi.sendRequest(req, &res)
+	_, err = restApi.sendRequest(req, res)
 	if err != nil {
 		return nil, err
 	}
@@ -264,7 +264,7 @@ retry:
 	backoff = initialBackoff
 
 	if response != nil {
-		err = json.NewDecoder(res.Body).Decode(&response)
+		err = json.NewDecoder(res.Body).Decode(response)
 		if err != nil {
 			return res.StatusCode, err
 		}


### PR DESCRIPTION
Hi @vojtad!
While reviewing all the `ZoneCreator` implementations, I noticed that the DNSMADEEASY provider has an incomplete caching implementation for zones. The provider is populating the cache once on first access. Any zones that are created will not be readable in the same life-cycle of dnscontrol. This PR is populating the zone cache after creating a zone. Would you mind giving this a try and let me know how it goes? Thanks!

Note: I've reduced the contents of the zone cache to just the domain ID as that is what each called is using only; and what the API response from creating the zone provides too (the API response from creating the zone is similar to the response from listing, but not quite the same).
Bonus: I've also done some code cleanup from spurious nested pointers. These changes are in it's own commit to ease the review.

Part of https://github.com/StackExchange/dnscontrol/issues/3007