### PR TITLE
INWX: populate zone cache after creating zone

### DIFF
--- a/providers/inwx/inwxProvider.go
+++ b/providers/inwx/inwxProvider.go
@@ -7,12 +7,13 @@ import (
 	"strings"
 	"time"
 
+	"github.com/nrdcg/goinwx"
+	"github.com/pquerna/otp/totp"
+
 	"github.com/StackExchange/dnscontrol/v4/models"
 	"github.com/StackExchange/dnscontrol/v4/pkg/diff"
 	"github.com/StackExchange/dnscontrol/v4/pkg/printer"
 	"github.com/StackExchange/dnscontrol/v4/providers"
-	"github.com/nrdcg/goinwx"
-	"github.com/pquerna/otp/totp"
 )
 
 /*
@@ -445,11 +446,11 @@ func (api *inwxAPI) EnsureZoneExists(domain string) error {
 		Type:        "MASTER",
 		Nameservers: api.getDefaultNameservers(),
 	}
-	var id int
 	id, err := api.client.Nameservers.Create(request)
 	if err != nil {
 		return err
 	}
 	printer.Printf("Added zone for %s to INWX account with id %d\n", domain, id)
+	api.domainIndex[domain] = id
 	return nil
 }


### PR DESCRIPTION
Hi @patschi!
While reviewing all the `ZoneCreator` implementations, I noticed that the INWX provider has an incomplete caching implementation for zones. The provider is populating the cache once on first access. Any zones that are created will not be readable in the same life-cycle of dnscontrol. This PR is populating the zone cache after creating a zone. Would you mind giving this a try and let me know how it goes? Thanks!

Part of https://github.com/StackExchange/dnscontrol/issues/3007