### PR TITLE
OVH: Allow Null MX Record

### DIFF
--- a/providers/ovh/auditrecords.go
+++ b/providers/ovh/auditrecords.go
@@ -11,7 +11,5 @@ import (
 func AuditRecords(records []*models.RecordConfig) []error {
 	a := rejectif.Auditor{}
 
-	a.Add("MX", rejectif.MxNull) // Last verified 2020-12-28
-
 	return a.Audit(records)
 }


### PR DESCRIPTION
It was not possible to add a Null MX record on OVH.
But it's now possible! (finally)

This pull request removes the restriction.

