### PR TITLE
PORKBUN: skip NS only APEX test

### DIFF
--- a/integrationTest/integration_test.go
+++ b/integrationTest/integration_test.go
@@ -435,6 +435,7 @@ func makeTests() []*TestGroup {
 				"JOKER",       // Not supported via the Zone API.
 				"NAMEDOTCOM",  // "Ignores @ for NS records"
 				"NETCUP",      // NS records not currently supported.
+				"PORKBUN",     // Record ignored.
 				"SAKURACLOUD", // Silently ignores requests to remove NS at @.
 				"TRANSIP",     // "it is not allowed to have an NS for an @ record"
 				"VERCEL",      // "invalid_name - Cannot set NS records at the root level. Only subdomain NS records are supported"


### PR DESCRIPTION
<!--
## Before submiting a pull request

Please make sure you've run the following commands from the root directory.

    bin/generate-all.sh

(this runs commands like "go generate", fixes formatting, and so on)

## Release changelog section

Help keep the release changelog clear by pre-naming the proper section in the GitHub pull request title.

Some examples:
* CICD: Add required GHA permissions for goreleaser
* DOCS: Fixed providers with "contributor support" table
* ROUTE53: Allow R53_ALIAS records to enable target health evaluation

More examples/context can be found in the file .goreleaser.yml under the 'build' > 'changelog' key.
!-->

Changes to APEX NS records will be ignored by their DNS server.