### PR TITLE
CLOUDFLAREAPI: Reduce confusion by making CF_CNAME_FLATTEN_ON and CF_PROXY_ON mutually exclusive

### DIFF
--- a/documentation/provider/cloudflareapi.md
+++ b/documentation/provider/cloudflareapi.md
@@ -230,6 +230,10 @@ D("example.com", REG_NONE, DnsProvider(DSP_CLOUDFLARE),
 **Paid plans only:** Per-record CNAME flattening requires a Cloudflare paid subscription (Pro, Business, or Enterprise). Free plans do not support this feature. If you attempt to enable CNAME flattening on a free zone, the Cloudflare API will return an error.
 {% endhint %}
 
+{% hint style="warning" %}
+**Mutual exclusivity:** `CF_CNAME_FLATTEN_ON` and `CF_PROXY_ON` cannot be used together on the same record. Cloudflare silently ignores CNAME flattening when proxy is enabled, which leads to confusing behavior. DNSControl will return an error if both are set. See [Opinion 6](https://docs.dnscontrol.org/developer-info/opinions#opinion-6-if-it-is-ambiguous-in-dns-it-is-forbidden-in-dnscontrol).
+{% endhint %}
+
 For more information, see [Cloudflare's CNAME flattening documentation](https://developers.cloudflare.com/dns/cname-flattening/).
 
 ## Old-style vs new-style redirects

--- a/providers/cloudflare/preprocess_test.go
+++ b/providers/cloudflare/preprocess_test.go
@@ -87,6 +87,22 @@ func TestPreprocess_DefaultProxy_Validation(t *testing.T) {
 	}
 }
 
+func TestPreprocess_CNAMEFlattenProxyMutualExclusion(t *testing.T) {
+	cf := &cloudflareProvider{}
+	domain := newDomainConfig()
+	rec := &models.RecordConfig{
+		Type:     "CNAME",
+		Metadata: map[string]string{metaCNAMEFlatten: "on", metaProxy: "on"},
+	}
+	rec.SetLabel("foo", "test.com")
+	rec.MustSetTarget("example.com.")
+	domain.Records = append(domain.Records, rec)
+	err := cf.preprocessConfig(domain)
+	if err == nil {
+		t.Fatal("Expected validation error for CNAME with both flatten and proxy, but got none")
+	}
+}
+
 func TestIpRewriting(t *testing.T) {
 	tests := []struct {
 		Given, Expected string


### PR DESCRIPTION
Cloudflare API silently ignores/discards the CNAME flattening setting when proxy is enabled, which leads to confusing behavior and drift.

Even worse, the CNAME flattening setting isn't set, so dnscontrol continuously sees drift and tries to re-apply the setting.

Per DNSControl Opinion 6 ("if it is ambiguous in DNS, it is forbidden in DNSControl"), we now reject configurations that set both modifiers on the same record.