### PR TITLE
CLOUDNS: fix format string for nameserver diff

### DIFF
--- a/providers/cloudns/cloudnsProvider.go
+++ b/providers/cloudns/cloudnsProvider.go
@@ -296,7 +296,7 @@ func (c *cloudnsProvider) GetRegistrarCorrections(dc *models.DomainConfig) ([]*m
 	if existingStr != desiredStr {
 		return []*models.Correction{
 			{
-				Msg: fmt.Sprintf("Update nameservers from '%q' to '%q'", existingStr, desiredStr),
+				Msg: fmt.Sprintf("Update nameservers from %q to %q", existingStr, desiredStr),
 				F: func() error {
 					return c.setNameservers(dc.Name, desired)
 				},


### PR DESCRIPTION
Fix a format string that used `%s` where `%q` is more appropriate, to escape the string fully.

This addresses the feedback in #3961 that I didn't get done in time to be merged. 