### PR TITLE
AUTODNS: Bugfix: More than 100 zones results in failure

### DIFF
--- a/providers/autodns/types.go
+++ b/providers/autodns/types.go
@@ -80,10 +80,16 @@ type NameServer struct {
 	IPAddresses []string `json:"ipAddresses,omitempty"`
 }
 
+type ListResponseMetaData struct {
+	ObjectType string `json:"type"`
+	ItemCount  int    `json:"summary"`
+}
+
 // JSONResponseDataZone represents the response to the DataZone call.
 type JSONResponseDataZone struct {
 	// The data for the response. The type of the objects are depending on the request and are also specified in the responseObject value of the response.
-	Data []*Zone `json:"data"`
+	Data     []*Zone               `json:"data"`
+	MetaData *ListResponseMetaData `json:"object"`
 }
 
 // JSONResponseDataDomain represents the response to the DataDomain call.


### PR DESCRIPTION
While debugging another issue I stumbled onto this behavior and I decided to fix it directly. Hope the lack of a corresponding issue isn't a problem.

This patch adds paginated requests to get the complete list of zones managed by this provider.

If the number of zones exceeded 100 (system default) those were never added to the `CmdZoneCache`, this resulted in messages like Ensuring zone "example.com" exists in "autodns".

The api.getZones() method is extended with a quick count after which a number of sequential request are performed.

<!--
## Before submiting a pull request

Please make sure you've run the following commands from the root directory.

    bin/generate-all.sh

(this runs commands like "go generate", fixes formatting, and so on)

## Release changelog section

Help keep the release changelog clear by pre-naming the proper section in the GitHub pull request title.

Some examples:
* CICD: Add required GHA permissions for goreleaser
* DOCS: Fixed providers with "contributor support" table
* ROUTE53: Allow R53_ALIAS records to enable target health evaluation

More examples/context can be found in the file .goreleaser.yml under the 'build' > 'changelog' key.
!-->
