### PR TITLE
Potential fix for code scanning alert no. 44: Incomplete regular expression for hostnames

### DIFF
--- a/providers/gcloud/gcloudProvider.go
+++ b/providers/gcloud/gcloudProvider.go
@@ -43,7 +43,7 @@ var features = providers.DocumentationNotes{
 
 var (
 	visibilityCheck  = regexp.MustCompile("^(public|private)$")
-	networkURLCheck  = regexp.MustCompile("^" + selfLinkBasePath + "[a-z][-a-z0-9]{4,28}[a-z0-9]/global/networks/[a-z]([-a-z0-9]{0,61}[a-z0-9])?$")
+	networkURLCheck  = regexp.MustCompile("^" + regexp.QuoteMeta(selfLinkBasePath) + "[a-z][-a-z0-9]{4,28}[a-z0-9]/global/networks/[a-z]([-a-z0-9]{0,61}[a-z0-9])?$")
 	networkNameCheck = regexp.MustCompile("^[a-z]([-a-z0-9]{0,61}[a-z0-9])?$")
 )
 


### PR DESCRIPTION
Potential fix for [https://github.com/StackExchange/dnscontrol/security/code-scanning/44](https://github.com/StackExchange/dnscontrol/security/code-scanning/44)

To fix the problem, all literal dots in the hostname portion of the regex must be escaped so they are treated as literal periods instead of “any character”. Since the base URL is held in `selfLinkBasePath` and then concatenated into the regex, the best approach is to escape the dots in `selfLinkBasePath` at construction time (while keeping `/` and `:` unescaped), so that the resulting full regex behaves as intended and still clearly expresses the expected URL prefix.

Concretely, in `providers/gcloud/gcloudProvider.go`, keep `selfLinkBasePath` as a normal string constant for use elsewhere, but when building `networkURLCheck`, wrap `selfLinkBasePath` with `regexp.QuoteMeta`. Then append the rest of the regex (project ID and network name parts) as before. `regexp.QuoteMeta(selfLinkBasePath)` will escape all regex metacharacters (including `.`), eliminating the over-permissive matching on the host, while preserving the intended matching of path structure and constraints on project/network names. No new imports are needed, since `regexp` is already imported. The only line to change is the definition of `networkURLCheck`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
