### PR TITLE
CICD: Restrict permissions in .github/workflows/pr_integration_tests.yml

### DIFF
--- a/.github/workflows/pr_integration_tests.yml
+++ b/.github/workflows/pr_integration_tests.yml
@@ -14,6 +14,9 @@ on:
     branches:
       - 'tlim_testpr'
 
+permissions:
+  contents: read
+
 # Environment Variables
 env:
   # cache-key: Change to force cache reset `pwsh > Get-Date -UFormat %s`


### PR DESCRIPTION
Potential fix for [https://github.com/StackExchange/dnscontrol/security/code-scanning/35](https://github.com/StackExchange/dnscontrol/security/code-scanning/35)

In general, the fix is to add an explicit `permissions` block that grants only the minimal scopes required for the workflow. For this workflow, the jobs need to (a) check out code, which requires `contents: read`, and (b) interact with the actions runtime (artifacts, cache) which uses the internal `actions` permission that is enabled by default and does not need to be specified. They do not appear to modify repository contents, issues, or pull requests. The best non-breaking change is to add a workflow-level `permissions` block after the `on:` section, setting `contents: read`. This will apply to both jobs since neither currently defines its own `permissions` block. No other functionality needs to change.

Concretely, in `.github/workflows/pr_integration_tests.yml`, insert:

```yaml
permissions:
  contents: read
```

between the `on:` block (ending at line 15) and the `env:` block (starting at line 18). This explicitly restricts the `GITHUB_TOKEN` permissions for all jobs in this workflow while keeping all current behavior intact. No imports or additional methods are needed because this is a pure YAML configuration change within the workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
