### PR TITLE
Split provider table redibe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ dnscontrol-Darwin
 dnscontrol-Linux
 dnscontrol.exe
 dnscontrol
+/build/generate/generate
 /dnsconfig.js
 /creds.json
 ExternalDNS
@@ -25,6 +26,7 @@ stack.sh
 *.nupkg
 .DS_Store
 .vscode
+*.sw[a-p]
 .jekyll-cache
 types-dnscontrol.d.ts
 

--- a/documentation/dual-host.md
+++ b/documentation/dual-host.md
@@ -1,0 +1,16 @@
+# Dual Host
+
+The dual hosting feature of DNSControl provides
+for the ability to use multiple DNS providers simultaneously.
+Consult your provider docs to ensure that **both** of them support this feature.
+
+✅  - A checkmark means "this has been tested, and the provider works with dual hosting".  
+❔  - The questionmark means "it hasn't been tested, safety unknown"  
+❌  - The red "X" means "this has been tested, and it does _not_ work currently".  
+
+## Source reference
+
+[The source](https://github.com/StackExchange/dnscontrol/blob/cdbd54016f93140548d846842b0d7575603069c8/providers/capabilities.go#L93)
+states that this flag
+
+>  provider allows full management of apex NS records, so we can safely dual-host with another provider

--- a/documentation/provider/index.md
+++ b/documentation/provider/index.md
@@ -12,61 +12,313 @@ a provider that supports it, we'd love your contribution to ensure it works corr
 If a feature is definitively not supported for whatever reason, we would also like a PR to clarify why it is not supported, and fill in this entire matrix.
 
 <!-- provider-matrix-start -->
-| Provider name | Official Support | DNS Provider | Registrar | [Concurrency Verified](../concurrency-verified.md) | [`ALIAS`](../language-reference/domain-modifiers/ALIAS.md) | [`CAA`](../language-reference/domain-modifiers/CAA.md) | [`AUTODNSSEC`](../language-reference/domain-modifiers/AUTODNSSEC_ON.md) | [`HTTPS`](../language-reference/domain-modifiers/HTTPS.md) | [`LOC`](../language-reference/domain-modifiers/LOC.md) | [`NAPTR`](../language-reference/domain-modifiers/NAPTR.md) | [`PTR`](../language-reference/domain-modifiers/PTR.md) | [`SOA`](../language-reference/domain-modifiers/SOA.md) | [`SRV`](../language-reference/domain-modifiers/SRV.md) | [`SSHFP`](../language-reference/domain-modifiers/SSHFP.md) | [`SVCB`](../language-reference/domain-modifiers/SVCB.md) | [`TLSA`](../language-reference/domain-modifiers/TLSA.md) | [`DS`](../language-reference/domain-modifiers/DS.md) | [`DHCID`](../language-reference/domain-modifiers/DHCID.md) | [`DNAME`](../language-reference/domain-modifiers/DNAME.md) | [`DNSKEY`](../language-reference/domain-modifiers/DNSKEY.md) | dual host | create-domains | get-zones |
-| ------------- | ---------------- | ------------ | --------- | -------------------------------------------------- | ---------------------------------------------------------- | ------------------------------------------------------ | ----------------------------------------------------------------------- | ---------------------------------------------------------- | ------------------------------------------------------ | ---------------------------------------------------------- | ------------------------------------------------------ | ------------------------------------------------------ | ------------------------------------------------------ | ---------------------------------------------------------- | -------------------------------------------------------- | -------------------------------------------------------- | ---------------------------------------------------- | ---------------------------------------------------------- | ---------------------------------------------------------- | ------------------------------------------------------------ | --------- | -------------- | --------- |
-| [`AKAMAIEDGEDNS`](akamaiedgedns.md) | ❌ | ✅ | ❌ | ❔ | ❌ | ✅ | ✅ | ❔ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | ❔ | ✅ | ❌ | ❔ | ❔ | ❔ | ✅ | ✅ | ✅ |
-| [`AUTODNS`](autodns.md) | ❌ | ✅ | ✅ | ✅ | ✅ | ✅ | ❔ | ❔ | ❔ | ❔ | ✅ | ❔ | ✅ | ❌ | ❔ | ❌ | ❌ | ❔ | ❔ | ❔ | ❌ | ❌ | ✅ |
-| [`AXFRDDNS`](axfrddns.md) | ❌ | ✅ | ❌ | ✅ | ❌ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ |
-| [`AZURE_DNS`](azure_dns.md) | ✅ | ✅ | ❌ | ✅ | ❌ | ✅ | ❔ | ❔ | ❌ | ❌ | ✅ | ❔ | ✅ | ❌ | ❔ | ❌ | ❔ | ❔ | ❔ | ❔ | ✅ | ✅ | ✅ |
-| [`AZURE_PRIVATE_DNS`](azure_private_dns.md) | ✅ | ✅ | ❌ | ❔ | ❌ | ❌ | ❔ | ❔ | ❌ | ❌ | ✅ | ❔ | ✅ | ❌ | ❔ | ❌ | ❔ | ❔ | ❔ | ❔ | ✅ | ✅ | ✅ |
-| [`BIND`](bind.md) | ✅ | ✅ | ❌ | ✅ | ❔ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| [`BUNNY_DNS`](bunny_dns.md) | ❌ | ✅ | ❌ | ❔ | ✅ | ✅ | ✅ | ❔ | ❌ | ❌ | ✅ | ❌ | ✅ | ❌ | ❔ | ❌ | ❌ | ❌ | ❔ | ❔ | ❌ | ✅ | ✅ |
-| [`CLOUDFLAREAPI`](cloudflareapi.md) | ✅ | ✅ | ❌ | ✅ | ✅ | ✅ | ❔ | ✅ | ❌ | ✅ | ✅ | ❔ | ✅ | ✅ | ✅ | ✅ | ✅ | ❔ | ❔ | ❌ | ❌ | ✅ | ✅ |
-| [`CLOUDNS`](cloudns.md) | ❌ | ✅ | ❌ | ✅ | ✅ | ✅ | ✅ | ❔ | ✅ | ❔ | ✅ | ❔ | ✅ | ✅ | ❔ | ✅ | ❔ | ❔ | ✅ | ❔ | ❔ | ✅ | ✅ |
-| [`CNR`](cnr.md) | ❌ | ✅ | ✅ | ✅ | ✅ | ✅ | ❔ | ❌ | ❌ | ✅ | ✅ | ❌ | ✅ | ✅ | ❌ | ✅ | ❔ | ❌ | ❌ | ❔ | ✅ | ✅ | ✅ |
-| [`CSCGLOBAL`](cscglobal.md) | ✅ | ✅ | ✅ | ✅ | ❔ | ✅ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ✅ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❌ | ✅ |
-| [`DESEC`](desec.md) | ❌ | ✅ | ❌ | ✅ | ❔ | ✅ | ✅ | ✅ | ❔ | ✅ | ✅ | ❔ | ✅ | ✅ | ✅ | ✅ | ✅ | ❔ | ❔ | ✅ | ❔ | ✅ | ✅ |
-| [`DIGITALOCEAN`](digitalocean.md) | ❌ | ✅ | ❌ | ✅ | ❔ | ✅ | ❔ | ❔ | ❌ | ❔ | ❔ | ❔ | ✅ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ✅ | ✅ |
-| [`DNSIMPLE`](dnsimple.md) | ❌ | ✅ | ✅ | ❔ | ✅ | ✅ | ✅ | ❔ | ❌ | ✅ | ✅ | ❔ | ✅ | ✅ | ❔ | ❌ | ❌ | ❔ | ❔ | ❔ | ❌ | ❌ | ✅ |
-| [`DNSMADEEASY`](dnsmadeeasy.md) | ❌ | ✅ | ❌ | ❔ | ✅ | ✅ | ❔ | ❔ | ❌ | ❔ | ✅ | ❔ | ✅ | ❌ | ❔ | ❌ | ❌ | ❔ | ❔ | ❔ | ✅ | ✅ | ✅ |
-| [`DNSOVERHTTPS`](dnsoverhttps.md) | ❌ | ❌ | ✅ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❌ | ❔ |
-| [`DOMAINNAMESHOP`](domainnameshop.md) | ❌ | ✅ | ❌ | ❔ | ❔ | ✅ | ❌ | ❔ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ |
-| [`DYNADOT`](dynadot.md) | ❌ | ❌ | ✅ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❌ | ❔ |
-| [`EASYNAME`](easyname.md) | ❌ | ❌ | ✅ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❌ | ❔ |
-| [`EXOSCALE`](exoscale.md) | ❌ | ✅ | ❌ | ❔ | ✅ | ✅ | ❔ | ❔ | ❌ | ❔ | ✅ | ❔ | ✅ | ❔ | ❔ | ❌ | ❔ | ❔ | ❔ | ❔ | ❌ | ❌ | ❔ |
-| [`GANDI_V5`](gandi_v5.md) | ❌ | ✅ | ✅ | ✅ | ✅ | ✅ | ❔ | ❔ | ❌ | ❔ | ✅ | ❔ | ✅ | ✅ | ❔ | ✅ | ❌ | ❔ | ❔ | ❔ | ❔ | ❌ | ✅ |
-| [`GCLOUD`](gcloud.md) | ✅ | ✅ | ❌ | ✅ | ✅ | ✅ | ❔ | ✅ | ❌ | ❔ | ✅ | ❔ | ✅ | ✅ | ✅ | ✅ | ❔ | ❔ | ❔ | ❔ | ✅ | ✅ | ✅ |
-| [`GCORE`](gcore.md) | ❌ | ✅ | ❌ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ✅ | ❔ | ✅ | ❌ | ✅ | ❌ | ❌ | ❔ | ❔ | ❔ | ✅ | ✅ | ✅ |
-| [`HEDNS`](hedns.md) | ❌ | ✅ | ❌ | ❔ | ✅ | ✅ | ❌ | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | ✅ | ❌ | ❌ | ❔ | ❔ | ❔ | ✅ | ✅ | ✅ |
-| [`HETZNER`](hetzner.md) | ❌ | ✅ | ❌ | ✅ | ❌ | ✅ | ❌ | ❔ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❔ | ✅ | ✅ | ❔ | ❔ | ❔ | ✅ | ✅ | ✅ |
-| [`HEXONET`](hexonet.md) | ❌ | ✅ | ✅ | ❔ | ❌ | ✅ | ❔ | ❔ | ❔ | ❔ | ✅ | ❔ | ✅ | ❔ | ❔ | ✅ | ❔ | ❔ | ❔ | ❔ | ✅ | ✅ | ❔ |
-| [`HOSTINGDE`](hostingde.md) | ❌ | ✅ | ✅ | ❔ | ✅ | ✅ | ✅ | ❔ | ❌ | ❌ | ✅ | ✅ | ✅ | ✅ | ❔ | ✅ | ✅ | ❔ | ❔ | ❔ | ✅ | ✅ | ✅ |
-| [`HUAWEICLOUD`](huaweicloud.md) | ❌ | ✅ | ❌ | ❔ | ❌ | ✅ | ❔ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❔ | ❔ | ❔ | ✅ | ✅ | ✅ |
-| [`INTERNETBS`](internetbs.md) | ❌ | ❌ | ✅ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❌ | ❔ |
-| [`INWX`](inwx.md) | ❌ | ✅ | ✅ | ❔ | ✅ | ✅ | ✅ | ✅ | ❔ | ✅ | ✅ | ❔ | ✅ | ✅ | ✅ | ✅ | ❔ | ❔ | ❔ | ❔ | ✅ | ✅ | ✅ |
-| [`LINODE`](linode.md) | ❌ | ✅ | ❌ | ❔ | ❔ | ✅ | ❔ | ❔ | ❌ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❌ | ❌ | ✅ |
-| [`LOOPIA`](loopia.md) | ❌ | ✅ | ✅ | ❔ | ❌ | ✅ | ❌ | ❔ | ✅ | ✅ | ❌ | ❌ | ✅ | ✅ | ❔ | ✅ | ❌ | ❔ | ❔ | ❔ | ✅ | ❌ | ✅ |
-| [`LUADNS`](luadns.md) | ❌ | ✅ | ❌ | ❔ | ✅ | ✅ | ❔ | ❔ | ❌ | ❔ | ✅ | ❔ | ✅ | ✅ | ❔ | ✅ | ❔ | ❔ | ❔ | ❔ | ✅ | ✅ | ✅ |
-| [`MSDNS`](msdns.md) | ✅ | ✅ | ❌ | ❔ | ❌ | ❌ | ❔ | ❔ | ❌ | ✅ | ✅ | ❔ | ✅ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❌ | ❌ | ✅ |
-| [`MYTHICBEASTS`](mythicbeasts.md) | ❌ | ✅ | ❌ | ❔ | ❌ | ✅ | ❔ | ❔ | ❌ | ❔ | ✅ | ❔ | ✅ | ✅ | ❔ | ✅ | ❔ | ❔ | ❔ | ❔ | ✅ | ❌ | ✅ |
-| [`NAMECHEAP`](namecheap.md) | ❌ | ✅ | ✅ | ✅ | ✅ | ✅ | ❔ | ❔ | ❌ | ❔ | ❌ | ❔ | ❌ | ❔ | ❔ | ❌ | ❔ | ❔ | ❔ | ❔ | ❌ | ❌ | ✅ |
-| [`NAMEDOTCOM`](namedotcom.md) | ❌ | ✅ | ✅ | ❔ | ✅ | ❔ | ❔ | ❔ | ❌ | ❔ | ❌ | ❔ | ✅ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ✅ | ❌ | ✅ |
-| [`NETCUP`](netcup.md) | ❌ | ✅ | ❌ | ❔ | ❔ | ✅ | ❔ | ❔ | ❌ | ❔ | ❌ | ❔ | ✅ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❌ | ❌ | ❌ |
-| [`NETLIFY`](netlify.md) | ❌ | ✅ | ❌ | ✅ | ✅ | ✅ | ❌ | ❔ | ❌ | ❌ | ❌ | ❔ | ✅ | ❌ | ❔ | ❌ | ❌ | ❔ | ❔ | ❔ | ❌ | ❌ | ✅ |
-| [`NS1`](ns1.md) | ❌ | ✅ | ❌ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | ❔ | ✅ | ❔ | ✅ | ✅ | ✅ | ✅ | ✅ | ❔ | ✅ | ✅ | ✅ |
-| [`OPENSRS`](opensrs.md) | ❌ | ❌ | ✅ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❌ | ❔ |
-| [`ORACLE`](oracle.md) | ❌ | ✅ | ❌ | ❔ | ✅ | ✅ | ❔ | ❔ | ❔ | ✅ | ✅ | ❔ | ✅ | ✅ | ❔ | ✅ | ❌ | ❔ | ❔ | ❔ | ✅ | ✅ | ✅ |
-| [`OVH`](ovh.md) | ❌ | ✅ | ✅ | ❔ | ❌ | ✅ | ❔ | ❔ | ❔ | ❔ | ❌ | ❔ | ✅ | ✅ | ❔ | ✅ | ❔ | ❔ | ❔ | ❔ | ✅ | ❌ | ✅ |
-| [`PACKETFRAME`](packetframe.md) | ❌ | ✅ | ❌ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ✅ | ❔ | ✅ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❌ | ❌ | ❔ |
-| [`PORKBUN`](porkbun.md) | ❌ | ✅ | ✅ | ❔ | ✅ | ✅ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ | ✅ | ❌ | ❔ | ❔ | ❔ | ❌ | ❌ | ✅ |
-| [`POWERDNS`](powerdns.md) | ❌ | ✅ | ❌ | ❔ | ✅ | ✅ | ✅ | ✅ | ❔ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| [`REALTIMEREGISTER`](realtimeregister.md) | ❌ | ✅ | ✅ | ❔ | ✅ | ✅ | ✅ | ❔ | ✅ | ✅ | ❌ | ❌ | ✅ | ✅ | ❔ | ✅ | ❌ | ❌ | ❔ | ❔ | ❌ | ✅ | ✅ |
-| [`ROUTE53`](route53.md) | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ❔ | ✅ | ❌ | ❔ | ✅ | ❔ | ✅ | ✅ | ✅ | ✅ | ❔ | ❔ | ❔ | ❔ | ✅ | ✅ | ✅ |
-| [`RWTH`](rwth.md) | ❌ | ✅ | ❌ | ❔ | ❌ | ✅ | ❔ | ❔ | ❌ | ❌ | ✅ | ❔ | ✅ | ✅ | ❔ | ❌ | ❔ | ❔ | ❔ | ❔ | ❌ | ❌ | ✅ |
-| [`SAKURACLOUD`](sakuracloud.md) | ❌ | ✅ | ❌ | ❔ | ✅ | ✅ | ❌ | ✅ | ❌ | ❌ | ✅ | ❌ | ✅ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ |
-| [`SOFTLAYER`](softlayer.md) | ❌ | ✅ | ❌ | ❔ | ❔ | ❔ | ❔ | ❔ | ❌ | ❔ | ❔ | ❔ | ✅ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❔ | ❌ | ❔ |
-| [`TRANSIP`](transip.md) | ❌ | ✅ | ❌ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ✅ | ✅ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ |
-| [`VULTR`](vultr.md) | ❌ | ✅ | ❌ | ❔ | ❌ | ✅ | ❔ | ❔ | ❌ | ❔ | ❌ | ❔ | ✅ | ✅ | ❔ | ❌ | ❔ | ❔ | ❔ | ❔ | ❔ | ✅ | ✅ |
+
+### Provider Type <!--(table 1/6)-->
+
+| Provider name | Official Support | DNS Provider | Registrar |
+| ------------- | ---------------- | ------------ | --------- |
+| [`AKAMAIEDGEDNS`](akamaiedgedns.md) | ❌ | ✅ | ❌ |
+| [`AUTODNS`](autodns.md) | ❌ | ✅ | ✅ |
+| [`AXFRDDNS`](axfrddns.md) | ❌ | ✅ | ❌ |
+| [`AZURE_DNS`](azure_dns.md) | ✅ | ✅ | ❌ |
+| [`AZURE_PRIVATE_DNS`](azure_private_dns.md) | ✅ | ✅ | ❌ |
+| [`BIND`](bind.md) | ✅ | ✅ | ❌ |
+| [`BUNNY_DNS`](bunny_dns.md) | ❌ | ✅ | ❌ |
+| [`CLOUDFLAREAPI`](cloudflareapi.md) | ✅ | ✅ | ❌ |
+| [`CLOUDNS`](cloudns.md) | ❌ | ✅ | ❌ |
+| [`CNR`](cnr.md) | ❌ | ✅ | ✅ |
+| [`CSCGLOBAL`](cscglobal.md) | ✅ | ✅ | ✅ |
+| [`DESEC`](desec.md) | ❌ | ✅ | ❌ |
+| [`DIGITALOCEAN`](digitalocean.md) | ❌ | ✅ | ❌ |
+| [`DNSIMPLE`](dnsimple.md) | ❌ | ✅ | ✅ |
+| [`DNSMADEEASY`](dnsmadeeasy.md) | ❌ | ✅ | ❌ |
+| [`DNSOVERHTTPS`](dnsoverhttps.md) | ❌ | ❌ | ✅ |
+| [`DOMAINNAMESHOP`](domainnameshop.md) | ❌ | ✅ | ❌ |
+| [`DYNADOT`](dynadot.md) | ❌ | ❌ | ✅ |
+| [`EASYNAME`](easyname.md) | ❌ | ❌ | ✅ |
+| [`EXOSCALE`](exoscale.md) | ❌ | ✅ | ❌ |
+| [`GANDI_V5`](gandi_v5.md) | ❌ | ✅ | ✅ |
+| [`GCLOUD`](gcloud.md) | ✅ | ✅ | ❌ |
+| [`GCORE`](gcore.md) | ❌ | ✅ | ❌ |
+| [`HEDNS`](hedns.md) | ❌ | ✅ | ❌ |
+| [`HETZNER`](hetzner.md) | ❌ | ✅ | ❌ |
+| [`HEXONET`](hexonet.md) | ❌ | ✅ | ✅ |
+| [`HOSTINGDE`](hostingde.md) | ❌ | ✅ | ✅ |
+| [`HUAWEICLOUD`](huaweicloud.md) | ❌ | ✅ | ❌ |
+| [`INTERNETBS`](internetbs.md) | ❌ | ❌ | ✅ |
+| [`INWX`](inwx.md) | ❌ | ✅ | ✅ |
+| [`LINODE`](linode.md) | ❌ | ✅ | ❌ |
+| [`LOOPIA`](loopia.md) | ❌ | ✅ | ✅ |
+| [`LUADNS`](luadns.md) | ❌ | ✅ | ❌ |
+| [`MSDNS`](msdns.md) | ✅ | ✅ | ❌ |
+| [`MYTHICBEASTS`](mythicbeasts.md) | ❌ | ✅ | ❌ |
+| [`NAMECHEAP`](namecheap.md) | ❌ | ✅ | ✅ |
+| [`NAMEDOTCOM`](namedotcom.md) | ❌ | ✅ | ✅ |
+| [`NETCUP`](netcup.md) | ❌ | ✅ | ❌ |
+| [`NETLIFY`](netlify.md) | ❌ | ✅ | ❌ |
+| [`NS1`](ns1.md) | ❌ | ✅ | ❌ |
+| [`OPENSRS`](opensrs.md) | ❌ | ❌ | ✅ |
+| [`ORACLE`](oracle.md) | ❌ | ✅ | ❌ |
+| [`OVH`](ovh.md) | ❌ | ✅ | ✅ |
+| [`PACKETFRAME`](packetframe.md) | ❌ | ✅ | ❌ |
+| [`PORKBUN`](porkbun.md) | ❌ | ✅ | ✅ |
+| [`POWERDNS`](powerdns.md) | ❌ | ✅ | ❌ |
+| [`REALTIMEREGISTER`](realtimeregister.md) | ❌ | ✅ | ✅ |
+| [`ROUTE53`](route53.md) | ✅ | ✅ | ✅ |
+| [`RWTH`](rwth.md) | ❌ | ✅ | ❌ |
+| [`SAKURACLOUD`](sakuracloud.md) | ❌ | ✅ | ❌ |
+| [`SOFTLAYER`](softlayer.md) | ❌ | ✅ | ❌ |
+| [`TRANSIP`](transip.md) | ❌ | ✅ | ❌ |
+| [`VULTR`](vultr.md) | ❌ | ✅ | ❌ |
+
+
+### Provider API <!--(table 2/6)-->
+
+| Provider name | [Concurrency Verified](../concurrency-verified.md) | [dual host](../dual-host.md) | create-domains | get-zones |
+| ------------- | -------------------------------------------------- | ---------------------------- | -------------- | --------- |
+| [`AKAMAIEDGEDNS`](akamaiedgedns.md) | ❔ | ✅ | ✅ | ✅ |
+| [`AUTODNS`](autodns.md) | ✅ | ❌ | ❌ | ✅ |
+| [`AXFRDDNS`](axfrddns.md) | ✅ | ❌ | ❌ | ❌ |
+| [`AZURE_DNS`](azure_dns.md) | ✅ | ✅ | ✅ | ✅ |
+| [`AZURE_PRIVATE_DNS`](azure_private_dns.md) | ❔ | ✅ | ✅ | ✅ |
+| [`BIND`](bind.md) | ✅ | ✅ | ✅ | ✅ |
+| [`BUNNY_DNS`](bunny_dns.md) | ❔ | ❌ | ✅ | ✅ |
+| [`CLOUDFLAREAPI`](cloudflareapi.md) | ✅ | ❌ | ✅ | ✅ |
+| [`CLOUDNS`](cloudns.md) | ✅ | ❔ | ✅ | ✅ |
+| [`CNR`](cnr.md) | ✅ | ✅ | ✅ | ✅ |
+| [`CSCGLOBAL`](cscglobal.md) | ✅ | ❔ | ❌ | ✅ |
+| [`DESEC`](desec.md) | ✅ | ❔ | ✅ | ✅ |
+| [`DIGITALOCEAN`](digitalocean.md) | ✅ | ❔ | ✅ | ✅ |
+| [`DNSIMPLE`](dnsimple.md) | ❔ | ❌ | ❌ | ✅ |
+| [`DNSMADEEASY`](dnsmadeeasy.md) | ❔ | ✅ | ✅ | ✅ |
+| [`DNSOVERHTTPS`](dnsoverhttps.md) | ❔ | ❔ | ❌ | ❔ |
+| [`DYNADOT`](dynadot.md) | ❔ | ❔ | ❌ | ❔ |
+| [`EASYNAME`](easyname.md) | ❔ | ❔ | ❌ | ❔ |
+| [`EXOSCALE`](exoscale.md) | ❔ | ❌ | ❌ | ❔ |
+| [`GANDI_V5`](gandi_v5.md) | ✅ | ❔ | ❌ | ✅ |
+| [`GCLOUD`](gcloud.md) | ✅ | ✅ | ✅ | ✅ |
+| [`GCORE`](gcore.md) | ✅ | ✅ | ✅ | ✅ |
+| [`HEDNS`](hedns.md) | ❔ | ✅ | ✅ | ✅ |
+| [`HETZNER`](hetzner.md) | ✅ | ✅ | ✅ | ✅ |
+| [`HEXONET`](hexonet.md) | ❔ | ✅ | ✅ | ❔ |
+| [`HOSTINGDE`](hostingde.md) | ❔ | ✅ | ✅ | ✅ |
+| [`HUAWEICLOUD`](huaweicloud.md) | ❔ | ✅ | ✅ | ✅ |
+| [`INTERNETBS`](internetbs.md) | ❔ | ❔ | ❌ | ❔ |
+| [`INWX`](inwx.md) | ❔ | ✅ | ✅ | ✅ |
+| [`LINODE`](linode.md) | ❔ | ❌ | ❌ | ✅ |
+| [`LOOPIA`](loopia.md) | ❔ | ✅ | ❌ | ✅ |
+| [`LUADNS`](luadns.md) | ❔ | ✅ | ✅ | ✅ |
+| [`MSDNS`](msdns.md) | ❔ | ❌ | ❌ | ✅ |
+| [`MYTHICBEASTS`](mythicbeasts.md) | ❔ | ✅ | ❌ | ✅ |
+| [`NAMECHEAP`](namecheap.md) | ✅ | ❌ | ❌ | ✅ |
+| [`NAMEDOTCOM`](namedotcom.md) | ❔ | ✅ | ❌ | ✅ |
+| [`NETCUP`](netcup.md) | ❔ | ❌ | ❌ | ❌ |
+| [`NETLIFY`](netlify.md) | ✅ | ❌ | ❌ | ✅ |
+| [`NS1`](ns1.md) | ✅ | ✅ | ✅ | ✅ |
+| [`OPENSRS`](opensrs.md) | ❔ | ❔ | ❌ | ❔ |
+| [`ORACLE`](oracle.md) | ❔ | ✅ | ✅ | ✅ |
+| [`OVH`](ovh.md) | ❔ | ✅ | ❌ | ✅ |
+| [`PACKETFRAME`](packetframe.md) | ❔ | ❌ | ❌ | ❔ |
+| [`PORKBUN`](porkbun.md) | ❔ | ❌ | ❌ | ✅ |
+| [`POWERDNS`](powerdns.md) | ❔ | ✅ | ✅ | ✅ |
+| [`REALTIMEREGISTER`](realtimeregister.md) | ❔ | ❌ | ✅ | ✅ |
+| [`ROUTE53`](route53.md) | ✅ | ✅ | ✅ | ✅ |
+| [`RWTH`](rwth.md) | ❔ | ❌ | ❌ | ✅ |
+| [`SAKURACLOUD`](sakuracloud.md) | ❔ | ❌ | ✅ | ✅ |
+| [`SOFTLAYER`](softlayer.md) | ❔ | ❔ | ❌ | ❔ |
+| [`TRANSIP`](transip.md) | ✅ | ❌ | ❌ | ✅ |
+| [`VULTR`](vultr.md) | ❔ | ❔ | ✅ | ✅ |
+
+
+### DNS extensions <!--(table 3/6)-->
+
+| Provider name | [`ALIAS`](../language-reference/domain-modifiers/ALIAS.md) | [`DNAME`](../language-reference/domain-modifiers/DNAME.md) | [`LOC`](../language-reference/domain-modifiers/LOC.md) | [`PTR`](../language-reference/domain-modifiers/PTR.md) | [`SOA`](../language-reference/domain-modifiers/SOA.md) |
+| ------------- | ---------------------------------------------------------- | ---------------------------------------------------------- | ------------------------------------------------------ | ------------------------------------------------------ | ------------------------------------------------------ |
+| [`AKAMAIEDGEDNS`](akamaiedgedns.md) | ❌ | ❔ | ✅ | ✅ | ❌ |
+| [`AUTODNS`](autodns.md) | ✅ | ❔ | ❔ | ✅ | ❔ |
+| [`AXFRDDNS`](axfrddns.md) | ❌ | ✅ | ✅ | ✅ | ❌ |
+| [`AZURE_DNS`](azure_dns.md) | ❌ | ❔ | ❌ | ✅ | ❔ |
+| [`AZURE_PRIVATE_DNS`](azure_private_dns.md) | ❌ | ❔ | ❌ | ✅ | ❔ |
+| [`BIND`](bind.md) | ❔ | ✅ | ✅ | ✅ | ✅ |
+| [`BUNNY_DNS`](bunny_dns.md) | ✅ | ❔ | ❌ | ✅ | ❌ |
+| [`CLOUDFLAREAPI`](cloudflareapi.md) | ✅ | ❔ | ❌ | ✅ | ❔ |
+| [`CLOUDNS`](cloudns.md) | ✅ | ✅ | ✅ | ✅ | ❔ |
+| [`CNR`](cnr.md) | ✅ | ❌ | ❌ | ✅ | ❌ |
+| [`DESEC`](desec.md) | ❔ | ❔ | ❔ | ✅ | ❔ |
+| [`DIGITALOCEAN`](digitalocean.md) | ❔ | ❔ | ❌ | ❔ | ❔ |
+| [`DNSIMPLE`](dnsimple.md) | ✅ | ❔ | ❌ | ✅ | ❔ |
+| [`DNSMADEEASY`](dnsmadeeasy.md) | ✅ | ❔ | ❌ | ✅ | ❔ |
+| [`DOMAINNAMESHOP`](domainnameshop.md) | ❔ | ❔ | ❌ | ❌ | ❌ |
+| [`EXOSCALE`](exoscale.md) | ✅ | ❔ | ❌ | ✅ | ❔ |
+| [`GANDI_V5`](gandi_v5.md) | ✅ | ❔ | ❌ | ✅ | ❔ |
+| [`GCLOUD`](gcloud.md) | ✅ | ❔ | ❌ | ✅ | ❔ |
+| [`GCORE`](gcore.md) | ✅ | ❔ | ❌ | ✅ | ❔ |
+| [`HEDNS`](hedns.md) | ✅ | ❔ | ✅ | ✅ | ❌ |
+| [`HETZNER`](hetzner.md) | ❌ | ❔ | ❌ | ❌ | ❌ |
+| [`HEXONET`](hexonet.md) | ❌ | ❔ | ❔ | ✅ | ❔ |
+| [`HOSTINGDE`](hostingde.md) | ✅ | ❔ | ❌ | ✅ | ✅ |
+| [`HUAWEICLOUD`](huaweicloud.md) | ❌ | ❔ | ❌ | ❌ | ❌ |
+| [`INWX`](inwx.md) | ✅ | ❔ | ❔ | ✅ | ❔ |
+| [`LINODE`](linode.md) | ❔ | ❔ | ❌ | ❔ | ❔ |
+| [`LOOPIA`](loopia.md) | ❌ | ❔ | ✅ | ❌ | ❌ |
+| [`LUADNS`](luadns.md) | ✅ | ❔ | ❌ | ✅ | ❔ |
+| [`MSDNS`](msdns.md) | ❌ | ❔ | ❌ | ✅ | ❔ |
+| [`MYTHICBEASTS`](mythicbeasts.md) | ❌ | ❔ | ❌ | ✅ | ❔ |
+| [`NAMECHEAP`](namecheap.md) | ✅ | ❔ | ❌ | ❌ | ❔ |
+| [`NAMEDOTCOM`](namedotcom.md) | ✅ | ❔ | ❌ | ❌ | ❔ |
+| [`NETCUP`](netcup.md) | ❔ | ❔ | ❌ | ❌ | ❔ |
+| [`NETLIFY`](netlify.md) | ✅ | ❔ | ❌ | ❌ | ❔ |
+| [`NS1`](ns1.md) | ✅ | ✅ | ❌ | ✅ | ❔ |
+| [`ORACLE`](oracle.md) | ✅ | ❔ | ❔ | ✅ | ❔ |
+| [`OVH`](ovh.md) | ❌ | ❔ | ❔ | ❌ | ❔ |
+| [`PACKETFRAME`](packetframe.md) | ❔ | ❔ | ❔ | ✅ | ❔ |
+| [`PORKBUN`](porkbun.md) | ✅ | ❔ | ❌ | ❌ | ❌ |
+| [`POWERDNS`](powerdns.md) | ✅ | ✅ | ❔ | ✅ | ✅ |
+| [`REALTIMEREGISTER`](realtimeregister.md) | ✅ | ❔ | ✅ | ❌ | ❌ |
+| [`ROUTE53`](route53.md) | ❌ | ❔ | ❌ | ✅ | ❔ |
+| [`RWTH`](rwth.md) | ❌ | ❔ | ❌ | ✅ | ❔ |
+| [`SAKURACLOUD`](sakuracloud.md) | ✅ | ❌ | ❌ | ✅ | ❌ |
+| [`SOFTLAYER`](softlayer.md) | ❔ | ❔ | ❌ | ❔ | ❔ |
+| [`TRANSIP`](transip.md) | ✅ | ❌ | ❌ | ❌ | ❌ |
+| [`VULTR`](vultr.md) | ❌ | ❔ | ❌ | ❌ | ❔ |
+
+
+### Service discovery <!--(table 4/6)-->
+
+| Provider name | [`DHCID`](../language-reference/domain-modifiers/DHCID.md) | [`NAPTR`](../language-reference/domain-modifiers/NAPTR.md) | [`SRV`](../language-reference/domain-modifiers/SRV.md) | [`SVCB`](../language-reference/domain-modifiers/SVCB.md) |
+| ------------- | ---------------------------------------------------------- | ---------------------------------------------------------- | ------------------------------------------------------ | -------------------------------------------------------- |
+| [`AKAMAIEDGEDNS`](akamaiedgedns.md) | ❔ | ✅ | ✅ | ❔ |
+| [`AUTODNS`](autodns.md) | ❔ | ❔ | ✅ | ❔ |
+| [`AXFRDDNS`](axfrddns.md) | ✅ | ✅ | ✅ | ✅ |
+| [`AZURE_DNS`](azure_dns.md) | ❔ | ❌ | ✅ | ❔ |
+| [`AZURE_PRIVATE_DNS`](azure_private_dns.md) | ❔ | ❌ | ✅ | ❔ |
+| [`BIND`](bind.md) | ✅ | ✅ | ✅ | ✅ |
+| [`BUNNY_DNS`](bunny_dns.md) | ❌ | ❌ | ✅ | ❔ |
+| [`CLOUDFLAREAPI`](cloudflareapi.md) | ❔ | ✅ | ✅ | ✅ |
+| [`CLOUDNS`](cloudns.md) | ❔ | ❔ | ✅ | ❔ |
+| [`CNR`](cnr.md) | ❌ | ✅ | ✅ | ❌ |
+| [`CSCGLOBAL`](cscglobal.md) | ❔ | ❔ | ✅ | ❔ |
+| [`DESEC`](desec.md) | ❔ | ✅ | ✅ | ✅ |
+| [`DIGITALOCEAN`](digitalocean.md) | ❔ | ❔ | ✅ | ❔ |
+| [`DNSIMPLE`](dnsimple.md) | ❔ | ✅ | ✅ | ❔ |
+| [`DNSMADEEASY`](dnsmadeeasy.md) | ❔ | ❔ | ✅ | ❔ |
+| [`DOMAINNAMESHOP`](domainnameshop.md) | ❔ | ❌ | ✅ | ❔ |
+| [`EXOSCALE`](exoscale.md) | ❔ | ❔ | ✅ | ❔ |
+| [`GANDI_V5`](gandi_v5.md) | ❔ | ❔ | ✅ | ❔ |
+| [`GCLOUD`](gcloud.md) | ❔ | ❔ | ✅ | ✅ |
+| [`GCORE`](gcore.md) | ❔ | ❌ | ✅ | ✅ |
+| [`HEDNS`](hedns.md) | ❔ | ✅ | ✅ | ✅ |
+| [`HETZNER`](hetzner.md) | ❔ | ❌ | ✅ | ❔ |
+| [`HEXONET`](hexonet.md) | ❔ | ❔ | ✅ | ❔ |
+| [`HOSTINGDE`](hostingde.md) | ❔ | ❌ | ✅ | ❔ |
+| [`HUAWEICLOUD`](huaweicloud.md) | ❔ | ❌ | ✅ | ❌ |
+| [`INWX`](inwx.md) | ❔ | ✅ | ✅ | ✅ |
+| [`LOOPIA`](loopia.md) | ❔ | ✅ | ✅ | ❔ |
+| [`LUADNS`](luadns.md) | ❔ | ❔ | ✅ | ❔ |
+| [`MSDNS`](msdns.md) | ❔ | ✅ | ✅ | ❔ |
+| [`MYTHICBEASTS`](mythicbeasts.md) | ❔ | ❔ | ✅ | ❔ |
+| [`NAMECHEAP`](namecheap.md) | ❔ | ❔ | ❌ | ❔ |
+| [`NAMEDOTCOM`](namedotcom.md) | ❔ | ❔ | ✅ | ❔ |
+| [`NETCUP`](netcup.md) | ❔ | ❔ | ✅ | ❔ |
+| [`NETLIFY`](netlify.md) | ❔ | ❌ | ✅ | ❔ |
+| [`NS1`](ns1.md) | ✅ | ✅ | ✅ | ✅ |
+| [`ORACLE`](oracle.md) | ❔ | ✅ | ✅ | ❔ |
+| [`OVH`](ovh.md) | ❔ | ❔ | ✅ | ❔ |
+| [`PACKETFRAME`](packetframe.md) | ❔ | ❔ | ✅ | ❔ |
+| [`PORKBUN`](porkbun.md) | ❔ | ❌ | ✅ | ✅ |
+| [`POWERDNS`](powerdns.md) | ✅ | ✅ | ✅ | ✅ |
+| [`REALTIMEREGISTER`](realtimeregister.md) | ❌ | ✅ | ✅ | ❔ |
+| [`ROUTE53`](route53.md) | ❔ | ❔ | ✅ | ✅ |
+| [`RWTH`](rwth.md) | ❔ | ❌ | ✅ | ❔ |
+| [`SAKURACLOUD`](sakuracloud.md) | ❌ | ❌ | ✅ | ✅ |
+| [`SOFTLAYER`](softlayer.md) | ❔ | ❔ | ✅ | ❔ |
+| [`TRANSIP`](transip.md) | ❌ | ✅ | ✅ | ❌ |
+| [`VULTR`](vultr.md) | ❔ | ❔ | ✅ | ❔ |
+
+
+### Security <!--(table 5/6)-->
+
+| Provider name | [`CAA`](../language-reference/domain-modifiers/CAA.md) | [`HTTPS`](../language-reference/domain-modifiers/HTTPS.md) | [`SSHFP`](../language-reference/domain-modifiers/SSHFP.md) | [`TLSA`](../language-reference/domain-modifiers/TLSA.md) |
+| ------------- | ------------------------------------------------------ | ---------------------------------------------------------- | ---------------------------------------------------------- | -------------------------------------------------------- |
+| [`AKAMAIEDGEDNS`](akamaiedgedns.md) | ✅ | ❔ | ✅ | ✅ |
+| [`AUTODNS`](autodns.md) | ✅ | ❔ | ❌ | ❌ |
+| [`AXFRDDNS`](axfrddns.md) | ✅ | ✅ | ✅ | ✅ |
+| [`AZURE_DNS`](azure_dns.md) | ✅ | ❔ | ❌ | ❌ |
+| [`AZURE_PRIVATE_DNS`](azure_private_dns.md) | ❌ | ❔ | ❌ | ❌ |
+| [`BIND`](bind.md) | ✅ | ✅ | ✅ | ✅ |
+| [`BUNNY_DNS`](bunny_dns.md) | ✅ | ❔ | ❌ | ❌ |
+| [`CLOUDFLAREAPI`](cloudflareapi.md) | ✅ | ✅ | ✅ | ✅ |
+| [`CLOUDNS`](cloudns.md) | ✅ | ❔ | ✅ | ✅ |
+| [`CNR`](cnr.md) | ✅ | ❌ | ✅ | ✅ |
+| [`CSCGLOBAL`](cscglobal.md) | ✅ | ❔ | ❔ | ❔ |
+| [`DESEC`](desec.md) | ✅ | ✅ | ✅ | ✅ |
+| [`DIGITALOCEAN`](digitalocean.md) | ✅ | ❔ | ❔ | ❔ |
+| [`DNSIMPLE`](dnsimple.md) | ✅ | ❔ | ✅ | ❌ |
+| [`DNSMADEEASY`](dnsmadeeasy.md) | ✅ | ❔ | ❌ | ❌ |
+| [`DOMAINNAMESHOP`](domainnameshop.md) | ✅ | ❔ | ❌ | ❔ |
+| [`EXOSCALE`](exoscale.md) | ✅ | ❔ | ❔ | ❌ |
+| [`GANDI_V5`](gandi_v5.md) | ✅ | ❔ | ✅ | ✅ |
+| [`GCLOUD`](gcloud.md) | ✅ | ✅ | ✅ | ✅ |
+| [`GCORE`](gcore.md) | ✅ | ✅ | ❌ | ❌ |
+| [`HEDNS`](hedns.md) | ✅ | ✅ | ✅ | ❌ |
+| [`HETZNER`](hetzner.md) | ✅ | ❔ | ❌ | ✅ |
+| [`HEXONET`](hexonet.md) | ✅ | ❔ | ❔ | ✅ |
+| [`HOSTINGDE`](hostingde.md) | ✅ | ❔ | ✅ | ✅ |
+| [`HUAWEICLOUD`](huaweicloud.md) | ✅ | ❌ | ❌ | ❌ |
+| [`INWX`](inwx.md) | ✅ | ✅ | ✅ | ✅ |
+| [`LINODE`](linode.md) | ✅ | ❔ | ❔ | ❔ |
+| [`LOOPIA`](loopia.md) | ✅ | ❔ | ✅ | ✅ |
+| [`LUADNS`](luadns.md) | ✅ | ❔ | ✅ | ✅ |
+| [`MSDNS`](msdns.md) | ❌ | ❔ | ❔ | ❔ |
+| [`MYTHICBEASTS`](mythicbeasts.md) | ✅ | ❔ | ✅ | ✅ |
+| [`NAMECHEAP`](namecheap.md) | ✅ | ❔ | ❔ | ❌ |
+| [`NETCUP`](netcup.md) | ✅ | ❔ | ❔ | ❔ |
+| [`NETLIFY`](netlify.md) | ✅ | ❔ | ❌ | ❌ |
+| [`NS1`](ns1.md) | ✅ | ✅ | ❔ | ✅ |
+| [`ORACLE`](oracle.md) | ✅ | ❔ | ✅ | ✅ |
+| [`OVH`](ovh.md) | ✅ | ❔ | ✅ | ✅ |
+| [`PORKBUN`](porkbun.md) | ✅ | ✅ | ❌ | ✅ |
+| [`POWERDNS`](powerdns.md) | ✅ | ✅ | ✅ | ✅ |
+| [`REALTIMEREGISTER`](realtimeregister.md) | ✅ | ❔ | ✅ | ✅ |
+| [`ROUTE53`](route53.md) | ✅ | ✅ | ✅ | ✅ |
+| [`RWTH`](rwth.md) | ✅ | ❔ | ✅ | ❌ |
+| [`SAKURACLOUD`](sakuracloud.md) | ✅ | ✅ | ❌ | ❌ |
+| [`TRANSIP`](transip.md) | ✅ | ❌ | ✅ | ✅ |
+| [`VULTR`](vultr.md) | ✅ | ❔ | ✅ | ❌ |
+
+
+### DNSSEC <!--(table 6/6)-->
+
+| Provider name | [`AUTODNSSEC`](../language-reference/domain-modifiers/AUTODNSSEC_ON.md) | [`DNSKEY`](../language-reference/domain-modifiers/DNSKEY.md) | [`DS`](../language-reference/domain-modifiers/DS.md) |
+| ------------- | ----------------------------------------------------------------------- | ------------------------------------------------------------ | ---------------------------------------------------- |
+| [`AKAMAIEDGEDNS`](akamaiedgedns.md) | ✅ | ❔ | ❌ |
+| [`AUTODNS`](autodns.md) | ❔ | ❔ | ❌ |
+| [`AXFRDDNS`](axfrddns.md) | ✅ | ❌ | ✅ |
+| [`BIND`](bind.md) | ✅ | ✅ | ✅ |
+| [`BUNNY_DNS`](bunny_dns.md) | ✅ | ❔ | ❌ |
+| [`CLOUDFLAREAPI`](cloudflareapi.md) | ❔ | ❌ | ✅ |
+| [`CLOUDNS`](cloudns.md) | ✅ | ❔ | ❔ |
+| [`DESEC`](desec.md) | ✅ | ✅ | ✅ |
+| [`DNSIMPLE`](dnsimple.md) | ✅ | ❔ | ❌ |
+| [`DNSMADEEASY`](dnsmadeeasy.md) | ❔ | ❔ | ❌ |
+| [`DOMAINNAMESHOP`](domainnameshop.md) | ❌ | ❔ | ❔ |
+| [`GANDI_V5`](gandi_v5.md) | ❔ | ❔ | ❌ |
+| [`GCORE`](gcore.md) | ✅ | ❔ | ❌ |
+| [`HEDNS`](hedns.md) | ❌ | ❔ | ❌ |
+| [`HETZNER`](hetzner.md) | ❌ | ❔ | ✅ |
+| [`HOSTINGDE`](hostingde.md) | ✅ | ❔ | ✅ |
+| [`HUAWEICLOUD`](huaweicloud.md) | ❔ | ❔ | ❌ |
+| [`INWX`](inwx.md) | ✅ | ❔ | ❔ |
+| [`LOOPIA`](loopia.md) | ❌ | ❔ | ❌ |
+| [`NETLIFY`](netlify.md) | ❌ | ❔ | ❌ |
+| [`NS1`](ns1.md) | ✅ | ❔ | ✅ |
+| [`ORACLE`](oracle.md) | ❔ | ❔ | ❌ |
+| [`PORKBUN`](porkbun.md) | ❌ | ❔ | ❌ |
+| [`POWERDNS`](powerdns.md) | ✅ | ✅ | ✅ |
+| [`REALTIMEREGISTER`](realtimeregister.md) | ✅ | ❔ | ❌ |
+| [`SAKURACLOUD`](sakuracloud.md) | ❌ | ❌ | ❌ |
+| [`TRANSIP`](transip.md) | ❌ | ❌ | ❌ |
+
 <!-- provider-matrix-end -->
 
 ### Providers with "official support"


### PR DESCRIPTION
<!--
## Before submiting a pull request

Please make sure you've run the following commands from the root directory.

go vet ./...
go fmt ./...
go generate ./...
go mod tidy

## Release changelog section

Help keep the release changelog clear by pre-naming the proper section in the GitHub pull request title.

Some examples:
* CICD: Add required GHA permissions for goreleaser
* DOCS: Fixed providers with "contributor support" table
* ROUTE53: Allow R53_ALIAS records to enable target health evaluation

More examples/context can be found in the file .goreleaser.yml under the 'build' > 'changelog' key.
!-->

# context

#3305 notes that the provider feature table does not display well in the GitBook-based documentation site.

This has also been brought up in a couple of the monthly live calls.

I tried to do this in #3579 but rebase led to weird merge conflicts so I started with a fresh branch.

# progress

This PR splits the features into different groups for different tables.  It generates the tables with H3 headings.  The changes to the generator and the documentation are included in this PR.

Some additions to `/.gitignore` are also included.

# future

Updating individual provider pages (#3584) is coming next.