### PR TITLE
CNR: Add support for ALIAS record type

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Currently supported Domain Registrars:
 
 - AWS Route 53
 - CSC Global
-- CentralNic Reseller (formerly RRPProxy)
+- CentralNic Reseller (CNR) - formerly RRPProxy
 - DNSOVERHTTPS
 - Dynadot
 - easyname

--- a/documentation/SUMMARY.md
+++ b/documentation/SUMMARY.md
@@ -112,7 +112,7 @@
 * [Azure Private DNS](provider/azure_private_dns.md)
 * [BIND](provider/bind.md)
 * [Bunny DNS](provider/bunny\_dns.md)
-* [CentralNic Reseller (fka RRPproxy)](provider/cnr.md)
+* [CentralNic Reseller (CNR) - formerly RRPProxy](provider/cnr.md)
 * [Cloudflare](provider/cloudflareapi.md)
 * [ClouDNS](provider/cloudns.md)
 * [CSC Global](provider/cscglobal.md)

--- a/documentation/provider/index.md
+++ b/documentation/provider/index.md
@@ -23,7 +23,7 @@ If a feature is definitively not supported for whatever reason, we would also li
 | [`BUNNY_DNS`](bunny_dns.md) | ❌ | ✅ | ❌ | ❌ | ✅ | ✅ | ❌ | ❔ | ❌ | ❌ | ✅ | ❌ | ✅ | ❌ | ❔ | ❌ | ❌ | ❌ | ❔ | ❔ | ❌ | ✅ | ✅ |
 | [`CLOUDFLAREAPI`](cloudflareapi.md) | ✅ | ✅ | ❌ | ✅ | ✅ | ✅ | ❔ | ✅ | ❌ | ✅ | ✅ | ❔ | ✅ | ✅ | ✅ | ✅ | ❔ | ❔ | ❔ | ❌ | ❌ | ✅ | ✅ |
 | [`CLOUDNS`](cloudns.md) | ❌ | ✅ | ❌ | ✅ | ✅ | ✅ | ✅ | ❔ | ✅ | ❔ | ✅ | ❔ | ✅ | ✅ | ❔ | ✅ | ❔ | ❔ | ✅ | ❔ | ❔ | ✅ | ✅ |
-| [`CNR`](cnr.md) | ❌ | ✅ | ✅ | ✅ | ❌ | ✅ | ❔ | ❌ | ❌ | ✅ | ✅ | ❌ | ✅ | ✅ | ❌ | ✅ | ❔ | ❌ | ❌ | ❔ | ✅ | ✅ | ✅ |
+| [`CNR`](cnr.md) | ❌ | ✅ | ✅ | ✅ | ✅ | ✅ | ❔ | ❌ | ❌ | ✅ | ✅ | ❌ | ✅ | ✅ | ❌ | ✅ | ❔ | ❌ | ❌ | ❔ | ✅ | ✅ | ✅ |
 | [`CSCGLOBAL`](cscglobal.md) | ✅ | ✅ | ✅ | ✅ | ❔ | ✅ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ✅ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❌ | ✅ |
 | [`DESEC`](desec.md) | ❌ | ✅ | ❌ | ✅ | ❔ | ✅ | ✅ | ✅ | ❔ | ✅ | ✅ | ❔ | ✅ | ✅ | ✅ | ✅ | ✅ | ❔ | ❔ | ✅ | ❔ | ✅ | ✅ |
 | [`DIGITALOCEAN`](digitalocean.md) | ❌ | ✅ | ❌ | ✅ | ❔ | ✅ | ❔ | ❔ | ❌ | ❔ | ❔ | ❔ | ✅ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ✅ | ✅ |

--- a/providers/cnr/cnrProvider.go
+++ b/providers/cnr/cnrProvider.go
@@ -36,7 +36,7 @@ var features = providers.DocumentationNotes{
 	providers.DocOfficiallySupported: providers.Cannot("Actively maintained provider module."),
 	// --- Supported record types ---
 	// providers.CanUseAKAMAICDN: 	      providers.Cannot(), // can only be supported by Akamai EdgeDns provider
-	providers.CanUseAlias: providers.Cannot("Not supported. You may use CNAME records instead. An Alternative solution is planned."),
+	providers.CanUseAlias: providers.Can(),
 	// providers.CanUseAzureAlias:		  providers.Cannot(), // can only be supported by Azure provider
 	providers.CanUseCAA:           providers.Can(),
 	providers.CanUseDHCID:         providers.Cannot("Ask for this feature."),


### PR DESCRIPTION
The integration tests for DNSControl Alias records were completed successfully. 

Here's a detailed summary:

For the domain dnscontroltest2-cnr.com:
- Various ALIAS records were tested:
- An ALIAS record was created at the root.
- The ALIAS record at the root was modified.
- The ALIAS record at the root was deleted.
- An ALIAS record pointing to a non-FQDN was created and then deleted.
- An ALIAS record was created on a subdomain and then modified.
- The ALIAS record on the subdomain was deleted.
- Tests for Azure and Route53 ALIAS records were skipped because these features are not supported.
- All tests passed without any issues.
