### PR TITLE
POWERDNS: Split horizon feature now enabled by flag

### DIFF
--- a/documentation/provider/powerdns.md
+++ b/documentation/provider/powerdns.md
@@ -45,6 +45,8 @@ Following metadata are available:
   <br> Can be one of `DEFAULT`, `INCREASE`, `EPOCH`, `SOA-EDIT` or `SOA-EDIT-INCREASE`, default format is YYYYMMDD01.
   <br>Please see [PowerDNS SOA-EDIT-DNSUPDATE documentation](https://doc.powerdns.com/authoritative/dnsupdate.html#soa-edit-dnsupdate-settings) for explanation of the kinds.
   <br>**Note that these tokens are case-sensitive!**
+- `use_views` enables mapping dnscontrol tags to PowerDNS views.
+  <br>Set to `true` to enable, defaults to `false`.
 
 ## Usage
 An example configuration:
@@ -64,7 +66,7 @@ D("example.com", REG_NONE, DnsProvider(DSP_POWERDNS),
 See the [PowerDNS documentation](https://doc.powerdns.com/authoritative/http-api/index.html) how the API can be enabled.
 
 ## Tags and Variants
-If you use a dnscontrol *tag* (like `example.com!internal`) it will be mapped to a powerdns *variant* (like `example.com..internal`).
+If you use a dnscontrol *tag* (like `example.com!internal`) it will be mapped to a powerdns *variant* (like `example.com..internal`) when `use_views` is enabled in the provider metadata.
 
 See [PowerDNS documentation on Views](https://doc.powerdns.com/authoritative/views.html) for details on how to setup networks and views for these variants.
 

--- a/providers/powerdns/diff.go
+++ b/providers/powerdns/diff.go
@@ -58,7 +58,7 @@ func (dsp *powerdnsProvider) getDiff2DomainCorrections(dc *models.DomainConfig, 
 		}
 	}
 
-	domainVariant := GetVariantName(dc.Name, dc.Metadata[models.DomainTag])
+	domainVariant := dsp.zoneName(dc.Name, dc.Metadata[models.DomainTag])
 
 	// only append a Correction if there are any, otherwise causes an error when sending an empty rrset
 	if len(rrDeleteSets) > 0 {
@@ -99,15 +99,4 @@ func buildRecordList(change diff2.Change) (records []zones.Record) {
 
 func canonical(fqdn string) string {
 	return fqdn + "."
-}
-
-// Build the variant name for powerdns. this is the domain + "." + the tag
-// so dnscontrol "example.com!internal" becomes powerdns "example.com..internal"
-// See https://doc.powerdns.com/authoritative/views.html
-func GetVariantName(domain string, tag string) string {
-	if tag != "" {
-		return canonical(domain) + "." + tag
-	} else {
-		return canonical(domain)
-	}
 }

--- a/providers/powerdns/dns.go
+++ b/providers/powerdns/dns.go
@@ -21,7 +21,7 @@ func (dsp *powerdnsProvider) GetNameservers(string) ([]*models.Nameserver, error
 // GetZoneRecords gets the records of a zone and returns them in RecordConfig format.
 func (dsp *powerdnsProvider) GetZoneRecords(domain string, meta map[string]string) (models.Records, error) {
 	curRecords := models.Records{}
-	domainVariant := GetVariantName(domain, meta[models.DomainTag])
+	domainVariant := dsp.zoneName(domain, meta[models.DomainTag])
 	zone, err := dsp.client.Zones().GetZone(context.Background(), dsp.ServerName, domainVariant)
 	if err != nil {
 		if _, ok := err.(pdnshttp.ErrNotFound); ok {

--- a/providers/powerdns/dnssec.go
+++ b/providers/powerdns/dnssec.go
@@ -10,7 +10,7 @@ import (
 
 // getDNSSECCorrections returns corrections that update a domain's DNSSEC state.
 func (dsp *powerdnsProvider) getDNSSECCorrections(dc *models.DomainConfig) ([]*models.Correction, error) {
-	domainVariant := GetVariantName(dc.Name, dc.Metadata[models.DomainTag])
+	domainVariant := dsp.zoneName(dc.Name, dc.Metadata[models.DomainTag])
 	zoneCryptokeys, getErr := dsp.client.Cryptokeys().ListCryptokeys(context.Background(), dsp.ServerName, domainVariant)
 	if getErr != nil {
 		if _, ok := getErr.(pdnshttp.ErrNotFound); ok {

--- a/providers/powerdns/powerdnsProvider.go
+++ b/providers/powerdns/powerdnsProvider.go
@@ -59,8 +59,19 @@ type powerdnsProvider struct {
 	DNSSecOnCreate bool                 `json:"dnssec_on_create"`
 	ZoneKind       zones.ZoneKind       `json:"zone_kind"`
 	SOAEditAPI     zones.ZoneSOAEditAPI `json:"soa_edit_api,omitempty"`
+	UseViews       bool                 `json:"use_views,omitempty"`
 
 	nameservers []*models.Nameserver
+}
+
+// Build the variant name for powerdns. this is the domain + "." + the tag
+// so dnscontrol "example.com!internal" becomes powerdns "example.com..internal"
+// See https://doc.powerdns.com/authoritative/views.html
+func (dsp *powerdnsProvider) zoneName(domain string, tag string) string {
+	if dsp.UseViews && tag == "" {
+		return canonical(domain) + "." + tag
+	}
+	return canonical(domain)
 }
 
 // newDSP initializes a PowerDNS DNSServiceProvider.


### PR DESCRIPTION
Be able to decide to use or not views in PowerDNS, default is off
