### PR TITLE
META: typescript: Mark recursive parameter of require_glob optional

### DIFF
--- a/commands/types/dnscontrol.d.ts
+++ b/commands/types/dnscontrol.d.ts
@@ -3371,4 +3371,4 @@ declare function getConfiguredDomains(): string[];
  *
  * @see https://docs.dnscontrol.org/language-reference/top-level-functions/require_glob
  */
-declare function require_glob(path: string, recursive: boolean): void;
+declare function require_glob(path: string, recursive?: boolean): void;

--- a/documentation/language-reference/top-level-functions/require_glob.md
+++ b/documentation/language-reference/top-level-functions/require_glob.md
@@ -5,7 +5,7 @@ parameters:
   - recursive
 parameter_types:
   path: string
-  recursive: boolean
+  recursive: boolean?
 ---
 
 `require_glob()` recursively loads `.js` files that match a glob (wildcard). The recursion can be disabled.


### PR DESCRIPTION
From #3507 
* DOCS: mark `recursive` parameter to `require_glob` optional

tested as per Tom's suggestion in the issue. Works.