### PR TITLE
AUTODNS: fix error when restoring existing MX or SRV records

### DIFF
--- a/providers/autodns/autoDnsProvider.go
+++ b/providers/autodns/autoDnsProvider.go
@@ -247,8 +247,11 @@ func toRecordConfig(domain string, record *ResourceRecord) (*models.RecordConfig
 	}
 	rc.SetLabel(record.Name, domain)
 
-	if err := rc.PopulateFromString(record.Type, record.Value, domain); err != nil {
-		return nil, err
+	// special record types are handled below, skip the `rc.PopulateFromString` method
+	if record.Type != "MX" && record.Type != "SRV" {
+		if err := rc.PopulateFromString(record.Type, record.Value, domain); err != nil {
+			return nil, err
+		}
 	}
 
 	if record.Type == "MX" {


### PR DESCRIPTION
This patch resolves the `MX value does not contain 2 fields: ("smtp.google.com.")` error. This occurs when records are restored from the API (converting raw response to internal objects). Most records can be restored properly using the `RecordConfig.PopulateFromString` method but due to some quirks in AutoDNS this yields an error if tried with SRV or MX.

This resolves the issue raised with #3403 

I ran integration tests before and after, the issue also occurred when running the tests. For the sake of completeness I'm including both reports.