### PR TITLE
CLOUDNS: Add GeoDNS support

### DIFF
--- a/integrationTest/integration_test.go
+++ b/integrationTest/integration_test.go
@@ -1876,6 +1876,25 @@ func makeTests() []*TestGroup {
 				ovhdmarc("_dmarc", "v=DMARC1; p=none; rua=mailto:dmarc@example.com")),
 		),
 
+		// CLOUDNS features
+
+		testgroup("CLOUDNS geodns tests",
+			only("CLOUDNS"),
+			tc("Add record with geodns code", withMeta(a("@", "1.2.3.4"), map[string]string{
+				"cloudns_geodns_code": "US",
+			})),
+			tc("Update record with default geodns code", withMeta(a("@", "1.2.3.4"), map[string]string{
+				"cloudns_geodns_code": "DEFAULT",
+			})),
+			tc("Update record with geodns code", withMeta(a("@", "1.2.3.4"), map[string]string{
+				"cloudns_geodns_code": "BR",
+			})),
+			tc("Delete metadata from record", a("@", "1.2.3.4")),
+			tc("Update a record with the value DEFAULT after removing the metadata should do nothing", withMeta(a("@", "1.2.3.4"), map[string]string{
+				"cloudns_geodns_code": "DEFAULT",
+			})).ExpectNoChanges(),
+		),
+
 		// PORKBUN features
 
 		testgroup("PORKBUN_URLFWD tests",

--- a/providers/cloudns/api.go
+++ b/providers/cloudns/api.go
@@ -62,6 +62,7 @@ type domainRecord struct {
 	Protocol         string `json:"protocol"`
 	TTL              string `json:"ttl"`
 	Status           int8   `json:"status"`
+	GeodnsCode       string `json:"geodns-location-code,omitempty"`
 	CaaFlag          string `json:"caa_flag,omitempty"`
 	CaaTag           string `json:"caa_type,omitempty"`
 	CaaValue         string `json:"caa_value,omitempty"`

--- a/providers/cloudns/metaConstants.go
+++ b/providers/cloudns/metaConstants.go
@@ -1,0 +1,6 @@
+package cloudns
+
+const (
+	// Only used for GeoDNS feature
+	metaGeodnsCode = "cloudns_geodns_code"
+)


### PR DESCRIPTION
Hello,

This pull request add the GeoDNS feature for ClouDNS.
Their API has 2 fields for adding a location, I choose to use only "geodns-code" because it is more user-friendly.
Following the advice from @tlimoncelli the new metadata name is ``cloudns_geodns_code``
```
// Example syntax using geodns-code instead of geodns-location
A("test", "1.2.3.4", {cloudns_geodns_code: "US"});
A("test", "1.2.3.4", {cloudns_geodns_code: "FR"});
A("test", "1.2.3.4", {cloudns_geodns_code: "PL"});
```
More tests have been added and they all pass!

To compare two records, i have to replace the value "DEFAULT" with an empty string temporary.
Their API always return "DEFAULT" as value by default instead of an empty string for any dns record which uses their geodns feature.
```
// API return something like this if your account has GeoDNS and the dns record has GeoDNS
{"id":"XXXX","type":"A","host":"","record":"1.2.3.7","dynamicurl_status":0,"failover":"0","ttl":"300","geodns-location":"2","geodns-location-name":"Africa","geodns-location-code":"AFR","status":1}
// API return something like this if your account doesn't have GeoDNS feature or the dns record is not compatible with their GeoDNS
{"id":"XXXX","type":"TXT","host":"","record":"test","failover":"0","ttl":"3600","status":1}
```

If this implementation is good enough, i will update the documentation ("ClouDNS > Metadata section")