### PR TITLE
AUTODNS: Enable "get-zones" (ListZones, EnsureZoneExists, GetRegistrarCorrections)

### DIFF
--- a/providers/autodns/api.go
+++ b/providers/autodns/api.go
@@ -114,6 +114,24 @@ func (api *autoDNSProvider) findZoneSystemNameServer(domain string) (*models.Nam
 	return systemNameServer, nil
 }
 
+func (api *autoDNSProvider) createZone(domain string, zone *Zone) (*Zone, error) {
+	responseData, err := api.request("POST", "zone", zone)
+	if err != nil {
+		return nil, err
+	}
+
+	var responseObject JSONResponseDataZone
+	if err := json.Unmarshal(responseData, &responseObject); err != nil {
+		return nil, err
+	}
+
+	if len(responseObject.Data) != 1 {
+		return nil, errors.New("Zone " + domain + " not returned")
+	}
+
+	return responseObject.Data[0], nil
+}
+
 func (api *autoDNSProvider) getZone(domain string) (*Zone, error) {
 	systemNameServer, err := api.findZoneSystemNameServer(domain)
 	if err != nil {

--- a/providers/autodns/api.go
+++ b/providers/autodns/api.go
@@ -4,9 +4,11 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"math"
 	"net/http"
+	"os"
 	"sort"
 	"time"
 
@@ -104,7 +106,7 @@ func (api *autoDNSProvider) findZoneSystemNameServer(domain string) (*models.Nam
 	}
 
 	if len(responseObject.Data) != 1 {
-		return nil, errors.New("Zone " + domain + " could not be found in AutoDNS")
+		return nil, fmt.Errorf("Zone "+domain+" could not be found in AutoDNS: %w", os.ErrNotExist)
 	}
 
 	systemNameServer := &models.Nameserver{Name: responseObject.Data[0].SystemNameServer}

--- a/providers/autodns/api.go
+++ b/providers/autodns/api.go
@@ -133,6 +133,24 @@ func (api *autoDNSProvider) createZone(domain string, zone *Zone) (*Zone, error)
 	return responseObject.Data[0], nil
 }
 
+func (api *autoDNSProvider) getDomain(domain string) (*Domain, error) {
+	responseData, err := api.request("GET", "domain/"+domain, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var responseObject JSONResponseDataDomain
+	if err := json.Unmarshal(responseData, &responseObject); err != nil {
+		return nil, err
+	}
+
+	if len(responseObject.Data) != 1 {
+		return nil, fmt.Errorf("Domain "+domain+" could not be found in AutoDNS: %w", os.ErrNotExist)
+	}
+
+	return responseObject.Data[0], nil
+}
+
 func (api *autoDNSProvider) getZone(domain string) (*Zone, error) {
 	systemNameServer, err := api.findZoneSystemNameServer(domain)
 	if err != nil {
@@ -210,6 +228,15 @@ func (api *autoDNSProvider) updateZone(domain string, resourceRecords []*Resourc
 
 	if putErr != nil {
 		return putErr
+	}
+
+	return nil
+}
+
+func (api *autoDNSProvider) updateDomain(name string, domain *Domain) error {
+	_, err := api.request("PUT", "domain/"+name, domain)
+	if err != nil {
+		return err
 	}
 
 	return nil

--- a/providers/autodns/api.go
+++ b/providers/autodns/api.go
@@ -64,7 +64,8 @@ func (api *autoDNSProvider) request(method string, requestPath string, data inte
 
 		responseText, _ := io.ReadAll(response.Body)
 
-		if response.StatusCode != http.StatusOK && response.StatusCode != http.StatusTooManyRequests {
+		// FUTUREWORK: 202 starts a long-running task. Should we instead poll here until task is completed?
+		if response.StatusCode != http.StatusOK && response.StatusCode != http.StatusAccepted && response.StatusCode != http.StatusTooManyRequests {
 			return nil, errors.New("Request to " + requestURL.Path + " failed: " + string(responseText))
 		}
 

--- a/providers/autodns/api.go
+++ b/providers/autodns/api.go
@@ -134,6 +134,25 @@ func (api *autoDNSProvider) getZone(domain string) (*Zone, error) {
 	return responseObject.Data[0], nil
 }
 
+func (api *autoDNSProvider) getZones() ([]string, error) {
+	responseData, err := api.request("POST", "zone/_search", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var responseObject JSONResponseDataZone
+	if err := json.Unmarshal(responseData, &responseObject); err != nil {
+		return nil, err
+	}
+
+	names := make([]string, 0, len(responseObject.Data))
+	for _, zone := range responseObject.Data {
+		names = append(names, zone.Origin)
+	}
+
+	return names, nil
+}
+
 func (api *autoDNSProvider) updateZone(domain string, resourceRecords []*ResourceRecord, nameServers []*models.Nameserver, zoneTTL uint32) error {
 	systemNameServer, err := api.findZoneSystemNameServer(domain)
 	if err != nil {

--- a/providers/autodns/api.go
+++ b/providers/autodns/api.go
@@ -99,7 +99,10 @@ func (api *autoDNSProvider) findZoneSystemNameServer(domain string) (*models.Nam
 	}
 
 	var responseObject JSONResponseDataZone
-	_ = json.Unmarshal(responseData, &responseObject)
+	if err := json.Unmarshal(responseData, &responseObject); err != nil {
+		return nil, err
+	}
+
 	if len(responseObject.Data) != 1 {
 		return nil, errors.New("Domain " + domain + " could not be found in AutoDNS")
 	}
@@ -124,9 +127,8 @@ func (api *autoDNSProvider) getZone(domain string) (*Zone, error) {
 
 	var responseObject JSONResponseDataZone
 	// make sure that the response is valid, the zone is in AutoDNS but we're not sure the returned data meets our expectation
-	unmErr := json.Unmarshal(responseData, &responseObject)
-	if unmErr != nil {
-		return nil, unmErr
+	if err := json.Unmarshal(responseData, &responseObject); err != nil {
+		return nil, err
 	}
 
 	return responseObject.Data[0], nil

--- a/providers/autodns/api.go
+++ b/providers/autodns/api.go
@@ -104,7 +104,7 @@ func (api *autoDNSProvider) findZoneSystemNameServer(domain string) (*models.Nam
 	}
 
 	if len(responseObject.Data) != 1 {
-		return nil, errors.New("Domain " + domain + " could not be found in AutoDNS")
+		return nil, errors.New("Zone " + domain + " could not be found in AutoDNS")
 	}
 
 	systemNameServer := &models.Nameserver{Name: responseObject.Data[0].SystemNameServer}

--- a/providers/autodns/auditrecords.go
+++ b/providers/autodns/auditrecords.go
@@ -11,7 +11,8 @@ import (
 func AuditRecords(records []*models.RecordConfig) []error {
 	a := rejectif.Auditor{}
 
-	a.Add("MX", rejectif.MxNull) // Last verified 2022-03-25
+	a.Add("MX", rejectif.MxNull)      // Last verified 2022-03-25
+	a.Add("TXT", rejectif.TxtIsEmpty) // Last verified 2025-05-13
 
 	return a.Audit(records)
 }

--- a/providers/autodns/autoDnsProvider.go
+++ b/providers/autodns/autoDnsProvider.go
@@ -243,6 +243,10 @@ func (api *autoDNSProvider) GetZoneRecords(domain string, meta map[string]string
 	return existingRecords, nil
 }
 
+func (api *autoDNSProvider) ListZones() ([]string, error) {
+	return api.getZones()
+}
+
 func toRecordConfig(domain string, record *ResourceRecord) (*models.RecordConfig, error) {
 	rc := &models.RecordConfig{
 		Type:     record.Type,

--- a/providers/autodns/types.go
+++ b/providers/autodns/types.go
@@ -61,8 +61,31 @@ type Zone struct {
 	SystemNameServer string `json:"virtualNameServer,omitempty"`
 }
 
+// Domain represents the Domain in API calls.
+// These are only present for domains where AUTODNS also is a registrar.
+type Domain struct {
+	Name string `json:"name,omitempty"`
+
+	NameServers []*NameServer `json:"nameServers"`
+	Zone        *Zone         `json:"zone,omitempty"`
+}
+
+type NameServer struct {
+	// Host name of the nameserver written as a Fully-Qualified-Domain-Name (FQDN).
+	Name string `json:"name"`
+	// Time-to-live value of the nameservers in seconds
+	TTL uint64 `json:"ttl,omitempty"`
+	// IPv4 and IPv6 addresses of the name server. For GLUE records only; optional. The values for the IP addresses are only relevant for domain operations and are only used there in the case of glue name servers.
+	IPAddresses []string `json:"ipAddresses,omitempty"`
+}
+
 // JSONResponseDataZone represents the response to the DataZone call.
 type JSONResponseDataZone struct {
 	// The data for the response. The type of the objects are depending on the request and are also specified in the responseObject value of the response.
 	Data []*Zone `json:"data"`
+}
+
+type JSONResponseDataDomain struct {
+	// The data for the response. The type of the objects are depending on the request and are also specified in the responseObject value of the response.
+	Data []*Domain `json:"data"`
 }


### PR DESCRIPTION
Best reviewed commit-by commit.

## ListZones 
We already advertised `providers.CanGetZones`, but `ZoneLister`'s `ListZones()` wasn't implemented yet. Adding support is very simple, we just need to `POST zone/_search` without filters. I made some of the error paths more concise (`if err := …; err != nil { … }`)

## EnsureZoneExists
This allows to create new zones. We do some error wrapping before to be able to distinguish a zone not existing from other failures, and then create the zone with dummy values, using the `POST /zone` endpoint.

## Registrar support
Use the `GET domain/{name}` endpoint to retrieve nameserver config of a domain, and use `PUT domain/{name}` to update it. Then `GetRegistrarCorrections` can simply compare the list of nameservers retrieved on `getDomain` with the desired values, and if different, do a (sparse) request to update these values.

I had to juggle some of the provider initialization around, to be able to use the same code for DomainServiceProvider and RegistrarType. We'll end up with two instances, but considering both deal with rate limiting it should be fine, and much more complicated if we'd try to aggregate clients based on the same settings, as rate-limits are per user.