### PR TITLE
DOCS: document redirect types

### DIFF
--- a/documentation/language-reference/domain-modifiers/FRAME.md
+++ b/documentation/language-reference/domain-modifiers/FRAME.md
@@ -11,5 +11,11 @@ parameter_types:
 ---
 
 {% hint style="info" %}
-Documentation needed.
+This is provider specific type of record and not a DNS standard. It may behave differently for each provider that handles it.
 {% endhint %}
+
+### Namecheap
+
+This is a URL Redirect record with a type of "Masked", it creates a framed HTML page to the target.
+
+You can read more at the [Namecheap documentation](https://www.namecheap.com/support/knowledgebase/article.aspx/385/2237/how-to-set-up-a-url-redirect-for-a-domain/).

--- a/documentation/language-reference/domain-modifiers/URL.md
+++ b/documentation/language-reference/domain-modifiers/URL.md
@@ -11,5 +11,11 @@ parameter_types:
 ---
 
 {% hint style="info" %}
-Documentation needed.
+This is provider specific type of record and not a DNS standard. It may behave differently for each provider that handles it.
 {% endhint %}
+
+### Namecheap
+
+This is a URL Redirect record with a type of "Unmasked", it creates a 302 redirect to the target.
+
+You can read more at the [Namecheap documentation](https://www.namecheap.com/support/knowledgebase/article.aspx/385/2237/how-to-set-up-a-url-redirect-for-a-domain/)

--- a/documentation/language-reference/domain-modifiers/URL301.md
+++ b/documentation/language-reference/domain-modifiers/URL301.md
@@ -2,6 +2,7 @@
 name: URL301
 parameters:
   - name
+  - target
   - modifiers...
 parameter_types:
   name: string
@@ -10,5 +11,11 @@ parameter_types:
 ---
 
 {% hint style="info" %}
-Documentation needed.
+This is provider specific type of record and not a DNS standard. It may behave differently for each provider that handles it.
 {% endhint %}
+
+### Namecheap
+
+This is a URL Redirect record with a type of "Permanent", it creates a 301 redirect to the target.
+
+You can read more at the [Namecheap documentation](https://www.namecheap.com/support/knowledgebase/article.aspx/385/2237/how-to-set-up-a-url-redirect-for-a-domain/).


### PR DESCRIPTION
I've filled in some blanks after the recent fixing of the types in question.

I think I got them the right way round, I'm not sure what the `parameters` are but I thought they should at least match.

The types are mentioned in the vultr provider but I could not find any reference to redirect DNS in vultr itself and I don't have an account with them so I'm not sure if that should be mentioned here or left as is.
