### PR TITLE
MYTHICBEASTS: Mark as concurrent verified.

### DIFF
--- a/documentation/provider/index.md
+++ b/documentation/provider/index.md
@@ -117,7 +117,7 @@ Jump to a table:
 | [`LOOPIA`](loopia.md) | ❔ | ✅ | ❌ | ✅ |
 | [`LUADNS`](luadns.md) | ❔ | ✅ | ✅ | ✅ |
 | [`MSDNS`](msdns.md) | ❔ | ❌ | ❌ | ✅ |
-| [`MYTHICBEASTS`](mythicbeasts.md) | ❔ | ✅ | ❌ | ✅ |
+| [`MYTHICBEASTS`](mythicbeasts.md) | ✅ | ✅ | ❌ | ✅ |
 | [`NAMECHEAP`](namecheap.md) | ✅ | ❌ | ❌ | ✅ |
 | [`NAMEDOTCOM`](namedotcom.md) | ❔ | ✅ | ❌ | ✅ |
 | [`NETCUP`](netcup.md) | ❔ | ❌ | ❌ | ❌ |

--- a/providers/mythicbeasts/mythicbeastsProvider.go
+++ b/providers/mythicbeasts/mythicbeastsProvider.go
@@ -34,7 +34,7 @@ var features = providers.DocumentationNotes{
 	// The default for unlisted capabilities is 'Cannot'.
 	// See providers/capabilities.go for the entire list of capabilities.
 	providers.CanGetZones:            providers.Can(),
-	providers.CanConcur:              providers.Unimplemented(),
+	providers.CanConcur:              providers.Can(),
 	providers.CanUseAlias:            providers.Cannot(),
 	providers.CanUseCAA:              providers.Can(),
 	providers.CanUseLOC:              providers.Cannot(),


### PR DESCRIPTION
Per https://docs.dnscontrol.org/advanced-features/concurrency-verified , this test was successful.

This is as expected, since the only mutable state is http.Client[0], which is documented as being concurrent safe[1].

0. https://github.com/StackExchange/dnscontrol/blob/1f8b7d01b6f0f184bd86cefe7d30ccc7ca6ac105/providers/mythicbeasts/mythicbeastsProvider.go#L27-L31
1. https://pkg.go.dev/net/http#hdr-Clients_and_Transports

<!--
## Before submiting a pull request

Please make sure you've run the following commands from the root directory.

go vet ./...
go fmt ./...
go generate ./...
go mod tidy

## Release changelog section

Help keep the release changelog clear by pre-naming the proper section in the GitHub pull request title.

Some examples:
* CICD: Add required GHA permissions for goreleaser
* DOCS: Fixed providers with "contributor support" table
* ROUTE53: Allow R53_ALIAS records to enable target health evaluation

More examples/context can be found in the file .goreleaser.yml under the 'build' > 'changelog' key.
!-->
