### PR TITLE
HETZNER: populate zone cache after creating zone

### DIFF
--- a/providers/hetzner/types.go
+++ b/providers/hetzner/types.go
@@ -17,6 +17,10 @@ type createZoneRequest struct {
 	Name string `json:"name"`
 }
 
+type createZoneResponse struct {
+	Zone zone `json:"zone"`
+}
+
 type getAllRecordsResponse struct {
 	Records []record `json:"records"`
 	Meta    struct {


### PR DESCRIPTION
Similar to the other providers, the HETZNER provider is now populating the zone cache after creating a zone as well (and saving a round-trip to the provider by dropping the need to fill the zone cache again).

Part of https://github.com/StackExchange/dnscontrol/issues/3007