### PR TITLE
DOCS: Remove golint, add golangci-lint

### DIFF
--- a/documentation/advanced-features/writing-providers.md
+++ b/documentation/advanced-features/writing-providers.md
@@ -265,27 +265,38 @@ the documentation.
 
 ## Step 11: Automated code tests
 
-Run `go vet` and [`staticcheck`](https://staticcheck.io/) and clean up any errors found.
+We use a number of automated code-checking systems. Please run your code
+through all of them and fix all warnings and errors.  Some of the automated
+fixes may not alway sbe perfect. Therefore, it is best to commit your code
+before running these and verify that you agree with the changes.
+
+Modernize your code:
+
+```shell
+go run golang.org/x/tools/go/analysis/passes/modernize/cmd/modernize@latest -fix ./...
+```
+
+Vet the code:
 
 ```shell
 go vet ./...
+```
+
+Use golangci-lint: (install [golangci-lint](https://golangci-lint.run/docs/welcome/install/local/))
+
+```shell
+golangci-lint run ./...
 staticcheck ./...
 ```
 
-Please use `go vet` from the [newest release of Go](https://golang.org/doc/devel/release.html#policy).
-
-golint is deprecated and frozen but it is still useful as it does a few checks that haven't been
-re-implemented in staticcheck.
-However golint fails on any file that uses generics, so
-be prepared to ignore errors about `expected '(', found '[' (and 1 more errors)`
-
-How to install and run [golint](https://github.com/golang/lint):
+Use staticcheck:
 
 ```shell
-go get -u golang.org/x/lint/golint
-go install golang.org/x/lint/golint
-golint ./...
+go install honnef.co/go/tools/cmd/staticcheck@latest
+staticcheck ./...
 ```
+
+Commit any changes.
 
 ## Step 12: Dependencies
 


### PR DESCRIPTION
# Issue

* `golint` is dead
* `golangci-lint` is now part of the CI/CD pipeline
* `modernize -fix` fixes a lot of old code
* Install instructions are missing

# Resolution

* Update docs
* Add install instructions for all utilities.