### PR TITLE
Refactor: Use Go Generics for RecordConfig processing

### DIFF
--- a/integrationTest/integration_test.go
+++ b/integrationTest/integration_test.go
@@ -529,14 +529,6 @@ func withMeta(record *models.RecordConfig, metadata map[string]string) *models.R
 	return record
 }
 
-func makeRec2(typ string) *models.RecordConfig {
-	r := &models.RecordConfig{
-		Type: typ,
-		TTL:  300,
-	}
-	return r
-}
-
 func a(name string, a string) *models.RecordConfig {
 	rdata, err := models.ParseA([]string{a}, "**current-domain**")
 	if err != nil {
@@ -555,23 +547,23 @@ func mx(name string, preference uint16, mx string) *models.RecordConfig {
 }
 
 func srv(name string, priority, weight, port uint16, target string) *models.RecordConfig {
-	rc := makeRec2("SRV")
 	spriority := strconv.Itoa(int(priority))
 	sweight := strconv.Itoa(int(weight))
 	sport := strconv.Itoa(int(port))
-	if err := models.FromRaw(rc, "**current-domain**", "SRV", []string{name, spriority, sweight, sport, target}, nil); err != nil {
+	rdata, err := models.ParseSRV([]string{name, spriority, sweight, sport, target}, "**current-domain**")
+	if err != nil {
 		panic(err)
 	}
-	return rc
+	return models.MustCreateRecord(name, rdata, nil, 300, "**current-domain**")
 }
 
 func cfSingleRedirect(name string, code uint16, when, then string) *models.RecordConfig {
-	rc := makeRec2("CF_SINGLE_REDIRECT")
 	scode := strconv.Itoa(int(code))
-	if err := models.FromRaw(rc, "label", "CF_SINGLE_REDIRECT", []string{name, scode, when, then}, nil); err != nil {
+	rdata, err := models.ParseCFSINGLEREDIRECT([]string{name, scode, when, then}, "**current-domain**")
+	if err != nil {
 		panic(err)
 	}
-	return rc
+	return models.MustCreateRecord(name, rdata, nil, 300, "**current-domain**")
 }
 
 func aaaa(name, target string) *models.RecordConfig {

--- a/integrationTest/integration_test.go
+++ b/integrationTest/integration_test.go
@@ -574,6 +574,15 @@ func srv(name string, priority, weight, port uint16, target string) *models.Reco
 	return rc
 }
 
+func cfSingleRedirect(name string, code uint16, when, then string) *models.RecordConfig {
+	rc := makeRec2("CF_SINGLE_REDIRECT")
+	scode := strconv.Itoa(int(code))
+	if err := models.FromRaw(rc, "label", "CF_SINGLE_REDIRECT", []string{name, scode, when, then}, nil); err != nil {
+		panic(err)
+	}
+	return rc
+}
+
 func aaaa(name, target string) *models.RecordConfig {
 	return makeRec(name, target, "AAAA")
 }
@@ -612,12 +621,6 @@ func cfProxyCNAME(name, target, status string) *models.RecordConfig {
 
 func cfSingleRedirectEnabled() bool {
 	return ((*enableCFRedirectMode) != "")
-}
-
-func cfSingleRedirect(name string, code uint16, when, then string) *models.RecordConfig {
-	r := makeRec("@", name, "CF_SINGLE_REDIRECT")
-	panicOnErr(models.MakeSingleRedirectFromRawRec(r, code, name, when, then))
-	return r
 }
 
 func cfWorkerRoute(pattern, target string) *models.RecordConfig {

--- a/integrationTest/integration_test.go
+++ b/integrationTest/integration_test.go
@@ -550,7 +550,7 @@ func srv(name string, priority, weight, port uint16, target string) *models.Reco
 	spriority := strconv.Itoa(int(priority))
 	sweight := strconv.Itoa(int(weight))
 	sport := strconv.Itoa(int(port))
-	rdata, err := models.ParseSRV([]string{name, spriority, sweight, sport, target}, "**current-domain**")
+	rdata, err := models.ParseSRV([]string{spriority, sweight, sport, target}, "**current-domain**")
 	if err != nil {
 		panic(err)
 	}

--- a/integrationTest/integration_test.go
+++ b/integrationTest/integration_test.go
@@ -538,29 +538,20 @@ func makeRec2(typ string) *models.RecordConfig {
 }
 
 func a(name string, a string) *models.RecordConfig {
-	rc, err := models.NewFromRawA([]string{name, a}, nil, "**current-domain**", 300)
+	rdata, err := models.ParseA([]string{a}, "**current-domain**")
 	if err != nil {
 		panic(err)
 	}
-	return rc
+	return models.MustCreateRecord(name, rdata, nil, 300, "**current-domain**")
 }
 
 func mx(name string, preference uint16, mx string) *models.RecordConfig {
-	rc := makeRec2("MX")
 	spreference := strconv.Itoa(int(preference))
-	if err := models.FromRaw(rc, "**current-domain**", "MX", []string{name, spreference, mx}, nil); err != nil {
+	rdata, err := models.ParseMX([]string{spreference, mx}, "**current-domain**")
+	if err != nil {
 		panic(err)
 	}
-
-	//fmt.Printf("DEBUG: MX Fields %v\n", rc.Fields)
-
-	if rc.Name != strings.ToLower(rc.Name) {
-		panic("MX short must be lowercase")
-	}
-	if rc.NameFQDN != strings.ToLower(rc.NameFQDN) {
-		panic("MX must be lowercase 2")
-	}
-	return rc
+	return models.MustCreateRecord(name, rdata, nil, 300, "**current-domain**")
 }
 
 func srv(name string, priority, weight, port uint16, target string) *models.RecordConfig {

--- a/models/cloudflare_from.go
+++ b/models/cloudflare_from.go
@@ -5,63 +5,8 @@ import (
 	"fmt"
 )
 
-// MakeSingleRedirectFromRawRec updates a RecordConfig to be a
-// SINGLEREDIRECT using the data from a RawRecord.
-func MakeSingleRedirectFromRawRec(rc *RecordConfig, code uint16, name, when, then string) error {
-	//// MakePageRule updates a RecordConfig to be a PAGE_RULE using PAGE_RULE data.
-	//func MakePageRule(rc *models.RecordConfig, priority int, code uint16, when, then string) error {
-	//	if rc == nil {
-	//		return errors.New("RecordConfig cannot be nil")
-	//	}
-	//	if when == "" || then == "" {
-	//		return errors.New("when and then parameters cannot be empty")
-	//	}
-	//
-	//	display := mkPageRuleBlob(priority, code, when, then)
-	//
-	//	rc.Type = "PAGE_RULE"
-	//	rc.TTL = 1
-	//	rc.CloudflareRedirect = &models.CloudflareSingleRedirectConfig{
-	//		Code: code,
-	//		//
-	//		PRWhen:     when,
-	//		PRThen:     then,
-	//		PRPriority: priority,
-	//		PRDisplay:  display,
-	//	}
-	//	return rc.SetTarget(display)
-	//}
-	//
-	//// mkPageRuleBlob creates the 1,301,when,then string used in displays.
-	//func mkPageRuleBlob(priority int, code uint16, when, then string) string {
-	//	return fmt.Sprintf("%d,%03d,%s,%s", priority, code, when, then)
-	//}
-	//
-	//// makeSingleRedirectFromRawRec updates a RecordConfig to be a
-	//// SINGLEREDIRECT using the data from a RawRecord.
-	//func makeSingleRedirectFromRawRec(rc *models.RecordConfig, code uint16, name, when, then string) error {
-	target := targetFromRaw(name, code, when, then)
-
-	rc.Type = "CF_SINGLE_REDIRECT"
-	rc.TTL = 1
-	rc.Fields = &CFSINGLEREDIRECT{
-		Code: code,
-		//
-		PRWhen:     "UNKNOWABLE",
-		PRThen:     "UNKNOWABLE",
-		PRPriority: 0,
-		PRDisplay:  "UNKNOWABLE",
-		//
-		SRName:    name,
-		SRWhen:    when,
-		SRThen:    then,
-		SRDisplay: target,
-	}
-	return rc.SetTarget(rc.AsCFSINGLEREDIRECT().SRDisplay)
-}
-
-// targetFromRaw create the display text used for a normal Redirect.
-func targetFromRaw(name string, code uint16, when, then string) string {
+// cfSingleRedirecttargetFromRaw create the display text used for a normal Redirect.
+func cfSingleRedirecttargetFromRaw(name string, code uint16, when, then string) string {
 	return fmt.Sprintf("%s code=(%03d) when=(%s) then=(%s)",
 		name,
 		code,

--- a/models/cloudflare_types.go
+++ b/models/cloudflare_types.go
@@ -96,12 +96,7 @@ func PopulateFromRawCFSINGLEREDIRECT(rc *RecordConfig, rawfields []string, meta 
 	if err != nil {
 		return err
 	}
-	//return MakeSingleRedirectFromRawRec(rc, rdata.Code, rdata.SRName, rdata.SRWhen, rdata.SRThen)
-	err = RecordUpdateFields(rc, rdata, meta)
-	if err != nil {
-		return err
-	}
-	return rc.SetTarget(rc.AsCFSINGLEREDIRECT().SRDisplay)
+	return RecordUpdateFields(rc, rdata, meta)
 }
 
 // AsCFSINGLEREDIRECT returns rc.Fields as an CFSINGLEREDIRECT struct.

--- a/models/cloudflare_types.go
+++ b/models/cloudflare_types.go
@@ -2,7 +2,6 @@ package models
 
 import (
 	"fmt"
-	"maps"
 	"strconv"
 
 	"github.com/StackExchange/dnscontrol/v4/pkg/fieldtypes"
@@ -35,6 +34,40 @@ type CFSINGLEREDIRECT struct {
 	SRDisplay        string `dns:"skip" json:"sr_display,omitempty"` // How is this displayed to the user (SetTarget) for CF_SINGLE_REDIRECT
 }
 
+func ParseCFSINGLEREDIRECT(rawfields []string, origin string) (CFSINGLEREDIRECT, error) {
+	var srname, srwhen, srthen string
+	var code uint16
+	var err error
+
+	if srname, err = fieldtypes.ParseStringTrimmed(rawfields[0]); err != nil {
+		return CFSINGLEREDIRECT{}, err
+	}
+	if code, err = fieldtypes.ParseUint16(rawfields[1]); err != nil {
+		return CFSINGLEREDIRECT{}, err
+	}
+	if srwhen, err = fieldtypes.ParseStringTrimmed(rawfields[2]); err != nil {
+		return CFSINGLEREDIRECT{}, err
+	}
+	if srthen, err = fieldtypes.ParseStringTrimmed(rawfields[3]); err != nil {
+		return CFSINGLEREDIRECT{}, err
+	}
+
+	return CFSINGLEREDIRECT{
+		PRWhen:     "UNKNOWABLE",
+		PRThen:     "UNKNOWABLE",
+		PRPriority: 0,
+		PRDisplay:  "UNKNOWABLE",
+
+		SRName:           srname,
+		Code:             code,
+		SRWhen:           srwhen,
+		SRThen:           srthen,
+		SRRRulesetID:     "",
+		SRRRulesetRuleID: "",
+		SRDisplay:        cfSingleRedirecttargetFromRaw(srname, code, srwhen, srthen),
+	}, nil
+}
+
 func NewFromRawCFSINGLEREDIRECT(rawfields []string, meta map[string]string, origin string, ttl uint32) (*RecordConfig, error) {
 	rc := &RecordConfig{TTL: ttl}
 	if err := PopulateFromRawCFSINGLEREDIRECT(rc, rawfields, meta, origin); err != nil {
@@ -45,66 +78,30 @@ func NewFromRawCFSINGLEREDIRECT(rawfields []string, meta map[string]string, orig
 
 // PopulateFromRawCFSINGLEREDIRECT updates rc to be an CFSINGLEREDIRECT record with contents from rawfields, meta and origin.
 func PopulateFromRawCFSINGLEREDIRECT(rc *RecordConfig, rawfields []string, meta map[string]string, origin string) error {
-	var err error
+	rc.Type = "CF_SINGLE_REDIRECT"
+	rc.TTL = 1
 
 	// Error checking
-
 	if len(rawfields) <= 3 {
 		return fmt.Errorf("rtype CFSINGLEREDIRECT wants %d field(s), found %d: %+v", 1, len(rawfields)-1, rawfields[1:])
 	}
 
-	// Convert each rawfield.
+	// First rawfield is the label.
+	if origin != "" { //  If we don't know the origin, don't muck with the label.
+		rc.SetLabel3(rawfields[0], rc.SubDomain, origin) // Label
+	}
 
-	rc.SetLabel(rawfields[0], origin) // Label
-
-	var srname string
-	if srname, err = fieldtypes.ParseStringTrimmed(rawfields[0]); err != nil {
+	// Parse the remaining fields.
+	rdata, err := ParseCFSINGLEREDIRECT(rawfields, origin)
+	if err != nil {
 		return err
 	}
-	var code uint16
-	if code, err = fieldtypes.ParseUint16(rawfields[1]); err != nil {
+	//return MakeSingleRedirectFromRawRec(rc, rdata.Code, rdata.SRName, rdata.SRWhen, rdata.SRThen)
+	err = RecordUpdateFields(rc, rdata, meta)
+	if err != nil {
 		return err
 	}
-	var srwhen string
-	if srwhen, err = fieldtypes.ParseStringTrimmed(rawfields[2]); err != nil {
-		return err
-	}
-	var srthen string
-	if srthen, err = fieldtypes.ParseStringTrimmed(rawfields[3]); err != nil {
-		return err
-	}
-
-	return rc.PopulateCFSINGLEREDIRECTFields(srname, code, srwhen, srthen, meta, origin)
-}
-
-// PopulateCFSINGLEREDIRECTFields updates rc to be an CFSINGLEREDIRECT record with contents from typed data, meta, and origin.
-func (rc *RecordConfig) PopulateCFSINGLEREDIRECTFields(srname string, code uint16,
-	srwhen, srthen string, meta map[string]string, origin string) error {
-	// Create the struct if needed.
-	if rc.Fields == nil {
-		rc.Fields = &CFSINGLEREDIRECT{}
-	}
-
-	// Process each field:
-
-	n := rc.Fields.(*CFSINGLEREDIRECT)
-	n.SRName = string(srname)
-	n.Code = uint16(code)
-	n.SRWhen = string(srwhen)
-	n.SRThen = string(srthen)
-
-	// Update legacy fields.
-	MakeSingleRedirectFromRawRec(rc, code, srname, srwhen, srthen)
-
-	// Update the RecordConfig:
-	if rc.Metadata == nil {
-		rc.Metadata = map[string]string{}
-	}
-	maps.Copy(rc.Metadata, meta) // Add the metadata
-	rc.Comparable = fmt.Sprintf("%q %d %q %q", srname, code, srwhen, srthen)
-	rc.Display = rc.Comparable
-
-	return nil
+	return rc.SetTarget(rc.AsCFSINGLEREDIRECT().SRDisplay)
 }
 
 // AsCFSINGLEREDIRECT returns rc.Fields as an CFSINGLEREDIRECT struct.

--- a/models/cloudflare_types.go
+++ b/models/cloudflare_types.go
@@ -87,10 +87,8 @@ func PopulateFromRawCFSINGLEREDIRECT(rc *RecordConfig, rawfields []string, meta 
 	}
 
 	// First rawfield is the label.
-	if origin != "" { //  If we don't know the origin, don't muck with the label.
-		if err := rc.SetLabel3(rawfields[0], rc.SubDomain, origin); err != nil {
-			return err
-		}
+	if err := rc.SetLabel3(rawfields[0], rc.SubDomain, origin); err != nil {
+		return err
 	}
 
 	// Parse the remaining fields.

--- a/models/cloudflare_types.go
+++ b/models/cloudflare_types.go
@@ -8,7 +8,7 @@ import (
 )
 
 func init() {
-	RegisterType("CF_SINGLE_REDIRECT", RegisterOpts{PopulateFromRaw: PopulateFromRawCFSINGLEREDIRECT})
+	MustRegisterType("CF_SINGLE_REDIRECT", RegisterOpts{PopulateFromRaw: PopulateFromRawCFSINGLEREDIRECT})
 }
 
 //// CFSINGLEREDIRECT

--- a/models/cloudflare_types.go
+++ b/models/cloudflare_types.go
@@ -88,7 +88,9 @@ func PopulateFromRawCFSINGLEREDIRECT(rc *RecordConfig, rawfields []string, meta 
 
 	// First rawfield is the label.
 	if origin != "" { //  If we don't know the origin, don't muck with the label.
-		rc.SetLabel3(rawfields[0], rc.SubDomain, origin) // Label
+		if err := rc.SetLabel3(rawfields[0], rc.SubDomain, origin); err != nil {
+			return err
+		}
 	}
 
 	// Parse the remaining fields.

--- a/models/dns_test.go
+++ b/models/dns_test.go
@@ -2,8 +2,6 @@ package models
 
 import (
 	"testing"
-	//"github.com/StackExchange/dnscontrol/v4/pkg/printer"
-	//"github.com/StackExchange/dnscontrol/v4/pkg/zonerecs"
 )
 
 func TestRR(t *testing.T) {
@@ -15,7 +13,7 @@ func TestRR(t *testing.T) {
 		TTL:          0,
 		MxPreference: 0,
 	}
-	experiment.ImportFromLegacy("example.com")
+	experiment.MustImportFromLegacy("example.com")
 	expected := "foo.example.com.\t300\tIN\tA\t1.2.3.4"
 	found := experiment.ToRR().String()
 	if found != expected {

--- a/models/rawrecords.go
+++ b/models/rawrecords.go
@@ -67,8 +67,8 @@ func (rc *RecordConfig) ImportFromLegacy(origin string) error {
 		if err != nil {
 			return err
 		}
-		//return RecordUpdateFields(rc, A{A: ip}, nil)
-		return rc.PopulateFieldsA(ip, nil)
+		//return rc.PopulateFieldsA(ip, nil)
+		return RecordUpdateFields(rc, A{A: ip}, nil)
 	case "MX":
 		//return rc.PopulateFieldsMX(rc.MxPreference, rc.target, nil, origin)
 		return RecordUpdateFields(rc,

--- a/models/rawrecords.go
+++ b/models/rawrecords.go
@@ -67,11 +67,20 @@ func (rc *RecordConfig) ImportFromLegacy(origin string) error {
 		if err != nil {
 			return err
 		}
-		return rc.PopulateFieldsA(ip, nil, origin)
+		//return RecordUpdateFields(rc, A{A: ip}, nil)
+		return rc.PopulateFieldsA(ip, nil)
 	case "MX":
-		return rc.PopulateFieldsMX(rc.MxPreference, rc.target, nil, origin)
+		//return rc.PopulateFieldsMX(rc.MxPreference, rc.target, nil, origin)
+		return RecordUpdateFields(rc,
+			MX{Preference: rc.MxPreference, Mx: rc.target},
+			nil,
+		)
 	case "SRV":
-		return rc.PopulateFieldsSRV(rc.SrvPriority, rc.SrvWeight, rc.SrvPort, rc.target, nil, origin)
+		//return rc.PopulateFieldsSRV(rc.SrvPriority, rc.SrvWeight, rc.SrvPort, rc.target, nil, origin)
+		return RecordUpdateFields(rc,
+			SRV{Priority: rc.SrvPriority, Weight: rc.SrvWeight, Port: rc.SrvPort, Target: rc.target},
+			nil,
+		)
 	}
 	panic("Should not happen")
 }

--- a/models/rawrecords.go
+++ b/models/rawrecords.go
@@ -28,7 +28,7 @@ func FromRaw(rc *RecordConfig, origin string, typeName string, args []string, me
 
 	rt, ok := rtypeDB[typeName]
 	if !ok {
-		return fmt.Errorf("unknown rtype %q", typeName)
+		return fmt.Errorf("unknown (FromRaw) rtype %q", typeName)
 	}
 
 	return rt.PopulateFromRaw(rc, args, meta, origin)
@@ -116,7 +116,7 @@ func TransformRawRecords(domains []*DomainConfig) error {
 
 			rt, ok := rtypeDB[rawRec.Type]
 			if !ok {
-				return fmt.Errorf("unknown rtype %q", rawRec.Type)
+				return fmt.Errorf("unknown (TRR) rtype %q", rawRec.Type)
 			}
 
 			err := rt.PopulateFromRaw(rec, rawRec.Args, rec.Metadata, dc.Name)

--- a/models/rawrecords.go
+++ b/models/rawrecords.go
@@ -46,7 +46,9 @@ func CheckAndFixImport(recs []*RecordConfig, origin string) bool {
 		if IsTypeUpgraded(rec.Type) && rec.Fields == nil {
 			found = true
 			log.Warnf("LEGACY PROVIDER needs fixing! Created invalid record: %s %s %v\n", rec.Type, rec.Name, rec)
-			rec.ImportFromLegacy(origin)
+			if err := rec.ImportFromLegacy(origin); err != nil {
+				log.Warnf("Error fixing record: %s %s %v: %v\n", rec.Type, rec.Name, rec, err)
+			}
 		}
 	}
 	return found
@@ -80,6 +82,13 @@ func (rc *RecordConfig) ImportFromLegacy(origin string) error {
 		)
 	}
 	panic("Should not happen")
+}
+
+// MustImportFromLegacy is like ImportFromLegacy but panics on error. Use only in tests and init() functions.
+func (rc *RecordConfig) MustImportFromLegacy(origin string) {
+	if err := rc.ImportFromLegacy(origin); err != nil {
+		panic(err)
+	}
 }
 
 // TransformRawRecords converts the RawRecordConfigs from dnsconfig.js into RecordConfig.

--- a/models/rawrecords.go
+++ b/models/rawrecords.go
@@ -67,16 +67,13 @@ func (rc *RecordConfig) ImportFromLegacy(origin string) error {
 		if err != nil {
 			return err
 		}
-		//return rc.PopulateFieldsA(ip, nil)
 		return RecordUpdateFields(rc, A{A: ip}, nil)
 	case "MX":
-		//return rc.PopulateFieldsMX(rc.MxPreference, rc.target, nil, origin)
 		return RecordUpdateFields(rc,
 			MX{Preference: rc.MxPreference, Mx: rc.target},
 			nil,
 		)
 	case "SRV":
-		//return rc.PopulateFieldsSRV(rc.SrvPriority, rc.SrvWeight, rc.SrvPort, rc.target, nil, origin)
 		return RecordUpdateFields(rc,
 			SRV{Priority: rc.SrvPriority, Weight: rc.SrvWeight, Port: rc.SrvPort, Target: rc.target},
 			nil,

--- a/models/record.go
+++ b/models/record.go
@@ -292,13 +292,14 @@ func (rc *RecordConfig) Copy() (*RecordConfig, error) {
 	switch rc.Type {
 	case "A":
 		newR.Fields = &A{}
-		newR.Fields = rc.Fields
+		//newR.Fields = rc.Fields.(*A)
+		newR.Fields.(*A).A = rc.Fields.(*A).A
 	case "MX":
 		newR.Fields = &MX{}
-		newR.Fields = rc.Fields
+		newR.Fields = rc.Fields.(*MX)
 	case "SRV":
 		newR.Fields = &SRV{}
-		newR.Fields = rc.Fields
+		newR.Fields = rc.Fields.(*SRV)
 	}
 	//fmt.Printf("DEBUG: COPYING rc=%v new=%v\n", rc.Fields, newR.Fields)
 	return newR, err

--- a/models/record.go
+++ b/models/record.go
@@ -655,7 +655,10 @@ func Downcase(recs []*RecordConfig) {
 			// Target is case insensitive. Downcase it.
 			r.target = strings.ToLower(r.target)
 			// BUGFIX(tlim): isn't ALIAS in the wrong case statement?
-			r.ImportFromLegacy("") // Convert legacy fields to raw fields.
+			if err := r.ImportFromLegacy(""); err != nil {
+				// Convert legacy fields to raw fields.
+				panic(err) // Should not happen.
+			}
 		case "A", "CAA", "CF_SINGLE_REDIRECT", "CF_REDIRECT", "CF_TEMP_REDIRECT", "CF_WORKER_ROUTE", "DHCID", "IMPORT_TRANSFORM", "LOC", "SSHFP", "TXT":
 			// Do nothing. (IP address or case sensitive target)
 		case "SOA":

--- a/models/t_mx.go
+++ b/models/t_mx.go
@@ -6,8 +6,10 @@ import (
 )
 
 // SetTargetMX sets the MX fields.
-func (rc *RecordConfig) SetTargetMX(pref uint16, target string) error {
-	return rc.PopulateFieldsMX(pref, target, nil, "")
+func (rc *RecordConfig) SetTargetMX(preference uint16, mx string) error {
+	//return rc.PopulateFieldsMX(pref, target, nil, "")
+	rc.Type = "MX"
+	return RecordUpdateFields(rc, MX{Preference: preference, Mx: mx}, nil)
 }
 
 // SetTargetMXStrings is like SetTargetMX but accepts strings.

--- a/models/t_mx.go
+++ b/models/t_mx.go
@@ -7,7 +7,6 @@ import (
 
 // SetTargetMX sets the MX fields.
 func (rc *RecordConfig) SetTargetMX(preference uint16, mx string) error {
-	//return rc.PopulateFieldsMX(pref, target, nil, "")
 	rc.Type = "MX"
 	return RecordUpdateFields(rc, MX{Preference: preference, Mx: mx}, nil)
 }

--- a/models/t_mx.go
+++ b/models/t_mx.go
@@ -1,7 +1,6 @@
 package models
 
 import (
-	"fmt"
 	"strings"
 )
 
@@ -13,14 +12,15 @@ func (rc *RecordConfig) SetTargetMX(preference uint16, mx string) error {
 
 // SetTargetMXStrings is like SetTargetMX but accepts strings.
 func (rc *RecordConfig) SetTargetMXStrings(pref, target string) error {
-	return PopulateFromRawMX(rc, []string{rc.Name, pref, target}, nil, "")
+	rdata, err := ParseMX([]string{rc.Name, pref, target}, "")
+	if err != nil {
+		return err
+	}
+	return RecordUpdateFields(rc, rdata, nil)
 }
 
 // SetTargetMXString is like SetTargetMX but accepts one big string.
 func (rc *RecordConfig) SetTargetMXString(s string) error {
 	part := strings.Fields(s)
-	if len(part) != 2 {
-		return fmt.Errorf("MX value does not contain 2 fields: (%#v)", s)
-	}
 	return rc.SetTargetMXStrings(part[0], part[1])
 }

--- a/models/t_parse.go
+++ b/models/t_parse.go
@@ -61,7 +61,7 @@ func (rc *RecordConfig) PopulateFromStringFunc(rtype, contents, origin string, t
 		return fmt.Errorf("assertion failed: rtype already set (%s) (%s)", rtype, rc.Type)
 	}
 
-	origin = strings.TrimRight(origin, ".")
+	origin = strings.TrimRight(origin, ".") // Needed for backwards compatibility. Code should be more strict in the future.
 
 	switch rc.Type = rtype; rtype { // #rtype_variations
 	case "A":

--- a/models/t_parse.go
+++ b/models/t_parse.go
@@ -61,11 +61,26 @@ func (rc *RecordConfig) PopulateFromStringFunc(rtype, contents, origin string, t
 		return fmt.Errorf("assertion failed: rtype already set (%s) (%s)", rtype, rc.Type)
 	}
 
-	origin = strings.TrimRight(origin, ".") // Needed for backwards compatibility. Code should be more strict in the future.
+	if IsTypeUpgraded(rtype) {
+		var err error
+		switch rtype {
+		case "A":
+			if rdata, err := ParseA([]string{contents}, origin); err == nil {
+				return RecordUpdateFields(rc, rdata, nil)
+			}
+		case "MX":
+			if rdata, err := ParseMX(strings.Fields(contents), origin); err == nil {
+				return RecordUpdateFields(rc, rdata, nil)
+			}
+		case "SRV":
+			if rdata, err := ParseSRV(strings.Fields(contents), origin); err == nil {
+				return RecordUpdateFields(rc, rdata, nil)
+			}
+		}
+		return err
+	}
 
 	switch rc.Type = rtype; rtype { // #rtype_variations
-	case "A":
-		return PopulateFromRawA(rc, []string{rc.Name, contents}, nil, origin)
 	case "AAAA":
 		ip := net.ParseIP(contents)
 		if ip == nil || ip.To16() == nil {
@@ -86,10 +101,6 @@ func (rc *RecordConfig) PopulateFromStringFunc(rtype, contents, origin string, t
 		return rc.SetTarget(contents)
 	case "LOC":
 		return rc.SetTargetLOCString(origin, contents)
-	case "MX":
-		//fmt.Printf("DEBUG: contents=%q\n", contents)
-		//fmt.Printf("DEBUG: PopulateMXRaw(rc, fields=%v, nil, %q)\n", append([]string{rc.Name}, strings.Fields(contents)...), origin)
-		return PopulateFromRawMX(rc, append([]string{rc.Name}, strings.Fields(contents)...), nil, origin)
 	case "NAPTR":
 		return rc.SetTargetNAPTRString(contents)
 	case "SOA":
@@ -103,8 +114,6 @@ func (rc *RecordConfig) PopulateFromStringFunc(rtype, contents, origin string, t
 			return fmt.Errorf("invalid TXT record: %s", contents)
 		}
 		return rc.SetTargetTXT(t)
-	case "SRV":
-		return PopulateFromRawSRV(rc, append([]string{rc.Name}, strings.Fields(contents)...), nil, origin)
 	case "SSHFP":
 		return rc.SetTargetSSHFPString(contents)
 	case "SVCB", "HTTPS":

--- a/models/t_parse.go
+++ b/models/t_parse.go
@@ -61,6 +61,8 @@ func (rc *RecordConfig) PopulateFromStringFunc(rtype, contents, origin string, t
 		return fmt.Errorf("assertion failed: rtype already set (%s) (%s)", rtype, rc.Type)
 	}
 
+	origin = strings.TrimRight(origin, ".")
+
 	switch rc.Type = rtype; rtype { // #rtype_variations
 	case "A":
 		return PopulateFromRawA(rc, []string{rc.Name, contents}, nil, origin)

--- a/models/t_parse.go
+++ b/models/t_parse.go
@@ -110,7 +110,7 @@ func (rc *RecordConfig) PopulateFromStringFunc(rtype, contents, origin string, t
 	case "TLSA":
 		return rc.SetTargetTLSAString(contents)
 	default:
-		// return fmt.Errorf("unknown rtype (%s) when parsing (%s) domain=(%s)", rtype, contents, origin)
+		// return fmt.Errorf("unknown (def) rtype (%s) when parsing (%s) domain=(%s)", rtype, contents, origin)
 		return MakeUnknown(rc, rtype, contents, origin)
 	}
 }

--- a/models/t_srv.go
+++ b/models/t_srv.go
@@ -8,7 +8,8 @@ import (
 
 // SetTargetSRV sets the SRV fields.
 func (rc *RecordConfig) SetTargetSRV(priority, weight, port uint16, target string) error {
-	return rc.PopulateFieldsSRV(priority, weight, port, target, nil)
+	rc.Type = "SRV"
+	return RecordUpdateFields(rc, SRV{Priority: priority, Weight: weight, Port: port, Target: target}, nil)
 }
 
 // SetTargetSRVStrings is like SetTargetSRV but accepts all parameters as strings.

--- a/models/t_srv.go
+++ b/models/t_srv.go
@@ -8,7 +8,7 @@ import (
 
 // SetTargetSRV sets the SRV fields.
 func (rc *RecordConfig) SetTargetSRV(priority, weight, port uint16, target string) error {
-	return rc.PopulateFieldsSRV(priority, weight, port, target, nil, "")
+	return rc.PopulateFieldsSRV(priority, weight, port, target, nil)
 }
 
 // SetTargetSRVStrings is like SetTargetSRV but accepts all parameters as strings.

--- a/models/t_srv.go
+++ b/models/t_srv.go
@@ -9,12 +9,19 @@ import (
 // SetTargetSRV sets the SRV fields.
 func (rc *RecordConfig) SetTargetSRV(priority, weight, port uint16, target string) error {
 	rc.Type = "SRV"
+
 	return RecordUpdateFields(rc, SRV{Priority: priority, Weight: weight, Port: port, Target: target}, nil)
 }
 
 // SetTargetSRVStrings is like SetTargetSRV but accepts all parameters as strings.
 func (rc *RecordConfig) SetTargetSRVStrings(priority, weight, port, target string) (err error) {
-	return PopulateFromRawSRV(rc, []string{rc.Name, priority, weight, port, target}, nil, "")
+	rc.Type = "SRV"
+
+	rdata, err := ParseSRV([]string{priority, weight, port, target}, "")
+	if err != nil {
+		return err
+	}
+	return RecordUpdateFields(rc, rdata, nil)
 }
 
 // SetTargetSRVPriorityString is like SetTargetSRV but accepts priority as an
@@ -22,22 +29,26 @@ func (rc *RecordConfig) SetTargetSRVStrings(priority, weight, port, target strin
 // This is a helper function that comes in handy when a provider re-uses the MX preference
 // field as the SRV priority.
 func (rc *RecordConfig) SetTargetSRVPriorityString(priority uint16, s string) error {
+	var rdata SRV
+	var err error
+
 	part := strings.Fields(s)
 	switch len(part) {
 	case 3:
-		return PopulateFromRawSRV(rc, []string{rc.Name, strconv.Itoa(int(priority)), part[0], part[1], part[2]}, nil, "")
+		rdata, err = ParseSRV([]string{strconv.Itoa(int(priority)), part[0], part[1], part[2]}, "")
 	case 2:
-		return PopulateFromRawSRV(rc, []string{rc.Name, strconv.Itoa(int(priority)), part[0], part[1], "."}, nil, "")
+		rdata, err = ParseSRV([]string{strconv.Itoa(int(priority)), part[0], part[1], "."}, "")
 	default:
 		return fmt.Errorf("SRV value does not contain 3 fields: (%#v)", s)
 	}
+	if err != nil {
+		return err
+	}
+	return RecordUpdateFields(rc, rdata, nil)
 }
 
 // SetTargetSRVString is like SetTargetSRV but accepts one big string to be parsed.
 func (rc *RecordConfig) SetTargetSRVString(s string) error {
 	part := strings.Fields(s)
-	if len(part) != 4 {
-		return fmt.Errorf("SRV value does not contain 4 fields: (%#v)", s)
-	}
 	return rc.SetTargetSRVStrings(part[0], part[1], part[2], part[3])
 }

--- a/models/target.go
+++ b/models/target.go
@@ -203,5 +203,9 @@ func (rc *RecordConfig) SetTargetIP(ip net.IP) error {
 
 // SetTargetA sets the target to an A record.
 func (rc *RecordConfig) SetTargetA(s string) error {
-	return PopulateFromRawA(rc, []string{rc.Name, s}, nil, "")
+	rdata, err := ParseA([]string{s}, "")
+	if err != nil {
+		return err
+	}
+	return RecordUpdateFields(rc, rdata, nil)
 }

--- a/models/typeregister.go
+++ b/models/typeregister.go
@@ -15,8 +15,8 @@ var rtypeDB map[string]RegisterOpts
 
 var validTypes = map[string]struct{}{}
 
-// RegisterType registers a new record type with the system.
-func RegisterType(typeName string, opts RegisterOpts) {
+// MustRegisterType registers a new record type with the system. Use it in init() functions.
+func MustRegisterType(typeName string, opts RegisterOpts) {
 
 	if rtypeDB == nil {
 		rtypeDB = map[string]RegisterOpts{}

--- a/models/typeregister.go
+++ b/models/typeregister.go
@@ -16,16 +16,14 @@ var rtypeDB map[string]RegisterOpts
 var validTypes = map[string]struct{}{}
 
 // RegisterType registers a new record type with the system.
-func RegisterType(typeName string, opts RegisterOpts) error {
-
-	//printer.Printf("rtypectl.Register(%q)\n", typeName)
+func RegisterType(typeName string, opts RegisterOpts) {
 
 	if rtypeDB == nil {
 		rtypeDB = map[string]RegisterOpts{}
 	}
 
 	if _, ok := rtypeDB[typeName]; ok {
-		return fmt.Errorf("rtype %q already registered", typeName)
+		panic(fmt.Errorf("rtype %q already registered", typeName))
 	}
 	rtypeDB[typeName] = opts
 
@@ -36,9 +34,6 @@ func RegisterType(typeName string, opts RegisterOpts) error {
 		panic("rtype %q already registered. Can't register it a second time!")
 	}
 	validTypes[typeName] = struct{}{}
-	//providers.RegisterCustomRecordType(typeName, "CLOUDFLAREAPI", "")
-
-	return nil
 }
 
 // GetTypeOps returns the RegisterOpts for a given record type.

--- a/models/types.go
+++ b/models/types.go
@@ -121,11 +121,9 @@ func PopulateFromRawA(rc *RecordConfig, rawfields []string, meta map[string]stri
 	rc.Type = "A"
 
 	// First rawfield is the label.
-	//if origin != "" { //  If we don't know the origin, don't muck with the label.
 	if err := rc.SetLabel3(rawfields[0], rc.SubDomain, origin); err != nil {
 		return err
 	}
-	//}
 
 	// Parse the remaining fields.
 	rdata, err := ParseA(rawfields[1:], origin)
@@ -186,11 +184,9 @@ func PopulateFromRawMX(rc *RecordConfig, rawfields []string, meta map[string]str
 	var err error
 
 	// First rawfield is the label.
-	//if origin != "" { //  If we don't know the origin, don't muck with the label.
 	if err := rc.SetLabel3(rawfields[0], rc.SubDomain, origin); err != nil {
 		return err
 	}
-	//}
 
 	// Parse the remaining fields.
 	rdata, err := ParseMX(rawfields[1:], origin)
@@ -259,11 +255,9 @@ func PopulateFromRawSRV(rc *RecordConfig, rawfields []string, meta map[string]st
 	var err error
 
 	// First rawfield is the label.
-	//if origin != "" { //  If we don't know the origin, don't muck with the label.
 	if err := rc.SetLabel3(rawfields[0], rc.SubDomain, origin); err != nil {
 		return err
 	}
-	//}
 
 	// Parse the remaining fields.
 	rdata, err := ParseSRV(rawfields[1:], origin)

--- a/models/types.go
+++ b/models/types.go
@@ -15,9 +15,9 @@ type RecordType interface {
 }
 
 func init() {
-	RegisterType("A", RegisterOpts{PopulateFromRaw: PopulateFromRawA})
-	RegisterType("MX", RegisterOpts{PopulateFromRaw: PopulateFromRawMX})
-	RegisterType("SRV", RegisterOpts{PopulateFromRaw: PopulateFromRawSRV})
+	MustRegisterType("A", RegisterOpts{PopulateFromRaw: PopulateFromRawA})
+	MustRegisterType("MX", RegisterOpts{PopulateFromRaw: PopulateFromRawMX})
+	MustRegisterType("SRV", RegisterOpts{PopulateFromRaw: PopulateFromRawSRV})
 }
 
 func RecordUpdateFields[T RecordType](rc *RecordConfig, rdata T, meta map[string]string) error {

--- a/models/types.go
+++ b/models/types.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"maps"
 	"strconv"
+	"strings"
 
 	"github.com/StackExchange/dnscontrol/v4/pkg/fieldtypes"
 )
@@ -106,6 +107,18 @@ func (rc *RecordConfig) Seal() error {
 	return nil
 }
 
+func MustCreateRecord[T RecordType](label string, rdata T, meta map[string]string, ttl uint32, origin string) *RecordConfig {
+	rc := &RecordConfig{
+		Type: strings.Split(fmt.Sprintf("%T", rdata), ".")[1],
+		TTL:  ttl,
+	}
+	rc.SetLabel3(label, "", origin) // Label
+	if err := RecordUpdateFields(rc, rdata, meta); err != nil {
+		panic(err)
+	}
+	return rc
+}
+
 //// A
 
 // A is the fields needed to store a DNS record of type A
@@ -120,15 +133,6 @@ func ParseA(rawfields []string, origin string) (A, error) {
 		return A{}, err
 	}
 	return A{A: a}, nil
-}
-
-// NewFromRawA creates a new RecordConfig of type A from rawfields, meta, and origin.
-func NewFromRawA(rawfields []string, meta map[string]string, origin string, ttl uint32) (*RecordConfig, error) {
-	rc := &RecordConfig{TTL: ttl}
-	if err := PopulateFromRawA(rc, rawfields, meta, origin); err != nil {
-		return nil, err
-	}
-	return rc, nil
 }
 
 // PopulateFromRawA updates rc to be an A record with contents from rawfields, meta and origin.
@@ -190,15 +194,6 @@ func ParseMX(rawfields []string, origin string) (MX, error) {
 		return MX{}, err
 	}
 	return MX{Preference: preference, Mx: mx}, nil
-}
-
-// NewFromRawMX creates a new RecordConfig of type MX from rawfields, meta, and origin.
-func NewFromRawMX(rawfields []string, meta map[string]string, origin string, ttl uint32) (*RecordConfig, error) {
-	rc := &RecordConfig{TTL: ttl}
-	if err := PopulateFromRawMX(rc, rawfields, meta, origin); err != nil {
-		return nil, err
-	}
-	return rc, nil
 }
 
 // PopulateFromRawMX updates rc to be an MX record with contents from rawfields, meta and origin.
@@ -270,15 +265,6 @@ func ParseSRV(rawfields []string, origin string) (SRV, error) {
 		return SRV{}, err
 	}
 	return SRV{Priority: priority, Weight: weight, Port: port, Target: target}, nil
-}
-
-// NewFromRawSRV creates a new RecordConfig of type SRV from rawfields, meta, and origin.
-func NewFromRawSRV(rawfields []string, meta map[string]string, origin string, ttl uint32) (*RecordConfig, error) {
-	rc := &RecordConfig{TTL: ttl}
-	if err := PopulateFromRawSRV(rc, rawfields, meta, origin); err != nil {
-		return nil, err
-	}
-	return rc, nil
 }
 
 // PopulateFromRawSRV updates rc to be an SRV record with contents from rawfields, meta and origin.

--- a/models/types.go
+++ b/models/types.go
@@ -91,7 +91,7 @@ func MustCreateRecord[T RecordType](label string, rdata T, meta map[string]strin
 }
 
 func errorCheckFieldCount(rawfields []string, expected int) bool {
-	return len(rawfields) != (expected + 1)
+	return len(rawfields) != expected
 }
 
 //// A
@@ -102,6 +102,12 @@ type A struct {
 }
 
 func ParseA(rawfields []string, origin string) (A, error) {
+
+	// Error checking
+	if errorCheckFieldCount(rawfields, 1) {
+		return A{}, fmt.Errorf("rtype A wants %d field(s), found %d: %+v", 1, len(rawfields), rawfields)
+	}
+
 	var a fieldtypes.IPv4
 	var err error
 	if a, err = fieldtypes.ParseIPv4(rawfields[0]); err != nil {
@@ -114,17 +120,12 @@ func ParseA(rawfields []string, origin string) (A, error) {
 func PopulateFromRawA(rc *RecordConfig, rawfields []string, meta map[string]string, origin string) error {
 	rc.Type = "A"
 
-	// Error checking
-	if errorCheckFieldCount(rawfields, 1) {
-		return fmt.Errorf("rtype A wants %d field(s), found %d: %+v", 1, len(rawfields)-1, rawfields[1:])
-	}
-
 	// First rawfield is the label.
-	if origin != "" { //  If we don't know the origin, don't muck with the label.
-		if err := rc.SetLabel3(rawfields[0], rc.SubDomain, origin); err != nil {
-			return err
-		}
+	//if origin != "" { //  If we don't know the origin, don't muck with the label.
+	if err := rc.SetLabel3(rawfields[0], rc.SubDomain, origin); err != nil {
+		return err
 	}
+	//}
 
 	// Parse the remaining fields.
 	rdata, err := ParseA(rawfields[1:], origin)
@@ -161,6 +162,12 @@ type MX struct {
 }
 
 func ParseMX(rawfields []string, origin string) (MX, error) {
+
+	// Error checking
+	if errorCheckFieldCount(rawfields, 2) {
+		return MX{}, fmt.Errorf("rtype MX wants %d field(s), found %d: %+v", 1, len(rawfields)-1, rawfields[1:])
+	}
+
 	var preference uint16
 	var mx string
 	var err error
@@ -178,17 +185,12 @@ func PopulateFromRawMX(rc *RecordConfig, rawfields []string, meta map[string]str
 	rc.Type = "MX"
 	var err error
 
-	// Error checking
-	if errorCheckFieldCount(rawfields, 2) {
-		return fmt.Errorf("rtype MX wants %d field(s), found %d: %+v", 1, len(rawfields)-1, rawfields[1:])
-	}
-
 	// First rawfield is the label.
-	if origin != "" { //  If we don't know the origin, don't muck with the label.
-		if err := rc.SetLabel3(rawfields[0], rc.SubDomain, origin); err != nil {
-			return err
-		}
+	//if origin != "" { //  If we don't know the origin, don't muck with the label.
+	if err := rc.SetLabel3(rawfields[0], rc.SubDomain, origin); err != nil {
+		return err
 	}
+	//}
 
 	// Parse the remaining fields.
 	rdata, err := ParseMX(rawfields[1:], origin)
@@ -227,6 +229,12 @@ type SRV struct {
 }
 
 func ParseSRV(rawfields []string, origin string) (SRV, error) {
+
+	// Error checking
+	if errorCheckFieldCount(rawfields, 4) {
+		return SRV{}, fmt.Errorf("rtype SRV wants %d field(s), found %d: %+v", 4, len(rawfields)-1, rawfields[1:])
+	}
+
 	var priority, weight, port uint16
 	var target string
 	var err error
@@ -250,17 +258,12 @@ func PopulateFromRawSRV(rc *RecordConfig, rawfields []string, meta map[string]st
 	rc.Type = "SRV"
 	var err error
 
-	// Error checking
-	if errorCheckFieldCount(rawfields, 4) {
-		return fmt.Errorf("rtype SRV wants %d field(s), found %d: %+v", 4, len(rawfields)-1, rawfields[1:])
-	}
-
 	// First rawfield is the label.
-	if origin != "" { //  If we don't know the origin, don't muck with the label.
-		if err := rc.SetLabel3(rawfields[0], rc.SubDomain, origin); err != nil {
-			return err
-		}
+	//if origin != "" { //  If we don't know the origin, don't muck with the label.
+	if err := rc.SetLabel3(rawfields[0], rc.SubDomain, origin); err != nil {
+		return err
 	}
+	//}
 
 	// Parse the remaining fields.
 	rdata, err := ParseSRV(rawfields[1:], origin)

--- a/models/types.go
+++ b/models/types.go
@@ -47,7 +47,6 @@ func (rc *RecordConfig) Seal() error {
 	case "A":
 		f := rc.Fields.(*A)
 		rc.target = f.A.String()
-
 		rc.Comparable = fmt.Sprintf("%d.%d.%d.%d", f.A[0], f.A[1], f.A[2], f.A[3])
 	case "MX":
 		f := rc.Fields.(*MX)
@@ -62,8 +61,9 @@ func (rc *RecordConfig) Seal() error {
 		rc.target = f.Target
 		rc.Comparable = fmt.Sprintf("%d %d %d %s", f.Priority, f.Weight, f.Port, f.Target)
 	case "CF_SINGLE_REDIRECT":
-		// Legacy fields have been eliminated.
+		// No legacy fields.
 		f := rc.Fields.(*CFSINGLEREDIRECT)
+		rc.target = f.SRDisplay
 		rc.Comparable = fmt.Sprintf("%q %d %q %q", f.SRName, f.Code, f.SRWhen, f.SRThen)
 	default:
 		return fmt.Errorf("unknown (Seal) rtype %q", rc.Type)

--- a/models/types.go
+++ b/models/types.go
@@ -24,6 +24,9 @@ func RecordUpdateFields[T RecordType](rc *RecordConfig, rdata T, meta map[string
 	rc.Fields = &rdata
 
 	// Update the RecordConfig:
+	if rc.Metadata == nil {
+		rc.Metadata = map[string]string{}
+	}
 	maps.Copy(rc.Metadata, meta) // Add the metadata
 
 	return rc.Seal()
@@ -78,7 +81,9 @@ func MustCreateRecord[T RecordType](label string, rdata T, meta map[string]strin
 		Type: GetTypeName(rdata),
 		TTL:  ttl,
 	}
-	rc.SetLabel3(label, "", origin) // Label
+	if err := rc.SetLabel3(label, "", origin); err != nil {
+		panic(err)
+	}
 	if err := RecordUpdateFields(rc, rdata, meta); err != nil {
 		panic(err)
 	}
@@ -116,7 +121,9 @@ func PopulateFromRawA(rc *RecordConfig, rawfields []string, meta map[string]stri
 
 	// First rawfield is the label.
 	if origin != "" { //  If we don't know the origin, don't muck with the label.
-		rc.SetLabel3(rawfields[0], rc.SubDomain, origin) // Label
+		if err := rc.SetLabel3(rawfields[0], rc.SubDomain, origin); err != nil {
+			return err
+		}
 	}
 
 	// Parse the remaining fields.
@@ -178,7 +185,9 @@ func PopulateFromRawMX(rc *RecordConfig, rawfields []string, meta map[string]str
 
 	// First rawfield is the label.
 	if origin != "" { //  If we don't know the origin, don't muck with the label.
-		rc.SetLabel3(rawfields[0], rc.SubDomain, origin) // Label
+		if err := rc.SetLabel3(rawfields[0], rc.SubDomain, origin); err != nil {
+			return err
+		}
 	}
 
 	// Parse the remaining fields.
@@ -248,7 +257,9 @@ func PopulateFromRawSRV(rc *RecordConfig, rawfields []string, meta map[string]st
 
 	// First rawfield is the label.
 	if origin != "" { //  If we don't know the origin, don't muck with the label.
-		rc.SetLabel3(rawfields[0], rc.SubDomain, origin) // Label
+		if err := rc.SetLabel3(rawfields[0], rc.SubDomain, origin); err != nil {
+			return err
+		}
 	}
 
 	// Parse the remaining fields.

--- a/models/types.go
+++ b/models/types.go
@@ -49,7 +49,6 @@ func init() {
 	RegisterType("A", RegisterOpts{PopulateFromRaw: PopulateFromRawA})
 	RegisterType("MX", RegisterOpts{PopulateFromRaw: PopulateFromRawMX})
 	RegisterType("SRV", RegisterOpts{PopulateFromRaw: PopulateFromRawSRV})
-	//fmt.Printf("DEBUG: REGISTERED A\n")
 }
 
 func RecordUpdateFields[T RecordType](rc *RecordConfig, rdata T, meta map[string]string) error {
@@ -63,8 +62,6 @@ func RecordUpdateFields[T RecordType](rc *RecordConfig, rdata T, meta map[string
 
 func (rc *RecordConfig) Seal() error {
 	if rc.Type == "" {
-		//fmt.Printf("DEBUG: rc.Type is %T\n", rc.Fields)
-		//panic("assertion failed: Seal called when .Type is not set. We can infer type type but is it worth it?")
 		switch rc.Fields.(type) {
 		case A:
 			rc.Type = "A"
@@ -72,6 +69,8 @@ func (rc *RecordConfig) Seal() error {
 			rc.Type = "MX"
 		case SRV:
 			rc.Type = "SRV"
+		case CFSINGLEREDIRECT:
+			rc.Type = "CF_SINGLE_REDIRECT"
 		}
 	}
 

--- a/models/types.go
+++ b/models/types.go
@@ -9,37 +9,6 @@ import (
 	"github.com/StackExchange/dnscontrol/v4/pkg/fieldtypes"
 )
 
-/*
-
-GetAFields()
-GetAStrings()
-GetA()
-
-PopulateARaw()
-PopulateAStrings() (not needed at this time)
-PopulateAFields()
-
-*/
-
-/*
-
-- Create from RawRecord
-                models.CreateRecordFromRaw(rc, rawstrings, meta, origin) (error)
-- Fully create an RC for Test purposes:
-                models.MustCreateRecord[models.A](T, Meta, TTL, Origin) (*models.RecordConfig)
-- Populate type=X from typed-fields
-                models.RecordUpdate[T](T, meta, origin) (error)
-- Populate type=X from strings
-                rc.RecordUpdateFromStrings([]string, meta, origin) (error)
-
- -ParseA([]string) (A, error)
- -ParseMX([]string) (MX, error)
- -ParseSRV[]string) (SRV, error)
-
- - Get the fields:
- 				models.GetFields[T]() (*T)
-*/
-
 // RecordType is a constraint for DNS records.
 type RecordType interface {
 	A | MX | SRV | CFSINGLEREDIRECT
@@ -162,14 +131,14 @@ func (rc *RecordConfig) AsA() *A {
 	return rc.Fields.(*A)
 }
 
-// GetAFields returns rc.Fields as individual typed values.
-func (rc *RecordConfig) GetAFields() fieldtypes.IPv4 {
+// GetFieldsA returns rc.Fields as individual typed values.
+func (rc *RecordConfig) GetFieldsA() fieldtypes.IPv4 {
 	n := rc.AsA()
 	return n.A
 }
 
-// GetAStrings returns rc.Fields as individual strings.
-func (rc *RecordConfig) GetAStrings() string {
+// GetFieldsAsStringsA returns rc.Fields as individual strings.
+func (rc *RecordConfig) GetFieldsAsStringsA() string {
 	n := rc.AsA()
 	return n.A.String()
 }
@@ -216,7 +185,6 @@ func PopulateFromRawMX(rc *RecordConfig, rawfields []string, meta map[string]str
 		return err
 	}
 
-	//return rc.PopulateFieldsMX(preference, mx, meta, origin)
 	return RecordUpdateFields(rc, rdata, meta)
 }
 
@@ -225,14 +193,14 @@ func (rc *RecordConfig) AsMX() *MX {
 	return rc.Fields.(*MX)
 }
 
-// GetMXFields returns rc.Fields as individual typed values.
-func (rc *RecordConfig) GetMXFields() (uint16, string) {
+// GetFieldsMX returns rc.Fields as individual typed values.
+func (rc *RecordConfig) GetFieldsMX() (uint16, string) {
 	n := rc.AsMX()
 	return n.Preference, n.Mx
 }
 
-// GetMXStrings returns rc.Fields as individual strings.
-func (rc *RecordConfig) GetMXStrings() [2]string {
+// GetFieldsAsStringsMX returns rc.Fields as individual strings.
+func (rc *RecordConfig) GetFieldsAsStringsMX() [2]string {
 	n := rc.AsMX()
 	return [2]string{strconv.Itoa(int(n.Preference)), n.Mx}
 }
@@ -296,14 +264,14 @@ func (rc *RecordConfig) AsSRV() *SRV {
 	return rc.Fields.(*SRV)
 }
 
-// GetSRVFields returns rc.Fields as individual typed values.
-func (rc *RecordConfig) GetSRVFields() (uint16, uint16, uint16, string) {
+// GetFieldsSRV returns rc.Fields as individual typed values.
+func (rc *RecordConfig) GetFieldsSRV() (uint16, uint16, uint16, string) {
 	n := rc.AsSRV()
 	return n.Priority, n.Weight, n.Port, n.Target
 }
 
-// GetSRVStrings returns rc.Fields as individual strings.
-func (rc *RecordConfig) GetSRVStrings() [4]string {
+// GetFieldsAsStringsSRV returns rc.Fields as individual strings.
+func (rc *RecordConfig) GetFieldsAsStringsSRV() [4]string {
 	n := rc.AsSRV()
 	return [4]string{strconv.Itoa(int(n.Priority)), strconv.Itoa(int(n.Weight)), strconv.Itoa(int(n.Port)), n.Target}
 }

--- a/pkg/acme/directoryStorage.go
+++ b/pkg/acme/directoryStorage.go
@@ -11,10 +11,10 @@ import (
 	"github.com/go-acme/lego/v4/certificate"
 )
 
-// directoryStorage implements storage in a local file directory
+// directoryStorage implements storage in a local file directory.
 type directoryStorage string
 
-// filename for certificate / key / json file
+// filename for certificate / key / json file.
 func (d directoryStorage) certFile(name, ext string) string {
 	return filepath.Join(d.certDir(name), name+"."+ext)
 }

--- a/pkg/acme/registration.go
+++ b/pkg/acme/registration.go
@@ -28,7 +28,6 @@ func (c *certManager) getOrCreateAccount() (*Account, error) {
 	return account, err
 }
 
-// func (c *certManager) createAccount(email string) (*Account, error) {
 func (c *certManager) createAccount(_ string) (*Account, error) {
 	privateKey, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
 	if err != nil {

--- a/pkg/fieldtypes/fieldtypes.go
+++ b/pkg/fieldtypes/fieldtypes.go
@@ -99,12 +99,6 @@ func ParseHostnameDot(short, subdomain, origin string) (string, error) {
 		return "FAIL", fmt.Errorf("short must not be empty")
 	}
 	short = strings.ToLower(short)
-	// if strings.ToLower(short) != short {
-	// 	return "", fmt.Errorf("short (%s) must be lowercase", short)
-	// }
-	// if short == "." {
-	// 	return "", fmt.Errorf("label (%s) must not be just a dot", short)
-	// }
 
 	if lastCharIs(short, '.') {
 		return short, nil

--- a/pkg/fieldtypes/fieldtypes.go
+++ b/pkg/fieldtypes/fieldtypes.go
@@ -148,6 +148,15 @@ func ParseIPv4(raw string) (IPv4, error) {
 	return ip, nil
 }
 
+// MustParseIPv4 is like ParseIPv4 but panics on error. For use in tests and init() functions only.
+func MustParseIPv4(raw string) IPv4 {
+	ip, err := ParseIPv4(raw)
+	if err != nil {
+		panic(err)
+	}
+	return ip
+}
+
 func (a *IPv4) String() string {
 	return fmt.Sprintf("%d.%d.%d.%d", a[0], a[1], a[2], a[3])
 }

--- a/pkg/js/parse_tests/007-importTransformTTL.json
+++ b/pkg/js/parse_tests/007-importTransformTTL.json
@@ -11,19 +11,19 @@
       "records": [
         {
           "Fields": {
-            "A": "4.4.4.101"
+            "A": "1.1.1.1"
           },
           "name": "bar",
-          "target": "4.4.4.101",
+          "target": "1.1.1.1",
           "ttl": 300,
           "type": "A"
         },
         {
           "Fields": {
-            "A": "6.6.6.3"
+            "A": "5.5.5.5"
           },
           "name": "foo",
-          "target": "6.6.6.3",
+          "target": "5.5.5.5",
           "ttl": 300,
           "type": "A"
         }
@@ -69,19 +69,19 @@
       "records": [
         {
           "Fields": {
-            "A": "4.4.4.101"
+            "A": "1.1.1.1"
           },
           "name": "bar.foo1",
-          "target": "4.4.4.101",
+          "target": "1.1.1.1",
           "ttl": 99,
           "type": "A"
         },
         {
           "Fields": {
-            "A": "6.6.6.3"
+            "A": "7.7.7.7"
           },
           "name": "foo.foo1",
-          "target": "6.6.6.3",
+          "target": "7.7.7.7",
           "ttl": 99,
           "type": "A"
         }

--- a/pkg/normalize/importTransform_test.go
+++ b/pkg/normalize/importTransform_test.go
@@ -20,8 +20,6 @@ func TestImportTransform(t *testing.T) {
 	src := &models.DomainConfig{
 		Name: "stackexchange.com",
 		Records: []*models.RecordConfig{
-			//makeRC("*", "stackexchange.com", "0.0.2.2", models.RecordConfig{Type: "A"}),
-			//makeRC("www", "stackexchange.com", "0.0.1.1", models.RecordConfig{Type: "A"}),
 			models.MustCreateRecord("*", models.A{A: fieldtypes.MustParseIPv4("0.0.2.2")}, nil, 0, "stackexchange.com"),
 			models.MustCreateRecord("www", models.A{A: fieldtypes.MustParseIPv4("0.0.1.1")}, nil, 0, "stackexchange.com"),
 		},

--- a/pkg/normalize/importTransform_test.go
+++ b/pkg/normalize/importTransform_test.go
@@ -4,12 +4,13 @@ import (
 	"testing"
 
 	"github.com/StackExchange/dnscontrol/v4/models"
+	"github.com/StackExchange/dnscontrol/v4/pkg/fieldtypes"
 )
 
 func makeRC(label, domain, target string, rc models.RecordConfig) *models.RecordConfig {
 	rc.SetLabel(label, domain)
 	rc.MustSetTarget(target)
-	rc.ImportFromLegacy(domain)
+	rc.MustImportFromLegacy(domain)
 	return &rc
 }
 
@@ -19,14 +20,16 @@ func TestImportTransform(t *testing.T) {
 	src := &models.DomainConfig{
 		Name: "stackexchange.com",
 		Records: []*models.RecordConfig{
-			makeRC("*", "stackexchange.com", "0.0.2.2", models.RecordConfig{Type: "A"}),
-			makeRC("www", "stackexchange.com", "0.0.1.1", models.RecordConfig{Type: "A"}),
+			//makeRC("*", "stackexchange.com", "0.0.2.2", models.RecordConfig{Type: "A"}),
+			//makeRC("www", "stackexchange.com", "0.0.1.1", models.RecordConfig{Type: "A"}),
+			models.MustCreateRecord("*", models.A{A: fieldtypes.MustParseIPv4("0.0.2.2")}, nil, 0, "stackexchange.com"),
+			models.MustCreateRecord("www", models.A{A: fieldtypes.MustParseIPv4("0.0.1.1")}, nil, 0, "stackexchange.com"),
 		},
 	}
 	dst := &models.DomainConfig{
 		Name: "internal",
 		Records: []*models.RecordConfig{
-			makeRC("*.stackexchange.com", "*.stackexchange.com.internal", "0.0.3.3", models.RecordConfig{Type: "A", Metadata: map[string]string{"transform_table": transformSingle}}),
+			models.MustCreateRecord("*.stackexchange.com", models.A{A: fieldtypes.MustParseIPv4("0.0.3.3")}, map[string]string{"transform_table": transformSingle}, 0, "stackexchange.com"),
 			makeRC("@", "internal", "stackexchange.com", models.RecordConfig{Type: "IMPORT_TRANSFORM", Metadata: map[string]string{"transform_table": transformDouble}}),
 		},
 	}

--- a/pkg/normalize/validate.go
+++ b/pkg/normalize/validate.go
@@ -861,7 +861,7 @@ func applyRecordTransforms(domain *models.DomainConfig) error {
 		if err != nil {
 			return err
 		}
-		fmt.Printf("DEBUG: transformed ip=%v to ips=%v\n", ip, newIPs)
+		//fmt.Printf("DEBUG: transformed ip=%v to ips=%v\n", ip, newIPs)
 		for i, newIP := range newIPs {
 			if i == 0 && !newIP.Equal(ip) {
 				// replace target of first record if different
@@ -875,7 +875,7 @@ func applyRecordTransforms(domain *models.DomainConfig) error {
 					return err
 				}
 				cpy.Fields = &models.A{} // Allocate new memory to prevent aliasing.
-				if err := cpy.SetTarget(newIP.String()); err != nil {
+				if err := cpy.SetTargetA(newIP.String()); err != nil {
 					return err
 				}
 				domain.Records = append(domain.Records, cpy)

--- a/pkg/normalize/validate_test.go
+++ b/pkg/normalize/validate_test.go
@@ -350,7 +350,7 @@ func TestCNAMEMutex(t *testing.T) {
 			recB := &models.RecordConfig{Type: tst.rType}
 			recB.SetLabel(tst.name, "example.com")
 			recB.MustSetTarget(tst.target)
-			recB.ImportFromLegacy("example.com")
+			recB.MustImportFromLegacy("example.com")
 			dc := &models.DomainConfig{
 				Name:    "example.com",
 				Records: []*models.RecordConfig{recA, recB},

--- a/providers/msdns/powershell_test.go
+++ b/providers/msdns/powershell_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/StackExchange/dnscontrol/v4/models"
+	"github.com/StackExchange/dnscontrol/v4/pkg/fieldtypes"
 )
 
 func Test_generatePSZoneAll(t *testing.T) {
@@ -109,14 +110,10 @@ func Test_generatePSZoneDump(t *testing.T) {
 // }
 
 func Test_generatePSModify(t *testing.T) {
-	recA1 := &models.RecordConfig{}
-	recA2 := &models.RecordConfig{}
-	recMX1 := &models.RecordConfig{}
-	recMX2 := &models.RecordConfig{}
-	models.PopulateFromRawA(recA1, []string{"@", "1.2.3.4"}, nil, "example.com")
-	models.PopulateFromRawA(recA2, []string{"@", "10.20.30.40"}, nil, "example.com")
-	models.PopulateFromRawMX(recMX1, []string{"@", "5", "foo.com."}, nil, "example.com")
-	models.PopulateFromRawMX(recMX2, []string{"@", "50", "foo2.com."}, nil, "example.com")
+	recA1 := models.MustCreateRecord("@", models.A{A: fieldtypes.MustParseIPv4("1.2.3.4")}, nil, 0, "example.com")
+	recA2 := models.MustCreateRecord("@", models.A{A: fieldtypes.MustParseIPv4("10.20.30.40")}, nil, 0, "example.com")
+	recMX1 := models.MustCreateRecord("@", models.MX{Preference: 5, Mx: "foo.com."}, nil, 0, "example.com")
+	recMX2 := models.MustCreateRecord("@", models.MX{Preference: 50, Mx: "foo2.com."}, nil, 0, "example.com")
 
 	type args struct {
 		domain    string


### PR DESCRIPTION
- Use Generics to reduce code repetition
- Split out the parser for each RecordType so they can be used in multiple places
- Make CF_SINGLE_REDIRECT more like the other RecorTypes
- Create MustImportFromLegacy() for use in testing.
- More error checking
- Replace PopulateFields*() with RecordUpdateFields()
- RegisterType() -> MustRegisterType()
- Add MustCreateRecord() for unit tests
- Fix pkg/js/parse_tests/007-importTransformTTL.json (expected result was wrong!)
- Change SetTarget() to SetTargetA() where possible
