### PR TITLE
BUG: fetch zones once in ZoneCache

### DIFF
--- a/pkg/zoneCache/zoneCache.go
+++ b/pkg/zoneCache/zoneCache.go
@@ -32,6 +32,7 @@ func (c *ZoneCache[Zone]) ensureCached() error {
 	for name, z := range zones {
 		c.cache[name] = z
 	}
+	c.cached = true
 	return nil
 }
 


### PR DESCRIPTION
:see_no_evil: Sorry, the zone cache failed to deliver it's core feature, caching of the zone listing. Oh well.

CLOUDFLARE integration tests run in 11min now, down from the 30min I mentioned in #3373.
HETZNER integration tests are down to 3min, from 8min.

I've repeated the manual testing for creating zones via preview/push as listed in #3373 for both CLOUDFLARE and HETZNER.

Closes https://github.com/StackExchange/dnscontrol/issues/3393