### PR TITLE
CICD: Restrict permissions in .github/workflows/pr_lint.yml 

### DIFF
--- a/.github/workflows/pr_lint.yml
+++ b/.github/workflows/pr_lint.yml
@@ -1,4 +1,6 @@
 name: "PR: Lint"
+permissions:
+  contents: read
 on:
   pull_request:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/StackExchange/dnscontrol/security/code-scanning/37](https://github.com/StackExchange/dnscontrol/security/code-scanning/37)

To fix the problem, explicitly define a `permissions` block that restricts the `GITHUB_TOKEN` to the minimal required scope. For a lint-only workflow that just checks out code and runs Go linters, `contents: read` is typically sufficient. This can be set either at the root of the workflow (applies to all jobs) or at the job level. Since the workflow currently has a single job, either is acceptable; adding it at the workflow root is the clearest and matches the CodeQL recommendation.

The best minimal fix without altering existing functionality is to add a root-level `permissions` section directly under the `name:` line, before `on:`, with `contents: read`. This will ensure the `golangci-lint` job gets a read-only token for repository contents while keeping all existing behavior intact. No other files, imports, or definitions are needed, and no changes to steps or actions are required.

Concretely, in `.github/workflows/pr_lint.yml`, insert:

```yaml
permissions:
  contents: read
```

after line 1 (`name: "PR: Lint"`). All other lines remain unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
