### PR TITLE
TESTING: increase minimum TTL values in tests

### DIFF
--- a/integrationTest/helpers_integration_test.go
+++ b/integrationTest/helpers_integration_test.go
@@ -433,7 +433,7 @@ func loc(name string, d1 uint8, m1 uint8, s1 float32, ns string,
 func makeRec(name, target, typ string) *models.RecordConfig {
 	r := &models.RecordConfig{
 		Type: typ,
-		TTL:  300,
+		TTL:  600,
 	}
 	SetLabel(r, name, "**current-domain**.")
 	r.MustSetTarget(target)

--- a/integrationTest/integration_test.go
+++ b/integrationTest/integration_test.go
@@ -216,7 +216,7 @@ func makeTests() []*TestGroup {
 
 		testgroup("Attl",
 			not("LINODE"), // Linode does not support arbitrary TTLs: both are rounded up to 3600.
-			tc("Create Arc", ttl(a("testa", "1.1.1.1"), 333)),
+			tc("Create Arc", ttl(a("testa", "1.1.1.1"), 666)),
 			tc("Change TTL", ttl(a("testa", "1.1.1.1"), 999)),
 		),
 
@@ -226,7 +226,7 @@ func makeTests() []*TestGroup {
 			tc("Start", ttl(a("@", "8.8.8.8"), 666), a("www", "1.2.3.4"), a("www", "5.6.7.8")),
 			tc("Change a ttl", ttl(a("@", "8.8.8.8"), 1000), a("www", "1.2.3.4"), a("www", "5.6.7.8")),
 			tc("Change single target from set", ttl(a("@", "8.8.8.8"), 1000), a("www", "2.2.2.2"), a("www", "5.6.7.8")),
-			tc("Change all ttls", ttl(a("@", "8.8.8.8"), 500), ttl(a("www", "2.2.2.2"), 400), ttl(a("www", "5.6.7.8"), 400)),
+			tc("Change all ttls", ttl(a("@", "8.8.8.8"), 900), ttl(a("www", "2.2.2.2"), 800), ttl(a("www", "5.6.7.8"), 700)),
 		),
 
 		// Narrative: Did you see that `not("NETCUP")` code?  NETCUP just
@@ -245,8 +245,8 @@ func makeTests() []*TestGroup {
 		// Next we add an additional record at the same label AND change
 		// the TTL of the existing record.
 		testgroup("add to label and change orig ttl",
-			tc("Setup", ttl(a("www", "5.6.7.8"), 400)),
-			tc("Add at same label, new ttl", ttl(a("www", "5.6.7.8"), 700), ttl(a("www", "1.2.3.4"), 700)),
+			tc("Setup", ttl(a("www", "5.6.7.8"), 700)),
+			tc("Add at same label, new ttl", ttl(a("www", "5.6.7.8"), 1000), ttl(a("www", "1.2.3.4"), 1000)),
 		),
 
 		// Narrative: We're done with TTL tests now.  If you fixed a bug
@@ -807,7 +807,7 @@ func makeTests() []*TestGroup {
 		// https://github.com/StackExchange/dnscontrol/issues/2066
 		testgroup("SRV",
 			requires(providers.CanUseSRV),
-			tc("Create SRV333", ttl(srv("_sip._tcp", 5, 6, 7, "foo.com."), 333)),
+			tc("Create SRV666", ttl(srv("_sip._tcp", 5, 6, 7, "foo.com."), 666)),
 			tc("Change TTL999", ttl(srv("_sip._tcp", 5, 6, 7, "foo.com."), 999)),
 		),
 

--- a/models/dns_test.go
+++ b/models/dns_test.go
@@ -22,11 +22,11 @@ func TestRR(t *testing.T) {
 		Name:     "@",
 		NameFQDN: "example.com",
 		target:   "mailto:test@example.com",
-		TTL:      300,
+		TTL:      600,
 		CaaTag:   "iodef",
 		CaaFlag:  1,
 	}
-	expected = "example.com.\t300\tIN\tCAA\t1 iodef \"mailto:test@example.com\""
+	expected = "example.com.\t600\tIN\tCAA\t1 iodef \"mailto:test@example.com\""
 	found = experiment.ToRR().String()
 	if found != expected {
 		t.Errorf("RR expected (%#v) got (%#v)\n", expected, found)
@@ -37,12 +37,12 @@ func TestRR(t *testing.T) {
 		Name:             "@",
 		NameFQDN:         "_443._tcp.example.com",
 		target:           "abcdef0123456789",
-		TTL:              300,
+		TTL:              600,
 		TlsaUsage:        0,
 		TlsaSelector:     0,
 		TlsaMatchingType: 1,
 	}
-	expected = "_443._tcp.example.com.\t300\tIN\tTLSA\t0 0 1 abcdef0123456789"
+	expected = "_443._tcp.example.com.\t600\tIN\tTLSA\t0 0 1 abcdef0123456789"
 	found = experiment.ToRR().String()
 	if found != expected {
 		t.Errorf("RR expected (%#v) got (%#v)\n", expected, found)


### PR DESCRIPTION
<!--
## Before submiting a pull request

Please make sure you've run the following commands from the root directory.

    bin/generate-all.sh

(this runs commands like "go generate", fixes formatting, and so on)

## Release changelog section

Help keep the release changelog clear by pre-naming the proper section in the GitHub pull request title.

Some examples:
* CICD: Add required GHA permissions for goreleaser
* DOCS: Fixed providers with "contributor support" table
* ROUTE53: Allow R53_ALIAS records to enable target health evaluation

More examples/context can be found in the file .goreleaser.yml under the 'build' > 'changelog' key.
!-->

As we mentioned in the https://github.com/StackExchange/dnscontrol/pull/3878#issuecomment-3607610584, I will first adjust the ttl in the integration test so that it can meet the alidns ttl requirements later.

@tlimoncelli 
