### PR TITLE
PORKBUN: Add support for SSHFP record types.

### DIFF
--- a/documentation/provider/index.md
+++ b/documentation/provider/index.md
@@ -305,7 +305,7 @@ Jump to a table:
 | [`NS1`](ns1.md) | ✅ | ✅ | ❔ | ❔ | ✅ |
 | [`ORACLE`](oracle.md) | ✅ | ❔ | ❔ | ✅ | ✅ |
 | [`OVH`](ovh.md) | ✅ | ❔ | ❔ | ✅ | ✅ |
-| [`PORKBUN`](porkbun.md) | ✅ | ✅ | ❔ | ❌ | ✅ |
+| [`PORKBUN`](porkbun.md) | ✅ | ✅ | ❔ | ✅ | ✅ |
 | [`POWERDNS`](powerdns.md) | ✅ | ✅ | ❔ | ✅ | ✅ |
 | [`REALTIMEREGISTER`](realtimeregister.md) | ✅ | ❔ | ❔ | ✅ | ✅ |
 | [`ROUTE53`](route53.md) | ✅ | ✅ | ❔ | ✅ | ✅ |

--- a/providers/porkbun/porkbunProvider.go
+++ b/providers/porkbun/porkbunProvider.go
@@ -91,7 +91,7 @@ var features = providers.DocumentationNotes{
 	providers.CanUsePTR:              providers.Cannot(),
 	providers.CanUseSOA:              providers.Cannot(),
 	providers.CanUseSRV:              providers.Can(),
-	providers.CanUseSSHFP:            providers.Cannot(),
+	providers.CanUseSSHFP:            providers.Can(),
 	providers.CanUseTLSA:             providers.Can(),
 	providers.CanUseHTTPS:            providers.Can(),
 	providers.CanUseSVCB:             providers.Can(),
@@ -338,6 +338,8 @@ func toRc(domain string, r *domainRecord) (*models.RecordConfig, error) {
 			rc.SvcParams = strings.Join(c[2:], " ")
 		}
 		err = rc.SetTarget(c[1])
+	case "SSHFP":
+		err = rc.SetTargetSSHFPString(r.Content)
 	default:
 		err = rc.SetTarget(r.Content)
 	}
@@ -392,6 +394,9 @@ func toReq(rc *models.RecordConfig) (requestParams, error) {
 	case "SVCB":
 		req["content"] = fmt.Sprintf("%d %s %s",
 			rc.SvcPriority, rc.GetTargetField(), rc.SvcParams)
+	case "SSHFP":
+		req["content"] = fmt.Sprintf("%v %v %s",
+			rc.SshfpAlgorithm, rc.SshfpFingerprint, rc.GetTargetField())
 	default:
 		return nil, fmt.Errorf("porkbun.toReq rtype %q unimplemented", rc.Type)
 	}


### PR DESCRIPTION
Porkbun's v3 API [supports SSHFP](https://porkbun.com/api/json/v3/documentation#DNS%20Create%20Record) using the same format as for other record types.