### PR TITLE
PORKBUN: Configurable retry parameters

### DIFF
--- a/documentation/provider/porkbun.md
+++ b/documentation/provider/porkbun.md
@@ -11,11 +11,31 @@ Example:
   "porkbun": {
     "TYPE": "PORKBUN",
     "api_key": "your-porkbun-api-key",
-    "secret_key": "your-porkbun-secret-key",
+    "secret_key": "your-porkbun-secret-key"
   }
 }
 ```
 {% endcode %}
+
+Porkbun has quite strict API limits. If you experience errors with this provider (common when you have many domains), you can set one or both of `max_attempts` and `max_duration` in the credentials configuration.
+
+Example:
+
+{% code title="creds.json" %}
+```json
+{
+  "porkbun": {
+    "TYPE": "PORKBUN",
+    "api_key": "your-porkbun-api-key",
+    "secret_key": "your-porkbun-secret-key",
+    "max_attempts": "10",
+    "max_duration": "5m"
+  }
+}
+```
+{% endcode %}
+
+The default for `max_attempts` is 5. There is no maximum duration by default, instead the provider will perform exponential backoff between 1 and 10 seconds, until `max_attempts` is reached. To retry indefinitely until `max_duration` is reached, set `max_attempts` to any value below 1.
 
 ## Metadata
 

--- a/integrationTest/profiles.json
+++ b/integrationTest/profiles.json
@@ -292,6 +292,8 @@
     "TYPE": "PORKBUN",
     "api_key": "$PORKBUN_API_KEY",
     "domain": "$PORKBUN_DOMAIN",
+    "max_attempts": "$PORKBUN_MAX_ATTEMPTS",
+    "max_duration": "$PORKBUN_MAX_DURATION",
     "secret_key": "$PORKBUN_SECRET_KEY"
   },
   "POWERDNS": {

--- a/providers/porkbun/porkbunProvider.go
+++ b/providers/porkbun/porkbunProvider.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/StackExchange/dnscontrol/v4/models"
 	"github.com/StackExchange/dnscontrol/v4/pkg/diff2"
@@ -23,6 +24,10 @@ const (
 	metaType        = "type"
 	metaIncludePath = "includePath"
 	metaWildcard    = "wildcard"
+)
+
+const (
+	defaultMaxAttempts = 5
 )
 
 // https://kb.porkbun.com/article/63-how-to-switch-to-porkbuns-nameservers
@@ -43,12 +48,29 @@ func newDsp(conf map[string]string, metadata json.RawMessage) (providers.DNSServ
 
 // newPorkbun creates the provider.
 func newPorkbun(m map[string]string, _ json.RawMessage) (*porkbunProvider, error) {
-	c := &porkbunProvider{}
+	c := &porkbunProvider{
+		maxAttempts: defaultMaxAttempts,
+	}
 
 	c.apiKey, c.secretKey = m["api_key"], m["secret_key"]
 
 	if c.apiKey == "" || c.secretKey == "" {
 		return nil, errors.New("missing porkbun api_key or secret_key")
+	}
+
+	if maxAttempts, ok := m["max_attempts"]; ok && maxAttempts != "" {
+		i, err := strconv.Atoi(maxAttempts)
+		if err != nil {
+			return nil, fmt.Errorf("porkbun: invalid max_attempts %q: must be a whole number", maxAttempts)
+		}
+		c.maxAttempts = i
+	}
+	if maxDuration, ok := m["max_duration"]; ok && maxDuration != "" {
+		d, err := time.ParseDuration(maxDuration)
+		if err != nil {
+			return nil, fmt.Errorf("porkbun: invalid max_duration %q: valid units are ns, us, ms, s, m, h", maxDuration)
+		}
+		c.maxDuration = d
 	}
 
 	return c, nil


### PR DESCRIPTION
The Porkbun provider can now configure the API retry mechanism by setting max_attempts and/or max_duration in the credentials configuration. This aims to help users who have many domains configured and run in to Porkbun API limits with the current retry mechanism.

The max_attempts setting controls how many attempts (in total, not retries) will be made for each domain. The default is 5.

The max_duration allows the retry mechanism to keep retrying up to this duration, for each domain.

The current behaviour is to do exponential backoff between 1 second and 10 seconds, with 5 retries (6 total attempts), with jitter of +/-100ms (max, it will vary). The jitter means the provider will often retry sooner than 1 second, which the Porkbun API doesn't like. To counter this, the minimum retry time is now 1.2 seconds.

With the new behaviour the max backoff time is still 10 seconds, but if a long max_duration is set it allows the provider to keep retrying every 10 seconds.

<!--
## Before submiting a pull request

Please make sure you've run the following commands from the root directory.

    bin/generate-all.sh

(this runs commands like "go generate", fixes formatting, and so on)

## Release changelog section

Help keep the release changelog clear by pre-naming the proper section in the GitHub pull request title.

Some examples:
* CICD: Add required GHA permissions for goreleaser
* DOCS: Fixed providers with "contributor support" table
* ROUTE53: Allow R53_ALIAS records to enable target health evaluation

More examples/context can be found in the file .goreleaser.yml under the 'build' > 'changelog' key.
!-->
