### PR TITLE
CHORE: Fix String Builder lint issues

### DIFF
--- a/build/generate/featureMatrix.go
+++ b/build/generate/featureMatrix.go
@@ -28,8 +28,7 @@ func generateFeatureMatrix() error {
 	}
 
 	for i, tableTitle := range matrix.FeatureTablesTitles {
-		replacementContent.WriteString(fmt.Sprintf("\n### %s <!--(table %d/%d)-->\n\n",
-			tableTitle, i+1, len(matrix.FeatureTablesTitles)))
+		fmt.Fprintf(&replacementContent, "\n### %s <!--(table %d/%d)-->\n\n", tableTitle, i+1, len(matrix.FeatureTablesTitles))
 		markdownTable, err := markdownTable(matrix, int32(i))
 		if err != nil {
 			return err

--- a/pkg/normalize/capabilities_test.go
+++ b/pkg/normalize/capabilities_test.go
@@ -21,7 +21,11 @@ func TestCapabilitiesAreFiltered(t *testing.T) {
 	// skipCheckCapabilities["CanUseBlahBlahBlah"] = struct{}{}
 
 	fset := token.NewFileSet()
+	pkgs, err := parser.ParseDir(fset, providersImportDir, nil, 0) //nolint:staticcheck
+	/* FIXME(tlim):
+	pkg/normalize/capabilities_test.go:24:15: SA1019: parser.ParseDir has been deprecated since Go 1.25 and an alternative has been available since Go 1.11: ParseDir does not consider build tags when associating files with packages. For precise information about the relationship between packages and files, use golang.org/x/tools/go/packages, which can also optionally parse and type-check the files too. (staticcheck)
 	pkgs, err := parser.ParseDir(fset, providersImportDir, nil, 0)
+	*/
 	if err != nil {
 		t.Fatalf("unable to load Go code from providers: %s", err)
 	}

--- a/pkg/rtypecontrol/stringify.go
+++ b/pkg/rtypecontrol/stringify.go
@@ -12,9 +12,9 @@ func StringifyQuoted(args []any) string {
 	}
 
 	var sb strings.Builder
-	sb.WriteString(fmt.Sprintf("%q", args[0]))
+	fmt.Fprintf(&sb, "%q", args[0])
 	for _, arg := range args[1:] {
-		sb.WriteString(fmt.Sprintf(" %q", arg))
+		fmt.Fprintf(&sb, " %q", arg)
 	}
 	return sb.String()
 }

--- a/providers/dnsimple/dnsimpleProvider.go
+++ b/providers/dnsimple/dnsimpleProvider.go
@@ -739,10 +739,10 @@ func getTargetRecordPriority(rc *models.RecordConfig) int {
 // Compile the error messages returned by DNSimple's API into a single error message.
 func compileAttributeErrors(err *dnsimpleapi.ErrorResponse) error {
 	var message strings.Builder
-	message.WriteString(fmt.Sprintf("%d %s", err.HTTPResponse.StatusCode, err.Message))
+	fmt.Fprintf(&message, "%d %s", err.HTTPResponse.StatusCode, err.Message)
 	for field, errors := range err.AttributeErrors {
 		e := strings.Join(errors, "& ")
-		message.WriteString(fmt.Sprintf(": %s %s", field, e))
+		fmt.Fprintf(&message, ": %s %s", field, e)
 	}
 	return errors.New(message.String())
 }


### PR DESCRIPTION
# Issue

```
```

# Resolution

File a bug for the ParseDir() error (https://github.com/StackExchange/dnscontrol/issues/4089) but fix the others.