### PR TITLE
LUADNS: populate zone cache after creating zone

### DIFF
--- a/providers/luadns/api.go
+++ b/providers/luadns/api.go
@@ -110,9 +110,15 @@ func (l *luadnsProvider) createDomain(domain string) error {
 	params := jsonRequestParams{
 		"name": domain,
 	}
-	if _, err := l.get("/zones", "POST", params); err != nil {
+	body, err := l.get("/zones", "POST", params)
+	if err != nil {
 		return fmt.Errorf("failed create domain (LuaDNS): %w", err)
 	}
+	z := zoneRecord{}
+	if err = json.Unmarshal(body, &z); err != nil {
+		return fmt.Errorf("error parsing zone response (LuaDNS): %w", err)
+	}
+	l.domainIndex[domain] = z.ID
 	return nil
 }
 


### PR DESCRIPTION
Hi @riku22!

While reviewing all the `ZoneCreator` implementations, I noticed that the LUADNS provider has an incomplete caching implementation for zones. The provider is populating the cache once on first access. Any zones that are created will not be readable in the same life-cycle of dnscontrol. This PR is populating the zone cache after creating a zone. Would you mind giving this a try and let me know how it goes? Thanks!

Part of https://github.com/StackExchange/dnscontrol/issues/3007