### PR TITLE
DEV: Add tool to reset js/parse_tests data

### DIFF
--- a/bin/fix_js_parse_tests.sh
+++ b/bin/fix_js_parse_tests.sh
@@ -1,5 +1,13 @@
 #!/bin/sh
 
+# fix_js_parse_tests.sh -- Fix up the pkg/js/parse_tests "want" files.
+#
+# DO NOT use this without carefully checking the output. You could
+# accidentally codify bad test data and commit it to the repo.
+#
+# Useful bash/zsh alias:
+# alias fixjsparse='"$(git rev-parse --show-toplevel)/bin/fix_js_parse_tests.sh"'
+
 set -e
 
 cd $(git rev-parse --show-toplevel)


### PR DESCRIPTION
# Issue

Add tool to reset js/parse_tests data gets out of date easily.  Manually updating it sucks.

# Resolution

Publish a script that copies the "actual" data to the "want" data.  DO NOT CHECK IN THE RESULTS WITHOUT CAREFUL REVIEW.