### PR TITLE
BUILD: GoReleaser add Docker Buildx setup to release workflow

### DIFF
--- a/.github/workflows/release_draft.yml
+++ b/.github/workflows/release_draft.yml
@@ -19,6 +19,9 @@ jobs:
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v3
 
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
     - name: Checkout repo
       uses: actions/checkout@v6
       with:


### PR DESCRIPTION
GoReleaser v2's `dockers_v2` adds `--attest=type=sbom` by default, which requires the docker-container driver. Without the setup-buildx-action step, the default docker driver was used, causing "Attestation is not supported for the docker driver" errors.

Fixes https://github.com/StackExchange/dnscontrol/issues/4102