### PR TITLE
BUNNY_DNS: Add support for `Redirect` record

### DIFF
--- a/documentation/provider/bunny_dns.md
+++ b/documentation/provider/bunny_dns.md
@@ -68,11 +68,11 @@ those explicitely listed below. Such records will be completely ignored by DNSCo
 
 ### Redirect
 
-You can configure Bunny's Redirect type with `BUNNY_DNS_REDIRECT`:
+You can configure Bunny's Redirect type with `BUNNY_DNS_RDR`:
 
 {% code title="dnsconfig.js" %}
 ```javascript
-    BUNNY_DNS_REDIRECT("@", "https://foo.bar"),
+    BUNNY_DNS_RDR("@", "https://foo.bar"),
 ```
 {% endcode %}
 

--- a/documentation/provider/bunny_dns.md
+++ b/documentation/provider/bunny_dns.md
@@ -61,9 +61,22 @@ records. You will need to generate an [API key](https://dash.bunny.net/account/s
 
 If a domain does not exist in your Bunny account, DNSControl will automatically add it with the `push` command.
 
+## Custom record types
+
+Any custom record types like Script, Flatten or Pull Zone are currently not supported by this provider, except
+those explicitely listed below. Such records will be completely ignored by DNSControl and left as-is.
+
+### Redirect
+
+You can configure Bunny's Redirect type with `BUNNY_DNS_REDIRECT`:
+
+{% code title="dnsconfig.js" %}
+```javascript
+    BUNNY_DNS_REDIRECT("@", "https://foo.bar"),
+```
+{% endcode %}
+
 ## Caveats
 
 - Bunny DNS does not support dual-hosting or configuring custom TTLs for NS records on the zone apex.
 - While custom nameservers are properly recognized by this provider, it is currently not possible to configure them.
-- Any custom record types like Script, Redirect, Flatten or Pull Zone are currently not supported by this provider. Such
-  records will be completely ignored by DNSControl and left as-is.

--- a/models/domain.go
+++ b/models/domain.go
@@ -129,7 +129,7 @@ func (dc *DomainConfig) Punycode() error {
 
 		// Set the target:
 		switch rec.Type { // #rtype_variations
-		case "ALIAS", "MX", "NS", "CNAME", "DNAME", "PTR", "SRV", "URL", "URL301", "FRAME", "R53_ALIAS", "AKAMAICDN", "CLOUDNS_WR", "PORKBUN_URLFWD":
+		case "ALIAS", "MX", "NS", "CNAME", "DNAME", "PTR", "SRV", "URL", "URL301", "FRAME", "R53_ALIAS", "AKAMAICDN", "CLOUDNS_WR", "PORKBUN_URLFWD", "BUNNY_DNS_RDR":
 			// These rtypes are hostnames, therefore need to be converted (unlike, for example, an AAAA record)
 			t, err := idna.ToASCII(rec.GetTargetField())
 			if err != nil {

--- a/pkg/js/helpers.js
+++ b/pkg/js/helpers.js
@@ -1406,7 +1406,7 @@ var URL301 = recordBuilder('URL301');
 var FRAME = recordBuilder('FRAME');
 var CLOUDNS_WR = recordBuilder('CLOUDNS_WR');
 var PORKBUN_URLFWD = recordBuilder('PORKBUN_URLFWD');
-
+var BUNNY_DNS_RDR = recordBuilder('BUNNY_DNS_RDR');
 // LOC_BUILDER_DD takes an object:
 // label: The DNS label for the LOC record. (default: '@')
 // x: Decimal X coordinate.

--- a/providers/bunnydns/bunnydnsProvider.go
+++ b/providers/bunnydns/bunnydnsProvider.go
@@ -45,6 +45,8 @@ func init() {
 	}
 	providers.RegisterDomainServiceProviderType(providerName, fns, features)
 	providers.RegisterMaintainer(providerName, providerMaintainer)
+
+	providers.RegisterCustomRecordType("BUNNY_DNS_RDR", providerName, "")
 }
 
 func newBunnydns(settings map[string]string, _ json.RawMessage) (providers.DNSServiceProvider, error) {

--- a/providers/bunnydns/convert.go
+++ b/providers/bunnydns/convert.go
@@ -61,6 +61,8 @@ func toRecordConfig(domain string, r *record) (*models.RecordConfig, error) {
 
 	var err error
 	switch rc.Type {
+	case "BUNNY_DNS_RDR":
+		err = rc.SetTarget(r.Value)
 	case "CAA":
 		err = rc.SetTargetCAA(r.Flags, r.Tag, recordValue)
 	case "MX":
@@ -107,8 +109,6 @@ func recordTypeFromString(t string) recordType {
 		return recordTypeTXT
 	case "MX":
 		return recordTypeMX
-	case "REDIRECT":
-		return recordTypeRedirect
 	case "FLATTEN":
 		return recordTypeFlatten
 	case "PULL_ZONE":
@@ -123,6 +123,8 @@ func recordTypeFromString(t string) recordType {
 		return recordTypeScript
 	case "NS":
 		return recordTypeNS
+	case "BUNNY_DNS_RDR":
+		return recordTypeRedirect
 	default:
 		panic(fmt.Errorf("BUNNY_DNS: rtype %v unimplemented", t))
 	}
@@ -141,7 +143,7 @@ func recordTypeToString(t recordType) string {
 	case recordTypeMX:
 		return "MX"
 	case recordTypeRedirect:
-		return "REDIRECT"
+		return "BUNNY_DNS_RDR"
 	case recordTypeFlatten:
 		return "FLATTEN"
 	case recordTypePullZone:

--- a/providers/bunnydns/records.go
+++ b/providers/bunnydns/records.go
@@ -31,7 +31,6 @@ func (b *bunnydnsProvider) GetZoneRecords(domain string, meta map[string]string)
 
 	// Define a list of record types that are currently not supported by this provider.
 	unsupportedTypes := []recordType{
-		recordTypeRedirect,
 		recordTypeFlatten,
 		recordTypePullZone,
 		recordTypeScript,
@@ -60,6 +59,10 @@ func (b *bunnydnsProvider) GetZoneRecordsCorrections(dc *models.DomainConfig, ex
 	// As no TTL can be configured or retrieved for these NS records, we set it to 0 to avoid unnecessary updates.
 	for _, rc := range dc.Records {
 		if rc.Name == "@" && rc.Type == "NS" {
+			rc.TTL = 0
+		}
+
+		if rc.Type == "BUNNY_DNS_RDR" {
 			rc.TTL = 0
 		}
 


### PR DESCRIPTION
This PR adds support for the custom Bunny DNS Redirect record. For example:

```javascript 
D("mydomain.com", REG_OVH, DnsProvider(DSP_BUNNY_DNS),
        BUNNY_DNS_RDR("@", "https://redirect.com"),
        BUNNY_DNS_RDR("www", "https://redirect.com"),
END);
```

will create these records in your DNS zone in Bunny:

![CleanShot 2025-03-01 at 12 22 52@2x](https://github.com/user-attachments/assets/a53d8cc5-f3b4-4442-9fa5-c68909f5729b)

I based this on the existing `PORKBUN_URLFWD` custom record, so hopefully these changes make sense. If a different approach is required, or whatever else, let me know! Thanks!