### PR TITLE
MSDNS: Provider is failing due to lint fix gone wrong

### DIFF
--- a/pkg/powershell/shell.go
+++ b/pkg/powershell/shell.go
@@ -60,7 +60,7 @@ func (s *shell) Execute(cmd string) (string, string, error) {
 	waiter.Add(2)
 
 	go streamReader(s.stdout, outBoundary, &sout, waiter) //nolint:errcheck
-	go streamReader(s.stdout, outBoundary, &sout, waiter) //nolint:errcheck
+	go streamReader(s.stderr, errBoundary, &serr, waiter) //nolint:errcheck
 
 	waiter.Wait()
 


### PR DESCRIPTION
# Issue

5dbe5e84c914e5a6e437dba1e4116d63e6492d8f broke the PowerShell Execute() function

# Resolution

Fix the incorrect line. 