### PR TITLE
DOCS: Warn that "" should be "@" in error messages & docs. Update docs to suggest safer onboarding process.

### DIFF
--- a/commands/types/dnscontrol.d.ts
+++ b/commands/types/dnscontrol.d.ts
@@ -670,7 +670,7 @@ declare function CNAME(name: string, target: string, ...modifiers: RecordModifie
  * ```javascript
  * // simple domain
  * D("example.com", REG_MY_PROVIDER, DnsProvider(DSP_MY_PROVIDER),
- *   A("@","1.2.3.4"),
+ *   A("@","1.2.3.4"),           // "@" means the apex domain. In this case, "example.com" itself.
  *   CNAME("test", "foo.example2.com."),
  * );
  *
@@ -683,12 +683,17 @@ declare function CNAME(name: string, target: string, ...modifiers: RecordModifie
  *     MX("@", 10, "alt4.aspmx.l.google.com."),
  * ]
  *
- * D("example.com", REG_MY_PROVIDER, DnsProvider(DSP_MY_PROVIDER),
+ * D("otherexample.com", REG_MY_PROVIDER, DnsProvider(DSP_MY_PROVIDER),
  *   A("@","1.2.3.4"),
  *   CNAME("test", "foo.example2.com."),
  *   GOOGLE_APPS_DOMAIN_MX,
  * );
  * ```
+ *
+ * **What is "@"** `@` is a special name that means the domain itself, otherwise
+ * known as the domain's apex, the bare domain, or the naked domain.  In the
+ * above example, `example.com` has an `A` record at the apex of the domain
+ * (`"1.2.3.4"`).
  *
  * # Split Horizon DNS
  *

--- a/documentation/getting-started/getting-started.md
+++ b/documentation/getting-started/getting-started.md
@@ -236,9 +236,9 @@ previously exist.
 +{% hint style="warn" %}
 +**Nervous?**  The first "push" can be nervous-making. How to migrate a zone
 safely?  It's best to loop through iterations of `preview` and editing
-`dnsconfig.js` until no "changes" are listed.  Once you see the preview is
-clean (or at least making the changes you desire), doing a `push` is relatively
-safe.  (Though, like any tool, backups are recommended.)
+`dnsconfig.js` until no changes are listed, or at least no unexpected changes.
+Once you see the preview is clean (or at least making the changes you desire),
+doing a `push` is safe.  (Though, as with any tool, backups are recommended.)
 +{% endhint %}
 
 ```shell

--- a/documentation/getting-started/getting-started.md
+++ b/documentation/getting-started/getting-started.md
@@ -97,7 +97,7 @@ var REG_NONE = NewRegistrar("none");
 var DNS_BIND = NewDnsProvider("bind");
 
 D("example.com", REG_NONE, DnsProvider(DNS_BIND),
-    A("@", "1.2.3.4"),
+    A("@", "1.2.3.4"),    // "@" means the domain's apex.
 );
 ```
 {% endcode %}
@@ -233,6 +233,14 @@ Next, run `dnscontrol push` to actually make the changes. In this
 case, the change will be to create a zone file where one didn't
 previously exist.
 
++{% hint style="warn" %}
++**Nervous?**  The first "push" can be nervous-making. How to migrate a zone
+safely?  It's best to loop through iterations of `preview` and editing
+`dnsconfig.js` until no "changes" are listed.  Once you see the preview is
+clean (or at least making the changes you desire), doing a `push` is relatively
+safe.  (Though, like any tool, backups are recommended.)
++{% endhint %}
+
 ```shell
 dnscontrol push
 ```
@@ -328,6 +336,12 @@ that can be added to `dnsconfig.js` and used with very little
 modification.
 
 Now you can make changes to the domain(s)  and run `dnscontrol preview`
+
++{% hint style="warn" %}
++**get-zones is not perfect** It is intended to be "a decent first draft", only
+requiring minimal editing. Please submit a bug report if you have suggestions
+on how it can be improved.
++{% endhint %}
 
 
 ## 8. Production Advice

--- a/documentation/getting-started/getting-started.md
+++ b/documentation/getting-started/getting-started.md
@@ -233,13 +233,13 @@ Next, run `dnscontrol push` to actually make the changes. In this
 case, the change will be to create a zone file where one didn't
 previously exist.
 
-+{% hint style="warn" %}
-+**Nervous?**  The first "push" can be nervous-making. How to migrate a zone
+{% hint style="warn" %}
+**Nervous?**  The first "push" can be nervous-making. How to migrate a zone
 safely?  It's best to loop through iterations of `preview` and editing
-`dnsconfig.js` until no changes are listed, or at least no unexpected changes.
+`dnsconfig.js` until no changes are listed.
 Once you see the preview is clean (or at least making the changes you desire),
-doing a `push` is safe.  (Though, as with any tool, backups are recommended.)
-+{% endhint %}
+doing a `push` is safe.  (Though, as with any tool, backups are recommended. Even a screenshot of your DNS provider's web portal is better than nothing!)
+{% endhint %}
 
 ```shell
 dnscontrol push

--- a/documentation/language-reference/top-level-functions/D.md
+++ b/documentation/language-reference/top-level-functions/D.md
@@ -25,7 +25,7 @@ Modifier arguments are processed according to type as follows:
 ```javascript
 // simple domain
 D("example.com", REG_MY_PROVIDER, DnsProvider(DSP_MY_PROVIDER),
-  A("@","1.2.3.4"),
+  A("@","1.2.3.4"),           // "@" means the apex domain. In this case, "example.com" itself.
   CNAME("test", "foo.example2.com."),
 );
 
@@ -38,13 +38,20 @@ var GOOGLE_APPS_DOMAIN_MX = [
     MX("@", 10, "alt4.aspmx.l.google.com."),
 ]
 
-D("example.com", REG_MY_PROVIDER, DnsProvider(DSP_MY_PROVIDER),
+D("otherexample.com", REG_MY_PROVIDER, DnsProvider(DSP_MY_PROVIDER),
   A("@","1.2.3.4"),
   CNAME("test", "foo.example2.com."),
   GOOGLE_APPS_DOMAIN_MX,
 );
 ```
 {% endcode %}
+
+{% hint style="info" %}
+**What is "@"** `@` is a special name that means the domain itself, otherwise
+known as the domain's apex, the bare domain, or the naked domain.  In the
+above example, `example.com` has an `A` record at the apex of the domain
+(`"1.2.3.4"`).
+{% endhint %}
 
 # Split Horizon DNS
 

--- a/pkg/normalize/validate.go
+++ b/pkg/normalize/validate.go
@@ -36,7 +36,7 @@ func checkTarget(target string) error {
 		return nil
 	}
 	if target == "" {
-		return errors.New("empty target")
+		return errors.New("empty target (\"\"). Did you mean \"@\" instead?")
 	}
 	if strings.ContainsAny(target, `'" +,|!£$%&()=?^*ç°§;:<>[]()@`) {
 		return fmt.Errorf("target (%v) includes invalid char", target)
@@ -113,7 +113,7 @@ func checkLabel(label string, rType string, domain string, meta map[string]strin
 		return nil
 	}
 	if label == "" {
-		return fmt.Errorf("empty %s label in %s", rType, domain)
+		return fmt.Errorf("empty %s label (\"\") in %s. Did you mean \"@\" instead?", rType, domain)
 	}
 	if label[len(label)-1] == '.' {
 		return fmt.Errorf("label %s.%s ends with a (.)", label, domain)


### PR DESCRIPTION
# Issue

As reported in https://github.com/StackExchange/dnscontrol/issues/3530 ...

- Using “@” as the apex.
  - The expectation is that the empty string would work.
  - Suggestion 1: The getting started doc should explain that "@" is used for the apex
  - Suggestion 2: When the user specifies `""`, the error message should suggest using `"@"`.
  - Suggestion 3: When the user specifies "example.com" (the apex domain), the error message should suggest using `"@"`

- Converting zones: Doing the first “push” is nervous-making.  How to migrate a zone safely?
  - The docs should suggest some testing methods to calm fears.
  - The docs should remind people that "get-zones" isn't perfect, but produces "a good first draft" you can edit.
  - Suggest trying iterations of `preview` and editing dnsconfig.js until no "changes" are listed. 

# Resolution

- Update documentation for `D()` and `getting started` to explain `@`
- Update error message when label or target is `""` to suggest using `"@"`
- Update docs to suggest preview/edit iterations before the first push.
