### PR TITLE
Remove unused --depopulate flag

### DIFF
--- a/commands/ppreviewPush.go
+++ b/commands/ppreviewPush.go
@@ -12,6 +12,11 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/nozzle/throttler"
+	"github.com/urfave/cli/v2"
+	"golang.org/x/exp/slices"
+	"golang.org/x/net/idna"
+
 	"github.com/StackExchange/dnscontrol/v4/models"
 	"github.com/StackExchange/dnscontrol/v4/pkg/bindserial"
 	"github.com/StackExchange/dnscontrol/v4/pkg/credsfile"
@@ -22,10 +27,6 @@ import (
 	"github.com/StackExchange/dnscontrol/v4/pkg/rfc4183"
 	"github.com/StackExchange/dnscontrol/v4/pkg/zonerecs"
 	"github.com/StackExchange/dnscontrol/v4/providers"
-	"github.com/nozzle/throttler"
-	"github.com/urfave/cli/v2"
-	"golang.org/x/exp/slices"
-	"golang.org/x/net/idna"
 )
 
 type cmdZoneCache struct {
@@ -55,7 +56,6 @@ type PPreviewArgs struct {
 	ConcurMode        string
 	ConcurMax         int // Maximum number of concurrent connections
 	NoPopulate        bool
-	DePopulate        bool
 	PopulateOnPreview bool
 	Report            string
 	Full              bool
@@ -113,11 +113,6 @@ func (args *PPreviewArgs) flags() []cli.Flag {
 		Name:        "no-populate",
 		Destination: &args.NoPopulate,
 		Usage:       `Do not auto-create zones at the provider`,
-	})
-	flags = append(flags, &cli.BoolFlag{
-		Name:        "depopulate",
-		Destination: &args.NoPopulate,
-		Usage:       `Delete unknown zones at provider (dangerous!)`,
 	})
 	flags = append(flags, &cli.BoolFlag{
 		Name:        "populate-on-preview",


### PR DESCRIPTION
`PPreviewArgs.DePopulate` is unused and the command line flag `--depopulate` is wired up to the wrong field (`PPreviewArgs.NoPopulate`). This PR is removing both references.

<!--
## Before submiting a pull request

Please make sure you've run the following commands from the root directory.

    bin/generate-all.sh

(this runs commands like "go generate", fixes formatting, and so on)

## Release changelog section

Help keep the release changelog clear by pre-naming the proper section in the GitHub pull request title.

Some examples:
* CICD: Add required GHA permissions for goreleaser
* DOCS: Fixed providers with "contributor support" table
* ROUTE53: Allow R53_ALIAS records to enable target health evaluation

More examples/context can be found in the file .goreleaser.yml under the 'build' > 'changelog' key.
!-->
