### PR TITLE
FEATURE: Support RFC 9495 issuemail tag in CAA records

### DIFF
--- a/pkg/normalize/validate.go
+++ b/pkg/normalize/validate.go
@@ -442,7 +442,7 @@ func ValidateAndNormalizeConfig(config *models.DNSConfig) (errs []error) {
 				}
 				rec.SetLabel(name, domain.Name)
 			} else if rec.Type == "CAA" {
-				if rec.CaaTag != "issue" && rec.CaaTag != "issuewild" && rec.CaaTag != "iodef" {
+				if rec.CaaTag != "issue" && rec.CaaTag != "issuewild" && rec.CaaTag != "iodef" && rec.CaaTag != "issuemail" {
 					errs = append(errs, fmt.Errorf("CAA tag %s is invalid", rec.CaaTag))
 				}
 			} else if rec.Type == "TLSA" {


### PR DESCRIPTION
This pull request adds support for the `issuemail` `CAA` tag introduced in [RFC 9495](https://datatracker.ietf.org/doc/html/rfc9495)
