### PR TITLE
BUGFIX: avoid impossible comparison (staticcheck/SA4003)

### DIFF
--- a/pkg/providers/capabilities.go
+++ b/pkg/providers/capabilities.go
@@ -7,7 +7,7 @@ import (
 )
 
 // Capability is a bitmasked set of "features" that a provider supports. Only use constants from this package.
-type Capability int32
+type Capability int
 
 const (
 	// Keep this list sorted.


### PR DESCRIPTION
Use of unsigned integer conflicts with assumptions of `stringer` generated code.