### PR TITLE
CICD: Enable testing of cloudflare redirects

### DIFF
--- a/.github/workflows/pr_integration_tests.yml
+++ b/.github/workflows/pr_integration_tests.yml
@@ -213,7 +213,7 @@ jobs:
       run: |-
         go install gotest.tools/gotestsum@latest
         if [ -n "$${{ matrix.provider }}_DOMAIN" ] ; then
-          gotestsum --junitfile ${TEST_RESULTS}/gotestsum-report.xml -- -timeout 30m -v -verbose -profile ${{ matrix.provider }} -cfworkers=true -cfredirect=true -cfflatten=false
+          gotestsum --junitfile ${TEST_RESULTS}/gotestsum-report.xml -- -timeout 30m -v -verbose -profile ${{ matrix.provider }} -cfworkers=true -cfredirect=false -cfflatten=false
         else
           echo "Skip test for ${{ matrix.provider }} provider"
         fi


### PR DESCRIPTION
# Issue

Cloudflare redirects are not being tested because those tests are behind a feature flag.

# Resolution

Be explicit which tests are enabled, since our testing account for Cloudflare allows workers and redirects, but not flattening.