### PR TITLE
INWX: BUGFIX: ALIAS RRs updates are broken due to trailing dot issue

### DIFF
--- a/providers/inwx/inwxProvider.go
+++ b/providers/inwx/inwxProvider.go
@@ -189,7 +189,7 @@ func makeNameserverRecordRequest(domain string, rec *models.RecordConfig) *goinw
 	   Records with empty targets (i.e. records with target ".")
 	   are allowed.
 	*/
-	case "CNAME", "NS":
+	case "CNAME", "NS", "ALIAS":
 		req.Content = content[:len(content)-1]
 	case "MX":
 		req.Priority = int(rec.MxPreference)
@@ -456,6 +456,7 @@ func (api *inwxAPI) GetZoneRecords(domain string, meta map[string]string) (model
 		   are allowed.
 		*/
 		rtypeAddDot := map[string]bool{
+			"ALIAS": true,
 			"CNAME": true,
 			"MX":    true,
 			"NS":    true,


### PR DESCRIPTION
#3499 was an incomplete fix for #2742 and #2856 

The INWX API strips trailing dots on ALIAS RRs so the provider needs to handle this similarly to NS and CNAME. The problem manifests as an unnecessary change detected after pushing an ALIAS RR.

## Release changelog section

* INWX: fix ALIAS RR trailing dot