### PR TITLE
PORKBUN: Improve retry handling, mark as concurrent

### DIFF
--- a/documentation/advanced-features/adding-new-rtypes.md
+++ b/documentation/advanced-features/adding-new-rtypes.md
@@ -16,12 +16,10 @@ Our general philosophy is:
 -   Anywhere we have a special case for a particular Rtype, we use a `switch` statement and have a `case` for every single record type, usually with a `default:` case that calls `panic()`. This way developers adding a new record type will quickly find where they need to add code (the panic will tell them where). Before we did this, missing implementation code would go unnoticed for months.
 -   Keep things alphabetical. If you are adding your record type to a case statement, function library, or whatever, please list it alphabetically along with the others when possible.
 
-Step 2 requires `stringer`.
+Step 2 requires `stringer` which is available using
 ```shell
-go install golang.org/x/tools/cmd/stringer@latest
+go tool stringer
 ```
-You may need to symlink stringer into your PATH.
-
 ## Step 1: Update `RecordConfig` in `models/record.go`
 
 If the record has any unique fields, add them to `RecordConfig`.
@@ -61,7 +59,7 @@ a minimum.
 
 ```shell
 pushd; cd providers/;
-stringer -type=Capability
+go tool stringer -type=Capability
 popd
 ```
 alternatively

--- a/documentation/provider/index.md
+++ b/documentation/provider/index.md
@@ -129,7 +129,7 @@ Jump to a table:
 | [`ORACLE`](oracle.md) | ❔ | ✅ | ✅ | ✅ |
 | [`OVH`](ovh.md) | ❔ | ✅ | ❌ | ✅ |
 | [`PACKETFRAME`](packetframe.md) | ❔ | ❌ | ❌ | ❔ |
-| [`PORKBUN`](porkbun.md) | ❔ | ❌ | ❌ | ✅ |
+| [`PORKBUN`](porkbun.md) | ✅ | ❌ | ❌ | ✅ |
 | [`POWERDNS`](powerdns.md) | ❔ | ✅ | ✅ | ✅ |
 | [`REALTIMEREGISTER`](realtimeregister.md) | ❔ | ❌ | ✅ | ✅ |
 | [`ROUTE53`](route53.md) | ✅ | ✅ | ✅ | ✅ |

--- a/go.mod
+++ b/go.mod
@@ -62,6 +62,7 @@ require (
 	github.com/G-Core/gcore-dns-sdk-go v0.3.0
 	github.com/centralnicgroup-opensource/rtldev-middleware-go-sdk/v5 v5.0.15
 	github.com/containrrr/shoutrrr v0.8.0
+	github.com/failsafe-go/failsafe-go v0.6.9
 	github.com/fatih/color v1.18.0
 	github.com/fbiville/markdown-table-formatter v0.3.0
 	github.com/go-acme/lego/v4 v4.23.1

--- a/go.mod
+++ b/go.mod
@@ -168,3 +168,5 @@ require (
 	gopkg.in/sourcemap.v1 v1.0.5 // indirect
 	moul.io/http2curl v1.0.0 // indirect
 )
+
+tool golang.org/x/tools/cmd/stringer

--- a/go.sum
+++ b/go.sum
@@ -81,6 +81,8 @@ github.com/babolivier/go-doh-client v0.0.0-20201028162107-a76cff4cb8b6/go.mod h1
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/billputer/go-namecheap v0.0.0-20210108011502-994a912fb7f9 h1:2vQTbEJvFsyd1VefzZ34GUkUD6TkJleYYJh9/25WBE4=
 github.com/billputer/go-namecheap v0.0.0-20210108011502-994a912fb7f9/go.mod h1:bqqNsI2akL+lLWyApkYY0cxquWPKwEBU0Wd3chi3TEg=
+github.com/bits-and-blooms/bitset v1.14.3 h1:Gd2c8lSNf9pKXom5JtD7AaKO8o7fGQ2LtFj1436qilA=
+github.com/bits-and-blooms/bitset v1.14.3/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
 github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
 github.com/boombuler/barcode v1.0.1 h1:NDBbPmhS+EqABEs5Kg3n/5ZNjy73Pz7SIV+KCeqyXcs=
 github.com/boombuler/barcode v1.0.1/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
@@ -126,6 +128,8 @@ github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1m
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/exoscale/egoscale v0.102.4 h1:GBKsZMIOzwBfSu+4ZmWka3Ejf2JLiaBDHp4CQUgvp2E=
 github.com/exoscale/egoscale v0.102.4/go.mod h1:ROSmPtle0wvf91iLZb09++N/9BH2Jo9XxIpAEumvocA=
+github.com/failsafe-go/failsafe-go v0.6.9 h1:7HWEzOlFOjNerxgWd8onWA2j/aEuqyAtuX6uWya/364=
+github.com/failsafe-go/failsafe-go v0.6.9/go.mod h1:zb7xfp1/DJ7Mn4xJhVSZ9F2qmmMEGvYHxEOHYK5SIm0=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.18.0 h1:S8gINlzdQ840/4pfAwic/ZE0djQEH3wM94VfqLTZcOM=
 github.com/fatih/color v1.18.0/go.mod h1:4FelSpRwEGDpQ12mAdzqdOukCy4u8WUtOY6lkT/6HfU=

--- a/pkg/diff2/diff2.go
+++ b/pkg/diff2/diff2.go
@@ -1,6 +1,6 @@
 package diff2
 
-//go:generate stringer -type=Verb
+//go:generate go tool stringer -type=Verb
 
 // This module provides functions that "diff" the existing records
 // against the desired records.

--- a/pkg/txtutil/txtcode.go
+++ b/pkg/txtutil/txtcode.go
@@ -1,4 +1,4 @@
-//go:generate stringer -type=State
+//go:generate go tool stringer -type=State
 
 package txtutil
 

--- a/pkg/txtutil/txtcombined.go
+++ b/pkg/txtutil/txtcombined.go
@@ -1,4 +1,4 @@
-//go:generate stringer -type=State
+//go:generate go tool stringer -type=State
 
 package txtutil
 

--- a/providers/capabilities.go
+++ b/providers/capabilities.go
@@ -1,4 +1,4 @@
-//go:generate stringer -type=Capability
+//go:generate go tool stringer -type=Capability
 
 package providers
 

--- a/providers/porkbun/api.go
+++ b/providers/porkbun/api.go
@@ -68,7 +68,7 @@ func (c *porkbunProvider) post(endpoint string, params requestParams) ([]byte, e
 	params["apikey"] = c.apiKey
 	params["secretapikey"] = c.secretKey
 
-	personJSON, err := json.Marshal(params)
+	paramsJSON, err := json.Marshal(params)
 	if err != nil {
 		return []byte{}, err
 	}
@@ -86,7 +86,7 @@ func (c *porkbunProvider) post(endpoint string, params requestParams) ([]byte, e
 	client := &http.Client{
 		Transport: failsafehttp.NewRoundTripper(nil, retryPolicy),
 	}
-	req, _ := http.NewRequest(http.MethodPost, baseURL+endpoint, bytes.NewBuffer(personJSON))
+	req, _ := http.NewRequest(http.MethodPost, baseURL+endpoint, bytes.NewBuffer(paramsJSON))
 
 	resp, err := client.Do(req)
 	if err != nil {

--- a/providers/porkbun/api.go
+++ b/providers/porkbun/api.go
@@ -12,6 +12,9 @@ import (
 	"time"
 
 	"github.com/StackExchange/dnscontrol/v4/pkg/printer"
+	"github.com/failsafe-go/failsafe-go"
+	"github.com/failsafe-go/failsafe-go/failsafehttp"
+	"github.com/failsafe-go/failsafe-go/retrypolicy"
 )
 
 const (
@@ -70,31 +73,31 @@ func (c *porkbunProvider) post(endpoint string, params requestParams) ([]byte, e
 		return []byte{}, err
 	}
 
-	client := &http.Client{}
+	retryPolicy := failsafehttp.RetryPolicyBuilder().
+		WithMaxRetries(5).
+		// Exponential backoff between 1 and 10 seconds
+		WithBackoff(time.Second, 10*time.Second).
+		WithJitter(100 * time.Millisecond).
+		OnRetryScheduled(func(f failsafe.ExecutionScheduledEvent[*http.Response]) {
+			printer.Debugf("Porkbun API response code %d, waiting for %s until next attempt\n", f.LastResult().StatusCode, f.Delay)
+		}).
+		Build()
+
+	client := &http.Client{
+		Transport: failsafehttp.NewRoundTripper(nil, retryPolicy),
+	}
 	req, _ := http.NewRequest(http.MethodPost, baseURL+endpoint, bytes.NewBuffer(personJSON))
 
-	retrycnt := 0
-
-	// If request sending too fast, the server will fail with the following error:
-	// porkbun API error: Create error: We were unable to create the DNS record.
-retry:
-	time.Sleep(time.Second)
 	resp, err := client.Do(req)
 	if err != nil {
-		return []byte{}, err
+		if errors.Is(err, retrypolicy.ErrExceeded) {
+			// Return the underlying error rather than the wrapped error, which has too much detail
+			return nil, retrypolicy.ErrExceeded
+		}
+		return nil, err
 	}
 
 	bodyString, _ := io.ReadAll(resp.Body)
-
-	if resp.StatusCode == http.StatusAccepted || resp.StatusCode == http.StatusServiceUnavailable {
-		retrycnt++
-		if retrycnt == 5 {
-			return bodyString, errors.New("rate limiting exceeded")
-		}
-		printer.Warnf("Rate limiting.. waiting for %d second(s)\n", retrycnt*10)
-		time.Sleep(time.Second * time.Duration(retrycnt*10))
-		goto retry
-	}
 
 	// Got error from API ?
 	var errResp errorResponse

--- a/providers/porkbun/porkbunProvider.go
+++ b/providers/porkbun/porkbunProvider.go
@@ -59,7 +59,7 @@ var features = providers.DocumentationNotes{
 	// See providers/capabilities.go for the entire list of capabilities.
 	providers.CanAutoDNSSEC:          providers.Cannot(),
 	providers.CanGetZones:            providers.Can(),
-	providers.CanConcur:              providers.Unimplemented(),
+	providers.CanConcur:              providers.Can(),
 	providers.CanUseAlias:            providers.Can(),
 	providers.CanUseCAA:              providers.Can(),
 	providers.CanUseDS:               providers.Cannot(),


### PR DESCRIPTION
### PORKBUN: Improve retry handling, mark as concurrent (9ba2c08e)

The Porkbun API frequently responds with HTTP 503. It seems like they
use this instead of 429.

The provider previously would cause the HTML response from the 503 to
leak through to the caller, causing JSON decode to fail: the provider
only checked for response codes 202 and 503. Before checking the
response code it had already read the body. If the API responded with
anything other than 202 or 503, the response body was returned as-is,
even if the response was not 200. Per the Porkbun API docs:

    Any HTTP response code other than 200 is an error

But the provider was not checking this. If there is a 5xx error, the
response body contains HTML, which causes the caller to output a warning
such as

    INFO#1: Domain "example.com" provider porkbun Error: failed parsing url forwarding record list from porkbun: invalid character '<' looking for beginning of value

Now the Failsafe HTTP library is used, which provides automatic handling
for 429 and any 5xx-class response. When a response has a Retry-After
header, the retry policy takes this into account and delays by an
acceptable amount. The retry policy is configured with the same number
of retries as before (5), with exponential backoff between 1 and 10
seconds, with a jitter of +/- 100ms.

Because the retry policy is configured as an HTTP client transport there
is no chance of leaking HTML to the caller because the post() method
sees this as an HTTP client error and fails earlier.

With these changes the Porkbun provider is now safe to use concurrently.

Fixes #2995

### PORKBUN: Fix typo in variable name (7a25aa58)


### CHORE: Add stringer as a tool (7e2a0ddc)

The stringer tool is needed by `go generate` and when adding new rtypes.

We now use the Go toolchain's ability to mark an external command as a
tool, and run it using `go tool` instead of requiring it to be installed
on the developer's machine.
