### PR TITLE
TOOLS: bin/generate-all.sh should skip .vscode

### DIFF
--- a/bin/generate-all.sh
+++ b/bin/generate-all.sh
@@ -7,7 +7,7 @@ if [[ -x node_modules/.bin/prettier ]]; then
 fi
 
 # JSON
-bin/fmtjson $(find . -type f -name "*.json" ! -name "package-lock.json" -print)
+bin/fmtjson $(find . -path ./.vscode -prune -o -type f -name "*.json" ! -name "package-lock.json" -print)
 
 # dnsconfig.js-compatible files:
 for i in pkg/js/parse_tests/*.js ; do dnscontrol fmt -i $i -o $i ; done


### PR DESCRIPTION
# Issue

bin/generate-all.sh is trying to reformat VSCode's launch.json, but it can't because it is not strict json.

```
Reformatting: ./.vscode/launch.json
ERROR: Expecting value: line 17 column 17 (char 465)
```

# Resolution

bin/generate-all.sh should skip the .vscode directory.