### PR TITLE
LINODE: Accept `CAA` records with non-zero flags

### DIFF
--- a/providers/linode/auditrecords.go
+++ b/providers/linode/auditrecords.go
@@ -11,8 +11,6 @@ import (
 func AuditRecords(records []*models.RecordConfig) []error {
 	a := rejectif.Auditor{}
 
-	a.Add("CAA", rejectif.CaaFlagIsNonZero) // Last verified 2022-03-25
-
 	a.Add("CAA", rejectif.CaaTargetContainsWhitespace) // Last verified 2023-01-15
 
 	return a.Audit(records)


### PR DESCRIPTION
Allow domains with Certification Authority Authorization (`CAA`) records that have flags. Previously `dnscontrol` reported:

> LINODE rejects domain example.com: caa flag is non-zero".

Linode does not, or no longer, rejects `CAA` records with non-zero flags. The flags are dropped by Linode but the `CAA` records are created.

In the example below, the flag `iodef_critical` is discarded by Linode. Otherwise the `CAA` records are populated as expected:

``` js
CAA_BUILDER({
  label: "@",
  iodef: "mailto:test@example.com",
  iodef_critical: true,
  issue: ["letsencrypt.org"],
  issuewild: "none",
})
```