### PR TITLE
AXFRDDNS: Ignore ZONEMD records

### DIFF
--- a/providers/axfrddns/axfrddnsProvider.go
+++ b/providers/axfrddns/axfrddnsProvider.go
@@ -309,6 +309,7 @@ func (c *axfrddnsProvider) GetZoneRecords(domain string, meta map[string]string)
 			dns.TypeNSEC,
 			dns.TypeNSEC3,
 			dns.TypeNSEC3PARAM,
+			dns.TypeZONEMD,
 			65534:
 			// Ignoring DNSSec RRs, but replacing it with a single
 			// "TXT" placeholder


### PR DESCRIPTION
`ZONEMD` records are DNSSEC-like, so we'll handle them like the other DNSSEC records and simply ignore them. See https://datatracker.ietf.org/doc/html/rfc8976 for more information.

I've enabled `ZONEMD` generation on the zone used in the `AXFRDDNS_DNSSEC` integration test server, so any other PRs are likely to fail until this is merged. I have _not_ enabled it on the `AXFRDDNS` (no DNSSEC) zone, so any failures there should be unrelated to this PR.