### PR TITLE
INWX: use provisioned nameservers, fall back to hardcoded defaults

### DIFF
--- a/providers/inwx/inwxProvider.go
+++ b/providers/inwx/inwxProvider.go
@@ -288,9 +288,10 @@ func (api *inwxAPI) getDefaultNameservers() []string {
 	return InwxProductionDefaultNs
 }
 
-// GetNameservers returns the default nameservers for INWX.
+// GetNameservers returns the nameservers provisioned for the domain or the
+// default INWX nameservers.
 func (api *inwxAPI) GetNameservers(domain string) ([]*models.Nameserver, error) {
-	return models.ToNameservers(api.getDefaultNameservers())
+	return models.ToNameservers(api.fetchRegistrationNSSet(domain))
 }
 
 // GetZoneRecords receives the current records from Inwx and converts them to models.RecordConfig.
@@ -386,18 +387,21 @@ func (api *inwxAPI) updateNameservers(ns []string, domain string) func() error {
 
 // GetRegistrarCorrections is part of the registrar provider and determines if the nameservers have to be updated.
 func (api *inwxAPI) GetRegistrarCorrections(dc *models.DomainConfig) ([]*models.Correction, error) {
-	info, err := api.client.Domains.Info(dc.Name, 0)
-	if err != nil {
-		return nil, err
-	}
-
-	sort.Strings(info.Nameservers)
-	foundNameservers := strings.Join(info.Nameservers, ",")
-	expected := []string{}
+	regNameservers := api.fetchRegistrationNSSet(dc.Name)
+	combined := map[string]bool{}
 	for _, ns := range dc.Nameservers {
-		expected = append(expected, ns.Name)
+		combined[ns.Name] = true
+	}
+	for _, rs := range regNameservers {
+		combined[rs] = true
+	}
+	var expected []string
+	for k := range combined {
+		expected = append(expected, k)
+
 	}
 	sort.Strings(expected)
+	foundNameservers := strings.Join(regNameservers, ",")
 	expectedNameservers := strings.Join(expected, ",")
 
 	if foundNameservers != expectedNameservers {
@@ -434,6 +438,15 @@ func (api *inwxAPI) fetchNameserverDomains() error {
 	return nil
 }
 
+func (api *inwxAPI) fetchRegistrationNSSet(domain string) []string {
+	info, err := api.client.Domains.Info(domain, 0)
+	if err != nil {
+		return api.getDefaultNameservers()
+	}
+	sort.Strings(info.Nameservers)
+	return info.Nameservers
+}
+
 // EnsureZoneExists creates a zone if it does not exist
 func (api *inwxAPI) EnsureZoneExists(domain string) error {
 	if api.domainIndex == nil { // only pull the data once.
@@ -450,7 +463,7 @@ func (api *inwxAPI) EnsureZoneExists(domain string) error {
 	request := &goinwx.NameserverCreateRequest{
 		Domain:      domain,
 		Type:        "MASTER",
-		Nameservers: api.getDefaultNameservers(),
+		Nameservers: api.fetchRegistrationNSSet(domain),
 	}
 	var id int
 	id, err := api.client.Nameservers.Create(request)


### PR DESCRIPTION
This changes the behavior of setting the default nameservers when creating a zone or collecting the NS set changes for an existing zone.

If the provider is a registrar and the call to INWX API endpoint 'domain.info' returns a list of nameservers, we will use those. If there is an API error (potentially authorization if using a secondary user with scoped permissions), we fall back to the previous behavior of using a static set of nameservers appropriate for the environment (live or sandbox)

fixes #3500 

BUGFIX: (INWX) use provisioned nameservers, fall back to hardcoded defaults

<!--
## Before submiting a pull request

Please make sure you've run the following commands from the root directory.

go vet ./...
go fmt ./...
go generate ./...
go mod tidy

## Release changelog section

Help keep the release changelog clear by pre-naming the proper section in the GitHub pull request title.

Some examples:
* CICD: Add required GHA permissions for goreleaser
* DOCS: Fixed providers with "contributor support" table
* ROUTE53: Allow R53_ALIAS records to enable target health evaluation

More examples/context can be found in the file .goreleaser.yml under the 'build' > 'changelog' key.
!-->
