### PR TITLE
GCLOUD: Retry once on 502 errors

### DIFF
--- a/providers/gcloud/gcloudProvider.go
+++ b/providers/gcloud/gcloudProvider.go
@@ -499,6 +499,7 @@ const (
 var (
 	backoff    = initialBackoff
 	backoff404 = false // Set if the last call requested a retry of a 404
+	backoff502 = false // Set if the last call requested a retry of a 502
 )
 
 func retryNeeded(resp *googleapi.ServerResponse, err error) bool {
@@ -530,7 +531,23 @@ func retryNeeded(resp *googleapi.ServerResponse, err error) bool {
 	}
 	backoff404 = false
 
-	if serr.Code != 429 && serr.Code != 502 && serr.Code != 503 {
+	if serr.Code == 502 {
+		// serr.Code == 502 happens occasionally when "The server
+		// encountered a temporary error and could not complete your
+		// request. Please try again in 30 seconds.  That’s all we know."
+		// We pause and retry exactly once.
+		if backoff502 {
+			backoff502 = false
+			return false // Give up. We've done this already.
+		}
+		log.Printf("Special 502 pause-and-retry for GCLOUD: Pausing %s\n", backoff)
+		time.Sleep(31 * time.Second)
+		backoff502 = true
+		return true // Request a retry.
+	}
+	backoff502 = false
+
+	if serr.Code != 429 && serr.Code != 503 {
 		return false // Not an error that permits retrying.
 	}
 


### PR DESCRIPTION
# Issue

GCLOUD occasionally asks us to pause for 30 sec and retry:

```
    integration_test.go:303: runChange error: googleapi: got HTTP response code 502 with body: <!DOCTYPE html>
        <html lang=en>
          <meta charset=utf-8>
          <meta name=viewport content="initial-scale=1, minimum-scale=1, width=device-width">
          <title>Error 502 (Server Error)!!1</title>
          <style>
            *{margin:0;padding:0}html,code{font:15px/22px arial,sans-serif}html{background:#fff;color:#222;padding:15px}body{margin:7% auto 0;max-width:390px;min-height:180px;padding:30px 0 15px}* > body{background:url(//www.google.com/images/errors/robot.png) 100% 5px no-repeat;padding-right:205px}p{margin:11px 0 22px;overflow:hidden}ins{color:#777;text-decoration:none}a img{border:0}@media screen and (max-width:772px){body{background:none;margin-top:0;max-width:none;padding-right:0}}#logo{background:url(//www.google.com/images/branding/googlelogo/1x/googlelogo_color_150x54dp.png) no-repeat;margin-left:-5px}@media only screen and (min-resolution:192dpi){#logo{background:url(//www.google.com/images/branding/googlelogo/2x/googlelogo_color_150x54dp.png) no-repeat 0% 0%/100% 100%;-moz-border-image:url(//www.google.com/images/branding/googlelogo/2x/googlelogo_color_150x54dp.png) 0}}@media only screen and (-webkit-min-device-pixel-ratio:2){#logo{background:url(//www.google.com/images/branding/googlelogo/2x/googlelogo_color_150x54dp.png) no-repeat;-webkit-background-size:100% 100%}}#logo{display:inline-block;height:54px;width:150px}
          </style>
          <a href=//www.google.com/><span id=logo aria-label=Google></span></a>
          <p><b>502.</b> <ins>That’s an error.</ins>
          <p>The server encountered a temporary error and could not complete your request.<p>Please try again in 30 seconds.  <ins>That’s all we know.</ins>
        
        --- FAIL: TestDNSProviders/***-gcloud.com/31:pager1201:Update_1200_records (60.64s)
```

# Resolution

When we receive a 502, sleep 31 seconds and try again.
