### PR TITLE
CLOUDFLARE: CF_REDIRECT "name" should be 3-digits so it sorts better

### DIFF
--- a/providers/cloudflare/rtypes/cfsingleredirect/from.go
+++ b/providers/cloudflare/rtypes/cfsingleredirect/from.go
@@ -33,7 +33,7 @@ func MakePageRule(rc *models.RecordConfig, priority int, code uint16, when, then
 
 // mkPageRuleBlob creates the 1,301,when,then string used in displays.
 func mkPageRuleBlob(priority int, code uint16, when, then string) string {
-	return fmt.Sprintf("%d,%03d,%s,%s", priority, code, when, then)
+	return fmt.Sprintf("%03d,%03d,%s,%s", priority, code, when, then)
 }
 
 // makeSingleRedirectFromRawRec updates a RecordConfig to be a
@@ -126,5 +126,5 @@ func makeSingleRedirectFromConvert(rc *models.RecordConfig,
 
 // targetFromConverted makes the display text used when a redirect was the result of converting a PAGE_RULE.
 func targetFromConverted(prPriority int, code uint16, prWhen, prThen, srWhen, srThen string) string {
-	return fmt.Sprintf("%d,%03d,%s,%s code=(%03d) when=(%s) then=(%s)", prPriority, code, prWhen, prThen, code, srWhen, srThen)
+	return fmt.Sprintf("%03d,%03d,%s,%s code=(%03d) when=(%s) then=(%s)", prPriority, code, prWhen, prThen, code, srWhen, srThen)
 }


### PR DESCRIPTION
# Issue

The "name" assigned to CF_REDIRECTs look like `1,302,https://from/*,https://dest` which don't sort well if there are more than 10.

# Resolution

Make  `001,302,https://from/*,https://dest` so they sort better.