### PR TITLE
INWX: Bugfix: NAMESERVER() should replace registrar list, not merge into it

### DIFF
--- a/providers/inwx/inwxProvider.go
+++ b/providers/inwx/inwxProvider.go
@@ -456,26 +456,26 @@ func (api *inwxAPI) updateNameservers(ns []string, domain string) func() error {
 
 // GetRegistrarCorrections is part of the registrar provider and determines if the nameservers have to be updated.
 func (api *inwxAPI) GetRegistrarCorrections(dc *models.DomainConfig) ([]*models.Correction, error) {
-    regNameservers := api.fetchRegistrationNSSet(dc.Name)
-    
-    var expected []string
-    for _, ns := range dc.Nameservers {
-        expected = append(expected, ns.Name)
-    }
-    sort.Strings(expected)
-    
-    foundNameservers := strings.Join(regNameservers, ",")
-    expectedNameservers := strings.Join(expected, ",")
+	regNameservers := api.fetchRegistrationNSSet(dc.Name)
 
-    if foundNameservers != expectedNameservers {
-        return []*models.Correction{
-            {
-                Msg: fmt.Sprintf("Update nameservers %s -> %s", foundNameservers, expectedNameservers),
-                F:   api.updateNameservers(expected, dc.Name),
-            },
-        }, nil
-    }
-    return nil, nil
+	var expected []string
+	for _, ns := range dc.Nameservers {
+		expected = append(expected, ns.Name)
+	}
+	sort.Strings(expected)
+
+	foundNameservers := strings.Join(regNameservers, ",")
+	expectedNameservers := strings.Join(expected, ",")
+
+	if foundNameservers != expectedNameservers {
+		return []*models.Correction{
+			{
+				Msg: fmt.Sprintf("Update nameservers %s -> %s", foundNameservers, expectedNameservers),
+				F:   api.updateNameservers(expected, dc.Name),
+			},
+		}, nil
+	}
+	return nil, nil
 }
 
 // fetchNameserverDomains returns the domains configured in INWX nameservers


### PR DESCRIPTION
## Summary

Fixes the INWX registrar provider to replace nameservers instead of merging existing and desired nameservers.

## Problem

The `GetRegistrarCorrections()` function was merging the currently registered nameservers with the desired nameservers from the configuration. This caused nameserver updates to fail when migrating a domain from one DNS provider to another.

Example failure:
Update nameservers arely.ns.cloudflare.com,pablo.ns.cloudflare.com -> arely.ns.cloudflare.com,ns.inwx.de,ns2.inwx.de,ns3.inwx.eu,pablo.ns.cloudflare.com
FAILURE! (2306)

## Solution

Changed the logic to use only the configured nameservers (`dc.Nameservers`) instead of creating a union with the existing registrar nameservers.

### Before
```go
combined := map[string]bool{}
for _, ns := range dc.Nameservers {
    combined[ns.Name] = true
}
for _, rs := range regNameservers {
    combined[rs] = true
}
```

### After
```go
var expected []string
for _, ns := range dc.Nameservers {
    expected = append(expected, ns.Name)
}
```