### PR TITLE
BUGFIX: fix regression on a SPF parsing

### DIFF
--- a/pkg/spflib/parse.go
+++ b/pkg/spflib/parse.go
@@ -61,7 +61,7 @@ func Parse(text string, dnsres Resolver) (*SPFRecord, error) {
 		if part == "all" {
 			// all. nothing else matters.
 			break
-		} else if lcpart == "a" || lcpart == "mx" {
+		} else if strings.HasPrefix(lcpart, "a") || strings.HasPrefix(lcpart, "mx") {
 			p.IsLookup = true
 		} else if strings.HasPrefix(lcpart, "ip4:") || strings.HasPrefix(lcpart, "ip6:") {
 			// ip address, 0 lookups


### PR DESCRIPTION
https://github.com/StackExchange/dnscontrol/commit/819253a5b0088920b34e9a54dbd6341cb95f7274 seems to have  caused a regression in the parsing of `a` mechanism SPF parts, e.g. a part like `a:something.wm.edu` would now return `ERROR: unsupported SPF part a:something.wm.edu`. This reverts back to the use `HasPrefix` to prevent those parts from erroring.

Parsing this way wouldn't error on bad parts like `asdf:something.wm.edu`, so maybe a larger fix is needed, but for now just fixing the regression seemed simplest.