### PR TITLE
HEXONET: Add error handling for MX and SRV record priority parsing

### DIFF
--- a/providers/hexonet/records.go
+++ b/providers/hexonet/records.go
@@ -3,6 +3,7 @@ package hexonet
 import (
 	"bytes"
 	"fmt"
+	"math"
 	"strconv"
 	"strings"
 
@@ -206,7 +207,13 @@ func (n *HXClient) getRecords(domain string) ([]*HXRecord, error) {
 				record.Fqdn = spl[0] + "." + record.Fqdn
 			}
 			if record.Type == "MX" || record.Type == "SRV" {
-				prio, _ := strconv.ParseUint(spl[4], 10, 32)
+				prio, err := strconv.ParseUint(spl[4], 10, 32)
+				if err != nil {
+					return nil, fmt.Errorf("failed to parse priority: %w", err)
+				}
+				if prio > math.MaxUint16 {
+					return nil, fmt.Errorf("priority value exceeds uint16 maximum: %s", spl[4])
+				}
 				record.Priority = uint32(prio)
 				record.Answer = strings.Join(spl[5:], " ")
 			} else {


### PR DESCRIPTION
This PR addresses an issue where integer values parsed using strconv.ParseUint were not being checked to ensure they fit within the bounds of the target type (uint16). This could lead to incorrect conversions and potential runtime errors.

Changes:
- Added an upper bound check after parsing the priority value with strconv.ParseUint.
- Ensured that the parsed value does not exceed the maximum value of uint16 before performing the conversion.
- Handled errors appropriately if the value exceeds the maximum allowable value for uint16.