### PR TITLE
DOCS: replace all `NewRegistrar('ThirdParty')`

### DIFF
--- a/documentation/advanced-features/nameservers.md
+++ b/documentation/advanced-features/nameservers.md
@@ -18,7 +18,7 @@ var REG_NAMECOM = NewRegistrar("namedotcom_main");
 // The "NONE" registrar is a "fake" registrar.
 // This is useful if the registrar is not supported by DNSControl,
 // or if you don't want to control the domain's delegation.
-var REG_THIRDPARTY = NewRegistrar("ThirdParty");
+var REG_NONE = NewRegistrar("none");
 
 // ========== DNS Providers:
 
@@ -83,7 +83,8 @@ updating the zone's records (most likely at a different provider).
 
 {% code title="dnsconfig.js" %}
 ```javascript
-D("example.com", REG_THIRDPARTY,
+var REG_NONE = NewRegistrar("none");
+D("example.com", REG_NONE,
   DnsProvider(DNS_NAMECOM),
   A("@", "10.2.3.4"),
 );

--- a/documentation/language-reference/domain-modifiers/NAMESERVER.md
+++ b/documentation/language-reference/domain-modifiers/NAMESERVER.md
@@ -83,8 +83,8 @@ It looks like this:
 
 {% code title="dnsconfig.js" %}
 ```javascript
-var REG_THIRDPARTY = NewRegistrar("ThirdParty");
-D("example.com", REG_THIRDPARTY,
+var REG_NONE = NewRegistrar("none");
+D("example.com", REG_NONE,
   ...
 );
 ```

--- a/documentation/language-reference/top-level-functions/D.md
+++ b/documentation/language-reference/top-level-functions/D.md
@@ -65,15 +65,15 @@ To differentiate the different domains, specify the domains as
 
 {% code title="dnsconfig.js" %}
 ```javascript
-var REG_THIRDPARTY = NewRegistrar("ThirdParty");
+var REG_NONE = NewRegistrar("none");
 var DNS_INSIDE = NewDnsProvider("Cloudflare");
 var DNS_OUTSIDE = NewDnsProvider("bind");
 
-D("example.com!inside", REG_THIRDPARTY, DnsProvider(DNS_INSIDE),
+D("example.com!inside", REG_NONE, DnsProvider(DNS_INSIDE),
   A("www", "10.10.10.10"),
 );
 
-D("example.com!outside", REG_THIRDPARTY, DnsProvider(DNS_OUTSIDE),
+D("example.com!outside", REG_NONE, DnsProvider(DNS_OUTSIDE),
   A("www", "20.20.20.20"),
 );
 


### PR DESCRIPTION
`NewRegistrar("ThirdParty");` has been replaced w/ `NewRegistrar("none");`

The PR updates the docs.