### PR TITLE
Require Go 1.24 or higher

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/StackExchange/dnscontrol/v4
 
-go 1.23.0
+go 1.24.0
 
 retract v4.8.0
 


### PR DESCRIPTION
# Issue

go.mod uses statements that are only valid in 1.24 and higher

# Resolution

Require Go 1.24 or higher.