### PR TITLE
chore: update go-powerdns to v0.6.7 and adjust SOAEditAPI type

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,7 @@ require (
 	github.com/hashicorp/vault/api v1.20.0
 	github.com/jinzhu/copier v0.4.0
 	github.com/miekg/dns v1.1.67
-	github.com/mittwald/go-powerdns v0.6.6
+	github.com/mittwald/go-powerdns v0.6.7
 	github.com/namedotcom/go v0.0.0-20180403034216-08470befbe04
 	github.com/nrdcg/goinwx v0.11.0
 	github.com/ovh/go-ovh v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -324,8 +324,8 @@ github.com/mitchellh/go-wordwrap v1.0.0/go.mod h1:ZXFpozHsX6DPmq2I0TCekCxypsnAUb
 github.com/mitchellh/mapstructure v1.4.1/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
-github.com/mittwald/go-powerdns v0.6.6 h1:yQcuszhl98+jJgELjD5ecfxCQWoshhnArexpwrwQxLY=
-github.com/mittwald/go-powerdns v0.6.6/go.mod h1:adWJ860laOgm14afg+7V0nCa5NQT37oEYe2HRhoS/CA=
+github.com/mittwald/go-powerdns v0.6.7 h1:r638QOYLWyJ5Wy+qynlq5nTRlhmfQMJvM9BDsbhyiro=
+github.com/mittwald/go-powerdns v0.6.7/go.mod h1:zFe/i17IP6/NGFkWGGsPL0t7VrL6u14HU8Hr06X4Qmg=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=

--- a/providers/powerdns/powerdnsProvider.go
+++ b/providers/powerdns/powerdnsProvider.go
@@ -53,10 +53,10 @@ type powerdnsProvider struct {
 	APIKey         string
 	APIUrl         string
 	ServerName     string
-	DefaultNS      []string       `json:"default_ns"`
-	DNSSecOnCreate bool           `json:"dnssec_on_create"`
-	ZoneKind       zones.ZoneKind `json:"zone_kind"`
-	SOAEditAPI     string         `json:"soa_edit_api,omitempty"`
+	DefaultNS      []string             `json:"default_ns"`
+	DNSSecOnCreate bool                 `json:"dnssec_on_create"`
+	ZoneKind       zones.ZoneKind       `json:"zone_kind"`
+	SOAEditAPI     zones.ZoneSOAEditAPI `json:"soa_edit_api,omitempty"`
 
 	nameservers []*models.Nameserver
 }


### PR DESCRIPTION
<!--
## Before submiting a pull request

Please make sure you've run the following commands from the root directory.

go vet ./...
go fmt ./...
go generate ./...
go mod tidy

## Release changelog section

Help keep the release changelog clear by pre-naming the proper section in the GitHub pull request title.

Some examples:
* CICD: Add required GHA permissions for goreleaser
* DOCS: Fixed providers with "contributor support" table
* ROUTE53: Allow R53_ALIAS records to enable target health evaluation

More examples/context can be found in the file .goreleaser.yml under the 'build' > 'changelog' key.
!-->

Bump go-powerdns to v0.6.7 and adjust SOAEditAPI type. This replaces #3647