### PR TITLE
GCLOUD: Enable support for metadata-driven DNSSEC

### DIFF
--- a/documentation/provider/gcloud.md
+++ b/documentation/provider/gcloud.md
@@ -121,6 +121,37 @@ D("example.tld", REG_NAMECOM, DnsProvider(DSP_GCLOUD),
 
 > split horizon zones using the `GCLOUD` provider are currently only supported when the providers' credentials target separate `project_id` values
 
+## DNSSEC
+
+DNSSEC can be enabled using one of two different methods. Either you can toggle it with AUTODNSSEC_ON/AUTODNSSEC_OFF or if you want more control over internal settings you can use a Metadata-field on the zone called `DnssecConfig` with a JSON-string matching the [ManagedZoneDnsSecConfig struct](https://pkg.go.dev/google.golang.org/api/dns/v1#ManagedZoneDnsSecConfig) from the Google Cloud DNS API.
+
+Example:
+
+{% code title="dnsconfig.js" %}
+```javascript
+D("example.com", REG_NONE, DnsProvider(GCLOUD),
+  {
+    DnssecConfig: JSON.stringify(
+    {
+      "state": "on",
+      "nonExistence": "nsec3",
+      "defaultKeySpecs": [
+        {
+          "algorithm": "ecdsap256sha256",
+          "keyLength": 256,
+          "keyType": "keySigning"
+        },
+        {
+          "algorithm": "ecdsap256sha256",
+          "keyLength": 256,
+          "keyType": "zoneSigning"
+        }
+      ]
+    }),
+  },
+```
+{% endcode %}
+
 # Debugging credentials
 
 You can test your `creds.json` entry with the command: `dnscontrol check-creds foo GCLOUD` where `foo` is the name of key used in `creds.json`.  Error messages you might see:

--- a/providers/gcloud/dnssec.go
+++ b/providers/gcloud/dnssec.go
@@ -13,7 +13,7 @@ import (
 func (g *gcloudProvider) getDnssecCorrections(dc *models.DomainConfig) ([]*models.Correction, error) {
 	// Don't allow combining AUTODNSSEC_{ON,OFF} with metadata DnssecConfig
 	if dc.AutoDNSSEC != "" && dc.Metadata["DnssecConfig"] != "" {
-		return nil, fmt.Errorf("Cannot use AUTODNSSEC and DnssecConfig-metadata at the same time")
+		return nil, fmt.Errorf("cannot use AUTODNSSEC and DnssecConfig-metadata at the same time")
 	}
 	if dc.Metadata["DnssecConfig"] != "" {
 		return g.getDnssecCorrectionsFromMetadata(dc)

--- a/providers/gcloud/dnssec.go
+++ b/providers/gcloud/dnssec.go
@@ -1,6 +1,9 @@
 package gcloud
 
 import (
+	"encoding/json"
+	"fmt"
+	"strings"
 	"time"
 
 	"github.com/StackExchange/dnscontrol/v4/models"
@@ -8,6 +11,14 @@ import (
 )
 
 func (g *gcloudProvider) getDnssecCorrections(dc *models.DomainConfig) ([]*models.Correction, error) {
+	// Don't allow combining AUTODNSSEC_{ON,OFF} with metadata DnssecConfig
+	if dc.AutoDNSSEC != "" && dc.Metadata["DnssecConfig"] != "" {
+		return nil, fmt.Errorf("Cannot use AUTODNSSEC and DnssecConfig-metadata at the same time")
+	}
+	if dc.Metadata["DnssecConfig"] != "" {
+		return g.getDnssecCorrectionsFromMetadata(dc)
+	}
+
 	enabled, err := g.isDnssecEnabled(dc.Name)
 	if err != nil {
 		return nil, err
@@ -15,7 +26,7 @@ func (g *gcloudProvider) getDnssecCorrections(dc *models.DomainConfig) ([]*model
 	if enabled && dc.AutoDNSSEC == "off" {
 		return []*models.Correction{
 			{
-				Msg: "Disable DNSSEC",
+				Msg: "Disable AUTODNSSEC",
 				F:   func() error { err := g.disableDnssec(dc.Name); return err },
 			},
 		}, nil
@@ -24,12 +35,11 @@ func (g *gcloudProvider) getDnssecCorrections(dc *models.DomainConfig) ([]*model
 	if !enabled && dc.AutoDNSSEC == "on" {
 		return []*models.Correction{
 			{
-				Msg: "Enable DNSSEC",
+				Msg: "Enable AUTODNSSEC",
 				F:   func() error { err := g.enableDnssec(dc.Name); return err },
 			},
 		}, nil
 	}
-
 	return nil, nil
 }
 
@@ -72,7 +82,6 @@ func (g *gcloudProvider) enableDnssec(domain string) error {
 			time.Sleep(2 * time.Second)
 		}
 	}
-
 	return nil
 }
 
@@ -99,6 +108,114 @@ func (g *gcloudProvider) disableDnssec(domain string) error {
 			time.Sleep(2 * time.Second)
 		}
 	}
+	return nil
+}
 
+func (g *gcloudProvider) getDnssecCorrectionsFromMetadata(dc *models.DomainConfig) ([]*models.Correction, error) {
+	var corrections []*models.Correction
+
+	// Get current state
+	current := g.zones[dc.Name+"."].DnssecConfig
+	if current == nil {
+		current = &gdns.ManagedZoneDnsSecConfig{}
+	}
+	jsonStr := dc.Metadata["DnssecConfig"]
+	if jsonStr == "" {
+		return nil, nil
+	}
+
+	desired := &gdns.ManagedZoneDnsSecConfig{}
+	if err := json.Unmarshal([]byte(jsonStr), desired); err != nil {
+		return nil, fmt.Errorf("invalid DnssecConfig JSON for %s: %w", dc.Name, err)
+	}
+
+	changes := getDnssecDiff(current, desired)
+	if len(changes) == 0 {
+		return nil, nil
+	}
+
+	msg := fmt.Sprintf("UPDATE DNSSEC from metadata: %s", strings.Join(changes, ", "))
+	corrections = append(corrections, &models.Correction{
+		Msg: msg,
+		F: func() error {
+			err := g.updateDnssecFromMetadata(dc.Name, desired)
+			return err
+		},
+	})
+	return corrections, nil
+}
+
+func getDnssecDiff(current, desired *gdns.ManagedZoneDnsSecConfig) []string {
+	var diffs []string
+
+	if desired.State != "" && desired.State != current.State {
+		diffs = append(diffs, fmt.Sprintf("State: %q -> %q", current.State, desired.State))
+	}
+
+	if desired.NonExistence != "" && desired.NonExistence != current.NonExistence {
+		diffs = append(diffs, fmt.Sprintf("NonExistence: %q -> %q", current.NonExistence, desired.NonExistence))
+	}
+
+	if len(desired.DefaultKeySpecs) > 0 {
+		keySpecDiffs := getKeySpecDiffs(current.DefaultKeySpecs, desired.DefaultKeySpecs)
+		if len(keySpecDiffs) != 0 {
+			diffs = append(diffs, keySpecDiffs...)
+		}
+	}
+	return diffs
+}
+
+func getKeySpecDiffs(current, desired []*gdns.DnsKeySpec) []string {
+	var details []string
+	currentMap := make(map[string]bool)
+	for _, k := range current {
+		currentMap[keySpecToString(k)] = true
+	}
+
+	desiredMap := make(map[string]bool)
+	for _, k := range desired {
+		desiredMap[keySpecToString(k)] = true
+	}
+	for _, k := range current {
+		fp := keySpecToString(k)
+		if !desiredMap[fp] {
+			details = append(details, fmt.Sprintf("Remove key %s", fp))
+		}
+	}
+
+	for _, k := range desired {
+		fp := keySpecToString(k)
+		if !currentMap[fp] {
+			details = append(details, fmt.Sprintf("Add key %s", fp))
+		}
+	}
+	return details
+}
+
+func keySpecToString(ks *gdns.DnsKeySpec) string {
+	return fmt.Sprintf("alg:%s|len:%d|type:%s", ks.Algorithm, ks.KeyLength, ks.KeyType)
+}
+
+func (g *gcloudProvider) updateDnssecFromMetadata(domain string, desired *gdns.ManagedZoneDnsSecConfig) error {
+	dnssecPatch := &gdns.ManagedZone{
+		DnssecConfig: desired,
+	}
+	resp, err := g.client.ManagedZones.Patch(g.project, g.zones[domain+"."].Name, dnssecPatch).Do()
+	if err != nil {
+		return err
+	}
+	if resp.Status != "done" {
+		// Should we have a timeout here?
+		for {
+			checkOperation, err := g.client.ManagedZoneOperations.Get(g.project, g.zones[domain+"."].Name, resp.Id).Do()
+			if err != nil {
+				return err
+			}
+			if checkOperation.Status == "done" {
+				return nil
+			}
+			time.Sleep(2 * time.Second)
+		}
+	}
 	return nil
 }


### PR DESCRIPTION
## Release changelog section
* GCLOUD: Add support for enabling DNSSEC through metadata for being able to control DNSSEC-parameters more granularly

<!--
## Before submiting a pull request

Please make sure you've run the following commands from the root directory.

    bin/generate-all.sh

(this runs commands like "go generate", fixes formatting, and so on)

## Release changelog section

Help keep the release changelog clear by pre-naming the proper section in the GitHub pull request title.

Some examples:
* CICD: Add required GHA permissions for goreleaser
* DOCS: Fixed providers with "contributor support" table
* ROUTE53: Allow R53_ALIAS records to enable target health evaluation

More examples/context can be found in the file .goreleaser.yml under the 'build' > 'changelog' key.
!-->
