### PR TITLE
PORKBUN: support URL and URL301

### DIFF
--- a/commands/types/dnscontrol.d.ts
+++ b/commands/types/dnscontrol.d.ts
@@ -2910,6 +2910,8 @@ declare function OPENPGPKEY(name: string, target: string, ...modifiers: RecordMo
 declare function PANIC(message: string): never;
 
 /**
+ * **DEPRECATED**: This record type is deprecated. Please use `URL` (for temporary redirects) or `URL301` (for permanent redirects) instead. PORKBUN_URLFWD will continue to work but is no longer recommended for new configurations.
+ *
  * `PORKBUN_URLFWD` is a Porkbun-specific feature that maps to Porkbun's URL forwarding feature, which creates HTTP 301 (permanent) or 302 (temporary) redirects.
  *
  * ```javascript
@@ -3572,7 +3574,7 @@ declare function SOA(name: string, ns: string, mbox: string, refresh: number, re
  *
  * ## Advanced Technique: Define once, use many
  *
- * In some situations we define an SPF setting once and want to reuse
+ * In some situations we define an SPF setting once and want to re-use
  * it on many domains. Here's how to do this:
  *
  * ```javascript
@@ -3835,6 +3837,18 @@ declare function TXT(name: string, contents: string, ...modifiers: RecordModifie
  *
  * You can read more at the [Namecheap documentation](https://www.namecheap.com/support/knowledgebase/article.aspx/385/2237/how-to-set-up-a-url-redirect-for-a-domain/)
  *
+ * ### Porkbun
+ *
+ * This creates a temporary (HTTP 302) redirect to the target URL. By default, it includes wildcard subdomains but does not include the URI path in redirection.
+ *
+ * Example:
+ *
+ * ```javascript
+ * D("example.com", REG_PORKBUN, DnsProvider(DSP_PORKBUN),
+ *     URL("redirect", "https://example.org"),
+ * );
+ * ```
+ *
  * @see https://docs.dnscontrol.org/language-reference/domain-modifiers/url
  */
 declare function URL(name: string, target: string, ...modifiers: RecordModifier[]): DomainModifier;
@@ -3847,6 +3861,18 @@ declare function URL(name: string, target: string, ...modifiers: RecordModifier[
  * This is a URL Redirect record with a type of "Permanent", it creates a 301 redirect to the target.
  *
  * You can read more at the [Namecheap documentation](https://www.namecheap.com/support/knowledgebase/article.aspx/385/2237/how-to-set-up-a-url-redirect-for-a-domain/).
+ *
+ * ### Porkbun
+ *
+ * This creates a permanent (HTTP 301) redirect to the target URL. By default, it includes wildcard subdomains but does not include the URI path in redirection.
+ *
+ * Example:
+ *
+ * ```javascript
+ * D("example.com", REG_PORKBUN, DnsProvider(DSP_PORKBUN),
+ *     URL301("redirect", "https://example.org"),
+ * );
+ * ```
  *
  * @see https://docs.dnscontrol.org/language-reference/domain-modifiers/url301
  */

--- a/documentation/language-reference/domain-modifiers/PORKBUN_URLFWD.md
+++ b/documentation/language-reference/domain-modifiers/PORKBUN_URLFWD.md
@@ -11,6 +11,10 @@ parameter_types:
   "modifiers...": RecordModifier[]
 ---
 
+{% hint style="warning" %}
+**DEPRECATED**: This record type is deprecated. Please use `URL` (for temporary redirects) or `URL301` (for permanent redirects) instead. PORKBUN_URLFWD will continue to work but is no longer recommended for new configurations.
+{% endhint %}
+
 `PORKBUN_URLFWD` is a Porkbun-specific feature that maps to Porkbun's URL forwarding feature, which creates HTTP 301 (permanent) or 302 (temporary) redirects.
 
 

--- a/documentation/language-reference/domain-modifiers/URL.md
+++ b/documentation/language-reference/domain-modifiers/URL.md
@@ -19,3 +19,17 @@ This is provider specific type of record and not a DNS standard. It may behave d
 This is a URL Redirect record with a type of "Unmasked", it creates a 302 redirect to the target.
 
 You can read more at the [Namecheap documentation](https://www.namecheap.com/support/knowledgebase/article.aspx/385/2237/how-to-set-up-a-url-redirect-for-a-domain/)
+
+### Porkbun
+
+This creates a temporary (HTTP 302) redirect to the target URL. By default, it includes wildcard subdomains but does not include the URI path in redirection.
+
+Example:
+
+{% code title="dnsconfig.js" %}
+```javascript
+D("example.com", REG_PORKBUN, DnsProvider(DSP_PORKBUN),
+    URL("redirect", "https://example.org"),
+);
+```
+{% endcode %}

--- a/documentation/language-reference/domain-modifiers/URL301.md
+++ b/documentation/language-reference/domain-modifiers/URL301.md
@@ -19,3 +19,17 @@ This is provider specific type of record and not a DNS standard. It may behave d
 This is a URL Redirect record with a type of "Permanent", it creates a 301 redirect to the target.
 
 You can read more at the [Namecheap documentation](https://www.namecheap.com/support/knowledgebase/article.aspx/385/2237/how-to-set-up-a-url-redirect-for-a-domain/).
+
+### Porkbun
+
+This creates a permanent (HTTP 301) redirect to the target URL. By default, it includes wildcard subdomains but does not include the URI path in redirection.
+
+Example:
+
+{% code title="dnsconfig.js" %}
+```javascript
+D("example.com", REG_PORKBUN, DnsProvider(DSP_PORKBUN),
+    URL301("redirect", "https://example.org"),
+);
+```
+{% endcode %}

--- a/documentation/provider/porkbun.md
+++ b/documentation/provider/porkbun.md
@@ -68,3 +68,36 @@ D("example.com", REG_PORKBUN, DnsProvider(DSP_R53),
 );
 ```
 {% endcode %}
+
+## URL Forwarding
+
+Porkbun supports URL forwarding (redirects) using the `URL` and `URL301` record types:
+
+{% code title="dnsconfig.js" %}
+```javascript
+var REG_PORKBUN = NewRegistrar("porkbun");
+var DSP_PORKBUN = NewDnsProvider("porkbun");
+
+D("example.com", REG_PORKBUN, DnsProvider(DSP_PORKBUN),
+    // Temporary redirect (HTTP 302)
+    URL("redirect", "https://example.org"),
+    // Permanent redirect (HTTP 301)
+    URL301("www", "https://example.com"),
+);
+```
+{% endcode %}
+
+By default, URL forwarding includes wildcard subdomains but does not include the URI path in redirection. You can customize this behavior using metadata:
+
+{% code title="dnsconfig.js" %}
+```javascript
+D("example.com", REG_PORKBUN, DnsProvider(DSP_PORKBUN),
+    // Include path and disable wildcard
+    URL("redirect", "https://example.org", {includePath: "yes", wildcard: "no"}),
+);
+```
+{% endcode %}
+
+{% hint style="info" %}
+**NOTE**: The legacy `PORKBUN_URLFWD` record type is deprecated. Please use `URL` or `URL301` instead.
+{% endhint %}

--- a/pkg/js/helpers.js
+++ b/pkg/js/helpers.js
@@ -1511,6 +1511,9 @@ var URL = recordBuilder('URL');
 var URL301 = recordBuilder('URL301');
 var FRAME = recordBuilder('FRAME');
 var CLOUDNS_WR = recordBuilder('CLOUDNS_WR');
+/**
+ * @deprecated Please use URL or URL301 instead
+ */
 var PORKBUN_URLFWD = recordBuilder('PORKBUN_URLFWD');
 var BUNNY_DNS_RDR = recordBuilder('BUNNY_DNS_RDR');
 // LOC_BUILDER_DD takes an object:


### PR DESCRIPTION
<!--
## Before submiting a pull request

Please make sure you've run the following commands from the root directory.

    bin/generate-all.sh

(this runs commands like "go generate", fixes formatting, and so on)

## Release changelog section

Help keep the release changelog clear by pre-naming the proper section in the GitHub pull request title.

Some examples:
* CICD: Add required GHA permissions for goreleaser
* DOCS: Fixed providers with "contributor support" table
* ROUTE53: Allow R53_ALIAS records to enable target health evaluation

More examples/context can be found in the file .goreleaser.yml under the 'build' > 'changelog' key.
!-->

Support `URL` and `URL301`, mark `PORKBUN_URLFWD` as DEPRECATED, maybe delete after one year or shorter.
Manually tested, and integration test mostly passed except #3950

close #3793