### PR TITLE
DIGITALOCEAN: self-documenting Cannot()s for unsupported features

### DIFF
--- a/commands/types/dnscontrol.d.ts
+++ b/commands/types/dnscontrol.d.ts
@@ -978,7 +978,7 @@ declare const DISABLE_IGNORE_SAFETY_CHECK: DomainModifier;
  * * `keytype` (string, optional): Key algorithm type. Maps to the `k=` tag. Default: `rsa`. Supported values:
  *    * `rsa`
  *    * `ed25519`
- * * `notes` (string, optional): Human-readable notes intended for administrators. Pass normal text here; DKIM-Quoted-Printable encoding will be applied automatically. Maps to the `n=` tag.
+ * * `note` (string, optional): Human-readable notes intended for administrators. Pass normal text here; DKIM-Quoted-Printable encoding will be applied automatically. Maps to the `n=` tag.
  * * `servicetypes` (array, optional): Service types using this key. Maps to the `s=` tag. Supported values:
  *   * `*`: explicitly allows all service types
  *   * `email`: restricts key to email service only

--- a/providers/digitalocean/digitaloceanProvider.go
+++ b/providers/digitalocean/digitaloceanProvider.go
@@ -73,25 +73,25 @@ retry:
 var features = providers.DocumentationNotes{
 	// The default for unlisted capabilities is 'Cannot'.
 	// See providers/capabilities.go for the entire list of capabilities.
-	providers.CanAutoDNSSEC:          providers.Cannot(), // per docs
+	providers.CanAutoDNSSEC:          providers.Cannot("Digital Ocean documents that this is not supported."),
 	providers.CanConcur:              providers.Can(),
 	providers.CanGetZones:            providers.Can(),
-	providers.CanUseAlias:            providers.Cannot(), // per docs
+	providers.CanUseAlias:            providers.Cannot("Digital Ocean documents that this is not supported."),
 	providers.CanUseCAA:              providers.Can(),
-	providers.CanUseDHCID:            providers.Cannot(), // per docs
-	providers.CanUseDNAME:            providers.Cannot(), // per docs
-	providers.CanUseDNSKEY:           providers.Cannot(), // per docs
-	providers.CanUseDS:               providers.Cannot(), // per docs
-	providers.CanUseHTTPS:            providers.Cannot(), // per docs
+	providers.CanUseDHCID:            providers.Cannot("Digital Ocean documents that this is not supported."),
+	providers.CanUseDNAME:            providers.Cannot("Digital Ocean documents that this is not supported."),
+	providers.CanUseDNSKEY:           providers.Cannot("Digital Ocean documents that this is not supported."),
+	providers.CanUseDS:               providers.Cannot("Digital Ocean documents that this is not supported."),
+	providers.CanUseHTTPS:            providers.Cannot("Digital Ocean documents that this is not supported."),
 	providers.CanUseLOC:              providers.Cannot(),
-	providers.CanUseNAPTR:            providers.Cannot(), // per docs
-	providers.CanUsePTR:              providers.Cannot(), // per docs
+	providers.CanUseNAPTR:            providers.Cannot("Digital Ocean documents that this is not supported."),
+	providers.CanUsePTR:              providers.Cannot("Digital Ocean documents that this is not supported."),
 	providers.CanUseSOA:              providers.Cannot("Technically SOA is supported but in reality the API only permits updates to the TTL. That is insufficient for DNSControl to claim 'support'"),
 	providers.CanUseSRV:              providers.Can(),
-	providers.CanUseSSHFP:            providers.Cannot(), // per docs
-	providers.CanUseSMIMEA:           providers.Cannot(), // per docs
-	providers.CanUseSVCB:             providers.Cannot(), // per docs
-	providers.CanUseTLSA:             providers.Cannot(), // per docs
+	providers.CanUseSSHFP:            providers.Cannot("Digital Ocean documents that this is not supported."),
+	providers.CanUseSMIMEA:           providers.Cannot("Digital Ocean documents that this is not supported."),
+	providers.CanUseSVCB:             providers.Cannot("Digital Ocean documents that this is not supported."),
+	providers.CanUseTLSA:             providers.Cannot("Digital Ocean documents that this is not supported."),
 	providers.DocCreateDomains:       providers.Can(),
 	providers.DocDualHost:            providers.Can(),
 	providers.DocOfficiallySupported: providers.Cannot(),


### PR DESCRIPTION
#3958 updated the digitalocean provider to make all of the feature flags explicit.

Later I noticed that `Cannot()` can take an argument so that the reason for it can
be seen by the end user.  So now I have moved the reason into the argument instead
of leaving it as a code-level comment.

- `dnscontrol` rebuilt fine
- `bin/generate-all.sh` picked up an unrelated file
