### PR TITLE
BIND: add missing implementation for ZoneCreator

### DIFF
--- a/providers/bind/bindProvider.go
+++ b/providers/bind/bindProvider.go
@@ -241,7 +241,7 @@ func ParseZoneContents(content string, zoneName string, zonefileName string) (mo
 	return foundRecords, nil
 }
 
-func (c *bindProvider) EnsureZoneExists(_ string) error {
+func (c *bindProvider) EnsureZoneExists(_ string, _ map[string]string) error {
 	return nil
 }
 


### PR DESCRIPTION
# Issue

The change of the interface introduced in 4.27.1 causes some issues if the zone does not exist and we're running the preview command. 

# Resolution

Fix the signature for EnsureZoneExists() in BIND so that it can be used as a zone-creator.

Fixes https://github.com/StackExchange/dnscontrol/issues/3939