### PR TITLE
documentation: SOA RNAME description isn't accurate

### DIFF
--- a/documentation/language-reference/domain-modifiers/SOA.md
+++ b/documentation/language-reference/domain-modifiers/SOA.md
@@ -25,14 +25,10 @@ parameter_types:
 {% code title="dnsconfig.js" %}
 ```javascript
 D("example.com", REG_MY_PROVIDER, DnsProvider(DSP_MY_PROVIDER),
-  SOA("@", "ns3.example.com.", "hostmaster@example.com", 3600, 600, 604800, 1440),
+  SOA("@", "ns3.example.com.", "hostmaster.example.com.", 3600, 600, 604800, 1440),
 );
 ```
 {% endcode %}
-
-If you accidentally include an `@` in the email field DNSControl will quietly
-change it to a `.`. This way you can specify a human-readable email address
-when you are making it easier for spammers how to find you.
 
 ## Notes
 * The serial number is managed automatically.  It isn't even a field in `SOA()`.


### PR DESCRIPTION
Using dnscontrol version 4.16.0, I get an error when using an `@` in the SOA RNAME for the example on this page:

```
2025/03/05 16:21:03 1 Validation errors:
2025/03/05 16:21:03 ERROR: in SOA @.example.com: SOA MBox must have '.' instead of '@'
exiting due to validation errors
```

As such the RNAME may not have an `@` character in it and must be fully qualified (else `$ORIGIN` is appended to it).
