### PR TITLE
CLOUDFLAREAPI: Prevent web UI from displaying warnings about TXT records

### DIFF
--- a/pkg/txtutil/txtcode_test.go
+++ b/pkg/txtutil/txtcode_test.go
@@ -84,6 +84,8 @@ func TestTxtEncode(t *testing.T) {
 		data     []string
 		expected string
 	}{
+		{[]string{"simple"}, `"simple"`},
+		{[]string{`"quoted"`}, `"\"quoted\""`},
 		{[]string{}, `""`},
 		{[]string{``}, `""`},
 		{[]string{`foo`}, `"foo"`},

--- a/providers/cloudflare/auditrecords.go
+++ b/providers/cloudflare/auditrecords.go
@@ -11,9 +11,7 @@ import (
 func AuditRecords(records []*models.RecordConfig) []error {
 	a := rejectif.Auditor{}
 
-	a.Add("TXT", rejectif.TxtHasTrailingSpace) // Last verified 2022-06-18
-
-	a.Add("TXT", rejectif.TxtIsEmpty) // Last verified 2022-06-18
+	a.Add("TXT", rejectif.TxtIsEmpty) // Last verified 2024-10-27
 
 	return a.Audit(records)
 }

--- a/providers/cloudflare/cloudflareProvider.go
+++ b/providers/cloudflare/cloudflareProvider.go
@@ -18,6 +18,7 @@ import (
 	"github.com/StackExchange/dnscontrol/v4/pkg/diff2"
 	"github.com/StackExchange/dnscontrol/v4/pkg/printer"
 	"github.com/StackExchange/dnscontrol/v4/pkg/transform"
+	"github.com/StackExchange/dnscontrol/v4/pkg/txtutil"
 	"github.com/StackExchange/dnscontrol/v4/pkg/zonecache"
 	"github.com/StackExchange/dnscontrol/v4/providers"
 	"github.com/StackExchange/dnscontrol/v4/providers/cloudflare/rtypes/cfsingleredirect"
@@ -871,7 +872,11 @@ func (c *cloudflareProvider) nativeToRecord(domain string, cr cloudflare.DNSReco
 			return nil, fmt.Errorf("unparsable SRV record received from cloudflare: %w", err)
 		}
 	case "TXT":
-		err := rc.SetTargetTXT(cr.Content)
+		s, err := txtutil.ParseQuoted(cr.Content)
+		if err != nil {
+			return rc, err
+		}
+		err = rc.SetTargetTXT(s)
 		return rc, err
 	default:
 		if err := rc.PopulateFromString(rType, cr.Content, domain); err != nil {

--- a/providers/cloudflare/rest.go
+++ b/providers/cloudflare/rest.go
@@ -10,6 +10,7 @@ import (
 	"golang.org/x/net/idna"
 
 	"github.com/StackExchange/dnscontrol/v4/models"
+	"github.com/StackExchange/dnscontrol/v4/pkg/txtutil"
 	"github.com/StackExchange/dnscontrol/v4/providers/cloudflare/rtypes/cfsingleredirect"
 )
 
@@ -154,7 +155,7 @@ func (c *cloudflareProvider) createRecDiff2(rec *models.RecordConfig, domainID s
 		prio = fmt.Sprintf(" %d ", rec.MxPreference)
 	}
 	if rec.Type == "TXT" {
-		content = rec.GetTargetTXTJoined()
+		content = txtutil.EncodeQuoted(rec.GetTargetTXTJoined())
 	}
 	if rec.Type == "DS" {
 		content = fmt.Sprintf("%d %d %d %s", rec.DsKeyTag, rec.DsAlgorithm, rec.DsDigestType, rec.DsDigest)
@@ -229,7 +230,7 @@ func (c *cloudflareProvider) modifyRecord(domainID, recID string, proxied bool, 
 		TTL:      int(rec.TTL),
 	}
 	if rec.Type == "TXT" {
-		r.Content = rec.GetTargetTXTJoined()
+		r.Content = txtutil.EncodeQuoted(rec.GetTargetTXTJoined())
 	}
 	if rec.Type == "SRV" {
 		r.Data = cfSrvData(rec)


### PR DESCRIPTION
# Issue

The way that DNSControl updates TXT records makes Cloudflare report this warning:

<img alt="Image" width="391" height="175" src="https://private-user-images.githubusercontent.com/7508531/505623477-cf8735cc-0c4b-4cf9-97c8-5b308d098981.png?jwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NjE1OTgxMTgsIm5iZiI6MTc2MTU5NzgxOCwicGF0aCI6Ii83NTA4NTMxLzUwNTYyMzQ3Ny1jZjg3MzVjYy0wYzRiLTRjZjktOTdjOC01YjMwOGQwOTg5ODEucG5nP1gtQW16LUFsZ29yaXRobT1BV1M0LUhNQUMtU0hBMjU2JlgtQW16LUNyZWRlbnRpYWw9QUtJQVZDT0RZTFNBNTNQUUs0WkElMkYyMDI1MTAyNyUyRnVzLWVhc3QtMSUyRnMzJTJGYXdzNF9yZXF1ZXN0JlgtQW16LURhdGU9MjAyNTEwMjdUMjA0MzM4WiZYLUFtei1FeHBpcmVzPTMwMCZYLUFtei1TaWduYXR1cmU9NmIwMjQ5N2QyODg5NGRkMjZiY2M4OTM0YTFlMGFhMmM5MzA2YjFiYjE0YWViODJjNDI0NDg5ZTA1NTI5N2IzYyZYLUFtei1TaWduZWRIZWFkZXJzPWhvc3QifQ.EBdWEcbRCG9shlYQ6aJhW6oYWx-YjxRe5meddwf-fZc">

They are *just warnings*.  Cloudflare serves the TXT records exactly as we desire.  However people see the warning and file bug reports such as https://github.com/StackExchange/dnscontrol/issues/3621#issuecomment-3446547371.

We have 2 options:

1. Ignore the warnings. This means code that is clean, simple, and works.  We could update the docs to tell people to ignore the warnings.
2. Apply this PR.  This code is complex, might have other bugs, but prevents this warning.

# Resolution

???