### PR TITLE
BUGFIX: Reverse order of domain ascii/unicode displayed

### DIFF
--- a/pkg/printer/printer.go
+++ b/pkg/printer/printer.go
@@ -93,7 +93,7 @@ func (c ConsolePrinter) StartDomain(dc *models.DomainConfig) {
 	if dc.Name == dc.NameUnicode {
 		fmt.Fprintf(c.Writer, "******************** Domain: %s\n", dc.Name)
 	} else {
-		fmt.Fprintf(c.Writer, "******************** Domain: %s (%s)\n", dc.NameUnicode, dc.Name)
+		fmt.Fprintf(c.Writer, "******************** Domain: %s (%s)\n", dc.Name, dc.NameUnicode)
 	}
 }
 


### PR DESCRIPTION
# Issue

Consensus in https://github.com/StackExchange/dnscontrol/pull/2874 is that the domains should be displayed as:

    xn--p1ai.com (рф.com) 
