### PR TITLE
BUNNY_DNS: Support DNSSEC and fix Null MX parsing

### DIFF
--- a/documentation/provider/index.md
+++ b/documentation/provider/index.md
@@ -20,7 +20,7 @@ If a feature is definitively not supported for whatever reason, we would also li
 | [`AZURE_DNS`](azure_dns.md) | ✅ | ✅ | ❌ | ✅ | ❌ | ✅ | ❔ | ❔ | ❌ | ❌ | ✅ | ❔ | ✅ | ❌ | ❔ | ❌ | ❔ | ❔ | ❔ | ❔ | ✅ | ✅ | ✅ |
 | [`AZURE_PRIVATE_DNS`](azure_private_dns.md) | ✅ | ✅ | ❌ | ❔ | ❌ | ❌ | ❔ | ❔ | ❌ | ❌ | ✅ | ❔ | ✅ | ❌ | ❔ | ❌ | ❔ | ❔ | ❔ | ❔ | ✅ | ✅ | ✅ |
 | [`BIND`](bind.md) | ✅ | ✅ | ❌ | ✅ | ❔ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| [`BUNNY_DNS`](bunny_dns.md) | ❌ | ✅ | ❌ | ❔ | ✅ | ✅ | ❌ | ❔ | ❌ | ❌ | ✅ | ❌ | ✅ | ❌ | ❔ | ❌ | ❌ | ❌ | ❔ | ❔ | ❌ | ✅ | ✅ |
+| [`BUNNY_DNS`](bunny_dns.md) | ❌ | ✅ | ❌ | ❔ | ✅ | ✅ | ✅ | ❔ | ❌ | ❌ | ✅ | ❌ | ✅ | ❌ | ❔ | ❌ | ❌ | ❌ | ❔ | ❔ | ❌ | ✅ | ✅ |
 | [`CLOUDFLAREAPI`](cloudflareapi.md) | ✅ | ✅ | ❌ | ✅ | ✅ | ✅ | ❔ | ✅ | ❌ | ✅ | ✅ | ❔ | ✅ | ✅ | ✅ | ✅ | ❔ | ❔ | ❔ | ❌ | ❌ | ✅ | ✅ |
 | [`CLOUDNS`](cloudns.md) | ❌ | ✅ | ❌ | ✅ | ✅ | ✅ | ✅ | ❔ | ✅ | ❔ | ✅ | ❔ | ✅ | ✅ | ❔ | ✅ | ❔ | ❔ | ✅ | ❔ | ❔ | ✅ | ✅ |
 | [`CNR`](cnr.md) | ❌ | ✅ | ✅ | ✅ | ✅ | ✅ | ❔ | ❌ | ❌ | ✅ | ✅ | ❌ | ✅ | ✅ | ❌ | ✅ | ❔ | ❌ | ❌ | ❔ | ✅ | ✅ | ✅ |

--- a/providers/bunnydns/api.go
+++ b/providers/bunnydns/api.go
@@ -23,6 +23,7 @@ type zone struct {
 	Domain      string `json:"Domain"`
 	Nameserver1 string `json:"Nameserver1"`
 	Nameserver2 string `json:"Nameserver2"`
+	HasDNSSEC   bool   `json:"DnsSecEnabled"`
 }
 
 func (zone *zone) Nameservers() []string {
@@ -165,6 +166,16 @@ func (b *bunnydnsProvider) modifyRecord(zoneID int64, recordID int64, r *record)
 func (b *bunnydnsProvider) deleteRecord(zoneID, recordID int64) error {
 	url := fmt.Sprintf("/dnszone/%d/records/%d", zoneID, recordID)
 	return b.request("DELETE", url, nil, nil, nil, []int{http.StatusNoContent})
+}
+
+func (b *bunnydnsProvider) enableDNSSEC(zoneID int64) error {
+	url := fmt.Sprintf("/dnszone/%d/dnssec", zoneID)
+	return b.request("POST", url, nil, nil, nil, []int{http.StatusOK})
+}
+
+func (b *bunnydnsProvider) disableDNSSEC(zoneID int64) error {
+	url := fmt.Sprintf("/dnszone/%d/dnssec", zoneID)
+	return b.request("DELETE", url, nil, nil, nil, []int{http.StatusOK})
 }
 
 func (b *bunnydnsProvider) request(method, endpoint string, query queryParams, body, target any, validStatus []int) error {

--- a/providers/bunnydns/bunnydnsProvider.go
+++ b/providers/bunnydns/bunnydnsProvider.go
@@ -11,7 +11,7 @@ import (
 var features = providers.DocumentationNotes{
 	// The default for unlisted capabilities is 'Cannot'.
 	// See providers/capabilities.go for the entire list of capabilities.
-	providers.CanAutoDNSSEC:          providers.Cannot(),
+	providers.CanAutoDNSSEC:          providers.Can(),
 	providers.CanGetZones:            providers.Can(),
 	providers.CanConcur:              providers.Unimplemented(),
 	providers.CanUseAlias:            providers.Can("Bunny flattens CNAME records into A/AAAA records dynamically"),

--- a/providers/bunnydns/dnssec.go
+++ b/providers/bunnydns/dnssec.go
@@ -1,0 +1,23 @@
+package bunnydns
+
+import "github.com/StackExchange/dnscontrol/v4/models"
+
+func (b *bunnydnsProvider) getDNSSECCorrections(dc *models.DomainConfig, zone *zone) ([]*models.Correction, error) {
+	if zone.HasDNSSEC && dc.AutoDNSSEC == "off" {
+		return []*models.Correction{
+			{Msg: "Disable DNSSEC", F: func() error {
+				return b.disableDNSSEC(zone.ID)
+			}},
+		}, nil
+	}
+
+	if !zone.HasDNSSEC && dc.AutoDNSSEC == "on" {
+		return []*models.Correction{
+			{Msg: "Enable DNSSEC", F: func() error {
+				return b.enableDNSSEC(zone.ID)
+			}},
+		}, nil
+	}
+
+	return []*models.Correction{}, nil
+}

--- a/providers/bunnydns/records.go
+++ b/providers/bunnydns/records.go
@@ -105,6 +105,12 @@ func (b *bunnydnsProvider) GetZoneRecordsCorrections(dc *models.DomainConfig, ex
 		}
 	}
 
+	dnssecCorrections, err := b.getDNSSECCorrections(dc, zone)
+	if err != nil {
+		return nil, 0, err
+	}
+	corrections = append(corrections, dnssecCorrections...)
+
 	return corrections, actualChangeCount, nil
 }
 


### PR DESCRIPTION
This change implements the`AUTODNSSEC` capability for Bunny DNS, based on the recently released API endpoints. I've tested proper state handling on my side and double-checked manually against the Bunny API too:

```
# Neither `AUTODNSSEC_ON` nor `AUTODNSSEC_OFF` specified, leaves manually enabled zone unchanged
CONCURRENTLY gathering 0 zone(s)
SERIALLY gathering 1 zone(s)
Serially Gathering: "dnscontrol.ppmathis.com"
******************** Domain: dnscontrol.ppmathis.com
Done. 0 corrections.

# Specifying `AUTODNSSEC_OFF` triggers correction
CONCURRENTLY gathering 0 zone(s)
SERIALLY gathering 1 zone(s)
Serially Gathering: "dnscontrol.ppmathis.com"
******************** Domain: dnscontrol.ppmathis.com
#1: Disable DNSSEC
SUCCESS!
Done. 0 corrections.

# Subsequent run shows no changes as expected
CONCURRENTLY gathering 0 zone(s)
SERIALLY gathering 1 zone(s)
Serially Gathering: "dnscontrol.ppmathis.com"
******************** Domain: dnscontrol.ppmathis.com
Done. 0 corrections.

# Specifying `AUTODNSSEC_ON` triggers correction
CONCURRENTLY gathering 0 zone(s)
SERIALLY gathering 1 zone(s)
Serially Gathering: "dnscontrol.ppmathis.com"
******************** Domain: dnscontrol.ppmathis.com
#1: Enable DNSSEC
SUCCESS!
Done. 0 corrections.

# Subsequent run shows no changes as expected
CONCURRENTLY gathering 0 zone(s)
SERIALLY gathering 1 zone(s)
Serially Gathering: "dnscontrol.ppmathis.com"
******************** Domain: dnscontrol.ppmathis.com
Done. 0 corrections.
```

Additionally, I've noticed that integration tests were failing for the renull NullMX test cases, which happened due to `fromRecordConfig` stripping `.` from any FQDN-like record unconditionally, as is usually desired and in alignment with `toRecordConfig`.

However in case of `type == MX && pref == 0 && value == "."` the single dot must be preserved as-is, given its special meaning as a NullMX record, which has been fixed in a separate commit. The full test suite is now properly passing again.

Fixes #3513 