### PR TITLE
BUILD: Fix bug preventing macOS binaries from being signed and notarized with an Apple Developer ID

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -3,7 +3,6 @@ project_name: dnscontrol
 version: 2
 builds:
   -
-    id: build
     env:
       - CGO_ENABLED=0
     goos:
@@ -67,7 +66,6 @@ archives:
 universal_binaries:
   -
     replace: true
-    id: build
 
 nfpms:
   - id: packages_rpm
@@ -96,9 +94,7 @@ nfpms:
     formats:
     - deb
 dockers_v2:
-  - ids:
-      - build
-    images:
+  - images:
       - "stackexchange/{{.ProjectName}}"
       - "ghcr.io/stackexchange/{{.ProjectName}}"
     tags:

--- a/documentation/developer-info/goreleaser.md
+++ b/documentation/developer-info/goreleaser.md
@@ -84,10 +84,11 @@ Sign up at [developer.apple.com/programs](https://developer.apple.com/programs/)
 
 ##### 5. GitHub Actions Secrets
 
-Encode the `.p12` file:
+Encode the `.p12` and `.p8` files:
 
 ```bash
 base64 -i DeveloperIDApplication.p12 | pbcopy
+base64 -i AuthKey_XXXXXX.p8 | pbcopy
 ```
 
 Configure under repo > **Settings** > **Secrets and variables** > **Actions**:
@@ -98,7 +99,7 @@ Configure under repo > **Settings** > **Secrets and variables** > **Actions**:
 | `MACOS_SIGN_PASSWORD` | Password of the `.p12` certificate |
 | `MACOS_NOTARY_ISSUER_ID` | Issuer ID from App Store Connect |
 | `MACOS_NOTARY_KEY_ID` | Key ID of the API key |
-| `MACOS_NOTARY_KEY` | Full contents of the `.p8` file (including BEGIN/END lines) |
+| `MACOS_NOTARY_KEY` | Base64-encoded `.p8` file |
 
 ##### 6. Testing
 
@@ -107,7 +108,7 @@ export MACOS_SIGN_P12=$(base64 -i DeveloperIDApplication.p12)
 export MACOS_SIGN_PASSWORD="password"
 export MACOS_NOTARY_ISSUER_ID="..."
 export MACOS_NOTARY_KEY_ID="..."
-export MACOS_NOTARY_KEY="$(cat AuthKey_XXXXXX.p8)"
+export MACOS_NOTARY_KEY=$(base64 -i AuthKey_XXXXXX.p8)
 goreleaser release --snapshot --clean
 ```
 


### PR DESCRIPTION
The `notarize.macos` section in `.goreleaser.yml` was silently skipped during the [v4.36.0 release build](https://github.com/StackExchange/dnscontrol/actions/runs/22767640745/job/66039633995#step:9:56):

```shell
sign & notarize macOS binaries
  pipe skipped or partially skipped  reason=no darwin binaries found with ids: dnscontrol
```

The notarize section defaults to looking for darwin binaries matching the project name ID (`dnscontrol`), but the build had an explicit `id: build`, causing the mismatch.

Remove all explicit `id: build` references and rely on the GoReleaser default ID (which is `project_name`, i.e. `dnscontrol`). This is the [convention for single-build projects](https://goreleaser.com/customization/builds/go/). Three references removed:

* `builds[0].id`
* `universal_binaries[0].id`
* `dockers_v2[0].ids`

Also fixes the documentation: `MACOS_NOTARY_KEY` must be base64-encoded, not passed as raw PEM content.

---

```shell
goreleaser check
```

```shell
  • checking                                  path=.goreleaser.yml
  • 1 configuration file(s) validated
  • thanks for using GoReleaser!
```

---

```shell
export MACOS_SIGN_P12=$(base64 -i DeveloperIDApplication.p12)
export MACOS_SIGN_PASSWORD="password"
export MACOS_NOTARY_ISSUER_ID="..."
export MACOS_NOTARY_KEY_ID="..."
export MACOS_NOTARY_KEY=$(base64 -i AuthKey_3ZPM5C6PF9.p8)
goreleaser build --snapshot --clean
```

```shell
  • skipping validate...
  • cleaning distribution directory
  • loading environment variables
  • getting and validating git state
    • git state                                      commit=05e6479ff4fd74c62b3d8f0e56ed0fa9f7d34d3e branch=build/goreleaser-signing-notarization current_tag=v4.36.0 previous_tag=v4.35.0 dirty=true
    • pipe skipped or partially skipped              reason=disabled during snapshot mode
  • parsing tag
  • setting defaults
  • snapshotting
    • building snapshot...                           version=4.36.1-next
  • running before hooks
    • running                                        hook=go fmt ./...
    • running                                        hook=go mod tidy
    • running                                        hook=go generate ./...
  • ensuring distribution directory
  • setting up metadata
  • writing release metadata
  • loading go mod information
  • build prerequisites
  • building binaries
    • building                                       binary=dist/dnscontrol_freebsd_arm64_v8.0/dnscontrol
    • building                                       binary=dist/dnscontrol_darwin_amd64_v1/dnscontrol
    • building                                       binary=dist/dnscontrol_linux_arm64_v8.0/dnscontrol
    • building                                       binary=dist/dnscontrol_darwin_arm64_v8.0/dnscontrol
    • building                                       binary=dist/dnscontrol_windows_amd64_v1/dnscontrol.exe
    • building                                       binary=dist/dnscontrol_windows_arm64_v8.0/dnscontrol.exe
    • building                                       binary=dist/dnscontrol_linux_amd64_v1/dnscontrol
    • building                                       binary=dist/dnscontrol_freebsd_amd64_v1/dnscontrol
  • universal binaries
    • creating from 2 binaries                       id=dnscontrol binary=dist/dnscontrol_darwin_all/dnscontrol
  • sign & notarize macOS binaries
    • signing                                        binary=dist/dnscontrol_darwin_all/dnscontrol
    • sending notarize request                       binary=dist/dnscontrol_darwin_all/dnscontrol
    • notarize still pending                         binary=dist/dnscontrol_darwin_all/dnscontrol
      • took: 12s
  • writing artifacts metadata
  • build succeeded after 20s
  • thanks for using GoReleaser!
```

Fixes https://github.com/StackExchange/dnscontrol/issues/4117