### PR TITLE
BUGFIX: Two global flags can be appreviated to -v, causing confusion

### DIFF
--- a/commands/commands.go
+++ b/commands/commands.go
@@ -51,7 +51,6 @@ func Run(v string) int {
 	app.Flags = []cli.Flag{
 		&cli.BoolFlag{
 			Name:        "debug",
-			Aliases:     []string{"v"},
 			Usage:       "Enable debug logging",
 			Destination: &printer.DefaultPrinter.Verbose,
 		},


### PR DESCRIPTION
# Issue

Two global flags can be abbreviated to `-v`.  Both `--debug` and `--version` can be abbreviated to `-v`. This causes confusion (example: https://github.com/StackExchange/dnscontrol/discussions/4138).

The "global options" section of `dnscontrol -h` shows:

```
GLOBAL OPTIONS:
   --debug, -v        Enable debug logging
   --allow-fetch      Enable JS fetch(), dangerous on untrusted code!
   --disableordering  Disables update reordering
   --no-colors        Disable colors
   --help, -h         show help
   --version, -v      print the version
```


# Resolution

Remove `-v` from `--debug`.  The flag parsing module we use really really really wants to own the `-v` flag.