### PR TITLE
AXFRDDNS: Enable DNS compression for DDNS

### DIFF
--- a/providers/axfrddns/axfrddnsProvider.go
+++ b/providers/axfrddns/axfrddnsProvider.go
@@ -375,6 +375,7 @@ func (c *axfrddnsProvider) BuildCorrection(dc *models.DomainConfig, msgs []strin
 	return &models.Correction{
 		Msg: fmt.Sprintf("DDNS UPDATES to '%s' (primary master: '%s'). Changes:\n%s", dc.Name, c.master, strings.Join(msgs, "\n")),
 		F: func() error {
+			update.Compress = true
 			client := new(dns.Client)
 			client.Net = c.updateMode
 			client.Timeout = dnsTimeout


### PR DESCRIPTION
This ideally reduces the transmitted size and alleviates https://github.com/StackExchange/dnscontrol/issues/2581 a bit. I couldn't really test this change yet, but that seems to be the documented and supported approach by github.com/miekg/dns.
@hnrgrgr 

<!--
## Before submiting a pull request

Please make sure you've run the following commands from the root directory.

    bin/generate-all.sh

(this runs commands like "go generate", fixes formatting, and so on)

## Release changelog section

Help keep the release changelog clear by pre-naming the proper section in the GitHub pull request title.

Some examples:
* CICD: Add required GHA permissions for goreleaser
* DOCS: Fixed providers with "contributor support" table
* ROUTE53: Allow R53_ALIAS records to enable target health evaluation

More examples/context can be found in the file .goreleaser.yml under the 'build' > 'changelog' key.
!-->
