### PR TITLE
WIP: PORKBUN: doesn't support concurrent

### DIFF
--- a/documentation/provider/index.md
+++ b/documentation/provider/index.md
@@ -131,7 +131,7 @@ Jump to a table:
 | [`ORACLE`](oracle.md) | ❔ | ✅ | ✅ | ✅ |
 | [`OVH`](ovh.md) | ❔ | ✅ | ❌ | ✅ |
 | [`PACKETFRAME`](packetframe.md) | ❔ | ❌ | ❌ | ❔ |
-| [`PORKBUN`](porkbun.md) | ✅ | ❌ | ❌ | ✅ |
+| [`PORKBUN`](porkbun.md) | ❌ | ❌ | ❌ | ✅ |
 | [`POWERDNS`](powerdns.md) | ❔ | ✅ | ✅ | ✅ |
 | [`REALTIMEREGISTER`](realtimeregister.md) | ❔ | ❌ | ✅ | ✅ |
 | [`ROUTE53`](route53.md) | ✅ | ✅ | ✅ | ✅ |

--- a/providers/porkbun/porkbunProvider.go
+++ b/providers/porkbun/porkbunProvider.go
@@ -59,7 +59,7 @@ var features = providers.DocumentationNotes{
 	// See providers/capabilities.go for the entire list of capabilities.
 	providers.CanAutoDNSSEC:          providers.Cannot(),
 	providers.CanGetZones:            providers.Can(),
-	providers.CanConcur:              providers.Can(),
+	providers.CanConcur:              providers.Cannot(),
 	providers.CanUseAlias:            providers.Can(),
 	providers.CanUseCAA:              providers.Can(),
 	providers.CanUseDS:               providers.Cannot(),


### PR DESCRIPTION
@jamesog enabled concurrent and introduced a nice retry handling works in #3652

#3741 is complaining about the concurrent when handling about 35 domains with Porkbun

I personally don't have that amount of domains with Porkbun

But as last time I ask Porkbun Supports, they told me there is a rate limit in 1 req/s, even it doesn't seem to be accurate. https://github.com/StackExchange/dnscontrol/issues/2995#issuecomment-2169074680

Sending lots of requests to their API endpoint at the same time, and then retry the error one, shouldn't be considered as the provider support concurrent. If it counts, we can simply make all providers as concurrent supported.

Therefor, I'm reverting the concurrent back to not support.