### PR TITLE
DOCS: Update VSCode debugging instructions for itests and cmd

### DIFF
--- a/documentation/advanced-features/debugging-with-dlv.md
+++ b/documentation/advanced-features/debugging-with-dlv.md
@@ -1,6 +1,6 @@
 ## Debugger
 
-Test a particular function:
+### Debug a particular function:
 
 ```shell
 dlv test github.com/StackExchange/dnscontrol/v4/pkg/diff2 -- -test.run Test_analyzeByRecordSet
@@ -8,7 +8,7 @@ dlv test github.com/StackExchange/dnscontrol/v4/pkg/diff2 -- -test.run Test_anal
                                                 Assumes you are in the pkg/diff2 directory.
 ```
 
-Debug the integration tests:
+### Debug an integration tests:
 
 ```shell
 dlv test github.com/StackExchange/dnscontrol/v4/integrationTest -- -test.v -test.run ^TestDNSProviders -verbose -profile BIND -start 7 -end 7
@@ -18,12 +18,15 @@ If you are using VSCode, the equivalent configuration is:
 
 ```
     "configurations": [
+
         {
             "name": "Debug Integration Test",
             "type": "go",
             "request": "launch",
             "mode": "test",
             "program": "${workspaceFolder}/integrationTest",
+            "cwd": "${workspaceFolder}/integrationTest",
+            "envFile": "${workspaceFolder}/integrationTest/.env",
             "args": [
                 "-test.v",
                 "-test.run",
@@ -39,5 +42,38 @@ If you are using VSCode, the equivalent configuration is:
             "buildFlags": "",
             "env": {},
             "showLog": true
-        },
+        }
+
+    ]
+}
+
 ```
+
+### Debug the `dnscontrol` command
+
+```shell
+dlv debug --wd /path/to/config/dir -- preview --domains examples.com
+```
+
+VSCode equivalent configuration is:
+
+```
+    "configurations": [
+
+        {
+            "name": "preview example.com",
+            "type": "go",
+            "request": "launch",
+            "mode": "debug",
+            "program": "${workspaceFolder}/",
+            "cwd": "/path/to/config/dir",
+            "args": [
+                "preview",
+                "--domains",
+                "example.com"
+            ]
+        }
+
+    ]
+```
+


### PR DESCRIPTION
# Issue

Activating the debugger in VSCode is tricky.

# Resolution

Document launch.json examples that work.