### PR TITLE
DOCS: Add Documentation MCP Server page

### DIFF
--- a/documentation/SUMMARY.md
+++ b/documentation/SUMMARY.md
@@ -224,6 +224,7 @@
 * [DNS records ordering](advanced-features/ordering.md)
 * [How to add a requested provider](developer-info/provider-request.md)
 * [GoReleaser](developer-info/goreleaser.md)
+* [Documentation MCP Server](developer-info/mcp-server.md)
 
 ## Release
 

--- a/documentation/developer-info/mcp-server.md
+++ b/documentation/developer-info/mcp-server.md
@@ -1,0 +1,54 @@
+# Documentation MCP Server
+
+The DNSControl documentation site exposes an [MCP (Model Context Protocol)](https://modelcontextprotocol.io/introduction) server. This allows AI assistants such as Claude Code, Claude Desktop, and other MCP-compatible tools to search and query the DNSControl documentation directly.
+
+## Endpoint
+
+The MCP server is available at:
+
+```text
+https://docs.dnscontrol.org/~gitbook/mcp
+```
+
+## Features
+
+- **Read-only access** to all published documentation (never drafts or unpublished changes).
+- **HTTP transport** only (stdio and SSE are not supported).
+- **No authentication required** since the DNSControl docs are public.
+- Provides a `searchDocumentation` tool that searches across all pages, code examples, API references, and guides.
+
+## Adding to Claude Code
+
+To connect the DNSControl docs MCP server to Claude Code, run:
+
+```bash
+claude mcp add --transport http dnscontrol-docs https://docs.dnscontrol.org/~gitbook/mcp
+```
+
+To share the configuration with your team via the project's `.mcp.json` file:
+
+```bash
+claude mcp add --transport http dnscontrol-docs --scope project https://docs.dnscontrol.org/~gitbook/mcp
+```
+
+Once configured, Claude Code gains access to a `searchDocumentation` tool that can find relevant information across the entire DNSControl documentation.
+
+## Adding to other MCP clients
+
+Any MCP client that supports HTTP transport can connect to the server. Add the following to your MCP configuration:
+
+```json
+{
+  "mcpServers": {
+    "dnscontrol-docs": {
+      "type": "http",
+      "url": "https://docs.dnscontrol.org/~gitbook/mcp"
+    }
+  }
+}
+```
+
+## Further reading
+
+- [Model Context Protocol](https://modelcontextprotocol.io/introduction)
+- [Claude Code MCP Documentation](https://code.claude.com/docs/en/mcp)


### PR DESCRIPTION
Adds a new page to the `Developer info` section documenting the MCP endpoint for the DNSControl docs site (`https://docs.dnscontrol.org/~gitbook/mcp`), with setup instructions for Claude Code and other MCP-compatible clients.

[The preview URL](https://docs.dnscontrol.org/~/revisions/dIakJD7oHpEV0HJUgpdm/developer-info/mcp-server) 📚