### PR TITLE
BUILD: Add version package

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -22,7 +22,7 @@ builds:
         goarch: "386"
     ldflags:
       - -linkmode=internal -s -w
-      - -X main.version={{ .Version }}
+      - -X github.com/StackExchange/dnscontrol/v4/pkg/version.version={{ .Version }}
 before:
   hooks:
     - go fmt ./...

--- a/build/build.go
+++ b/build/build.go
@@ -15,7 +15,7 @@ var goos = flag.String("os", "", "OS to build (linux, windows, or darwin) Defaul
 
 func main() {
 	flag.Parse()
-	flags := fmt.Sprintf(`-s -w -X "main.version=%s"`, getVersion())
+	flags := fmt.Sprintf(`-s -w -X "github.com/StackExchange/dnscontrol/v4/pkg/version.version=%s"`, getVersion())
 	pkg := "github.com/StackExchange/dnscontrol/v4"
 
 	build := func(out, goos string) {

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -11,6 +11,7 @@ import (
 	"github.com/StackExchange/dnscontrol/v4/pkg/diff2"
 	"github.com/StackExchange/dnscontrol/v4/pkg/js"
 	"github.com/StackExchange/dnscontrol/v4/pkg/printer"
+	"github.com/StackExchange/dnscontrol/v4/pkg/version"
 	"github.com/fatih/color"
 	"github.com/urfave/cli/v2"
 )
@@ -34,16 +35,15 @@ var _ = cmd(catDebug, &cli.Command{
 	Name:  "version",
 	Usage: "Print version information",
 	Action: func(c *cli.Context) error {
-		_, err := fmt.Println(version)
+		_, err := fmt.Println(version.Version())
 		return err
 	},
 })
 
 // Run will execute the CLI
 func Run(v string) int {
-	version = v
 	app := cli.NewApp()
-	app.Version = version
+	app.Version = v
 	app.Name = "dnscontrol"
 	app.HideVersion = true
 	app.Usage = "DNSControl is a compiler and DSL for managing dns zones"

--- a/commands/writeTypes.go
+++ b/commands/writeTypes.go
@@ -4,12 +4,8 @@ import (
 	_ "embed" // Required by go:embed
 	"os"
 
+	"github.com/StackExchange/dnscontrol/v4/pkg/version"
 	"github.com/urfave/cli/v2"
-)
-
-// GoReleaser: version
-var (
-	version = "dev"
 )
 
 var _ = cmd(catUtils, func() *cli.Command {
@@ -58,7 +54,7 @@ func WriteTypes(args TypesArgs) error {
 	if _, err := file.WriteString("// To update it, run `dnscontrol write-types`.\n\n"); err != nil {
 		return err
 	}
-	if _, err := file.WriteString("// " + version + "\n"); err != nil {
+	if _, err := file.WriteString("// " + version.Version() + "\n"); err != nil {
 		return err
 	}
 	if _, err := file.WriteString(dtsContent); err != nil {

--- a/main.go
+++ b/main.go
@@ -6,19 +6,12 @@ import (
 	"runtime/debug"
 
 	"github.com/StackExchange/dnscontrol/v4/commands"
+	"github.com/StackExchange/dnscontrol/v4/pkg/version"
 	_ "github.com/StackExchange/dnscontrol/v4/providers/_all"
 	"github.com/fatih/color"
 )
 
 //go:generate go run build/generate/generate.go build/generate/featureMatrix.go build/generate/functionTypes.go build/generate/dtsFile.go build/generate/ownersFile.go
-
-// Version management. Goals:
-// 1. Someone who just does "go get" has at least some information.
-// 2. If built with build/build.go, more specific build information gets put in.
-// GoReleaser: version
-var (
-	version = "dev"
-)
 
 func main() {
 	if os.Getenv("CI") == "true" {
@@ -27,5 +20,5 @@ func main() {
 	if info, ok := debug.ReadBuildInfo(); !ok && info == nil {
 		fmt.Fprint(os.Stderr, "Warning: dnscontrol was built without Go modules. See https://docs.dnscontrol.org/getting-started/getting-started#source for more information on how to build dnscontrol correctly.\n\n")
 	}
-	os.Exit(commands.Run("DNSControl version " + version))
+	os.Exit(commands.Run("DNSControl version " + version.Version()))
 }

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,17 @@
+package version
+
+import "runtime/debug"
+
+// Set by GoReleaser
+var version string
+
+func Version() string {
+	if version != "" {
+		return version
+	}
+	bi, ok := debug.ReadBuildInfo()
+	if !ok {
+		return "dev"
+	}
+	return bi.Main.Version
+}

--- a/providers/cnr/cnrProvider.go
+++ b/providers/cnr/cnrProvider.go
@@ -6,13 +6,9 @@ import (
 	"encoding/json"
 	"errors"
 
+	"github.com/StackExchange/dnscontrol/v4/pkg/version"
 	"github.com/StackExchange/dnscontrol/v4/providers"
 	cnrcl "github.com/centralnicgroup-opensource/rtldev-middleware-go-sdk/v5/apiclient"
-)
-
-// GoReleaser: version
-var (
-	version = "dev"
 )
 
 // Client describes a connection to the CNR API.
@@ -61,7 +57,7 @@ func newProvider(conf map[string]string) (*Client, error) {
 		conf:   conf,
 		client: cnrcl.NewAPIClient(),
 	}
-	api.client.SetUserAgent("DNSControl", version)
+	api.client.SetUserAgent("DNSControl", version.Version())
 	api.APILogin, api.APIPassword, api.APIEntity = conf["apilogin"], conf["apipassword"], conf["apientity"]
 	if conf["debugmode"] == "2" {
 		api.client.EnableDebugMode()

--- a/providers/hexonet/hexonetProvider.go
+++ b/providers/hexonet/hexonetProvider.go
@@ -5,13 +5,9 @@ import (
 	"encoding/json"
 	"errors"
 
+	"github.com/StackExchange/dnscontrol/v4/pkg/version"
 	"github.com/StackExchange/dnscontrol/v4/providers"
 	hxcl "github.com/centralnicgroup-opensource/rtldev-middleware-go-sdk/v4/apiclient"
-)
-
-// GoReleaser: version
-var (
-	version = "dev"
 )
 
 // HXClient describes a connection to the hexonet API.
@@ -42,7 +38,7 @@ func newProvider(conf map[string]string) (*HXClient, error) {
 	api := &HXClient{
 		client: hxcl.NewAPIClient(),
 	}
-	api.client.SetUserAgent("DNSControl", version)
+	api.client.SetUserAgent("DNSControl", version.Version())
 	api.APILogin, api.APIPassword, api.APIEntity = conf["apilogin"], conf["apipassword"], conf["apientity"]
 	if conf["debugmode"] == "1" {
 		api.client.EnableDebugMode()


### PR DESCRIPTION
Commit 9873f9f4b2fece7a46053eaa375fe24070971e09 (v4.7.4) removed the version package in favour of using GoReleaser to set the version, which it only sets in main and is not passed down to other packages.

This means that if any other package, notably two providers which use the version for setting a User-Agent, wants access to the version, they no longer have it.

This change reintroduces the version package, setting GoReleaser to set the version here, and refactors all uses of the version to use the package.

Note that if you run `go run main.go version` the version output by Go for the main module is "(devel)". Using build/build.go gives the commit hash.

Fixes #3651
