### PR TITLE
BUGFIX: types fix: CAA_BUILDER accepts string[] or string for issue

### DIFF
--- a/commands/types/dnscontrol.d.ts
+++ b/commands/types/dnscontrol.d.ts
@@ -469,7 +469,7 @@ declare function CAA(name: string, tag: "issue" | "issuewild" | "iodef", value: 
  *
  * @see https://docs.dnscontrol.org/language-reference/domain-modifiers/caa_builder
  */
-declare function CAA_BUILDER(opts: { label?: string; iodef: string; iodef_critical?: boolean; issue: string[]; issue_critical?: boolean; issuewild: string[]; issuewild_critical?: boolean; ttl?: Duration }): DomainModifier;
+declare function CAA_BUILDER(opts: { label?: string; iodef: string; iodef_critical?: boolean; issue: string[]|string; issue_critical?: boolean; issuewild: string[]|string; issuewild_critical?: boolean; ttl?: Duration }): DomainModifier;
 
 /**
  * WARNING: Cloudflare is removing this feature and replacing it with a new

--- a/documentation/language-reference/domain-modifiers/CAA_BUILDER.md
+++ b/documentation/language-reference/domain-modifiers/CAA_BUILDER.md
@@ -14,9 +14,9 @@ parameter_types:
   label: string?
   iodef: string
   iodef_critical: boolean?
-  issue: string[]
+  issue: string[]|string
   issue_critical: boolean?
-  issuewild: string[]
+  issuewild: string[]|string
   issuewild_critical: boolean?
   ttl: Duration?
 ---

--- a/pkg/js/helpers.js
+++ b/pkg/js/helpers.js
@@ -1675,8 +1675,8 @@ function SPF_BUILDER(value) {
 // label: The DNS label for the CAA record. (default: '@')
 // iodef: The contact mail address. (optional)
 // iodef_critical: Boolean if sending report is required/critical. If not supported, certificate should be refused. (optional)
-// issue: List of CAs which are allowed to issue certificates for the domain (creates one record for each).
-// issuewild: Allowed CAs which can issue wildcard certificates for this domain. (creates one record for each)
+// issue: List of CAs which are allowed to issue certificates for the domain (creates one record for each), or the string 'none'.
+// issuewild: List of allowed CAs which can issue wildcard certificates for this domain, or the string 'none'. (creates one record for each)
 // ttl: The time for TTL, integer or string. (default: not defined, using DefaultTTL)
 
 function CAA_BUILDER(value) {


### PR DESCRIPTION
This updates the CAA_BUILDER type definition that ends up in types-dnscontrol.d.ts to comport with the implementation - both `string[]` and `string` are allowed for `issue` and `issuewild`

The [CAA_BUILDER](https://docs.dnscontrol.org/language-reference/domain-modifiers/caa_builder#simple-example) helper function's `issue` and `issuewild` parameters can be list of strings or the special string 'none'. If the value is `'none'` the resulting CAA record will have an issue/issuewild value of `';'`.

```javascript
// @ts-check
/// <reference path="types-dnscontrol-4.18.0.d.ts" />

var REG_MY_PROVIDER = NewRegistrar('none');
var DSP_MY_PROVIDER = NewDnsProvider('none');

D(
    'example.com',
    REG_MY_PROVIDER,
    DnsProvider(DSP_MY_PROVIDER),
    CAA_BUILDER({
        label: '@',
        iodef: 'mailto:test@example.com',
        iodef_critical: true,
        issue: ['some-ca-example.com'],
        issue_critical: true,
        issuewild: 'none',
        issuewild_critical: true,
    })
);
```

The type definition rendered by `dnscontrol write-types` only accepts a list of strings, so when using the typedef file, IDEs will complain:

<img width="270" alt="Screenshot 2025-04-22 at 5 58 09 PM" src="https://github.com/user-attachments/assets/0bdd527b-1682-4935-bf41-38713e8f688c" />

```
[...]
types-dnscontrol.d.ts(476, 138): The expected type comes from property 'issuewild' which is declared here on type '{ label?: string | undefined; iodef: string; iodef_critical?: boolean | undefined; issue: string[]; issue_critical?: boolean | undefined; issuewild: string[]; issuewild_critical?: boolean | undefined; ttl?: Duration | undefined; }'
(property) issuewild: string[]
```

This change updates the type definition in `CAA_BUILDER.md` and includes the rebuilt `dnscontrol.d.ts`, and also updates relevant comments in `pkg/js/helpers.js`
