### PR TITLE
DOCS: Fix DKIM_BUILDER instruction typo ("note" not "notes")

### DIFF
--- a/documentation/language-reference/domain-modifiers/DKIM_BUILDER.md
+++ b/documentation/language-reference/domain-modifiers/DKIM_BUILDER.md
@@ -90,7 +90,7 @@ k2._domainkey.subdomain   IN  TXT "v=DKIM1; h=sha1:sha256; k=rsa; n=some=20human
 * `keytype` (string, optional): Key algorithm type. Maps to the `k=` tag. Default: `rsa`. Supported values:
    * `rsa`
    * `ed25519`
-* `notes` (string, optional): Human-readable notes intended for administrators. Pass normal text here; DKIM-Quoted-Printable encoding will be applied automatically. Maps to the `n=` tag.
+* `note` (string, optional): Human-readable notes intended for administrators. Pass normal text here; DKIM-Quoted-Printable encoding will be applied automatically. Maps to the `n=` tag.
 * `servicetypes` (array, optional): Service types using this key. Maps to the `s=` tag. Supported values:
   * `*`: explicitly allows all service types
   * `email`: restricts key to email service only


### PR DESCRIPTION
Removed 's' from instructions to match implementation. God that ´s´ has been annoying me for a long time :-)