### PR TITLE
BUGFIX: Fix SPF parsing of qualified mechanisms like +mx

### DIFF
--- a/pkg/spflib/parse.go
+++ b/pkg/spflib/parse.go
@@ -52,11 +52,11 @@ func Parse(text string, dnsres Resolver) (*SPFRecord, error) {
 		if part == "" {
 			continue
 		}
-		lcpart := strings.ToLower(part) // We have seen "Ip4" instead of "ip4".  Let's be gracious and allow it.
 		p := &SPFPart{Text: part}
 		if qualifiers[part[0]] {
 			part = part[1:]
 		}
+		lcpart := strings.ToLower(part) // We have seen "Ip4" instead of "ip4".  Let's be gracious and allow it.
 		rec.Parts = append(rec.Parts, p)
 		if part == "all" {
 			// all. nothing else matters.


### PR DESCRIPTION
<!--
## Before submiting a pull request

Please make sure you've run the following commands from the root directory.

    bin/generate-all.sh

(this runs commands like "go generate", fixes formatting, and so on)

## Release changelog section

Help keep the release changelog clear by pre-naming the proper section in the GitHub pull request title.

Some examples:
* CICD: Add required GHA permissions for goreleaser
* DOCS: Fixed providers with "contributor support" table
* ROUTE53: Allow R53_ALIAS records to enable target health evaluation

More examples/context can be found in the file .goreleaser.yml under the 'build' > 'changelog' key.
!-->

Fixes a regression where `SPF_BUILDER` with `overflow` rejected valid RFC 7208 qualified mechanisms like `+mx`, `~mx`, `?a`, etc. with the error `unsupported SPF part mx`. The root cause was that `lcpart` (the lowercase comparison variable) was created before stripping the qualifier prefix (`+`,`-`,`~`,`?`), so `HasPrefix` checks against `"mx"` or `"a"` failed when the string was still `"+mx"` or `"+a"`. Qualifiers on mechanisms are valid per [RFC 7208 Section 4.7](https://www.rfc-editor.org/rfc/rfc7208#section-4.7). A regression test covering all qualifier/mechanism combinations has been added.

Fixes #4042