### PR TITLE
BUILD: GoReleaser changelog dependencies regex

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -48,7 +48,7 @@ changelog:
       regexp: "(?i)^.*(build|ci|cicd)[(\\w)]*:+.*$"
       order: 4
     - title: 'Dependencies:'
-      regexp: "(?i)^.*Build\\(deps\\)*:+.*$|(?i)^.*update deps+.*$"
+      regexp: "(?i)^.*\\b(deps|dependencies)\\b.*$"
       order: 5
     - title: 'Other changes and improvements:'
       order: 9


### PR DESCRIPTION
This pull request ensures that commits with messages like `CHORE: Update dependencies` are correctly grouped under the **Dependencies** section in the generated changelog, instead of being placed under **Other changes and improvements**.

To achieve this, the regular expression for the `Dependencies` changelog group has been updated to match a broader range of commit message patterns related to dependency updates.
