### PR TITLE
BUGFIX: error contains advice for presentation (staticcheck/ST1005)

### DIFF
--- a/pkg/rtypecontrol/import.go
+++ b/pkg/rtypecontrol/import.go
@@ -36,9 +36,8 @@ func ImportRawRecords(domains []*models.DomainConfig) error {
 				} else {
 					shortname = strings.TrimSuffix(rec.Name, "."+dc.Name)
 				}
-				//lint:ignore ST1005 providing advice in a presentation ready format.
 				return fmt.Errorf(
-					"The name %q is an error (repeats the domain). Maybe instead of %q you intended %q? If not add DISABLE_REPEATED_DOMAIN_CHECK to this record to disable this check",
+					"name %q is an error (repeats the domain): Hint: Maybe instead of %q you intended %q? If not add DISABLE_REPEATED_DOMAIN_CHECK to this record to disable this check",
 					rec.NameFQDNRaw,
 					rec.NameRaw,
 					shortname,


### PR DESCRIPTION
Quieten [`staticcheck`](https://staticcheck.dev) for error message with a capital. Ideally advice would be returned to the user by another means.