### PR TITLE
ADGUARDHOME: updated documentation with links to AGH pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Windows). The provider model is extensible, so more providers can be added.
 
 Currently supported DNS providers:
 
+- AdGuard Home
 - Akamai Edge DNS
 - AutoDNS
 - AWS Route 53

--- a/documentation/SUMMARY.md
+++ b/documentation/SUMMARY.md
@@ -106,6 +106,7 @@
 ## Provider
 
 * [Supported providers](provider/index.md)
+* [AdGuard Home](provider/adguardhome.md)
 * [Akamai Edge DNS](provider/akamaiedgedns.md)
 * [Amazon Route 53](provider/route53.md)
 * [AutoDNS](provider/autodns.md)

--- a/documentation/provider/index.md
+++ b/documentation/provider/index.md
@@ -372,6 +372,7 @@ Providers in this category and their maintainers are:
 
 |Name|Maintainer|
 |---|---|
+|[`ADGUARDHOME`](adguardhome.md)|@ishanjain28|
 |[`AZURE_PRIVATE_DNS`](azure_private_dns.md)|@matthewmgamble|
 |[`AKAMAIEDGEDNS`](akamaiedgedns.md)|@edglynes|
 |[`AXFRDDNS`](axfrddns.md)|@hnrgrgr|


### PR DESCRIPTION
* ADGUARDHOME: added links to AGH documentation pages in the documentation




@tlimoncelli I have not updated the integration tests CI config to run adguard home tests. I think it is not super beneficial right now. I can add a separate job to run a dummy adguard home instance and run tests against it if this provider picks up / becomes more complex. Please let me know what do you think about this? I can also do this now if you feel it's helpful 

---

Please create the GitHub label 'provider-ADGUARDHOME'