### PR TITLE
LINODE: Enable Service (SRV) record support

### DIFF
--- a/documentation/provider/index.md
+++ b/documentation/provider/index.md
@@ -251,6 +251,7 @@ Jump to a table:
 | [`INFOMANIAK`](infomaniak.md) | ❔ | ❔ | ✅ | ❔ |
 | [`INWX`](inwx.md) | ❔ | ✅ | ✅ | ✅ |
 | [`JOKER`](joker.md) | ❔ | ✅ | ✅ | ❌ |
+| [`LINODE`](linode.md) | ❔ | ❔ | ✅ | ❔ |
 | [`LOOPIA`](loopia.md) | ❌ | ✅ | ✅ | ❌ |
 | [`LUADNS`](luadns.md) | ❔ | ❔ | ✅ | ❔ |
 | [`MYTHICBEASTS`](mythicbeasts.md) | ❔ | ❔ | ✅ | ❔ |

--- a/documentation/provider/linode.md
+++ b/documentation/provider/linode.md
@@ -56,3 +56,5 @@ Linode does not allow all TTLs, but only a specific subset of TTLs. The followin
 
 The provider will automatically round up your TTL to one of these values. For example, 600 seconds would become 3600
 seconds, but 300 seconds would stay 300 seconds.
+
+Linode requires [`SRV`](../language-reference/domain-modifiers/SRV.md) records to have a non-zero priority.

--- a/providers/linode/linodeProvider.go
+++ b/providers/linode/linodeProvider.go
@@ -95,6 +95,7 @@ var features = providers.DocumentationNotes{
 	providers.CanGetZones:            providers.Can(),
 	providers.CanOnlyDiff1Features:   providers.Can(),
 	providers.CanUseCAA:              providers.Can("Linode doesn't support changing the CAA flag"),
+	providers.CanUseSRV:              providers.Can("Linode requires non-zero priority"),
 	providers.CanUseLOC:              providers.Cannot(),
 	providers.DocDualHost:            providers.Cannot(),
 	providers.DocOfficiallySupported: providers.Cannot(),


### PR DESCRIPTION
Linode supports Service (`SRV`) records. Code already exists for `SRV` records in the linode provider but it was disabled by a lack of `CanUseSRV` capability.