### PR TITLE
INWX: Permit "." target for SRV records

### DIFF
--- a/providers/inwx/auditrecords.go
+++ b/providers/inwx/auditrecords.go
@@ -11,8 +11,6 @@ import (
 func AuditRecords(records []*models.RecordConfig) []error {
 	a := rejectif.Auditor{}
 
-	a.Add("SRV", rejectif.SrvHasNullTarget) // Last verified 2020-12-28
-
 	a.Add("TXT", rejectif.TxtHasBackticks) // Last verified 2021-03-01
 
 	a.Add("TXT", rejectif.TxtHasTrailingSpace) // Last verified 2021-03-01


### PR DESCRIPTION
# Issue

It has been reported that INWX now permits "." as a target in SRV records.

# Resolution

Remove rejectif.SrvHasNullTarget in auditrecords.go

CC @patschi

CC @rubgfx