### PR TITLE
DESEC: improve formatting of DS records on domain creation

### DIFF
--- a/documentation/provider/desec.md
+++ b/documentation/provider/desec.md
@@ -44,3 +44,9 @@ integration test suite can not be run in a single session. See
 [https://desec.readthedocs.io/en/latest/rate-limits.html#api-request-throttling](https://desec.readthedocs.io/en/latest/rate-limits.html#api-request-throttling)
 {% endhint %}
 
+Upon domain creation, the DNSKEY and DS records needed for DNSSEC setup are
+printed in the command output. If you need these values later, get them from
+the deSEC web interface or query deSEC nameservers for the CDS records. For
+example: `dig +short @ns1.desec.io example.com CDS` will return the published
+CDS records which can be used to insert the required DS records into the parent
+zone.

--- a/providers/desec/protocol.go
+++ b/providers/desec/protocol.go
@@ -261,7 +261,13 @@ func (c *desecProvider) createDomain(domain string) error {
 		return err
 	}
 	printer.Printf("To enable DNSSEC validation for your domain, make sure to convey the DS record(s) to your registrar:\n")
-	printer.Printf("%+q", dm.Keys)
+	for _, key := range dm.Keys {
+		printer.Printf("DNSKEY: %s\n", key.Dnskey)
+		printer.Printf("DS record(s):\n")
+		for _, d := range key.Ds {
+			printer.Printf("  %s\n", d)
+		}
+	}
 	return nil
 }
 


### PR DESCRIPTION
This makes the DS record returned from the deSEC API readable and also adds a note to the provider page about alternative ways to get the DS records after the domain is created.

* DESEC: improve formatting of DS records on domain creation
* DOCS: add note to deSEC provider detailing how to get the domain DS records