### PR TITLE
CLOUDFLAREAPI: Add per-record CNAME flattening support

### DIFF
--- a/commands/types/dnscontrol.d.ts
+++ b/commands/types/dnscontrol.d.ts
@@ -138,6 +138,10 @@ declare const CF_PROXY_OFF: RecordModifier;
 declare const CF_PROXY_ON: RecordModifier;
 /** Proxy+Railgun enabled. */
 declare const CF_PROXY_FULL: RecordModifier;
+/** Per-record CNAME flattening disabled (default) */
+declare const CF_CNAME_FLATTEN_OFF: RecordModifier;
+/** Per-record CNAME flattening enabled (requires Cloudflare paid plan) */
+declare const CF_CNAME_FLATTEN_ON: RecordModifier;
 
 /** Proxy default off for entire domain (the default) */
 declare const CF_PROXY_DEFAULT_OFF: DomainModifier;

--- a/commands/types/others.d.ts
+++ b/commands/types/others.d.ts
@@ -27,6 +27,10 @@ declare const CF_PROXY_OFF: RecordModifier;
 declare const CF_PROXY_ON: RecordModifier;
 /** Proxy+Railgun enabled. */
 declare const CF_PROXY_FULL: RecordModifier;
+/** Per-record CNAME flattening disabled (default) */
+declare const CF_CNAME_FLATTEN_OFF: RecordModifier;
+/** Per-record CNAME flattening enabled (requires Cloudflare paid plan) */
+declare const CF_CNAME_FLATTEN_ON: RecordModifier;
 
 /** Proxy default off for entire domain (the default) */
 declare const CF_PROXY_DEFAULT_OFF: DomainModifier;

--- a/integrationTest/helpers_integration_test.go
+++ b/integrationTest/helpers_integration_test.go
@@ -41,6 +41,16 @@ func CfProxyOn() *TestCase  { return tc("proxyon", cfProxyA("prxy", "174.136.107
 func CfCProxyOff() *TestCase { return tc("cproxyoff", cfProxyCNAME("cproxy", "example.com.", "off")) }
 func CfCProxyOn() *TestCase  { return tc("cproxyon", cfProxyCNAME("cproxy", "example.com.", "on")) }
 
+// Helper constants/funcs for the CLOUDFLARE CNAME flattening testing:
+
+// CNAME flattening off/on (requires paid plan)
+func CfFlattenOff() *TestCase {
+	return tc("flattenoff", cfFlattenCNAME("cflatten", "example.com.", "off"))
+}
+func CfFlattenOn() *TestCase {
+	return tc("flattenon", cfFlattenCNAME("cflatten", "example.com.", "on"))
+}
+
 func getDomainConfigWithNameservers(t *testing.T, prv providers.DNSServiceProvider, domainName string) *models.DomainConfig {
 	dc := &models.DomainConfig{
 		Name: domainName,
@@ -337,6 +347,13 @@ func cfProxyCNAME(name, target, status string) *models.RecordConfig {
 	r := cname(name, target)
 	r.Metadata = make(map[string]string)
 	r.Metadata["cloudflare_proxy"] = status
+	return r
+}
+
+func cfFlattenCNAME(name, target, status string) *models.RecordConfig {
+	r := cname(name, target)
+	r.Metadata = make(map[string]string)
+	r.Metadata["cloudflare_cname_flatten"] = status
 	return r
 }
 

--- a/integrationTest/helpers_test.go
+++ b/integrationTest/helpers_test.go
@@ -19,6 +19,7 @@ var (
 	profileFlag          = flag.String("profile", "", "Entry in profiles.json to use (if empty, copied from -provider)")
 	enableCFWorkers      = flag.Bool("cfworkers", true, "enable CF worker tests (default true)")
 	enableCFRedirectMode = flag.Bool("cfredirect", false, "enable CF SingleRedirect tests (default false)")
+	enableCFFlatten      = flag.Bool("cfflatten", false, "enable CF CNAME flattening tests (requires paid plan, default false)")
 )
 
 func init() {

--- a/integrationTest/integration_test.go
+++ b/integrationTest/integration_test.go
@@ -1227,6 +1227,27 @@ func makeTests() []*TestGroup {
 			CfCProxyOn(), CfCProxyOff(),
 		),
 
+		// CLOUDFLAREAPI: CNAME FLATTENING (requires paid plan)
+
+		testgroup("CF_CNAME_FLATTEN create",
+			only("CLOUDFLAREAPI"),
+			alltrue(*enableCFFlatten),
+			CfFlattenOff(), tcEmptyZone(),
+			CfFlattenOn(), tcEmptyZone(),
+		),
+
+		testgroup("CF_CNAME_FLATTEN off to on",
+			only("CLOUDFLAREAPI"),
+			alltrue(*enableCFFlatten),
+			CfFlattenOff(), CfFlattenOn(),
+		),
+
+		testgroup("CF_CNAME_FLATTEN on to off",
+			only("CLOUDFLAREAPI"),
+			alltrue(*enableCFFlatten),
+			CfFlattenOn(), CfFlattenOff(),
+		),
+
 		testgroup("CF_WORKER_ROUTE",
 			only("CLOUDFLAREAPI"),
 			alltrue(*enableCFWorkers),

--- a/pkg/js/helpers.js
+++ b/pkg/js/helpers.js
@@ -1452,6 +1452,8 @@ function num2dot(num) {
 var CF_PROXY_OFF = { cloudflare_proxy: 'off' }; // Proxy disabled.
 var CF_PROXY_ON = { cloudflare_proxy: 'on' }; // Proxy enabled.
 var CF_PROXY_FULL = { cloudflare_proxy: 'full' }; // Proxy+Railgun enabled.
+var CF_CNAME_FLATTEN_OFF = { cloudflare_cname_flatten: 'off' }; // CNAME flattening disabled (default).
+var CF_CNAME_FLATTEN_ON = { cloudflare_cname_flatten: 'on' }; // CNAME flattening enabled (paid plans only).
 // Per-domain meta settings:
 // Proxy default off for entire domain (the default):
 var CF_PROXY_DEFAULT_OFF = { cloudflare_proxy_default: 'off' };

--- a/pkg/prettyzone/prettyzone.go
+++ b/pkg/prettyzone/prettyzone.go
@@ -137,8 +137,16 @@ func (z *ZoneGenData) generateZoneFileHelper(w io.Writer) error {
 		comment := ""
 		if cp, ok := rr.Metadata["cloudflare_proxy"]; ok {
 			if cp == "true" {
-				comment = " ; CF_PROXY_ON"
+				comment += " CF_PROXY_ON"
 			}
+		}
+		if cf, ok := rr.Metadata["cloudflare_cname_flatten"]; ok {
+			if cf == "on" {
+				comment += " CF_CNAME_FLATTEN_ON"
+			}
+		}
+		if comment != "" {
+			comment = " ;" + comment
 		}
 
 		fmt.Fprintf(w, "%s%s%s\n",


### PR DESCRIPTION
Add support for Cloudflare's per-record CNAME flattening feature using CF_CNAME_FLATTEN_ON and CF_CNAME_FLATTEN_OFF modifiers, similar to the existing CF_PROXY_ON/OFF pattern.

CNAME flattening resolves CNAME targets to their IP addresses at Cloudflare's edge, which can improve performance and compatibility. This feature requires a paid Cloudflare plan (Pro, Business, or Enterprise).

New record modifiers for CNAME records:
- CF_CNAME_FLATTEN_ON: Enable CNAME flattening for the record
- CF_CNAME_FLATTEN_OFF: Disable CNAME flattening (default)

Example usage:
```javascript
D("example.com", REG, DSP,
    CNAME("cdn", "cdn.provider.com.", CF_CNAME_FLATTEN_ON),
    CNAME("www", "www.example.com.", CF_CNAME_FLATTEN_OFF),
);
```

- Uses Cloudflare API's `settings.flatten_cname` field
- Stores state in record metadata as `cloudflare_cname_flatten`
- Only applies to CNAME record types
- Integrated with diff detection via genComparable()

- pkg/js/helpers.js: Add CF_CNAME_FLATTEN_ON/OFF constants
- commands/types/others.d.ts: Add TypeScript declarations for IDE support
- providers/cloudflare/cloudflareProvider.go:
  - Add metaCNAMEFlatten constant
  - Add checkCNAMEFlattenVal() validation function
  - Update preprocessConfig() to validate CNAME flatten setting
  - Update nativeToRecord() to read settings.flatten_cname from API
  - Update genComparable() to include flatten state in diff comparison
- providers/cloudflare/rest.go:
  - Update createRecDiff2() to set Settings.FlattenCNAME
  - Update modifyRecord() to set Settings.FlattenCNAME
- commands/getZones.go:
  - Update TSV export to include cloudflare_cname_flatten metadata
  - Update JS/DJS export to include CF_CNAME_FLATTEN_ON modifier
- pkg/prettyzone/prettyzone.go:
  - Update zone file export to include CF_CNAME_FLATTEN_ON comment

Added gated integration tests that are disabled by default since CNAME flattening requires a paid plan:
- integrationTest/helpers_test.go: Add -cfflatten flag (default false)
- integrationTest/helpers_integration_test.go: Add test helper functions
- integrationTest/integration_test.go: Add CF_CNAME_FLATTEN test groups

Run tests on paid zones with: go test -v -provider=CLOUDFLAREAPI -cfflatten=true

Updated documentation/provider/cloudflareapi.md with:
- New CNAME flattening section with usage examples
- Warning about paid plan requirement
- Integration test flag documentation
