### PR TITLE
DOCS: Linkspector URI fixes

### DIFF
--- a/.linkspector.yml
+++ b/.linkspector.yml
@@ -7,6 +7,7 @@ files:
 ignorePatterns:
   - pattern: '.*?plain=1$'
   - pattern: '.*.md#$'
+  - pattern: '^https://cloud.digitalocean.com/account/api/tokens'
   - pattern: '^https://cloud.digitalocean.com/settings/applications'
   - pattern: '^https://dns.hetzner.com/settings/api-token'
   - pattern: '^https://github.com/StackExchange/dnscontrol/settings/.*$'

--- a/.linkspector.yml
+++ b/.linkspector.yml
@@ -5,6 +5,7 @@ files:
   - README.md
   - SECURITY.md
 ignorePatterns:
+  - pattern: '.*#opinion-3-dnsconfig.js-are-not-zonefiles$'
   - pattern: '.*?plain=1$'
   - pattern: '.*.md#$'
   - pattern: '^https://cloud.digitalocean.com/account/api/tokens'

--- a/documentation/advanced-features/adding-new-rtypes.md
+++ b/documentation/advanced-features/adding-new-rtypes.md
@@ -300,7 +300,7 @@ Add a new Markdown file to `documentation/language-reference/domain-modifiers`. 
 
 The rest of the file is the documentation. You can use Markdown syntax to format the text.
 
-Add the new file `FOO.md` to the documentation table of contents [`documentation/SUMMARY.md`](../SUMMARY.md#domain-modifiers), and/or to the [`Service Provider specific`](../SUMMARY.md#service-provider-specific) section if you made a record specific to a provider, and to the [`Record Modifiers`](../SUMMARY.md#record-modifiers) section if you created any `*_BUILDER` or `*_HELPER` or similar functions for the new record type:
+Add the new file `FOO.md` to the documentation table of contents `documentation/SUMMARY.md` > `Domain Modifiers`, and/or to the `Service Provider specific` section if you made a record specific to a provider, and to the `Record Modifiers` section if you created any `*_BUILDER` or `*_HELPER` or similar functions for the new record type:
 
 {% code title="documentation/SUMMARY.md" %}
 ```diff

--- a/documentation/advanced-features/writing-providers.md
+++ b/documentation/advanced-features/writing-providers.md
@@ -219,7 +219,7 @@ an automated way to test for this bug.  The manual steps are here in
   * Add the name of the provider to the PROVIDERS list.
 * Edit `documentation/providers.md`:
   * Remove the provider from the `Requested providers` list (near the end of the doc) (if needed).
-  * Add the new provider to the [Providers with "contributor support"](provider/index#providers-with-contributor-support) section.
+  * Add the new provider to the [Providers with "contributor support"](../provider/index.md#providers-with-contributor-support) section.
 * Edit `documentation/SUMMARY.md`:
   * Add the provider to the "Providers" list.
 * Create `documentation/provider/PROVIDERNAME.md`:

--- a/documentation/index.md
+++ b/documentation/index.md
@@ -22,7 +22,7 @@ Take advantage of the advanced features. Use macros and variables for easier upd
 * Runs on Linux, Windows, Mac, or any operating system supported by Go.
 * Enable/disable Cloudflare proxying (the "orange cloud" button) directly from your DNSControl files.
 * [Assign an IP address to a constant](getting-started/examples.md#variables-for-common-ip-addresses) and use the variable name throughout the configuration. Need to change the IP address globally? Just change the variable and "recompile".
-* Keep similar domains in sync with transforms, [macros](getting-started/examples.md#macro-to-for-repeated-records), and variables.
+* Keep similar domains in sync with transforms, [macros](getting-started/examples.md#macro-for-repeated-records), and variables.
 {% endhint %}
 
 # Get Involved

--- a/documentation/provider/axfrddns.md
+++ b/documentation/provider/axfrddns.md
@@ -6,7 +6,7 @@ IP-based authentication (ACLs).
 It is able to work with any standards-compliant
 authoritative DNS server. It has been tested with
 [BIND](https://www.isc.org/bind/), [Knot](https://www.knot-dns.cz/),
-and [Yadifa](https://www.yadifa.eu/home).
+and [Yadifa](https://yadifa.eu/home.html).
 
 ## Configuration
 


### PR DESCRIPTION
Ran `Linkspector` again to verify documentation links and fixed several invalid URLs.

The following result remained after the update:

```shell
npx linkspector check
```

```shell
🚫 documentation/provider/namedotcom.md, https://www.name.com/reseller/apply , 404, 71, null
💥 Error: Some hyperlinks in the specified files are invalid.
```

See:  
https://github.com/StackExchange/dnscontrol/blob/0d081ba10c2776c48f04208c99b0100a84593594/documentation/provider/namedotcom.md#L71

Fixes https://github.com/StackExchange/dnscontrol/issues/3431