### PR TITLE
fix(DKIM_BUILDER): allow empty pubkey

### DIFF
--- a/pkg/js/helpers.js
+++ b/pkg/js/helpers.js
@@ -1818,7 +1818,7 @@ function CAA_BUILDER(value) {
 // DKIM_BUILDER takes an object:
 // label: The DNS label for the DKIM record ([selector]._domainkey prefix is added; default: '@')
 // selector: Selector used for the label. e.g. s1 or mail
-// pubkey: Public key (p) to be used for DKIM.
+// pubkey: Public key (p) to be used for DKIM (optional)
 // keytype: Key type (k). Defaults to 'rsa' if missing (optional)
 // flags: Which types (t) of flags to activate, ie. 'y' and/or 's'. Array, defaults to 's' (optional)
 // hashtypes: Acceptable hash algorithma (h) (optional)
@@ -1834,10 +1834,6 @@ function DKIM_BUILDER(value) {
 
     if (!value.selector) {
         throw 'DKIM_BUILDER selector cannot be empty';
-    }
-
-    if (!value.pubkey) {
-        throw 'DKIM_BUILDER pubkey cannot be empty';
     }
 
     // build the label


### PR DESCRIPTION
Support scenarios where a DKIM public key may be intentionally empty, for example to protect domains without email services.

See: https://www.cloudflare.com/learning/dns/dns-records/protect-domains-without-email/

<!--
## Before submiting a pull request

Please make sure you've run the following commands from the root directory.

    bin/generate-all.sh

(this runs commands like "go generate", fixes formatting, and so on)

## Release changelog section

Help keep the release changelog clear by pre-naming the proper section in the GitHub pull request title.

Some examples:
* CICD: Add required GHA permissions for goreleaser
* DOCS: Fixed providers with "contributor support" table
* ROUTE53: Allow R53_ALIAS records to enable target health evaluation

More examples/context can be found in the file .goreleaser.yml under the 'build' > 'changelog' key.
!-->
