### PR TITLE
DNSIMPLE: preview data is now gathered concurrently (CanConcur)

### DIFF
--- a/documentation/advanced-features/concurrency-verified.md
+++ b/documentation/advanced-features/concurrency-verified.md
@@ -2,15 +2,15 @@
 name: CONCURRENCY_VERIFIED
 ---
 
-✅  - A checkmark means "this has been tested, and will run concurrently".  
-❔  - The questionmark means "it hasn't been tested, safety unknown"  
-❌  - The red "X" means "this has been tested, and it will _not_ work concurrently".  
+✅  - A checkmark means "this has been tested, and will run concurrently".
+❔  - The questionmark means "it hasn't been tested, safety unknown"
+❌  - The red "X" means "this has been tested, and it will _not_ work concurrently".
 
 
 ### Here's how to perform a test:
 
 1. Build dnscontrol with the -race flag: go build -race (this makes a special binary)
-2. Run this special binary: `dnscontrol preview` with a configuration that lists at least 4 domains using Porkbun. More domains is better.
-3. The special binary runs much slower (1/10th the speed) because it is doing a lot of checking. 
-If it reports problems, the error message will indicate where the problem is. 
+2. Run this special binary: `dnscontrol preview` with a configuration that lists at least 4 domains using the provider in question. More domains is better.
+3. The special binary runs much slower (1/10th the speed) because it is doing a lot of checking.
+If it reports problems, the error message will indicate where the problem is.
 It might not be 100% accurate, but it will be in the right area.

--- a/documentation/provider/index.md
+++ b/documentation/provider/index.md
@@ -99,7 +99,7 @@ Jump to a table:
 | [`CSCGLOBAL`](cscglobal.md) | ✅ | ❔ | ❌ | ✅ |
 | [`DESEC`](desec.md) | ✅ | ❔ | ✅ | ✅ |
 | [`DIGITALOCEAN`](digitalocean.md) | ✅ | ❔ | ✅ | ✅ |
-| [`DNSIMPLE`](dnsimple.md) | ❔ | ❌ | ❌ | ✅ |
+| [`DNSIMPLE`](dnsimple.md) | ✅ | ❌ | ❌ | ✅ |
 | [`DNSMADEEASY`](dnsmadeeasy.md) | ❔ | ✅ | ✅ | ✅ |
 | [`DNSOVERHTTPS`](dnsoverhttps.md) | ❔ | ❔ | ❌ | ❔ |
 | [`DYNADOT`](dynadot.md) | ❔ | ❔ | ❌ | ❔ |

--- a/providers/dnsimple/dnsimpleProvider.go
+++ b/providers/dnsimple/dnsimpleProvider.go
@@ -24,7 +24,7 @@ var features = providers.DocumentationNotes{
 	// See providers/capabilities.go for the entire list of capabilities.
 	providers.CanAutoDNSSEC:          providers.Can(),
 	providers.CanGetZones:            providers.Can(),
-	providers.CanConcur:              providers.Unimplemented(),
+	providers.CanConcur:              providers.Can(),
 	providers.CanUseAlias:            providers.Can(),
 	providers.CanUseCAA:              providers.Can(),
 	providers.CanUseDS:               providers.Cannot(),


### PR DESCRIPTION
The `dnsimpleProvider` is a simple object of 3 strings with no state.

Using `dnscontrol preview --cmode all` in a configuration with 12 DNSimple zones, and the binary built with race detection, results in no warnings.

Fixed `concurrency-verified.md` to state "the provider in question" instead of an early provider to support this.  (Also some end-of-line cleanups for Markdown; trailing whitespace is semantically significant in block mode but not AFAIK for lists, so I think this is a safe change; this was my text-editor honoring the project's `.editorconfig` settings, which don't have an EOL whitespace exemption for markdown).

Index doc regenerated.