### PR TITLE
Potential fix for code scanning alert no. 43: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr_check_git_status.yml
+++ b/.github/workflows/pr_check_git_status.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   go-fmt:
     name: "Check: go fmt"


### PR DESCRIPTION
Potential fix for [https://github.com/StackExchange/dnscontrol/security/code-scanning/43](https://github.com/StackExchange/dnscontrol/security/code-scanning/43)

In general, the fix is to add an explicit `permissions` block that grants only the scopes required. Here, all jobs only need to read repository contents to check out the code; they do not push or modify GitHub resources, so `contents: read` is sufficient. To avoid duplication and ensure consistent permissions, the best fix is to add a single `permissions` block at the top (workflow) level, right under the `name:` or `on:` key, so it applies to all jobs that do not define their own `permissions`. No imports or additional methods are needed because this is a YAML workflow configuration change only.

Concretely, edit `.github/workflows/pr_check_git_status.yml` to insert:

```yaml
permissions:
  contents: read
```

between the `on:` block and the `jobs:` block (for example, after line 7 / the `workflow_dispatch:` line and the following blank line). This will restrict `GITHUB_TOKEN` to read-only contents for every job in this workflow without changing any of the existing steps or their behavior.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
