### PR TITLE
BUILD: Speed up GoReleaser in PR builds with --single-target --skip=before

### DIFF
--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -83,4 +83,4 @@ jobs:
       if: github.ref_type != 'tag'
       uses: goreleaser/goreleaser-action@v7
       with:
-        args: build --snapshot
+        args: build --snapshot --single-target

--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -83,4 +83,4 @@ jobs:
       if: github.ref_type != 'tag'
       uses: goreleaser/goreleaser-action@v7
       with:
-        args: build --snapshot --single-target
+        args: build --snapshot --single-target --skip=before


### PR DESCRIPTION
The main bottleneck in the PR CI/CD pipeline is the `goreleaser build --snapshot` step, which takes \~8m19s out of the total \~10m45s ([run 23057743439](https://github.com/StackExchange/dnscontrol/actions/runs/23057743439)).

| **Step** | **Duration** |
| --- | --- |
| Unit tests | 1m 46s |
| Build binaries (not tagged) | 8m 19s |
| Rest (setup, cache, etc.) | \~10s |

Two things make it slow:

1. **Cross-compilation for all 8 targets** (linux, windows, darwin, freebsd x amd64/arm64). For a PR build, we only need to verify the code compiles.
2. **Before hooks** (`go fmt ./...`, `go mod tidy`, `go generate ./...`) run every time, but are redundant in CI -- formatting/tidy should already be done, and `go generate` is covered by the stringer install step.

This PR adds `--single-target` and `--skip=before` to the snapshot build, which should bring the GoReleaser step from \~8 minutes down to \~1 minute. The full release build (on tag) remains unchanged.

Fixes https://github.com/StackExchange/dnscontrol/issues/4165