### PR TITLE
MYTHICBEASTS: Performance improvement: Use the OAuth2 client credentials protocol

### DIFF
--- a/providers/mythicbeasts/mythicbeastsProvider.go
+++ b/providers/mythicbeasts/mythicbeastsProvider.go
@@ -4,6 +4,7 @@
 package mythicbeasts
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -15,6 +16,8 @@ import (
 	"github.com/StackExchange/dnscontrol/v4/pkg/diff2"
 	"github.com/StackExchange/dnscontrol/v4/providers"
 	"github.com/miekg/dns"
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/clientcredentials"
 )
 
 // mythicBeastsDefaultNS lists the default nameservers, per https://www.mythic-beasts.com/support/domains/nameservers.
@@ -25,8 +28,6 @@ var mythicBeastsDefaultNS = []string{
 
 // mythicBeastsProvider is the handle for this provider.
 type mythicBeastsProvider struct {
-	secret string
-	keyID  string
 	client *http.Client
 }
 
@@ -65,10 +66,16 @@ func newDsp(conf map[string]string, metadata json.RawMessage) (providers.DNSServ
 	if conf["secret"] == "" {
 		return nil, errors.New("missing Mythic Beasts auth secret")
 	}
+	// Use https://www.mythic-beasts.com/support/api/auth
+	cfg := clientcredentials.Config{
+		ClientID:     conf["keyID"],
+		ClientSecret: conf["secret"],
+		TokenURL:     "https://auth.mythic-beasts.com/login",
+		Scopes:       []string{"client_credentials"},
+		AuthStyle:    oauth2.AuthStyleInHeader,
+	}
 	return &mythicBeastsProvider{
-		keyID:  conf["keyID"],
-		secret: conf["secret"],
-		client: &http.Client{},
+		client: cfg.Client(context.Background()),
 	}, nil
 }
 
@@ -77,8 +84,6 @@ func (n *mythicBeastsProvider) httpRequest(method, url string, body io.Reader) (
 	if err != nil {
 		return nil, err
 	}
-	// https://www.mythic-beasts.com/support/api/auth
-	req.SetBasicAuth(n.keyID, n.secret)
 	req.Header.Add("Content-Type", "text/dns")
 	req.Header.Add("Accept", "text/dns")
 	return n.client.Do(req)


### PR DESCRIPTION
Motivation: Speed up integration tests.

I've tested this works.

I measured the speed up for requests (as measured between curl's `time_pretransfer` and `time_total`, i.e. ignoring DNS/handshake/auth):

* Before: 1s
* After: 0.6s

40% improvement for me. Further, since I'm located ~maximally from the API server (~350ms RTT), which accounts for most the 0.6s I observe, hopefully Github Actions isn't as far, and so observes an even larger proportional speedup.

Fixes https://github.com/StackExchange/dnscontrol/issues/3628