### PR TITLE
BUG: create zones on push regardless of --populate-on-preview=false

### DIFF
--- a/commands/ppreviewPush.go
+++ b/commands/ppreviewPush.go
@@ -310,7 +310,7 @@ func prun(args PPreviewArgs, push bool, interactive bool, out printer.CLI, repor
 					totalCorrections += len(corrections)
 					out.EndProvider2(provider.Name, len(corrections))
 					reportItems = append(reportItems, genReportItem(zone.Name, corrections, provider.Name))
-					anyErrors = cmp.Or(anyErrors, pprintOrRunCorrections(zone.Name, provider.Name, corrections, out, args.PopulateOnPreview, interactive, notifier, report))
+					anyErrors = cmp.Or(anyErrors, pprintOrRunCorrections(zone.Name, provider.Name, corrections, out, push || args.PopulateOnPreview, interactive, notifier, report))
 				}
 			}
 		}


### PR DESCRIPTION
Here is a quick one-line fix for https://github.com/StackExchange/dnscontrol/issues/3399.