### PR TITLE
ROUTE53: BUGFIX converting alias to cname causes failure

### DIFF
--- a/integrationTest/integration_test.go
+++ b/integrationTest/integration_test.go
@@ -1073,6 +1073,36 @@ func makeTests() []*TestGroup {
 			),
 		),
 
+		// Bug https://github.com/StackExchange/dnscontrol/issues/3493
+		// Summary: R53_ALIAS -> CNAME conversion doesn't work.
+		testgroup("R53_B3493",
+			requires(providers.CanUseRoute53Alias),
+			// Create the R53_ALIAS:
+			tc("b3493 create alias+cname in one step",
+				r53alias("dev-system", "CNAME", "dev-system18.**current-domain**.", "false"),
+				cname("dev-system18", "ec2-54-91-33-155.compute-1.amazonaws.com."),
+			),
+			// Convert R53_ALIAS -> CNAME.
+			tc("convert r53alias to cname",
+				cname("dev-system", "dev-system18.**current-domain**."),
+				cname("dev-system18", "ec2-54-91-33-155.compute-1.amazonaws.com."),
+			),
+		),
+		// Verify CNAME -> R53_ALIAS works too. (not part of the bug, but worth verifying)
+		testgroup("R53_B3493_REV",
+			requires(providers.CanUseRoute53Alias),
+			// Create the CNAME
+			tc("b3493 create cnames",
+				cname("dev-system", "dev-system18.**current-domain**."),
+				cname("dev-system18", "ec2-54-91-33-155.compute-1.amazonaws.com."),
+			),
+			// Convert CNAME -> R53_ALIAS.
+			tc("convert cname to r53_alias",
+				r53alias("dev-system", "CNAME", "dev-system18.**current-domain**.", "false"),
+				cname("dev-system18", "ec2-54-91-33-155.compute-1.amazonaws.com."),
+			),
+		),
+
 		// CLOUDFLAREAPI features
 
 		// CLOUDFLAREAPI: Redirects:


### PR DESCRIPTION
# Issue

Converting a R53_ALIAS to a CNAME (in the ROUTE53 provider) is broken.

The API calls are done in the wrong order and are thus rejected. DNS RFCs dictate that if a CNAME exists at a label, it can be the only record at that label. Therefore R53_ALIAS -> CNAME conversion must first remove the cname CNAME, then create the R53_ALIAS replacement.  If the R53_ALIAS is created first, that fails because the CNAME exists; and thus the creation of the R53_ALIAS violates the DNS rule mentioned previously.

# Resolution

Remove ROUTE53's attempt to reorder instructions.

The pkg/dnssort module reorders the instructions to be executed (i.e. the API calls) such that CNAME ordering and other DNS rules are obeyed.

The ROUTE53 provider was written before the pkg/dnssort module was created. The legacy code makes an attempt to re-order the instructions.  This attempt is correct in most cases, but not in the case of R53_ALIAS -> CNAME conversion.  Therefore it un-does the correct order created by pkg/dnssort.

The solution is simple: Remove the legacy code in ROUTE53 that reorders the instructions.  This permits pkg/dnssort to do its job which 