### PR TITLE
DOCS: add links to help jump to provider table anchors

### DIFF
--- a/build/generate/featureMatrix.go
+++ b/build/generate/featureMatrix.go
@@ -15,7 +15,7 @@ func generateFeatureMatrix() error {
 	var replacementContent string = "Jump to a table:\n\n"
 	matrix := matrixData()
 
-	for i, tableTitle := range matrix.FeatureTablesTitles; i++ {
+	for _, tableTitle := range matrix.FeatureTablesTitles {
 		var jumptotableContent string = ""
 
 		var anchor string = strings.ToLower(tableTitle)
@@ -25,10 +25,9 @@ func generateFeatureMatrix() error {
 		replacementContent += jumptotableContent
 	}
 
-	for i := 0; i < len(matrix.FeatureTables); i++ {
-		var tableTitle = matrix.FeatureTablesTitles[i]
+	for i, tableTitle := range matrix.FeatureTablesTitles {
 		replacementContent += fmt.Sprintf("\n### %s <!--(table %d/%d)-->\n\n",
-			tableTitle, i+1, len(matrix.FeatureTables))
+			tableTitle, i+1, len(matrix.FeatureTablesTitles))
 		markdownTable, err := markdownTable(matrix, int32(i))
 		if err != nil {
 			return err

--- a/build/generate/featureMatrix.go
+++ b/build/generate/featureMatrix.go
@@ -12,8 +12,19 @@ import (
 )
 
 func generateFeatureMatrix() error {
-	var replacementContent string = ""
+	var replacementContent string = "Jump to a table:\n\n"
 	matrix := matrixData()
+
+	for i := 0; i < len(matrix.FeatureTables); i++ {
+		var tableTitle = matrix.FeatureTablesTitles[i]
+		var jumptotableContent string = ""
+
+		var anchor string = strings.ToLower(tableTitle)
+		anchor = strings.Replace(anchor, " ", "-", -1)
+
+		jumptotableContent += fmt.Sprintf("- [%s](#%s)\n", tableTitle, anchor)
+		replacementContent += jumptotableContent
+	}
 
 	for i := 0; i < len(matrix.FeatureTables); i++ {
 		var tableTitle = matrix.FeatureTablesTitles[i]

--- a/build/generate/featureMatrix.go
+++ b/build/generate/featureMatrix.go
@@ -15,8 +15,7 @@ func generateFeatureMatrix() error {
 	var replacementContent string = "Jump to a table:\n\n"
 	matrix := matrixData()
 
-	for i := 0; i < len(matrix.FeatureTables); i++ {
-		var tableTitle = matrix.FeatureTablesTitles[i]
+	for i, tableTitle := range matrix.FeatureTablesTitles; i++ {
 		var jumptotableContent string = ""
 
 		var anchor string = strings.ToLower(tableTitle)

--- a/documentation/provider/index.md
+++ b/documentation/provider/index.md
@@ -12,6 +12,14 @@ a provider that supports it, we'd love your contribution to ensure it works corr
 If a feature is definitively not supported for whatever reason, we would also like a PR to clarify why it is not supported, and fill in this entire matrix.
 
 <!-- provider-matrix-start -->
+Jump to a table:
+
+- [Provider Type](#provider-type)
+- [Provider API](#provider-api)
+- [DNS extensions](#dns-extensions)
+- [Service discovery](#service-discovery)
+- [Security](#security)
+- [DNSSEC](#dnssec)
 
 ### Provider Type <!--(table 1/6)-->
 


### PR DESCRIPTION
<!--
## Before submiting a pull request

Please make sure you've run the following commands from the root directory.

go vet ./...
go fmt ./...
go generate ./...
go mod tidy

## Release changelog section

Help keep the release changelog clear by pre-naming the proper section in the GitHub pull request title.

Some examples:
* CICD: Add required GHA permissions for goreleaser
* DOCS: Fixed providers with "contributor support" table
* ROUTE53: Allow R53_ALIAS records to enable target health evaluation

More examples/context can be found in the file .goreleaser.yml under the 'build' > 'changelog' key.
!-->

## Context

Fixes: #3607

## Does

Since the anchors were automatically provided by GitBook I just needed to:

- create an inline table of contents for the generated tables

This information is also in the sidebar on the right, but having it inline seems nicer.

## Maybe

Should we provide links to jump back to the top?  I'm leaving it out for now.

## Verify

[The preview](https://docs.dnscontrol.org/~/revisions/tqzh8eb8YmxphuX5Ufbw/provider/index) lets me jump around to the different tables with the inline links and the sidebar links.
