### PR TITLE
DOCS: Add fmt for .js files to releng process

### DIFF
--- a/commands/types/dnscontrol.d.ts
+++ b/commands/types/dnscontrol.d.ts
@@ -624,7 +624,7 @@ declare function CNAME(name: string, target: string, ...modifiers: RecordModifie
  *
  * Modifier arguments are processed according to type as follows:
  *
- * - A function argument will be called with the domain object as it's only argument. Most of the [built-in modifier functions](https://docs.dnscontrol.org/language-reference/domain-modifiers-modifiers) return such functions.
+ * - A function argument will be called with the domain object as it's only argument. Most of the [built-in modifier functions](https://docs.dnscontrol.org/language-reference/domain-modifiers) return such functions.
  * - An object argument will be merged into the domain's metadata collection.
  * - An array argument will have all of it's members evaluated recursively. This allows you to combine multiple common records or modifiers into a variable that can
  *    be used like a macro in multiple domains.

--- a/documentation/release-engineering.md
+++ b/documentation/release-engineering.md
@@ -25,6 +25,7 @@ git checkout main
 git pull
 go fmt ./...
 bin/fmtjson $(find . -type f -name \*.json -print)
+for i in pkg/js/parse_tests/*.js ; do dnscontrol fmt -i $i -o $i ; done
 go generate ./...
 go mod tidy
 git status


### PR DESCRIPTION
# Issue

The `.js` files in the `pkg/js/parse_tests` directory should be properly formatted.

# Resolution

Document a process for doing that.