### PR TITLE
CNR: prevent duplicate nameservers in registrar corrections to fix #3985

### DIFF
--- a/providers/cnr/nameservers.go
+++ b/providers/cnr/nameservers.go
@@ -3,6 +3,7 @@ package cnr
 import (
 	"fmt"
 	"regexp"
+	"slices"
 	"sort"
 	"strings"
 
@@ -73,12 +74,12 @@ func (n *Client) GetRegistrarCorrections(dc *models.DomainConfig) ([]*models.Cor
 	sort.Strings(foundLower)
 	foundNameservers := strings.Join(foundLower, ",")
 
-	expected := []string{}
+	expected := make([]string, 0, len(dc.Nameservers))
 	for _, ns := range dc.Nameservers {
-		name := strings.ToLower(strings.TrimRight(ns.Name, "."))
-		expected = append(expected, name)
+		expected = append(expected, strings.ToLower(strings.TrimRight(ns.Name, ".")))
 	}
-	sort.Strings(expected)
+	slices.Sort(expected)
+	expected = slices.Compact(expected)
 	expectedNameservers := strings.Join(expected, ",")
 
 	if foundNameservers != expectedNameservers {


### PR DESCRIPTION
Fixes https://github.com/StackExchange/dnscontrol/issues/3985 the duplicate nameservers issue
