### PR TITLE
Bug: HASH() outputs debug info

### DIFF
--- a/pkg/js/hash.go
+++ b/pkg/js/hash.go
@@ -19,13 +19,13 @@ func hashFunc(call otto.FunctionCall) otto.Value {
 	value := call.Argument(1).String()     // The value to hash
 	//lint:ignore SA4006 work around bug in staticcheck. This value is needed if the switch statement follows the default path.
 	result := otto.Value{} //nolint:staticcheck
-	fmt.Printf("%s\n", value)
+	// fmt.Printf("%s\n", value)
 
 	switch algorithm {
 	case "SHA1", "sha1":
 		tmp := sha1.New()
 		tmp.Write([]byte(value))
-		fmt.Printf("%s\n", hex.EncodeToString(tmp.Sum(nil)))
+		// fmt.Printf("%s\n", hex.EncodeToString(tmp.Sum(nil)))
 		result, _ = otto.ToValue(hex.EncodeToString(tmp.Sum(nil)))
 	case "SHA256", "sha256":
 		tmp := sha256.New()


### PR DESCRIPTION
I note that when using `HASH("SHA1", ..)` the value and hash are printed on _stdout_:

```console
$ dnscontrol preview
Reading dnsconfig.js or equiv.
example.com.
22b77bea9d7a8cf2147bb0616aaa388b0d152013
example.
9133ab60caa1c7be379f21f1ba2968365a54bf36
```

If I use `SHA256` instead, the hashes aren't emitted (but the values are).

Looking at this code, it would appear as though two `Printf()` were forgotten. This small patch removes them.
