### PR TITLE
CNR: Update docs with proper Nameserver example

### DIFF
--- a/documentation/provider/cnr.md
+++ b/documentation/provider/cnr.md
@@ -90,10 +90,9 @@ DEFAULTS(
 );
 
 D("example.com", REG_CNR, DnsProvider(DSP_CNR),
-    NAMESERVER("ns1.rrpproxy.net"),
-    NAMESERVER("ns2.rrpproxy.net"),
-    NAMESERVER("ns3.rrpproxy.net"),
-    NAMESERVER("ns4.rrpproxy.net"),
+    NAMESERVER("ns1.rrpproxy.net."),
+    NAMESERVER("ns2.rrpproxy.net."),
+    NAMESERVER("ns3.rrpproxy.net."),
     A("elk1", "10.190.234.178"),
     A("test", "56.123.54.12"),
 );


### PR DESCRIPTION
'NAMESERVER' values should be specified with a trailing dot, and, according to the documentation and the 'CNR' provider code, there are three known NS records;

https://kb.centralnicreseller.com/dns/keydns/keydns-upgrade-to-anycast

<!--
## Before submiting a pull request

Please make sure you've run the following commands from the root directory.

go vet ./...
go fmt ./...
go generate ./...
go mod tidy

## Release changelog section

Help keep the release changelog clear by pre-naming the proper section in the GitHub pull request title.

Some examples:
* CICD: Add required GHA permissions for goreleaser
* DOCS: Fixed providers with "contributor support" table
* ROUTE53: Allow R53_ALIAS records to enable target health evaluation

More examples/context can be found in the file .goreleaser.yml under the 'build' > 'changelog' key.
!-->
