### PR TITLE
FEATURE: --notify now makes errors visible to make debugging easier

### DIFF
--- a/commands/ppreviewPush.go
+++ b/commands/ppreviewPush.go
@@ -525,7 +525,10 @@ func pprintOrRunCorrections(zoneName string, providerName string, corrections []
 
 			// If it is an action (not an informational message), notify and execute.
 			if correction.F != nil {
-				notifier.Notify(zoneName, providerName, correction.Msg, err, false)
+				err = notifier.Notify(zoneName, providerName, correction.Msg, err, false)
+				if err != nil {
+					out.Printf("Error sending notification: %s\n", err)
+				}
 				err = correction.F()
 				out.EndCorrection(err)
 				if err != nil {

--- a/pkg/notifications/bonfire.go
+++ b/pkg/notifications/bonfire.go
@@ -18,7 +18,7 @@ func init() {
 // bonfire notifier for stack exchange internal chat. String is just url with room and token in it
 type bonfireNotifier string
 
-func (b bonfireNotifier) Notify(domain, provider, msg string, err error, preview bool) {
+func (b bonfireNotifier) Notify(domain, provider, msg string, err error, preview bool) error {
 	var payload string
 	if preview {
 		payload = fmt.Sprintf(`**Preview: %s[%s] -** %s`, domain, provider, msg)
@@ -30,8 +30,12 @@ func (b bonfireNotifier) Notify(domain, provider, msg string, err error, preview
 	// chat doesn't markdownify multiline messages. Split in two so the first line can have markdown
 	parts := strings.SplitN(payload, "\n", 2)
 	for _, p := range parts {
-		_, _ = http.Post(string(b), "text/markdown", strings.NewReader(p))
+		_, err = http.Post(string(b), "text/markdown", strings.NewReader(p))
+		if err != nil {
+			return err
+		}
 	}
+	return nil
 }
 
 func (b bonfireNotifier) Done() {}

--- a/pkg/notifications/shoutrrr.go
+++ b/pkg/notifications/shoutrrr.go
@@ -17,7 +17,7 @@ func init() {
 
 type shoutrrrNotifier string
 
-func (b shoutrrrNotifier) Notify(domain, provider, msg string, err error, preview bool) {
+func (b shoutrrrNotifier) Notify(domain, provider, msg string, err error, preview bool) error {
 	var payload string
 	if preview {
 		payload = fmt.Sprintf("DNSControl preview: %s[%s]:\n%s", domain, provider, msg)
@@ -26,7 +26,7 @@ func (b shoutrrrNotifier) Notify(domain, provider, msg string, err error, previe
 	} else {
 		payload = fmt.Sprintf("DNSControl successfully ran correction for %s[%s]:\n%s", domain, provider, msg)
 	}
-	_ = shoutrrr.Send(string(b), payload)
+	return shoutrrr.Send(string(b), payload)
 }
 
 func (b shoutrrrNotifier) Done() {}

--- a/pkg/notifications/slack.go
+++ b/pkg/notifications/slack.go
@@ -24,7 +24,7 @@ type slackNotifier struct {
 	URL string
 }
 
-func (s *slackNotifier) Notify(domain, provider, msg string, err error, preview bool) {
+func (s *slackNotifier) Notify(domain, provider, msg string, err error, preview bool) error {
 	var payload struct {
 		Username string `json:"username"`
 		Text     string `json:"text"`
@@ -40,7 +40,8 @@ func (s *slackNotifier) Notify(domain, provider, msg string, err error, preview 
 	}
 
 	json, _ := json.Marshal(payload)
-	_, _ = http.Post(s.URL, "text/json", bytes.NewReader(json))
+	_, posterr := http.Post(s.URL, "text/json", bytes.NewReader(json))
+	return posterr
 }
 
 func (s *slackNotifier) Done() {}

--- a/pkg/notifications/teams.go
+++ b/pkg/notifications/teams.go
@@ -27,7 +27,7 @@ type teamsNotifier struct {
 	URL string
 }
 
-func (s *teamsNotifier) Notify(domain, provider, msg string, err error, preview bool) {
+func (s *teamsNotifier) Notify(domain, provider, msg string, err error, preview bool) error {
 	var payload struct {
 		Username string `json:"username"`
 		Text     string `json:"text"`
@@ -46,7 +46,8 @@ func (s *teamsNotifier) Notify(domain, provider, msg string, err error, preview 
 	}
 
 	json, _ := json.Marshal(payload)
-	_, _ = http.Post(s.URL, "text/json", bytes.NewReader(json))
+	_, posterr := http.Post(s.URL, "text/json", bytes.NewReader(json))
+	return posterr
 }
 
 func (s *teamsNotifier) Done() {}

--- a/pkg/notifications/telegram.go
+++ b/pkg/notifications/telegram.go
@@ -29,7 +29,7 @@ type telegramNotifier struct {
 	ChatID   string
 }
 
-func (s *telegramNotifier) Notify(domain, provider, msg string, err error, preview bool) {
+func (s *telegramNotifier) Notify(domain, provider, msg string, err error, preview bool) error {
 	var payload struct {
 		ChatID int64  `json:"chat_id"`
 		Text   string `json:"text"`
@@ -49,7 +49,8 @@ func (s *telegramNotifier) Notify(domain, provider, msg string, err error, previ
 
 	marshaledPayload, _ := json.Marshal(payload)
 
-	_, _ = http.Post(url, "application/json", bytes.NewBuffer(marshaledPayload))
+	_, posterr := http.Post(url, "application/json", bytes.NewBuffer(marshaledPayload))
+	return posterr
 }
 
 func (s *telegramNotifier) Done() {}


### PR DESCRIPTION
Currently there are no errors reported from the notifications, which can make it difficult to spot configuration errors. This change logs the first error reported by any notifier for each change.