### PR TITLE
BUG: Output better "version" string when running main.go directly

### DIFF
--- a/build/build.go
+++ b/build/build.go
@@ -6,16 +6,15 @@ import (
 	"log"
 	"os"
 	"os/exec"
-	"strings"
-)
 
-var sha = flag.String("sha", "", "SHA of current commit")
+	"github.com/StackExchange/dnscontrol/v4/pkg/version"
+)
 
 var goos = flag.String("os", "", "OS to build (linux, windows, or darwin) Defaults to all.")
 
 func main() {
 	flag.Parse()
-	flags := fmt.Sprintf(`-s -w -X "github.com/StackExchange/dnscontrol/v4/pkg/version.version=%s"`, getVersion())
+	flags := fmt.Sprintf(`-s -w -X "github.com/StackExchange/dnscontrol/v4/pkg/version.version=%s"`, version.Version())
 	pkg := "github.com/StackExchange/dnscontrol/v4"
 
 	build := func(out, goos string) {
@@ -49,33 +48,4 @@ func main() {
 			build(env.binary, env.goos)
 		}
 	}
-}
-
-func getVersion() string {
-	if *sha != "" {
-		return *sha
-	}
-	// check teamcity build version
-	if v := os.Getenv("BUILD_VCS_NUMBER"); v != "" {
-		return v
-	}
-	// check git
-	cmd := exec.Command("git", "rev-parse", "HEAD")
-	v, err := cmd.CombinedOutput()
-	if err != nil {
-		return ""
-	}
-	ver := strings.TrimSpace(string(v))
-	// see if dirty
-	cmd = exec.Command("git", "diff-index", "--quiet", "HEAD", "--")
-	err = cmd.Run()
-	// exit status 1 indicates dirty tree
-	if err != nil {
-		if err.Error() == "exit status 1" {
-			ver += "[dirty]"
-		} else {
-			log.Printf("!%s!", err.Error())
-		}
-	}
-	return ver
 }

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,17 +1,44 @@
 package version
 
-import "runtime/debug"
+import (
+	"os/exec"
+	"runtime/debug"
+	"strings"
+)
 
 // Set by GoReleaser
 var version string
 
+// VCSVersion retrieves the version information from git.
+//
+// If the current commit is untagged, the version string will show the last
+// tag, followed by the number of commits since the tag, then the short
+// hash of the current commit.
+//
+// If the tree is dirty, "-dirty" is appended.
+func VCSVersion() string {
+	cmd := exec.Command("git", "describe", "--tags", "--always", "--dirty")
+	v, err := cmd.CombinedOutput()
+	if err != nil {
+		return ""
+	}
+	ver := strings.TrimSpace(string(v))
+	return ver
+}
+
+// Version returns either the tag set by GoReleaser, or the version information
+// from Git.
 func Version() string {
 	if version != "" {
 		return version
 	}
 	bi, ok := debug.ReadBuildInfo()
-	if !ok {
-		return "dev"
+	if !ok ||
+		// When running with "go run main.go" no module information is available
+		bi.Main.Version == "" ||
+		// Go gives no commit information if not on a tag
+		bi.Main.Version == "(devel)" {
+		return VCSVersion()
 	}
 	return bi.Main.Version
 }


### PR DESCRIPTION
Go has different semantics when you run with `go run .` vs `go run main.go`.

In the former case, Go provides information about the module, including some version info. If the tree is not on a semver tag, it outputs "(devel)".

In the latter case, Go provides no information about the module and running `go run main.go version` would output a blank line.

The getVersion function from build/build.go has been factored out to the version package, and simplified to use `git describe` instead of the multi-step `git rev-parse` and `git diff-index`. Where this previously output the version as

    <sha>[dirty]

It now outputs it as

    <last tag>-<num commits since tag>-<short sha>

Optionally with a trailing -dirty.

The -sha flag has been removed from build.go as we get the information directly from git.

<!--
## Before submiting a pull request

Please make sure you've run the following commands from the root directory.

go vet ./...
go fmt ./...
go generate ./...
go mod tidy

## Release changelog section

Help keep the release changelog clear by pre-naming the proper section in the GitHub pull request title.

Some examples:
* CICD: Add required GHA permissions for goreleaser
* DOCS: Fixed providers with "contributor support" table
* ROUTE53: Allow R53_ALIAS records to enable target health evaluation

More examples/context can be found in the file .goreleaser.yml under the 'build' > 'changelog' key.
!-->
