### PR TITLE
GANDI_V5: BUGFIX: Uppercase labels fail to update

### DIFF
--- a/providers/gandiv5/gandi_v5Provider.go
+++ b/providers/gandiv5/gandi_v5Provider.go
@@ -254,14 +254,20 @@ func (client *gandiv5Provider) GetZoneRecordsCorrections(dc *models.DomainConfig
 		case diff2.CHANGE:
 			msgs := strings.Join(inst.Msgs, "\n")
 			domain := dc.Name
-			label := inst.Key.NameFQDN
-			shortname := dnsutil.TrimDomainName(label, dc.Name)
+			// DNSControl attempts to lowercase all labels (See Opinion #4 in
+			// https://docs.dnscontrol.org/developer-info/opinions).
+			// Sadly, the Gandi API has a bug (I consider it a bug) that to
+			// update the records at a particular label, the request must use
+			// the same case for the label as what is stored at Gandi.
+			// In other words, the update API is not case-insensitive for labels.
+			// Luckily we save the record as it came from the API in `.Original`.
+			originalRrsetName := inst.Old[0].Original.(livedns.DomainRecord).RrsetName
 			ns := recordsToNative(inst.New, dc.Name)
 			corrections = append(corrections,
 				&models.Correction{
 					Msg: msgs,
 					F: func() error {
-						res, err := g.UpdateDomainRecordsByName(domain, shortname, ns)
+						res, err := g.UpdateDomainRecordsByName(domain, originalRrsetName, ns)
 						if err != nil {
 							return fmt.Errorf("%+v ret=%03d: %w", res, res.Code, err)
 						}

--- a/providers/gandiv5/gandi_v5Provider.go
+++ b/providers/gandiv5/gandi_v5Provider.go
@@ -256,11 +256,16 @@ func (client *gandiv5Provider) GetZoneRecordsCorrections(dc *models.DomainConfig
 			domain := dc.Name
 			// DNSControl attempts to lowercase all labels (See Opinion #4 in
 			// https://docs.dnscontrol.org/developer-info/opinions).
-			// Sadly, the Gandi API has a bug (I consider it a bug) that to
-			// update the records at a particular label, the request must use
-			// the same case for the label as what is stored at Gandi.
-			// In other words, the update API is not case-insensitive for labels.
-			// Luckily we save the record as it came from the API in `.Original`.
+
+			// Sadly, the Gandi API has a bug (I consider it a bug) that to update the
+			// records at a particular label, the request must specify the label with the
+			// same case as what is stored at Gandi.   In other words, the update API does
+			// not use a case-insensitive comparison when looking up the label being
+			// updated.
+
+			// Luckily we save the record as it came from the API in
+			// `.Original`.  We can use that to gurantee we specify the label
+			// with the case that Gandi is expecting.
 			originalRrsetName := inst.Old[0].Original.(livedns.DomainRecord).RrsetName
 			ns := recordsToNative(inst.New, dc.Name)
 			corrections = append(corrections,


### PR DESCRIPTION
Fixes https://github.com/StackExchange/dnscontrol/issues/3581

# Issue

DNSControl attempts to lowercase all labels (See Opinion #4 in https://docs.dnscontrol.org/developer-info/opinions).

Sadly, the Gandi API has a bug (I consider it a bug) that to update the records at a particular label, the request must specify the label with the same case as what is stored at Gandi.   In other words, the update API does not use a case-insensitive comparison when looking up the label being updated.

# Resolution

Luckily we save the record as it came from the API in `.Original`.  We can use that to specify the label that Gandi expects.
