### PR TITLE
FEAT: Add ZoneCache primitive

### DIFF
--- a/pkg/zoneCache/zoneCache.go
+++ b/pkg/zoneCache/zoneCache.go
@@ -1,0 +1,86 @@
+package zoneCache
+
+import (
+	"errors"
+	"sync"
+)
+
+func New[Zone any](fetchAll func() (map[string]Zone, error)) ZoneCache[Zone] {
+	return ZoneCache[Zone]{fetchAll: fetchAll}
+}
+
+var ErrZoneNotFound = errors.New("zone not found")
+
+type ZoneCache[Zone any] struct {
+	mu       sync.Mutex
+	cached   bool
+	cache    map[string]Zone
+	fetchAll func() (map[string]Zone, error)
+}
+
+func (c *ZoneCache[Zone]) ensureCached() error {
+	if c.cached {
+		return nil
+	}
+	zones, err := c.fetchAll()
+	if err != nil {
+		return err
+	}
+	if c.cache == nil {
+		c.cache = make(map[string]Zone, len(zones))
+	}
+	for name, z := range zones {
+		c.cache[name] = z
+	}
+	return nil
+}
+
+func (c *ZoneCache[Zone]) HasZone(name string) (bool, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if err := c.ensureCached(); err != nil {
+		return false, err
+	}
+	_, ok := c.cache[name]
+	return ok, nil
+}
+
+func (c *ZoneCache[Zone]) GetZone(name string) (Zone, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if err := c.ensureCached(); err != nil {
+		var z Zone
+		return z, err
+	}
+	z, ok := c.cache[name]
+	if !ok {
+		return z, ErrZoneNotFound
+	}
+	return z, nil
+}
+
+func (c *ZoneCache[Zone]) GetZoneNames() ([]string, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if err := c.ensureCached(); err != nil {
+		return nil, err
+	}
+	names := make([]string, 0, len(c.cache))
+	for name := range c.cache {
+		names = append(names, name)
+	}
+	return names, nil
+}
+
+func (c *ZoneCache[Zone]) SetZone(name string, z Zone) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.cache == nil {
+		c.cache = make(map[string]Zone, 1)
+	}
+	c.cache[name] = z
+}


### PR DESCRIPTION
This PR is kicking off a shared, thread-safe "zone cache" implementation for all the drivers to use instead of the various implementations out there today. The new zone cache uses Go-generics to let each driver choose their zone struct and retain type-safety. See https://github.com/StackExchange/dnscontrol/pull/3337 and the below commits for more details.

I've left out the provider changes. Let me know if you want to ship them here already:
- HETZNER driver c7789ccd886d317f98ba5a042d87a517a5f6f297 (chained onto tweaks in https://github.com/StackExchange/dnscontrol/pull/3336)
- CLOUDFLARE driver 85e796586f61690ffc39aa19eebad2b04b06662c (chained onto fixes in https://github.com/StackExchange/dnscontrol/pull/3330)
