### PR TITLE
bug(split horizon): Domains with split horizons not working

### DIFF
--- a/commands/ppreviewPush_test.go
+++ b/commands/ppreviewPush_test.go
@@ -22,6 +22,7 @@ func Test_whichZonesToProcess(t *testing.T) {
 		dcTaggedEmpty,
 	}
 
+	// This is needed since we aren't calling js.ExecuteJavaScript().
 	for _, dc := range allDC {
 		dc.PostProcess()
 	}

--- a/commands/printIR.go
+++ b/commands/printIR.go
@@ -129,11 +129,6 @@ func ExecuteDSL(args ExecuteDSLArgs) (*models.DNSConfig, error) {
 		return nil, fmt.Errorf("executing %s: %w", args.JSFile, err)
 	}
 
-	err = dnsConfig.PostProcess()
-	if err != nil {
-		return nil, err
-	}
-
 	return dnsConfig, nil
 }
 

--- a/models/domain.go
+++ b/models/domain.go
@@ -24,7 +24,7 @@ type DomainConfig struct {
 	NameUnicode string `json:"-"`    // name in Unicode format
 
 	Tag        string `json:"tag,omitempty"` // Split horizon tag.
-	UniqueName string `json:"-"`             // .Name + "!" + .Tag
+	UniqueName string `json:"uniquename"`    // .Name + "!" + .Tag (no !tag added if tag is "")
 
 	RegistrarName    string         `json:"registrar"`
 	DNSProviderNames map[string]int `json:"dnsProviders"`

--- a/pkg/js/parse_tests/001-basic.json
+++ b/pkg/js/parse_tests/001-basic.json
@@ -23,7 +23,8 @@
           "type": "A"
         }
       ],
-      "registrar": "Third-Party"
+      "registrar": "Third-Party",
+      "uniquename": "foo.com"
     }
   ],
   "registrars": [

--- a/pkg/js/parse_tests/002-ttl.json
+++ b/pkg/js/parse_tests/002-ttl.json
@@ -23,7 +23,8 @@
           "type": "A"
         }
       ],
-      "registrar": "Third-Party"
+      "registrar": "Third-Party",
+      "uniquename": "foo.com"
     }
   ],
   "registrars": [

--- a/pkg/js/parse_tests/003-meta.json
+++ b/pkg/js/parse_tests/003-meta.json
@@ -19,7 +19,8 @@
           "type": "A"
         }
       ],
-      "registrar": "Cloudflare"
+      "registrar": "Cloudflare",
+      "uniquename": "foo.com"
     }
   ],
   "registrars": [

--- a/pkg/js/parse_tests/004-ips.json
+++ b/pkg/js/parse_tests/004-ips.json
@@ -37,7 +37,8 @@
           "type": "A"
         }
       ],
-      "registrar": "Third-Party"
+      "registrar": "Third-Party",
+      "uniquename": "foo.com"
     }
   ],
   "registrars": [

--- a/pkg/js/parse_tests/005-ignored-records.json
+++ b/pkg/js/parse_tests/005-ignored-records.json
@@ -9,6 +9,7 @@
       "name": "foo.com",
       "records": [],
       "registrar": "none",
+      "uniquename": "foo.com",
       "unmanaged": [
         {
           "label_pattern": "testignore",
@@ -60,6 +61,7 @@
       "name": "diff2.com",
       "records": [],
       "registrar": "none",
+      "uniquename": "diff2.com",
       "unmanaged": [
         {
           "label_pattern": "mylabel",

--- a/pkg/js/parse_tests/006-transforms.json
+++ b/pkg/js/parse_tests/006-transforms.json
@@ -46,7 +46,8 @@
           "type": "A"
         }
       ],
-      "registrar": "Third-Party"
+      "registrar": "Third-Party",
+      "uniquename": "foo.com"
     }
   ],
   "registrars": [

--- a/pkg/js/parse_tests/007-importTransformTTL.json
+++ b/pkg/js/parse_tests/007-importTransformTTL.json
@@ -23,7 +23,8 @@
           "type": "A"
         }
       ],
-      "registrar": "reg"
+      "registrar": "reg",
+      "uniquename": "foo1.com"
     },
     {
       "dnsProviders": {},
@@ -47,7 +48,8 @@
           "type": "A"
         }
       ],
-      "registrar": "reg"
+      "registrar": "reg",
+      "uniquename": "inny"
     },
     {
       "dnsProviders": {},
@@ -71,7 +73,8 @@
           "type": "A"
         }
       ],
-      "registrar": "reg"
+      "registrar": "reg",
+      "uniquename": "com.inny"
     }
   ],
   "registrars": []

--- a/pkg/js/parse_tests/008-import.json
+++ b/pkg/js/parse_tests/008-import.json
@@ -16,7 +16,8 @@
           "type": "A"
         }
       ],
-      "registrar": "none"
+      "registrar": "none",
+      "uniquename": "foo.com"
     }
   ],
   "registrars": []

--- a/pkg/js/parse_tests/009-reverse.json
+++ b/pkg/js/parse_tests/009-reverse.json
@@ -8,7 +8,8 @@
       },
       "name": "2.1.in-addr.arpa",
       "records": [],
-      "registrar": "none"
+      "registrar": "none",
+      "uniquename": "2.1.in-addr.arpa"
     }
   ],
   "registrars": []

--- a/pkg/js/parse_tests/010-alias.json
+++ b/pkg/js/parse_tests/010-alias.json
@@ -16,7 +16,8 @@
           "type": "ALIAS"
         }
       ],
-      "registrar": "none"
+      "registrar": "none",
+      "uniquename": "foo.com"
     }
   ],
   "registrars": []

--- a/pkg/js/parse_tests/011-cfRedirect.json
+++ b/pkg/js/parse_tests/011-cfRedirect.json
@@ -45,7 +45,8 @@
           "zonfefilepartial": "name=(302,test2.foo.com,https://goo.com/$1) code=(302) when=(http.host eq \"test2.foo.com\" and http.request.uri.path eq \"/\") then=(concat(\"https://goo.com\", http.request.uri.path))"
         }
       ],
-      "registrar": "none"
+      "registrar": "none",
+      "uniquename": "foo.com"
     }
   ],
   "registrars": []

--- a/pkg/js/parse_tests/012-duration.json
+++ b/pkg/js/parse_tests/012-duration.json
@@ -44,7 +44,8 @@
           "type": "A"
         }
       ],
-      "registrar": "none"
+      "registrar": "none",
+      "uniquename": "foo.com"
     }
   ],
   "registrars": []

--- a/pkg/js/parse_tests/013-mx.json
+++ b/pkg/js/parse_tests/013-mx.json
@@ -17,7 +17,8 @@
           "type": "MX"
         }
       ],
-      "registrar": "none"
+      "registrar": "none",
+      "uniquename": "foo.com"
     }
   ],
   "registrars": []

--- a/pkg/js/parse_tests/014-caa.json
+++ b/pkg/js/parse_tests/014-caa.json
@@ -51,7 +51,8 @@
           "type": "CAA"
         }
       ],
-      "registrar": "none"
+      "registrar": "none",
+      "uniquename": "foo.com"
     }
   ],
   "registrars": []

--- a/pkg/js/parse_tests/015-tlsa.json
+++ b/pkg/js/parse_tests/015-tlsa.json
@@ -19,7 +19,8 @@
           "type": "TLSA"
         }
       ],
-      "registrar": "none"
+      "registrar": "none",
+      "uniquename": "foo.com"
     }
   ],
   "registrars": []

--- a/pkg/js/parse_tests/017-txt.json
+++ b/pkg/js/parse_tests/017-txt.json
@@ -44,7 +44,8 @@
           "type": "TXT"
         }
       ],
-      "registrar": "none"
+      "registrar": "none",
+      "uniquename": "foo.com"
     }
   ],
   "registrars": []

--- a/pkg/js/parse_tests/018-dkim.json
+++ b/pkg/js/parse_tests/018-dkim.json
@@ -16,7 +16,8 @@
           "type": "TXT"
         }
       ],
-      "registrar": "none"
+      "registrar": "none",
+      "uniquename": "foo.com"
     }
   ],
   "registrars": []

--- a/pkg/js/parse_tests/019-r53-alias.json
+++ b/pkg/js/parse_tests/019-r53-alias.json
@@ -193,7 +193,8 @@
           "type": "R53_ALIAS"
         }
       ],
-      "registrar": "none"
+      "registrar": "none",
+      "uniquename": "foo.com"
     }
   ],
   "registrars": []

--- a/pkg/js/parse_tests/020-complexRequire.json
+++ b/pkg/js/parse_tests/020-complexRequire.json
@@ -44,7 +44,8 @@
           "type": "CNAME"
         }
       ],
-      "registrar": "none"
+      "registrar": "none",
+      "uniquename": "sortfoo.com"
     }
   ],
   "registrars": []

--- a/pkg/js/parse_tests/021-srv.json
+++ b/pkg/js/parse_tests/021-srv.json
@@ -57,7 +57,8 @@
           "type": "SRV"
         }
       ],
-      "registrar": "none"
+      "registrar": "none",
+      "uniquename": "foo.com"
     }
   ],
   "registrars": []

--- a/pkg/js/parse_tests/022-sshfp.json
+++ b/pkg/js/parse_tests/022-sshfp.json
@@ -81,7 +81,8 @@
           "type": "SSHFP"
         }
       ],
-      "registrar": "none"
+      "registrar": "none",
+      "uniquename": "foo.com"
     }
   ],
   "registrars": []

--- a/pkg/js/parse_tests/023-ignored-glob-records.json
+++ b/pkg/js/parse_tests/023-ignored-glob-records.json
@@ -9,6 +9,7 @@
       "name": "foo.com",
       "records": [],
       "registrar": "none",
+      "uniquename": "foo.com",
       "unmanaged": [
         {
           "label_pattern": "\\*.testignore",

--- a/pkg/js/parse_tests/024-json-import.json
+++ b/pkg/js/parse_tests/024-json-import.json
@@ -16,7 +16,8 @@
           "type": "A"
         }
       ],
-      "registrar": "none"
+      "registrar": "none",
+      "uniquename": "foo.com"
     }
   ],
   "registrars": []

--- a/pkg/js/parse_tests/025-autodnssec.json
+++ b/pkg/js/parse_tests/025-autodnssec.json
@@ -8,7 +8,8 @@
       },
       "name": "nothing.com",
       "records": [],
-      "registrar": "none"
+      "registrar": "none",
+      "uniquename": "nothing.com"
     },
     {
       "auto_dnssec": "on",
@@ -18,7 +19,8 @@
       },
       "name": "with.com",
       "records": [],
-      "registrar": "none"
+      "registrar": "none",
+      "uniquename": "with.com"
     },
     {
       "auto_dnssec": "off",
@@ -28,7 +30,8 @@
       },
       "name": "without.com",
       "records": [],
-      "registrar": "none"
+      "registrar": "none",
+      "uniquename": "without.com"
     }
   ],
   "registrars": []

--- a/pkg/js/parse_tests/026-azure-alias.json
+++ b/pkg/js/parse_tests/026-azure-alias.json
@@ -48,7 +48,8 @@
           "type": "AZURE_ALIAS"
         }
       ],
-      "registrar": "none"
+      "registrar": "none",
+      "uniquename": "foo.com"
     }
   ],
   "registrars": []

--- a/pkg/js/parse_tests/027-ds.json
+++ b/pkg/js/parse_tests/027-ds.json
@@ -31,7 +31,8 @@
           "type": "DS"
         }
       ],
-      "registrar": "none"
+      "registrar": "none",
+      "uniquename": "foo.com"
     }
   ],
   "registrars": []

--- a/pkg/js/parse_tests/028-dextend.json
+++ b/pkg/js/parse_tests/028-dextend.json
@@ -30,7 +30,8 @@
           "type": "A"
         }
       ],
-      "registrar": "Third-Party"
+      "registrar": "Third-Party",
+      "uniquename": "foo.com"
     },
     {
       "dnsProviders": {
@@ -56,7 +57,8 @@
           "type": "A"
         }
       ],
-      "registrar": "Third-Party"
+      "registrar": "Third-Party",
+      "uniquename": "bar.foo.com"
     },
     {
       "dnsProviders": {
@@ -96,7 +98,8 @@
           "type": "A"
         }
       ],
-      "registrar": "Third-Party"
+      "registrar": "Third-Party",
+      "uniquename": "foo.edu"
     }
   ],
   "registrars": [

--- a/pkg/js/parse_tests/029-dextendsub.json
+++ b/pkg/js/parse_tests/029-dextendsub.json
@@ -62,7 +62,8 @@
           "type": "A"
         }
       ],
-      "registrar": "Third-Party"
+      "registrar": "Third-Party",
+      "uniquename": "foo.net"
     },
     {
       "dnsProviders": {
@@ -95,7 +96,8 @@
           "type": "A"
         }
       ],
-      "registrar": "Third-Party"
+      "registrar": "Third-Party",
+      "uniquename": "foo.tld"
     },
     {
       "dnsProviders": {
@@ -128,7 +130,8 @@
           "type": "A"
         }
       ],
-      "registrar": "Third-Party"
+      "registrar": "Third-Party",
+      "uniquename": "bar.foo.tld"
     },
     {
       "dnsProviders": {
@@ -170,7 +173,8 @@
           "type": "A"
         }
       ],
-      "registrar": "Third-Party"
+      "registrar": "Third-Party",
+      "uniquename": "foo.help"
     },
     {
       "dnsProviders": {
@@ -212,7 +216,8 @@
           "type": "A"
         }
       ],
-      "registrar": "Third-Party"
+      "registrar": "Third-Party",
+      "uniquename": "bar.foo.help"
     },
     {
       "dnsProviders": {
@@ -270,7 +275,8 @@
           "type": "A"
         }
       ],
-      "registrar": "Third-Party"
+      "registrar": "Third-Party",
+      "uniquename": "foo.here"
     },
     {
       "dnsProviders": {
@@ -328,7 +334,8 @@
           "type": "A"
         }
       ],
-      "registrar": "Third-Party"
+      "registrar": "Third-Party",
+      "uniquename": "example.com"
     },
     {
       "dnsProviders": {
@@ -402,7 +409,8 @@
           "type": "A"
         }
       ],
-      "registrar": "Third-Party"
+      "registrar": "Third-Party",
+      "uniquename": "xn--dsseldorf-q9a.example.net"
     },
     {
       "dnsProviders": {
@@ -476,7 +484,8 @@
           "type": "A"
         }
       ],
-      "registrar": "Third-Party"
+      "registrar": "Third-Party",
+      "uniquename": "xn--tda.example.net"
     },
     {
       "dnsProviders": {
@@ -520,7 +529,8 @@
           "type": "CNAME"
         }
       ],
-      "registrar": "Third-Party"
+      "registrar": "Third-Party",
+      "uniquename": "example.tld"
     }
   ],
   "registrars": [

--- a/pkg/js/parse_tests/030-dextenddoc.json
+++ b/pkg/js/parse_tests/030-dextenddoc.json
@@ -107,7 +107,8 @@
           "type": "A"
         }
       ],
-      "registrar": "Third-Party"
+      "registrar": "Third-Party",
+      "uniquename": "domain.tld"
     }
   ],
   "registrars": [

--- a/pkg/js/parse_tests/031-dextendnames.json
+++ b/pkg/js/parse_tests/031-dextendnames.json
@@ -106,7 +106,8 @@
           "type": "CNAME"
         }
       ],
-      "registrar": "Third-Party"
+      "registrar": "Third-Party",
+      "uniquename": "domain.tld"
     },
     {
       "dnsProviders": {
@@ -160,7 +161,8 @@
           "type": "CNAME"
         }
       ],
-      "registrar": "Third-Party"
+      "registrar": "Third-Party",
+      "uniquename": "sub.domain.tld"
     }
   ],
   "registrars": [

--- a/pkg/js/parse_tests/032-reverseip.json
+++ b/pkg/js/parse_tests/032-reverseip.json
@@ -88,7 +88,8 @@
           "type": "PTR"
         }
       ],
-      "registrar": "none"
+      "registrar": "none",
+      "uniquename": "3.2.1.in-addr.arpa"
     }
   ],
   "registrars": [

--- a/pkg/js/parse_tests/033-revextend.json
+++ b/pkg/js/parse_tests/033-revextend.json
@@ -31,7 +31,8 @@
           "type": "NS"
         }
       ],
-      "registrar": "none"
+      "registrar": "none",
+      "uniquename": "8.9.in-addr.arpa"
     },
     {
       "dnsProviders": {
@@ -66,7 +67,8 @@
           "type": "NS"
         }
       ],
-      "registrar": "none"
+      "registrar": "none",
+      "uniquename": "example.com"
     }
   ],
   "registrars": [

--- a/pkg/js/parse_tests/034-nameserver-ttl.json
+++ b/pkg/js/parse_tests/034-nameserver-ttl.json
@@ -9,7 +9,8 @@
       },
       "name": "foo.com",
       "records": [],
-      "registrar": "none"
+      "registrar": "none",
+      "uniquename": "foo.com"
     },
     {
       "dnsProviders": {},
@@ -19,7 +20,8 @@
       },
       "name": "bar.com",
       "records": [],
-      "registrar": "none"
+      "registrar": "none",
+      "uniquename": "bar.com"
     }
   ],
   "registrars": []

--- a/pkg/js/parse_tests/035-naptr.json
+++ b/pkg/js/parse_tests/035-naptr.json
@@ -57,7 +57,8 @@
           "type": "NAPTR"
         }
       ],
-      "registrar": "none"
+      "registrar": "none",
+      "uniquename": "foo.com"
     }
   ],
   "registrars": []

--- a/pkg/js/parse_tests/036-dextendcf.json
+++ b/pkg/js/parse_tests/036-dextendcf.json
@@ -86,7 +86,8 @@
           "type": "A"
         }
       ],
-      "registrar": "Third-Party"
+      "registrar": "Third-Party",
+      "uniquename": "foo.com"
     }
   ],
   "registrars": [

--- a/pkg/js/parse_tests/037-splithor.json
+++ b/pkg/js/parse_tests/037-splithor.json
@@ -38,7 +38,8 @@
           "type": "A"
         }
       ],
-      "registrar": "Third-Party"
+      "registrar": "Third-Party",
+      "uniquename": "example.com"
     },
     {
       "dnsProviders": {
@@ -66,7 +67,8 @@
         }
       ],
       "registrar": "Third-Party",
-      "tag": "inside"
+      "tag": "inside",
+      "uniquename": "example.com!inside"
     },
     {
       "dnsProviders": {
@@ -87,7 +89,8 @@
         }
       ],
       "registrar": "Third-Party",
-      "tag": "outside"
+      "tag": "outside",
+      "uniquename": "example.com!outside"
     },
     {
       "dnsProviders": {
@@ -113,7 +116,8 @@
           "type": "A"
         }
       ],
-      "registrar": "Third-Party"
+      "registrar": "Third-Party",
+      "uniquename": "example.net"
     },
     {
       "dnsProviders": {
@@ -148,7 +152,8 @@
         }
       ],
       "registrar": "Third-Party",
-      "tag": "inside"
+      "tag": "inside",
+      "uniquename": "example.net!inside"
     },
     {
       "dnsProviders": {
@@ -183,7 +188,8 @@
         }
       ],
       "registrar": "Third-Party",
-      "tag": "outside"
+      "tag": "outside",
+      "uniquename": "example.net!outside"
     },
     {
       "dnsProviders": {
@@ -209,7 +215,8 @@
           "type": "A"
         }
       ],
-      "registrar": "Third-Party"
+      "registrar": "Third-Party",
+      "uniquename": "empty.example.net"
     },
     {
       "dnsProviders": {
@@ -235,7 +242,8 @@
           "type": "A"
         }
       ],
-      "registrar": "Third-Party"
+      "registrar": "Third-Party",
+      "uniquename": "example-b.net!"
     }
   ],
   "registrars": [

--- a/pkg/js/parse_tests/038-soa.json
+++ b/pkg/js/parse_tests/038-soa.json
@@ -21,7 +21,8 @@
           "type": "SOA"
         }
       ],
-      "registrar": "none"
+      "registrar": "none",
+      "uniquename": "foo.com"
     }
   ],
   "registrars": []

--- a/pkg/js/parse_tests/039-include.json
+++ b/pkg/js/parse_tests/039-include.json
@@ -25,7 +25,8 @@
         }
       ],
       "registrar": "Third-Party",
-      "tag": "external"
+      "tag": "external",
+      "uniquename": "foo.com!external"
     },
     {
       "dnsProviders": {
@@ -53,7 +54,8 @@
         }
       ],
       "registrar": "Third-Party",
-      "tag": "internal"
+      "tag": "internal",
+      "uniquename": "foo.com!internal"
     }
   ],
   "registrars": [

--- a/pkg/js/parse_tests/040-cfWorkerRoute.json
+++ b/pkg/js/parse_tests/040-cfWorkerRoute.json
@@ -19,7 +19,8 @@
           "type": "CF_WORKER_ROUTE"
         }
       ],
-      "registrar": "none"
+      "registrar": "none",
+      "uniquename": "foo.com"
     }
   ],
   "registrars": []

--- a/pkg/js/parse_tests/040-r53-zone.json
+++ b/pkg/js/parse_tests/040-r53-zone.json
@@ -9,7 +9,8 @@
       },
       "name": "foo.com",
       "records": [],
-      "registrar": "none"
+      "registrar": "none",
+      "uniquename": "foo.com"
     },
     {
       "dnsProviders": {},
@@ -37,7 +38,8 @@
         }
       ],
       "registrar": "none",
-      "tag": "internal"
+      "tag": "internal",
+      "uniquename": "foo.com!internal"
     }
   ],
   "registrars": []

--- a/pkg/js/parse_tests/043-safety.json
+++ b/pkg/js/parse_tests/043-safety.json
@@ -9,6 +9,7 @@
       "name": "unsafe.com",
       "records": [],
       "registrar": "none",
+      "uniquename": "unsafe.com",
       "unmanaged_disable_safety_check": true
     },
     {
@@ -18,7 +19,8 @@
       },
       "name": "safe.com",
       "records": [],
-      "registrar": "none"
+      "registrar": "none",
+      "uniquename": "safe.com"
     }
   ],
   "registrars": []

--- a/pkg/js/parse_tests/044-ensureabsent.json
+++ b/pkg/js/parse_tests/044-ensureabsent.json
@@ -24,7 +24,8 @@
           "type": "A"
         }
       ],
-      "registrar": "none"
+      "registrar": "none",
+      "uniquename": "example.com"
     }
   ],
   "registrars": []

--- a/pkg/js/parse_tests/045-loc.json
+++ b/pkg/js/parse_tests/045-loc.json
@@ -328,7 +328,8 @@
           "type": "LOC"
         }
       ],
-      "registrar": "none"
+      "registrar": "none",
+      "uniquename": "foo.com"
     }
   ],
   "registrars": []

--- a/pkg/js/parse_tests/046-DHCID.json
+++ b/pkg/js/parse_tests/046-DHCID.json
@@ -16,7 +16,8 @@
           "type": "DHCID"
         }
       ],
-      "registrar": "none"
+      "registrar": "none",
+      "uniquename": "foo.com"
     }
   ],
   "registrars": []

--- a/pkg/js/parse_tests/047-DNAME.json
+++ b/pkg/js/parse_tests/047-DNAME.json
@@ -16,7 +16,8 @@
           "type": "DNAME"
         }
       ],
-      "registrar": "none"
+      "registrar": "none",
+      "uniquename": "foo.com"
     }
   ],
   "registrars": []

--- a/pkg/js/parse_tests/047-SVCB.json
+++ b/pkg/js/parse_tests/047-SVCB.json
@@ -26,7 +26,8 @@
           "type": "SVCB"
         }
       ],
-      "registrar": "none"
+      "registrar": "none",
+      "uniquename": "foo.com"
     }
   ],
   "registrars": []

--- a/pkg/js/parse_tests/048-DNSKEY.json
+++ b/pkg/js/parse_tests/048-DNSKEY.json
@@ -20,7 +20,8 @@
           "type": "DNSKEY"
         }
       ],
-      "registrar": "none"
+      "registrar": "none",
+      "uniquename": "foo.com"
     }
   ],
   "registrars": []

--- a/pkg/js/parse_tests/049-json5-require.json
+++ b/pkg/js/parse_tests/049-json5-require.json
@@ -16,7 +16,8 @@
           "type": "A"
         }
       ],
-      "registrar": "none"
+      "registrar": "none",
+      "uniquename": "foo.com"
     }
   ],
   "registrars": []

--- a/pkg/js/parse_tests/050-cfSingleRedirect.json
+++ b/pkg/js/parse_tests/050-cfSingleRedirect.json
@@ -109,7 +109,8 @@
           "type": "A"
         }
       ],
-      "registrar": "none"
+      "registrar": "none",
+      "uniquename": "foo.com"
     }
   ],
   "registrars": []

--- a/pkg/js/parse_tests/051-HASH.json
+++ b/pkg/js/parse_tests/051-HASH.json
@@ -8,7 +8,8 @@
       },
       "name": "a9993e364706816aba3e25717850c26c9cd0d89d",
       "records": [],
-      "registrar": "reg"
+      "registrar": "reg",
+      "uniquename": "a9993e364706816aba3e25717850c26c9cd0d89d"
     }
   ],
   "registrars": []

--- a/pkg/js/parse_tests/054-b3487_d_extend_rev.json
+++ b/pkg/js/parse_tests/054-b3487_d_extend_rev.json
@@ -110,7 +110,8 @@
           "type": "PTR"
         }
       ],
-      "registrar": "none"
+      "registrar": "none",
+      "uniquename": "6.10.in-addr.arpa"
     }
   ],
   "registrars": [

--- a/pkg/js/parse_tests/055-b3550-ipv6ptr.json
+++ b/pkg/js/parse_tests/055-b3550-ipv6ptr.json
@@ -30,7 +30,8 @@
           "type": "PTR"
         }
       ],
-      "registrar": "none"
+      "registrar": "none",
+      "uniquename": "d.c.b.a.1.1.0.2.ip6.arpa"
     },
     {
       "dnsProviders": {
@@ -64,7 +65,8 @@
           "type": "PTR"
         }
       ],
-      "registrar": "none"
+      "registrar": "none",
+      "uniquename": "8.b.d.0.1.0.0.2.ip6.arpa"
     }
   ],
   "registrars": [

--- a/pkg/js/parse_tests/056-openpgpkey.json
+++ b/pkg/js/parse_tests/056-openpgpkey.json
@@ -16,7 +16,8 @@
           "type": "OPENPGPKEY"
         }
       ],
-      "registrar": "none"
+      "registrar": "none",
+      "uniquename": "foo.com"
     }
   ],
   "registrars": []

--- a/pkg/js/parse_tests/057-smimea.json
+++ b/pkg/js/parse_tests/057-smimea.json
@@ -17,7 +17,8 @@
           "type": "SMIMEA"
         }
       ],
-      "registrar": "none"
+      "registrar": "none",
+      "uniquename": "foo.com"
     }
   ],
   "registrars": []

--- a/pkg/js/parse_tests/058-ignore-external-dns.json
+++ b/pkg/js/parse_tests/058-ignore-external-dns.json
@@ -9,7 +9,8 @@
       },
       "name": "extdns-default.com",
       "records": [],
-      "registrar": "none"
+      "registrar": "none",
+      "uniquename": "extdns-default.com"
     },
     {
       "dnsProviders": {},
@@ -20,7 +21,8 @@
       },
       "name": "extdns-custom.com",
       "records": [],
-      "registrar": "none"
+      "registrar": "none",
+      "uniquename": "extdns-custom.com"
     },
     {
       "dnsProviders": {},
@@ -45,7 +47,8 @@
           "type": "A"
         }
       ],
-      "registrar": "none"
+      "registrar": "none",
+      "uniquename": "extdns-combined.com"
     }
   ],
   "registrars": []


### PR DESCRIPTION
Fixes https://github.com/StackExchange/dnscontrol/issues/3894

# Issue

* Split horizon DNS broke in 4.28.0
* Insufficient automated testing to detect this in the future 

# Resolution

* domain.PostProcess() was called twice.  The first time the tag was properly parsed, removing the tag from DomainConfig.Name and putting it in DomainConfig.Tag.  The second time DomainConfig.Name no longer had the tag and .Tag was set to "".
* The JSON output of DomainConfig doesn't output .UniqueName. If it had, this bug would have been noticed prior to release.  Test updated to include that field.