### PR TITLE
CHORE: fixed parser test data for the MIKROTIK provider

### DIFF
--- a/pkg/js/parse_tests/061-mikrotik.json
+++ b/pkg/js/parse_tests/061-mikrotik.json
@@ -23,7 +23,7 @@
           "type": "MIKROTIK_FWD"
         },
         {
-          "filepos": "[line:3:5]",
+          "filepos": "[line:6:5]",
           "meta": {
             "orig_custom_type": "MIKROTIK_NXDOMAIN"
           },
@@ -33,7 +33,7 @@
           "type": "MIKROTIK_NXDOMAIN"
         },
         {
-          "filepos": "[line:4:5]",
+          "filepos": "[line:7:5]",
           "meta": {
             "orig_custom_type": "MIKROTIK_FORWARDER"
           },


### PR DESCRIPTION
I must have forgotten to update the test data while iterating on the MIKROTIK provider. This PR should fix the failed tests observed in https://github.com/StackExchange/dnscontrol/actions/runs/22239213380/job/64338367329