### PR TITLE
CICD: Update PR instructions

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,7 +3,7 @@
 
 Please make sure you've run the following commands from the root directory.
 
-    bin/generate.sh
+    bin/generate-all.sh
 
 (this runs commands like "go generate", fixes formatting, and so on)
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,10 +3,9 @@
 
 Please make sure you've run the following commands from the root directory.
 
-go vet ./...
-go fmt ./...
-go generate ./...
-go mod tidy
+    bin/generate.sh
+
+(this runs commands like "go generate", fixes formatting, and so on)
 
 ## Release changelog section
 


### PR DESCRIPTION
# Issue

The PR template is out of date. bin/generate-all.sh should be used instead of individual commands.

# Resolution

Fix it.