### PR TITLE
Warn if IGNORE() is unreliable for this provider

### DIFF
--- a/integrationTest/integration_test.go
+++ b/integrationTest/integration_test.go
@@ -1725,6 +1725,7 @@ func makeTests() []*TestGroup {
 
 		// IGNORE with changes
 		testgroup("IGNORE with modify",
+			not("NAMECHEAP"), // Will fail until converted to use diff2 module.
 			tc("Create some records",
 				a("foo", "1.1.1.1"),
 				a("foo", "10.10.10.10"),
@@ -1876,6 +1877,7 @@ func makeTests() []*TestGroup {
 
 		// https://github.com/StackExchange/dnscontrol/issues/3227
 		testgroup("IGNORE w/change b3227",
+			not("NAMECHEAP"), // Will fail until converted to use diff2 module.
 			tc("Create some records",
 				a("testignore", "8.8.8.8"),
 				a("testdefined", "9.9.9.9"),

--- a/integrationTest/profiles.json
+++ b/integrationTest/profiles.json
@@ -138,11 +138,11 @@
   "FORTIGATE": {
     "TYPE": "FORTIGATE",
     "apiKey": "$FORTIGATE_API_KEY",
+    "debug_http": "$FORTIGATE_DEBUG_HTTP",
     "domain": "$FORTIGATE_DOMAIN",
     "host": "$FORTIGATE_HOST",
     "insecure_tls": "$FORTIGATE_NO_SSL_VERIFY",
-    "vdom": "$FORTIGATE_VDOM",
-    "debug_http": "$FORTIGATE_DEBUG_HTTP"
+    "vdom": "$FORTIGATE_VDOM"
   },
   "GANDI_V5": {
     "TYPE": "GANDI_V5",

--- a/pkg/diff/diff2compat.go
+++ b/pkg/diff/diff2compat.go
@@ -41,10 +41,10 @@ func (d *differCompat) IncrementalDiff(existing []*models.RecordConfig) (reportM
 	if len(d.dc.EnsureAbsent) != 0 {
 		reportMsgs = append(reportMsgs, "WARNING: This provider does not reliably support ENSURE_ABSENT")
 	}
-	if d.dc.KeepUknown {
+	if d.dc.KeepUnknown {
 		reportMsgs = append(reportMsgs, "WARNING: This provider does not reliably support NO_PURGE")
 	}
-	if len(d.dc.UnmanagedConfig) != 0 {
+	if len(d.dc.Unmanaged) != 0 {
 		reportMsgs = append(reportMsgs, "WARNING: This provider does not reliably support IGNORE() and friends")
 	}
 	if d.dc.UnmanagedUnsafe {

--- a/pkg/diff/diff2compat.go
+++ b/pkg/diff/diff2compat.go
@@ -38,6 +38,19 @@ func (d *differCompat) IncrementalDiff(existing []*models.RecordConfig) (reportM
 		return nil, nil, nil, nil, 0, err
 	}
 
+	if len(dc.EnsureAbsent) != 0 {
+		reportMsgs = append(reportMsgs, "WARNING: This provider does not reliably support ENSURE_ABSENT")
+	}
+	if dc.KeepUknown {
+		reportMsgs = append(reportMsgs, "WARNING: This provider does not reliably support NO_PURGE")
+	}
+	if len(dc.UnmanagedConfig) != 0 {
+		reportMsgs = append(reportMsgs, "WARNING: This provider does not reliably support IGNORE() and friends")
+	}
+	if dc.UnmanagedUnsafe {
+		reportMsgs = append(reportMsgs, "WARNING: This provider does not reliably support DISABLE_IGNORE_SAFETY_CHECK")
+	}
+
 	for _, inst := range instructions {
 		cor := Correlation{}
 		switch inst.Type {

--- a/pkg/diff/diff2compat.go
+++ b/pkg/diff/diff2compat.go
@@ -38,16 +38,16 @@ func (d *differCompat) IncrementalDiff(existing []*models.RecordConfig) (reportM
 		return nil, nil, nil, nil, 0, err
 	}
 
-	if len(dc.EnsureAbsent) != 0 {
+	if len(d.dc.EnsureAbsent) != 0 {
 		reportMsgs = append(reportMsgs, "WARNING: This provider does not reliably support ENSURE_ABSENT")
 	}
-	if dc.KeepUknown {
+	if d.dc.KeepUknown {
 		reportMsgs = append(reportMsgs, "WARNING: This provider does not reliably support NO_PURGE")
 	}
-	if len(dc.UnmanagedConfig) != 0 {
+	if len(d.dc.UnmanagedConfig) != 0 {
 		reportMsgs = append(reportMsgs, "WARNING: This provider does not reliably support IGNORE() and friends")
 	}
-	if dc.UnmanagedUnsafe {
+	if d.dc.UnmanagedUnsafe {
 		reportMsgs = append(reportMsgs, "WARNING: This provider does not reliably support DISABLE_IGNORE_SAFETY_CHECK")
 	}
 

--- a/pkg/js/helpers.js
+++ b/pkg/js/helpers.js
@@ -1812,9 +1812,7 @@ function DKIM_BUILDER(value) {
     }
 
     r = []; // The list of records to return.
-    r.push(
-        TXT(value.label, kvs.join('\; '), DKIM_TTL)
-    );
+    r.push(TXT(value.label, kvs.join('\; '), DKIM_TTL));
     return r;
 }
 

--- a/providers/akamaiedgedns/akamaiEdgeDnsProvider.go
+++ b/providers/akamaiedgedns/akamaiEdgeDnsProvider.go
@@ -24,8 +24,9 @@ var features = providers.DocumentationNotes{
 	// The default for unlisted capabilities is 'Cannot'.
 	// See providers/capabilities.go for the entire list of capabilities.
 	providers.CanAutoDNSSEC:          providers.Can(),
-	providers.CanGetZones:            providers.Can(),
 	providers.CanConcur:              providers.Unimplemented(),
+	providers.CanGetZones:            providers.Can(),
+	providers.CanOnlyDiff1Features:   providers.Can(),
 	providers.CanUseAKAMAICDN:        providers.Can(),
 	providers.CanUseAlias:            providers.Cannot(),
 	providers.CanUseCAA:              providers.Can(),

--- a/providers/capabilities.go
+++ b/providers/capabilities.go
@@ -25,18 +25,18 @@ const (
 	// work when used concurrently.  The default is Cannot().
 	CanConcur
 
-	// CanDiff2Features indicates the provider uses the "diff2" engine natively
-	// instead of the backwards compatibility mode.
-	// The diff2 engine is required to repliably provide IGNORE(), NO_PURGE, and
-	// other features.
-	// This capability is set automatically for the provider during the call to
-	// RegisterDomainServiceProviderType.  It is set to Cannot() if we detect
-	// compatibility mode is in use. All other values (Unimplemented and Can)
-	// are equivalent.
-	CanDiff2Features
-
 	// CanGetZones indicates the provider supports the get-zones subcommand.
 	CanGetZones
+
+	// CanOnlyDiff1Features indicates the provider has not yet been upgraded to
+	// use the "diff2" differencing engine.  Instead, it uses the the backwards
+	// compatibility mode.  The diff2 engine is required to repliably provide
+	// IGNORE(), NO_PURGE, and other features.
+	// This capability is set automatically for the provider during the call to
+	// RegisterDomainServiceProviderType.  It is set to Can() if we detect
+	// compatibility mode is in use. All other values (Unimplemented and Cannot)
+	// are equivalent.
+	CanOnlyDiff1Features
 
 	// CanUseAKAMAICDN indicates the provider support the specific AKAMAICDN records that only the Akamai EdgeDns provider supports
 	CanUseAKAMAICDN

--- a/providers/capabilities.go
+++ b/providers/capabilities.go
@@ -25,6 +25,10 @@ const (
 	// work when used concurrently.  The default is Cannot().
 	CanConcur
 
+	// CanDiff2 indicates the diff2 engine is used.  Without this capability,
+	// IGNORE() and other features simply do not work.
+	CanDiff2
+
 	// CanGetZones indicates the provider supports the get-zones subcommand.
 	CanGetZones
 

--- a/providers/capabilities.go
+++ b/providers/capabilities.go
@@ -25,9 +25,15 @@ const (
 	// work when used concurrently.  The default is Cannot().
 	CanConcur
 
-	// CanDiff2 indicates the diff2 engine is used.  Without this capability,
-	// IGNORE() and other features simply do not work.
-	CanDiff2
+	// CanDiff2Features indicates the provider uses the "diff2" engine natively
+	// instead of the backwards compatibility mode.
+	// The diff2 engine is required to repliably provide IGNORE(), NO_PURGE, and
+	// other features.
+	// This capability is set automatically for the provider during the call to
+	// RegisterDomainServiceProviderType.  It is set to Cannot() if we detect
+	// compatibility mode is in use. All other values (Unimplemented and Can)
+	// are equivalent.
+	CanDiff2Features
 
 	// CanGetZones indicates the provider supports the get-zones subcommand.
 	CanGetZones

--- a/providers/capability_string.go
+++ b/providers/capability_string.go
@@ -10,8 +10,8 @@ func _() {
 	var x [1]struct{}
 	_ = x[CanAutoDNSSEC-0]
 	_ = x[CanConcur-1]
-	_ = x[CanDiff2Features-2]
-	_ = x[CanGetZones-3]
+	_ = x[CanGetZones-2]
+	_ = x[CanOnlyDiff1Features-3]
 	_ = x[CanUseAKAMAICDN-4]
 	_ = x[CanUseAlias-5]
 	_ = x[CanUseAzureAlias-6]
@@ -36,9 +36,9 @@ func _() {
 	_ = x[DocOfficiallySupported-25]
 }
 
-const _Capability_name = "CanAutoDNSSECCanConcurCanDiff2FeaturesCanGetZonesCanUseAKAMAICDNCanUseAliasCanUseAzureAliasCanUseCAACanUseDHCIDCanUseDNAMECanUseDSCanUseDSForChildrenCanUseHTTPSCanUseLOCCanUseNAPTRCanUsePTRCanUseRoute53AliasCanUseSOACanUseSRVCanUseSSHFPCanUseSVCBCanUseTLSACanUseDNSKEYDocCreateDomainsDocDualHostDocOfficiallySupported"
+const _Capability_name = "CanAutoDNSSECCanConcurCanGetZonesCanOnlyDiff1FeaturesCanUseAKAMAICDNCanUseAliasCanUseAzureAliasCanUseCAACanUseDHCIDCanUseDNAMECanUseDSCanUseDSForChildrenCanUseHTTPSCanUseLOCCanUseNAPTRCanUsePTRCanUseRoute53AliasCanUseSOACanUseSRVCanUseSSHFPCanUseSVCBCanUseTLSACanUseDNSKEYDocCreateDomainsDocDualHostDocOfficiallySupported"
 
-var _Capability_index = [...]uint16{0, 13, 22, 38, 49, 64, 75, 91, 100, 111, 122, 130, 149, 160, 169, 180, 189, 207, 216, 225, 236, 246, 256, 268, 284, 295, 317}
+var _Capability_index = [...]uint16{0, 13, 22, 33, 53, 68, 79, 95, 104, 115, 126, 134, 153, 164, 173, 184, 193, 211, 220, 229, 240, 250, 260, 272, 288, 299, 321}
 
 func (i Capability) String() string {
 	if i >= Capability(len(_Capability_index)-1) {

--- a/providers/capability_string.go
+++ b/providers/capability_string.go
@@ -10,34 +10,35 @@ func _() {
 	var x [1]struct{}
 	_ = x[CanAutoDNSSEC-0]
 	_ = x[CanConcur-1]
-	_ = x[CanGetZones-2]
-	_ = x[CanUseAKAMAICDN-3]
-	_ = x[CanUseAlias-4]
-	_ = x[CanUseAzureAlias-5]
-	_ = x[CanUseCAA-6]
-	_ = x[CanUseDHCID-7]
-	_ = x[CanUseDNAME-8]
-	_ = x[CanUseDS-9]
-	_ = x[CanUseDSForChildren-10]
-	_ = x[CanUseHTTPS-11]
-	_ = x[CanUseLOC-12]
-	_ = x[CanUseNAPTR-13]
-	_ = x[CanUsePTR-14]
-	_ = x[CanUseRoute53Alias-15]
-	_ = x[CanUseSOA-16]
-	_ = x[CanUseSRV-17]
-	_ = x[CanUseSSHFP-18]
-	_ = x[CanUseSVCB-19]
-	_ = x[CanUseTLSA-20]
-	_ = x[CanUseDNSKEY-21]
-	_ = x[DocCreateDomains-22]
-	_ = x[DocDualHost-23]
-	_ = x[DocOfficiallySupported-24]
+	_ = x[CanDiff2-2]
+	_ = x[CanGetZones-3]
+	_ = x[CanUseAKAMAICDN-4]
+	_ = x[CanUseAlias-5]
+	_ = x[CanUseAzureAlias-6]
+	_ = x[CanUseCAA-7]
+	_ = x[CanUseDHCID-8]
+	_ = x[CanUseDNAME-9]
+	_ = x[CanUseDS-10]
+	_ = x[CanUseDSForChildren-11]
+	_ = x[CanUseHTTPS-12]
+	_ = x[CanUseLOC-13]
+	_ = x[CanUseNAPTR-14]
+	_ = x[CanUsePTR-15]
+	_ = x[CanUseRoute53Alias-16]
+	_ = x[CanUseSOA-17]
+	_ = x[CanUseSRV-18]
+	_ = x[CanUseSSHFP-19]
+	_ = x[CanUseSVCB-20]
+	_ = x[CanUseTLSA-21]
+	_ = x[CanUseDNSKEY-22]
+	_ = x[DocCreateDomains-23]
+	_ = x[DocDualHost-24]
+	_ = x[DocOfficiallySupported-25]
 }
 
-const _Capability_name = "CanAutoDNSSECCanConcurCanGetZonesCanUseAKAMAICDNCanUseAliasCanUseAzureAliasCanUseCAACanUseDHCIDCanUseDNAMECanUseDSCanUseDSForChildrenCanUseHTTPSCanUseLOCCanUseNAPTRCanUsePTRCanUseRoute53AliasCanUseSOACanUseSRVCanUseSSHFPCanUseSVCBCanUseTLSACanUseDNSKEYDocCreateDomainsDocDualHostDocOfficiallySupported"
+const _Capability_name = "CanAutoDNSSECCanConcurCanDiff2CanGetZonesCanUseAKAMAICDNCanUseAliasCanUseAzureAliasCanUseCAACanUseDHCIDCanUseDNAMECanUseDSCanUseDSForChildrenCanUseHTTPSCanUseLOCCanUseNAPTRCanUsePTRCanUseRoute53AliasCanUseSOACanUseSRVCanUseSSHFPCanUseSVCBCanUseTLSACanUseDNSKEYDocCreateDomainsDocDualHostDocOfficiallySupported"
 
-var _Capability_index = [...]uint16{0, 13, 22, 33, 48, 59, 75, 84, 95, 106, 114, 133, 144, 153, 164, 173, 191, 200, 209, 220, 230, 240, 252, 268, 279, 301}
+var _Capability_index = [...]uint16{0, 13, 22, 30, 41, 56, 67, 83, 92, 103, 114, 122, 141, 152, 161, 172, 181, 199, 208, 217, 228, 238, 248, 260, 276, 287, 309}
 
 func (i Capability) String() string {
 	if i >= Capability(len(_Capability_index)-1) {

--- a/providers/capability_string.go
+++ b/providers/capability_string.go
@@ -10,7 +10,7 @@ func _() {
 	var x [1]struct{}
 	_ = x[CanAutoDNSSEC-0]
 	_ = x[CanConcur-1]
-	_ = x[CanDiff2-2]
+	_ = x[CanDiff2Features-2]
 	_ = x[CanGetZones-3]
 	_ = x[CanUseAKAMAICDN-4]
 	_ = x[CanUseAlias-5]
@@ -36,9 +36,9 @@ func _() {
 	_ = x[DocOfficiallySupported-25]
 }
 
-const _Capability_name = "CanAutoDNSSECCanConcurCanDiff2CanGetZonesCanUseAKAMAICDNCanUseAliasCanUseAzureAliasCanUseCAACanUseDHCIDCanUseDNAMECanUseDSCanUseDSForChildrenCanUseHTTPSCanUseLOCCanUseNAPTRCanUsePTRCanUseRoute53AliasCanUseSOACanUseSRVCanUseSSHFPCanUseSVCBCanUseTLSACanUseDNSKEYDocCreateDomainsDocDualHostDocOfficiallySupported"
+const _Capability_name = "CanAutoDNSSECCanConcurCanDiff2FeaturesCanGetZonesCanUseAKAMAICDNCanUseAliasCanUseAzureAliasCanUseCAACanUseDHCIDCanUseDNAMECanUseDSCanUseDSForChildrenCanUseHTTPSCanUseLOCCanUseNAPTRCanUsePTRCanUseRoute53AliasCanUseSOACanUseSRVCanUseSSHFPCanUseSVCBCanUseTLSACanUseDNSKEYDocCreateDomainsDocDualHostDocOfficiallySupported"
 
-var _Capability_index = [...]uint16{0, 13, 22, 30, 41, 56, 67, 83, 92, 103, 114, 122, 141, 152, 161, 172, 181, 199, 208, 217, 228, 238, 248, 260, 276, 287, 309}
+var _Capability_index = [...]uint16{0, 13, 22, 38, 49, 64, 75, 91, 100, 111, 122, 130, 149, 160, 169, 180, 189, 207, 216, 225, 236, 246, 256, 268, 284, 295, 317}
 
 func (i Capability) String() string {
 	if i >= Capability(len(_Capability_index)-1) {

--- a/providers/cloudns/cloudnsProvider.go
+++ b/providers/cloudns/cloudnsProvider.go
@@ -39,8 +39,9 @@ var features = providers.DocumentationNotes{
 	// The default for unlisted capabilities is 'Cannot'.
 	// See providers/capabilities.go for the entire list of capabilities.
 	providers.CanAutoDNSSEC:          providers.Can(),
-	providers.CanGetZones:            providers.Can(),
 	providers.CanConcur:              providers.Can(),
+	providers.CanGetZones:            providers.Can(),
+	providers.CanOnlyDiff1Features:   providers.Can(),
 	providers.CanUseAlias:            providers.Can(),
 	providers.CanUseCAA:              providers.Can(),
 	providers.CanUseDNAME:            providers.Can(),

--- a/providers/cnr/cnrProvider.go
+++ b/providers/cnr/cnrProvider.go
@@ -27,6 +27,7 @@ var features = providers.DocumentationNotes{
 	providers.CanAutoDNSSEC:          providers.Unimplemented("Ask for this feature."),
 	providers.CanConcur:              providers.Can(),
 	providers.CanGetZones:            providers.Can(),
+	providers.CanOnlyDiff1Features:   providers.Can(),
 	providers.DocCreateDomains:       providers.Can(),
 	providers.DocDualHost:            providers.Can(),
 	providers.DocOfficiallySupported: providers.Cannot("Actively maintained provider module."),

--- a/providers/cscglobal/cscglobalProvider.go
+++ b/providers/cscglobal/cscglobalProvider.go
@@ -27,8 +27,9 @@ type providerClient struct {
 var features = providers.DocumentationNotes{
 	// The default for unlisted capabilities is 'Cannot'.
 	// See providers/capabilities.go for the entire list of capabilities.
-	providers.CanGetZones:            providers.Can(),
 	providers.CanConcur:              providers.Can(),
+	providers.CanGetZones:            providers.Can(),
+	providers.CanOnlyDiff1Features:   providers.Can(),
 	providers.CanUseCAA:              providers.Can(),
 	providers.CanUseSRV:              providers.Can(),
 	providers.DocOfficiallySupported: providers.Can(),

--- a/providers/desec/desecProvider.go
+++ b/providers/desec/desecProvider.go
@@ -35,12 +35,13 @@ var features = providers.DocumentationNotes{
 	// The default for unlisted capabilities is 'Cannot'.
 	// See providers/capabilities.go for the entire list of capabilities.
 	providers.CanAutoDNSSEC:          providers.Can("deSEC always signs all records. When trying to disable, a notice is printed."),
-	providers.CanGetZones:            providers.Can(),
 	providers.CanConcur:              providers.Can(),
+	providers.CanGetZones:            providers.Can(),
+	providers.CanOnlyDiff1Features:   providers.Can(),
 	providers.CanUseAlias:            providers.Unimplemented("Apex aliasing is supported via new SVCB and HTTPS record types. For details, check the deSEC docs."),
 	providers.CanUseCAA:              providers.Can(),
-	providers.CanUseDS:               providers.Can(),
 	providers.CanUseDNSKEY:           providers.Can(),
+	providers.CanUseDS:               providers.Can(),
 	providers.CanUseHTTPS:            providers.Can(),
 	providers.CanUseLOC:              providers.Unimplemented(),
 	providers.CanUseNAPTR:            providers.Can(),

--- a/providers/digitalocean/digitaloceanProvider.go
+++ b/providers/digitalocean/digitaloceanProvider.go
@@ -75,7 +75,6 @@ var features = providers.DocumentationNotes{
 	// See providers/capabilities.go for the entire list of capabilities.
 	providers.CanConcur:              providers.Can(),
 	providers.CanGetZones:            providers.Can(),
-	providers.CanOnlyDiff1Features:   providers.Can(),
 	providers.CanUseCAA:              providers.Can(),
 	providers.CanUseLOC:              providers.Cannot(),
 	providers.CanUseSRV:              providers.Can(),

--- a/providers/digitalocean/digitaloceanProvider.go
+++ b/providers/digitalocean/digitaloceanProvider.go
@@ -73,8 +73,9 @@ retry:
 var features = providers.DocumentationNotes{
 	// The default for unlisted capabilities is 'Cannot'.
 	// See providers/capabilities.go for the entire list of capabilities.
-	providers.CanGetZones:            providers.Can(),
 	providers.CanConcur:              providers.Can(),
+	providers.CanGetZones:            providers.Can(),
+	providers.CanOnlyDiff1Features:   providers.Can(),
 	providers.CanUseCAA:              providers.Can(),
 	providers.CanUseLOC:              providers.Cannot(),
 	providers.CanUseSRV:              providers.Can(),

--- a/providers/dnsimple/dnsimpleProvider.go
+++ b/providers/dnsimple/dnsimpleProvider.go
@@ -24,8 +24,9 @@ var features = providers.DocumentationNotes{
 	// The default for unlisted capabilities is 'Cannot'.
 	// See providers/capabilities.go for the entire list of capabilities.
 	providers.CanAutoDNSSEC:          providers.Can(),
-	providers.CanGetZones:            providers.Can(),
 	providers.CanConcur:              providers.Can(),
+	providers.CanGetZones:            providers.Can(),
+	providers.CanOnlyDiff1Features:   providers.Can(),
 	providers.CanUseAlias:            providers.Can(),
 	providers.CanUseCAA:              providers.Can(),
 	providers.CanUseDS:               providers.Cannot(),

--- a/providers/dnsmadeeasy/dnsMadeEasyProvider.go
+++ b/providers/dnsmadeeasy/dnsMadeEasyProvider.go
@@ -14,8 +14,9 @@ import (
 var features = providers.DocumentationNotes{
 	// The default for unlisted capabilities is 'Cannot'.
 	// See providers/capabilities.go for the entire list of capabilities.
-	providers.CanGetZones:            providers.Can(),
 	providers.CanConcur:              providers.Unimplemented(),
+	providers.CanGetZones:            providers.Can(),
+	providers.CanOnlyDiff1Features:   providers.Can(),
 	providers.CanUseAlias:            providers.Can(),
 	providers.CanUseCAA:              providers.Can(),
 	providers.CanUseDS:               providers.Cannot(),

--- a/providers/domainnameshop/domainnameshopProvider.go
+++ b/providers/domainnameshop/domainnameshopProvider.go
@@ -25,9 +25,10 @@ type domainNameShopProvider struct {
 var features = providers.DocumentationNotes{
 	// The default for unlisted capabilities is 'Cannot'.
 	// See providers/capabilities.go for the entire list of capabilities.
-	providers.CanAutoDNSSEC:          providers.Cannot(),        // Maybe there is support for it
-	providers.CanGetZones:            providers.Unimplemented(), //
+	providers.CanAutoDNSSEC:          providers.Cannot(), // Maybe there is support for it
 	providers.CanConcur:              providers.Unimplemented(),
+	providers.CanGetZones:            providers.Unimplemented(), //
+	providers.CanOnlyDiff1Features:   providers.Can(),
 	providers.CanUseAlias:            providers.Unimplemented("Needs custom implementation"), // Can possibly be implemented, needs further research
 	providers.CanUseCAA:              providers.Can(),
 	providers.CanUseDS:               providers.Unimplemented(), // Seems to support but needs to be implemented

--- a/providers/exoscale/exoscaleProvider.go
+++ b/providers/exoscale/exoscaleProvider.go
@@ -55,8 +55,9 @@ func NewExoscale(m map[string]string, metadata json.RawMessage) (providers.DNSSe
 var features = providers.DocumentationNotes{
 	// The default for unlisted capabilities is 'Cannot'.
 	// See providers/capabilities.go for the entire list of capabilities.
-	providers.CanGetZones:            providers.Unimplemented(),
 	providers.CanConcur:              providers.Unimplemented(),
+	providers.CanGetZones:            providers.Unimplemented(),
+	providers.CanOnlyDiff1Features:   providers.Can(),
 	providers.CanUseAlias:            providers.Can(),
 	providers.CanUseCAA:              providers.Can(),
 	providers.CanUseLOC:              providers.Cannot(),

--- a/providers/hetzner/hetznerProvider.go
+++ b/providers/hetzner/hetznerProvider.go
@@ -15,8 +15,9 @@ var features = providers.DocumentationNotes{
 	// The default for unlisted capabilities is 'Cannot'.
 	// See providers/capabilities.go for the entire list of capabilities.
 	providers.CanAutoDNSSEC:          providers.Cannot(),
-	providers.CanGetZones:            providers.Can(),
 	providers.CanConcur:              providers.Can(),
+	providers.CanGetZones:            providers.Can(),
+	providers.CanOnlyDiff1Features:   providers.Can(),
 	providers.CanUseAlias:            providers.Cannot(),
 	providers.CanUseCAA:              providers.Can(),
 	providers.CanUseDS:               providers.Can(),

--- a/providers/hexonet/hexonetProvider.go
+++ b/providers/hexonet/hexonetProvider.go
@@ -21,8 +21,9 @@ type HXClient struct {
 var features = providers.DocumentationNotes{
 	// The default for unlisted capabilities is 'Cannot'.
 	// See providers/capabilities.go for the entire list of capabilities.
-	providers.CanGetZones:            providers.Unimplemented(),
 	providers.CanConcur:              providers.Unimplemented(),
+	providers.CanGetZones:            providers.Unimplemented(),
+	providers.CanOnlyDiff1Features:   providers.Can(),
 	providers.CanUseAlias:            providers.Cannot("Using ALIAS is possible through our extended DNS (X-DNS) service. Feel free to get in touch with us."),
 	providers.CanUseCAA:              providers.Can(),
 	providers.CanUseLOC:              providers.Unimplemented(),

--- a/providers/hostingde/hostingdeProvider.go
+++ b/providers/hostingde/hostingdeProvider.go
@@ -20,8 +20,9 @@ var features = providers.DocumentationNotes{
 	// The default for unlisted capabilities is 'Cannot'.
 	// See providers/capabilities.go for the entire list of capabilities.
 	providers.CanAutoDNSSEC:          providers.Can(),
-	providers.CanGetZones:            providers.Can(),
 	providers.CanConcur:              providers.Unimplemented(),
+	providers.CanGetZones:            providers.Can(),
+	providers.CanOnlyDiff1Features:   providers.Can(),
 	providers.CanUseAlias:            providers.Can(),
 	providers.CanUseCAA:              providers.Can(),
 	providers.CanUseDS:               providers.Can(),

--- a/providers/linode/linodeProvider.go
+++ b/providers/linode/linodeProvider.go
@@ -91,8 +91,9 @@ func NewLinode(m map[string]string, metadata json.RawMessage) (providers.DNSServ
 var features = providers.DocumentationNotes{
 	// The default for unlisted capabilities is 'Cannot'.
 	// See providers/capabilities.go for the entire list of capabilities.
-	providers.CanGetZones:            providers.Can(),
 	providers.CanConcur:              providers.Unimplemented(),
+	providers.CanGetZones:            providers.Can(),
+	providers.CanOnlyDiff1Features:   providers.Can(),
 	providers.CanUseCAA:              providers.Can("Linode doesn't support changing the CAA flag"),
 	providers.CanUseLOC:              providers.Cannot(),
 	providers.DocDualHost:            providers.Cannot(),

--- a/providers/loopia/loopiaProvider.go
+++ b/providers/loopia/loopiaProvider.go
@@ -50,8 +50,9 @@ var features = providers.DocumentationNotes{
 	// The default for unlisted capabilities is 'Cannot'.
 	// See providers/capabilities.go for the entire list of capabilities.
 	providers.CanAutoDNSSEC:          providers.Cannot(),
-	providers.CanGetZones:            providers.Can(),
 	providers.CanConcur:              providers.Unimplemented(),
+	providers.CanGetZones:            providers.Can(),
+	providers.CanOnlyDiff1Features:   providers.Can(),
 	providers.CanUseAKAMAICDN:        providers.Cannot(),
 	providers.CanUseAlias:            providers.Cannot(),
 	providers.CanUseAzureAlias:       providers.Cannot(),

--- a/providers/namecheap/namecheapProvider.go
+++ b/providers/namecheap/namecheapProvider.go
@@ -31,7 +31,7 @@ var features = providers.DocumentationNotes{
 	// See providers/capabilities.go for the entire list of capabilities.
 	providers.CanConcur:              providers.Can(),
 	providers.CanGetZones:            providers.Can(),
-	providers.CanOnlyDiff1Features:   providers.Can(),
+	providers.CanOnlyDiff1Features:   providers.Can(), // If you remove this, also update not() statements in integrationTest/integration_test.go
 	providers.CanUseAlias:            providers.Can(),
 	providers.CanUseCAA:              providers.Can(),
 	providers.CanUseLOC:              providers.Cannot(),

--- a/providers/namecheap/namecheapProvider.go
+++ b/providers/namecheap/namecheapProvider.go
@@ -29,8 +29,9 @@ type namecheapProvider struct {
 var features = providers.DocumentationNotes{
 	// The default for unlisted capabilities is 'Cannot'.
 	// See providers/capabilities.go for the entire list of capabilities.
-	providers.CanGetZones:            providers.Can(),
 	providers.CanConcur:              providers.Can(),
+	providers.CanGetZones:            providers.Can(),
+	providers.CanOnlyDiff1Features:   providers.Can(),
 	providers.CanUseAlias:            providers.Can(),
 	providers.CanUseCAA:              providers.Can(),
 	providers.CanUseLOC:              providers.Cannot(),

--- a/providers/namedotcom/namedotcomProvider.go
+++ b/providers/namedotcom/namedotcomProvider.go
@@ -23,8 +23,9 @@ type namedotcomProvider struct {
 var features = providers.DocumentationNotes{
 	// The default for unlisted capabilities is 'Cannot'.
 	// See providers/capabilities.go for the entire list of capabilities.
-	providers.CanGetZones:            providers.Can(),
 	providers.CanConcur:              providers.Unimplemented(),
+	providers.CanGetZones:            providers.Can(),
+	providers.CanOnlyDiff1Features:   providers.Can(),
 	providers.CanUseAlias:            providers.Can(),
 	providers.CanUseLOC:              providers.Cannot(),
 	providers.CanUsePTR:              providers.Cannot("PTR records are not supported (See Link)", "https://www.name.com/support/articles/205188508-Reverse-DNS-records"),

--- a/providers/netcup/netcupProvider.go
+++ b/providers/netcup/netcupProvider.go
@@ -13,8 +13,9 @@ import (
 var features = providers.DocumentationNotes{
 	// The default for unlisted capabilities is 'Cannot'.
 	// See providers/capabilities.go for the entire list of capabilities.
-	providers.CanGetZones:            providers.Cannot(),
 	providers.CanConcur:              providers.Unimplemented(),
+	providers.CanGetZones:            providers.Cannot(),
+	providers.CanOnlyDiff1Features:   providers.Can(),
 	providers.CanUseCAA:              providers.Can(),
 	providers.CanUseLOC:              providers.Cannot(),
 	providers.CanUsePTR:              providers.Cannot(),

--- a/providers/netlify/netlifyProvider.go
+++ b/providers/netlify/netlifyProvider.go
@@ -16,8 +16,9 @@ var features = providers.DocumentationNotes{
 	// The default for unlisted capabilities is 'Cannot'.
 	// See providers/capabilities.go for the entire list of capabilities.
 	providers.CanAutoDNSSEC:          providers.Cannot(),
-	providers.CanGetZones:            providers.Can(),
 	providers.CanConcur:              providers.Can(),
+	providers.CanGetZones:            providers.Can(),
+	providers.CanOnlyDiff1Features:   providers.Can(),
 	providers.CanUseAlias:            providers.Can(),
 	providers.CanUseCAA:              providers.Can(),
 	providers.CanUseDS:               providers.Cannot(),

--- a/providers/oracle/oracleProvider.go
+++ b/providers/oracle/oracleProvider.go
@@ -20,8 +20,9 @@ import (
 var features = providers.DocumentationNotes{
 	// The default for unlisted capabilities is 'Cannot'.
 	// See providers/capabilities.go for the entire list of capabilities.
-	providers.CanGetZones:            providers.Can(),
 	providers.CanConcur:              providers.Unimplemented(),
+	providers.CanGetZones:            providers.Can(),
+	providers.CanOnlyDiff1Features:   providers.Can(),
 	providers.CanUseAlias:            providers.Can(),
 	providers.CanUseCAA:              providers.Can(),
 	providers.CanUseDS:               providers.Cannot(), // should be supported, but getting 500s in tests

--- a/providers/packetframe/packetframeProvider.go
+++ b/providers/packetframe/packetframeProvider.go
@@ -42,8 +42,9 @@ func newPacketframe(m map[string]string, metadata json.RawMessage) (providers.DN
 var features = providers.DocumentationNotes{
 	// The default for unlisted capabilities is 'Cannot'.
 	// See providers/capabilities.go for the entire list of capabilities.
-	providers.CanGetZones:            providers.Unimplemented(),
 	providers.CanConcur:              providers.Unimplemented(),
+	providers.CanGetZones:            providers.Unimplemented(),
+	providers.CanOnlyDiff1Features:   providers.Can(),
 	providers.CanUsePTR:              providers.Can(),
 	providers.CanUseSRV:              providers.Can(),
 	providers.DocDualHost:            providers.Cannot(),

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -71,11 +71,7 @@ func RegisterDomainServiceProviderType(name string, fns DspFuncs, pm ...Provider
 	}
 	DNSProviderTypes[name] = fns
 
-	var features = DocumentationNotes{
-		CanDiff2Features: Cannot(),
-	}
-
-	unwrapProviderCapabilities(name, append(pm, features))
+	unwrapProviderCapabilities(name, pm)
 }
 
 var ProviderMaintainers = map[string]string{}

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -70,10 +70,9 @@ func RegisterDomainServiceProviderType(name string, fns DspFuncs, pm ...Provider
 		log.Fatalf("Cannot register registrar type %q multiple times", name)
 	}
 	DNSProviderTypes[name] = fns
-	pm = append(pm, Can())
 
 	var features = DocumentationNotes{
-		CanDiff2: Can(),
+		CanDiff2Features: Cannot(),
 	}
 
 	unwrapProviderCapabilities(name, append(pm, features))

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -70,7 +70,13 @@ func RegisterDomainServiceProviderType(name string, fns DspFuncs, pm ...Provider
 		log.Fatalf("Cannot register registrar type %q multiple times", name)
 	}
 	DNSProviderTypes[name] = fns
-	unwrapProviderCapabilities(name, pm)
+	pm = append(pm, Can())
+
+	var features = DocumentationNotes{
+		CanDiff2: Can(),
+	}
+
+	unwrapProviderCapabilities(name, append(pm, features))
 }
 
 var ProviderMaintainers = map[string]string{}

--- a/providers/rwth/rwthProvider.go
+++ b/providers/rwth/rwthProvider.go
@@ -17,8 +17,9 @@ var features = providers.DocumentationNotes{
 	// The default for unlisted capabilities is 'Cannot'.
 	// See providers/capabilities.go for the entire list of capabilities.
 	providers.CanAutoDNSSEC:          providers.Unimplemented("Supported by RWTH but not implemented yet."),
-	providers.CanGetZones:            providers.Can(),
 	providers.CanConcur:              providers.Unimplemented(),
+	providers.CanGetZones:            providers.Can(),
+	providers.CanOnlyDiff1Features:   providers.Can(),
 	providers.CanUseAlias:            providers.Cannot(),
 	providers.CanUseCAA:              providers.Can(),
 	providers.CanUseDS:               providers.Unimplemented("DS records are only supported at the apex and require a different API call that hasn't been implemented yet."),

--- a/providers/softlayer/softlayerProvider.go
+++ b/providers/softlayer/softlayerProvider.go
@@ -25,10 +25,11 @@ type softlayerProvider struct {
 var features = providers.DocumentationNotes{
 	// The default for unlisted capabilities is 'Cannot'.
 	// See providers/capabilities.go for the entire list of capabilities.
-	providers.CanGetZones: providers.Unimplemented(),
-	providers.CanConcur:   providers.Unimplemented(),
-	providers.CanUseLOC:   providers.Cannot(),
-	providers.CanUseSRV:   providers.Can(),
+	providers.CanConcur:            providers.Unimplemented(),
+	providers.CanGetZones:          providers.Unimplemented(),
+	providers.CanOnlyDiff1Features: providers.Can(),
+	providers.CanUseLOC:            providers.Cannot(),
+	providers.CanUseSRV:            providers.Can(),
 }
 
 func init() {


### PR DESCRIPTION
# Issue

IGNORE() is unreliable for providers that haven't adopted the diff2 library.

A few years ago we replaced the diffing engine ("diff") with a new one that handled IGNORE() and many features much better.  Most of the providers were rewritten to use the new library.  Since rewriting the provider was such a burden (and in some cases the maintainer of the provider had disappeared), I created a backwards compatibility mode called diff.NewCompat().  While it had the benefit of only requiring 2-3 lines of code changes, it doesn't implement IGNORE() reliably in all cases.  Other, newer, features also don't work.

# Resolution

1. Add a new capability called `CanOnlyDiff1Features` to mark which providers have not been upgraded yet. It is not automatically generated, thus we should be careful when converting providers to use diff2.

2. Alphabetize the "features" list for affected providers.  It seems that CanGetZones() wasn't added in the right place.

3. Output a warning if any of the following features are used:

* ENSURE_ABSENT
* NO_PURGE
* IGNORE() and friends
* DISABLE_IGNORE_SAFETY_CHECK

FYI:  Affected providers:

```
providers/akamaiedgedns/akamaiEdgeDnsProvider.go
providers/cloudns/cloudnsProvider.go
providers/cnr/records.go
providers/cscglobal/dns.go
providers/desec/desecProvider.go
providers/digitalocean/digitaloceanProvider.go
providers/dnsimple/dnsimpleProvider.go
providers/dnsmadeeasy/dnsMadeEasyProvider.go
providers/domainnameshop/dns.go
providers/exoscale/exoscaleProvider.go
providers/hetzner/hetznerProvider.go
providers/hexonet/records.go
providers/hostingde/hostingdeProvider.go
providers/linode/linodeProvider.go
providers/loopia/loopiaProvider.go
providers/namecheap/namecheapProvider.go
providers/namedotcom/records.go
providers/netcup/netcupProvider.go
providers/netlify/netlifyProvider.go
providers/oracle/oracleProvider.go
providers/packetframe/packetframeProvider.go
providers/rwth/dns.go
providers/softlayer/softlayerProvider.go
```

