### PR TITLE
CICD: Restrict permissions in .github/workflows/pr_integration_tests.yml

### DIFF
--- a/.github/workflows/pr_integration_tests.yml
+++ b/.github/workflows/pr_integration_tests.yml
@@ -1,5 +1,8 @@
 name: "PR: Run INTEGRATION tests"
 
+permissions:
+  contents: read
+
 # When will this pipeline be activated?
 # 1. On any pull-request, or if someone pushes to a branch called
 # "tlim_testpr".


### PR DESCRIPTION
Potential fix for [https://github.com/StackExchange/dnscontrol/security/code-scanning/38](https://github.com/StackExchange/dnscontrol/security/code-scanning/38)

In general, this issue is fixed by adding an explicit `permissions` block for the GITHUB_TOKEN at the workflow root or at each job, restricting it to the minimum scopes needed. For a typical test workflow that only checks out code, uses cache, and uploads artifacts, `contents: read` is sufficient.

For this specific workflow in `.github/workflows/pr_integration_tests.yml`, the simplest non-invasive fix is to add a top-level `permissions` block right after the `name:` (or before `jobs:`). The jobs use `actions/checkout`, `actions/cache`, and `actions/upload-artifact`, none of which require write access to repository contents. Therefore, we can safely set:

```yaml
permissions:
  contents: read
```

This will apply to all jobs (`integration-test-providers` and `integration-tests`) since they do not define their own `permissions`. No other changes, imports, or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
