### PR TITLE
DOCS: Fix link to contributor responsibilities

### DIFF
--- a/documentation/writing-providers.md
+++ b/documentation/writing-providers.md
@@ -219,7 +219,7 @@ an automated way to test for this bug.  The manual steps are here in
   * Add the name of the provider to the PROVIDERS list.
 * Edit `documentation/providers.md`:
   * Remove the provider from the `Requested providers` list (near the end of the doc) (if needed).
-  * Add the new provider to the [Providers with "contributor support"](provider/index.md#providers-with-contributor-support) section.
+  * Add the new provider to the [Providers with "contributor support"](provider/index#providers-with-contributor-support) section.
 * Edit `documentation/SUMMARY.md`:
   * Add the provider to the "Providers" list.
 * Create `documentation/provider/PROVIDERNAME.md`:


### PR DESCRIPTION
<!--
## Before submiting a pull request

Please make sure you've run the following commands from the root directory.

go vet ./...
go fmt ./...
go generate ./...
go mod tidy

## Release changelog section

Help keep the release changelog clear by pre-naming the proper section in the GitHub pull request title.

Some examples:
* CICD: Add required GHA permissions for goreleaser
* DOCS: Fixed providers with "contributor support" table
* ROUTE53: Allow R53_ALIAS records to enable target health evaluation

More examples/context can be found in the file .goreleaser.yml under the 'build' > 'changelog' key.
!-->
