### PR TITLE
CICD: GoReleaser archives format_overrides deprecation

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -63,7 +63,8 @@ changelog:
 archives:
   - format_overrides:
     - goos: windows
-      format: zip
+      formats:
+        - "zip"
 universal_binaries:
   -
     replace: true


### PR DESCRIPTION
Fixes https://github.com/StackExchange/dnscontrol/issues/3415

```shell
goreleaser check
```

**Before**

```shell
  • checking                                 path=.goreleaser.yml
  • DEPRECATED:  archives.format_overrides.format  should not be used anymore, check https://goreleaser.com/deprecations#archivesformat_overridesformat for more info
  • .goreleaser.yml                                  error=configuration is valid, but uses deprecated properties
  ⨯ command failed                                   error=1 out of 1 configuration file(s) have issues
```

**After**

```shell
  • checking                                 path=.goreleaser.yml
  • 1 configuration file(s) validated
  • thanks for using GoReleaser!
```