### PR TITLE
HETZNER: adopt ZoneCache

### DIFF
--- a/providers/hetzner/api.go
+++ b/providers/hetzner/api.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/StackExchange/dnscontrol/v4/pkg/printer"
+	"github.com/StackExchange/dnscontrol/v4/pkg/zoneCache"
 )
 
 const (
@@ -19,8 +20,7 @@ const (
 
 type hetznerProvider struct {
 	apiKey             string
-	mu                 sync.Mutex
-	cachedZones        map[string]zone
+	zoneCache          zoneCache.ZoneCache[zone]
 	requestRateLimiter requestRateLimiter
 }
 
@@ -67,9 +67,7 @@ func (api *hetznerProvider) createZone(name string) error {
 	if err != nil {
 		return err
 	}
-	api.mu.Lock()
-	defer api.mu.Unlock()
-	api.cachedZones[name] = response.Zone
+	api.zoneCache.SetZone(name, response.Zone)
 	return nil
 }
 
@@ -79,7 +77,7 @@ func (api *hetznerProvider) deleteRecord(record *record) error {
 }
 
 func (api *hetznerProvider) getAllRecords(domain string) ([]record, error) {
-	z, err := api.getZone(domain)
+	z, err := api.zoneCache.GetZone(domain)
 	if err != nil {
 		return nil, err
 	}
@@ -113,12 +111,7 @@ func (api *hetznerProvider) getAllRecords(domain string) ([]record, error) {
 	return records, nil
 }
 
-// fetchAllZonesLocked populates the zone cache.
-// The caller must hold mu.
-func (api *hetznerProvider) fetchAllZonesLocked() error {
-	if api.cachedZones != nil {
-		return nil
-	}
+func (api *hetznerProvider) fetchAllZones() (map[string]zone, error) {
 	var zones map[string]zone
 	page := 1
 	statusOK := func(code int) bool {
@@ -136,7 +129,7 @@ func (api *hetznerProvider) fetchAllZonesLocked() error {
 		response := getAllZonesResponse{}
 		url := fmt.Sprintf("/zones?per_page=100&page=%d", page)
 		if err := api.request(url, "GET", nil, &response, statusOK); err != nil {
-			return fmt.Errorf("failed fetching zones: %w", err)
+			return nil, fmt.Errorf("failed fetching zones: %w", err)
 		}
 		if zones == nil {
 			zones = make(map[string]zone, response.Meta.Pagination.TotalEntries)
@@ -150,21 +143,7 @@ func (api *hetznerProvider) fetchAllZonesLocked() error {
 		}
 		page++
 	}
-	api.cachedZones = zones
-	return nil
-}
-
-func (api *hetznerProvider) getZone(name string) (*zone, error) {
-	api.mu.Lock()
-	defer api.mu.Unlock()
-	if err := api.fetchAllZonesLocked(); err != nil {
-		return nil, err
-	}
-	z, ok := api.cachedZones[name]
-	if !ok {
-		return nil, fmt.Errorf("%q is not a zone in this HETZNER account", name)
-	}
-	return &z, nil
+	return zones, nil
 }
 
 func (api *hetznerProvider) request(endpoint string, method string, request interface{}, target interface{}, statusOK func(code int) bool) error {

--- a/providers/hetzner/hetznerProvider.go
+++ b/providers/hetzner/hetznerProvider.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/StackExchange/dnscontrol/v4/models"
 	"github.com/StackExchange/dnscontrol/v4/pkg/diff"
+	"github.com/StackExchange/dnscontrol/v4/pkg/zoneCache"
 	"github.com/StackExchange/dnscontrol/v4/providers"
 )
 
@@ -50,25 +51,18 @@ func New(settings map[string]string, _ json.RawMessage) (providers.DNSServicePro
 		return nil, errors.New("missing HETZNER api_key")
 	}
 
-	return &hetznerProvider{
-		apiKey: apiKey,
-	}, nil
+	api := &hetznerProvider{apiKey: apiKey}
+	api.zoneCache = zoneCache.New(api.fetchAllZones)
+	return api, nil
 }
 
 // EnsureZoneExists creates a zone if it does not exist
 func (api *hetznerProvider) EnsureZoneExists(domain string) error {
-	domains, err := api.ListZones()
-	if err != nil {
+	if ok, err := api.zoneCache.HasZone(domain); err != nil || ok {
 		return err
 	}
 
-	for _, d := range domains {
-		if d == domain {
-			return nil
-		}
-	}
-
-	if err = api.createZone(domain); err != nil {
+	if err := api.createZone(domain); err != nil {
 		return err
 	}
 	return nil
@@ -85,7 +79,7 @@ func (api *hetznerProvider) GetZoneRecordsCorrections(dc *models.DomainConfig, e
 	// Start corrections with the reports
 	corrections := diff.GenerateMessageCorrections(toReport)
 
-	z, err := api.getZone(domain)
+	z, err := api.zoneCache.GetZone(domain)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -142,7 +136,7 @@ func (api *hetznerProvider) GetZoneRecordsCorrections(dc *models.DomainConfig, e
 
 // GetNameservers returns the nameservers for a domain.
 func (api *hetznerProvider) GetNameservers(domain string) ([]*models.Nameserver, error) {
-	z, err := api.getZone(domain)
+	z, err := api.zoneCache.GetZone(domain)
 	if err != nil {
 		return nil, err
 	}
@@ -168,15 +162,5 @@ func (api *hetznerProvider) GetZoneRecords(domain string, meta map[string]string
 
 // ListZones lists the zones on this account.
 func (api *hetznerProvider) ListZones() ([]string, error) {
-	api.mu.Lock()
-	defer api.mu.Unlock()
-	err := api.fetchAllZonesLocked()
-	if err != nil {
-		return nil, err
-	}
-	domains := make([]string, 0, len(api.cachedZones))
-	for domain := range api.cachedZones {
-		domains = append(domains, domain)
-	}
-	return domains, nil
+	return api.zoneCache.GetZoneNames()
 }

--- a/providers/hetzner/types.go
+++ b/providers/hetzner/types.go
@@ -57,7 +57,7 @@ type zone struct {
 	TTL         uint32   `json:"ttl"`
 }
 
-func fromRecordConfig(in *models.RecordConfig, zone *zone) record {
+func fromRecordConfig(in *models.RecordConfig, zone zone) record {
 	r := record{
 		Name:   in.GetLabel(),
 		Type:   in.Type,

--- a/providers/hetzner/types.go
+++ b/providers/hetzner/types.go
@@ -17,6 +17,10 @@ type createZoneRequest struct {
 	Name string `json:"name"`
 }
 
+type createZoneResponse struct {
+	Zone zone `json:"zone"`
+}
+
 type getAllRecordsResponse struct {
 	Records []record `json:"records"`
 	Meta    struct {


### PR DESCRIPTION
This PR is adopting the new `ZoneCache` for the HETZNER driver.

(https://github.com/StackExchange/dnscontrol/pull/3336 plus the zone cache changes as linked in https://github.com/StackExchange/dnscontrol/pull/3337)