### PR TITLE
BUNNYDNS: Permit SRV "." targets

### DIFF
--- a/providers/bunnydns/auditrecords.go
+++ b/providers/bunnydns/auditrecords.go
@@ -10,8 +10,7 @@ import (
 // supported, an empty list is returned.
 func AuditRecords(records []*models.RecordConfig) []error {
 	a := rejectif.Auditor{}
-	a.Add("TXT", rejectif.TxtIsEmpty)       // Last verified 2024-01-02
-	a.Add("SRV", rejectif.SrvHasNullTarget) // Last verified 2024-01-02
+	a.Add("TXT", rejectif.TxtIsEmpty) // Last verified 2024-01-02
 
 	return a.Audit(records)
 }

--- a/providers/bunnydns/convert.go
+++ b/providers/bunnydns/convert.go
@@ -47,11 +47,16 @@ func fromRecordConfig(rc *models.RecordConfig) (*record, error) {
 		r.Value = strings.TrimSuffix(r.Value, ".")
 	}
 
-	// In the case of SVCB/HTTPS records, the Target is part of the Value.
-	// After removing trailing dots for said target, we can add the params to the value.
 	switch r.Type {
 	case recordTypeSVCB, recordTypeHTTPS:
+		// In the case of SVCB/HTTPS records, the Target is part of the Value.
+		// After removing trailing dots for said target, we can add the params to the value.
 		r.Value = fmt.Sprintf("%s %s", r.Value, rc.SvcParams)
+	case recordTypeSRV:
+		// SRV empty target is represented as "."
+		if r.Value == "" {
+			r.Value = "."
+		}
 	}
 
 	return &r, nil


### PR DESCRIPTION
Fixes https://github.com/StackExchange/dnscontrol/issues/3997

# Issue

BunnyDNS no longer prohibits SRV "null targets".

# Resolution

Permit them.