### PR TITLE
CICD: Warn user if -provider does not match profiles.json:TYPE

### DIFF
--- a/integrationTest/integration_test.go
+++ b/integrationTest/integration_test.go
@@ -99,15 +99,19 @@ func getProvider(t *testing.T) (providers.DNSServiceProvider, string, map[string
 	if *profileFlag == "" {
 		*profileFlag = profileName
 	}
+	// Fill in -provider if blank.
+	if *providerFlag == "" {
+		*providerFlag = profileType
+	}
 
-	// Fix legacy use of -provider.
+	// Sanity check. If the user-specifed -provider flag doesn't match what was in the file, warn them.
 	if *providerFlag != profileType {
 		fmt.Printf("WARNING: -provider=%q does not match profile TYPE=%q.  Using profile TYPE.\n", *providerFlag, profileType)
 		*providerFlag = profileType
 	}
 
 	// fmt.Printf("DEBUG flag=%q Profile=%q TYPE=%q\n", *providerFlag, profileName, profileType)
-	fmt.Printf("Testing Profile=%q TYPE=%q\n", profileName, profileType)
+	fmt.Printf("Testing Profile=%q (TYPE=%q)\n", profileName, profileType)
 
 	var metadata json.RawMessage
 


### PR DESCRIPTION
<!--
## Before submiting a pull request

Please make sure you've run the following commands from the root directory.

go vet ./...
go fmt ./...
go generate ./...
go mod tidy

## Release changelog section

Help keep the release changelog clear by pre-naming the proper section in the GitHub pull request title.

Some examples:
* CICD: Add required GHA permissions for goreleaser
* DOCS: Fixed providers with "contributor support" table
* ROUTE53: Allow R53_ALIAS records to enable target health evaluation

More examples/context can be found in the file .goreleaser.yml under the 'build' > 'changelog' key.
!-->
