### PR TITLE
CNR: nameserver corrections should be case insensitive

### DIFF
--- a/providers/cnr/nameservers.go
+++ b/providers/cnr/nameservers.go
@@ -66,11 +66,16 @@ func (n *Client) GetRegistrarCorrections(dc *models.DomainConfig) ([]*models.Cor
 	if err != nil {
 		return nil, err
 	}
-	foundNameservers := strings.Join(nss, ",")
+	foundLower := make([]string, len(nss))
+	for i, ns := range nss {
+		foundLower[i] = strings.ToLower(ns)
+	}
+	sort.Strings(foundLower)
+	foundNameservers := strings.Join(foundLower, ",")
 
 	expected := []string{}
 	for _, ns := range dc.Nameservers {
-		name := strings.TrimRight(ns.Name, ".")
+		name := strings.ToLower(strings.TrimRight(ns.Name, "."))
 		expected = append(expected, name)
 	}
 	sort.Strings(expected)


### PR DESCRIPTION
> ## Before submiting a pull request
> 
> Please make sure you've run the following commands from the root directory.
> 
> go vet ./...
> go fmt ./...
> go generate ./...
> go mod tidy

Done

> ## Release changelog section
> 
> Help keep the release changelog clear by pre-naming the proper section in the GitHub pull request title.
> 
> Some examples:
> * CICD: Add required GHA permissions for goreleaser
> * DOCS: Fixed providers with "contributor support" table
> * ROUTE53: Allow R53_ALIAS records to enable target health evaluation
> 
> More examples/context can be found in the file .goreleaser.yml under the 'build' > 'changelog' key.

Done

This PR is reviewing the CNR Provider Module in direction of reported issue #3663.
