### PR TITLE
CICD: only run GHA release_draft on the main repo

### DIFF
--- a/.github/workflows/release_draft.yml
+++ b/.github/workflows/release_draft.yml
@@ -1,70 +1,71 @@
-name: "RELEASE: Make release candidate"
+name: 'RELEASE: Make release candidate'
 
 on:
-  push:
-    tags:
-      - v[0-9]+.[0-9]+.[0-9]+
-      - v[0-9]+.[0-9]+.[0-9]+-*
+    push:
+        tags:
+            - v[0-9]+.[0-9]+.[0-9]+
+            - v[0-9]+.[0-9]+.[0-9]+-*
 
 jobs:
-  draft_release:
-    name: draft release
-    runs-on: ubuntu-latest
-    permissions:
-      packages: write
-      contents: write
-      pull-requests: write
-    steps:
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+    draft_release:
+        name: draft release
+        runs-on: ubuntu-latest
+        if: github.repository == 'StackExchange/dnscontrol'
+        permissions:
+            packages: write
+            contents: write
+            pull-requests: write
+        steps:
+            - name: Set up QEMU
+              uses: docker/setup-qemu-action@v4
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+            - name: Set up Docker Buildx
+              uses: docker/setup-buildx-action@v4
 
-      - name: Checkout repo
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-      # Why "fetch-depth: 0"?  To generate the release notes, we need the
-      # full git history.  A shallow checkout would make release notes going
-      # back one commit.
+            - name: Checkout repo
+              uses: actions/checkout@v6
+              with:
+                  fetch-depth: 0
+            # Why "fetch-depth: 0"?  To generate the release notes, we need the
+            # full git history.  A shallow checkout would make release notes going
+            # back one commit.
 
-      - name: Login to Docker Hub
-        uses: docker/login-action@v4
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
+            - name: Login to Docker Hub
+              uses: docker/login-action@v4
+              with:
+                  username: ${{ secrets.DOCKERHUB_USERNAME }}
+                  password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
 
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v4
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+            - name: Login to GitHub Container Registry
+              uses: docker/login-action@v4
+              with:
+                  registry: ghcr.io
+                  username: ${{ github.repository_owner }}
+                  password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Set up Go
-        uses: actions/setup-go@v6
-        with:
-          go-version: stable
+            - name: Set up Go
+              uses: actions/setup-go@v6
+              with:
+                  go-version: stable
 
-      # Stringer is needed because .goreleaser includes "go generate ./..."
-      - name: Install stringer
-        run: |
-          go install golang.org/x/tools/cmd/stringer@latest
+            # Stringer is needed because .goreleaser includes "go generate ./..."
+            - name: Install stringer
+              run: |
+                  go install golang.org/x/tools/cmd/stringer@latest
 
-      # use GoReleaser to build for all platforms.
-      - id: release
-        name: Goreleaser release
-        uses: goreleaser/goreleaser-action@v7
-        with:
-          distribution: goreleaser
-          version: latest
-          args: release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
-          MACOS_SIGN_P12: ${{ secrets.MACOS_SIGN_P12 }}
-          MACOS_SIGN_PASSWORD: ${{ secrets.MACOS_SIGN_PASSWORD }}
-          MACOS_NOTARY_ISSUER_ID: ${{ secrets.MACOS_NOTARY_ISSUER_ID }}
-          MACOS_NOTARY_KEY_ID: ${{ secrets.MACOS_NOTARY_KEY_ID }}
-          MACOS_NOTARY_KEY: ${{ secrets.MACOS_NOTARY_KEY }}
+            # use GoReleaser to build for all platforms.
+            - id: release
+              name: Goreleaser release
+              uses: goreleaser/goreleaser-action@v7
+              with:
+                  distribution: goreleaser
+                  version: latest
+                  args: release
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+                  MACOS_SIGN_P12: ${{ secrets.MACOS_SIGN_P12 }}
+                  MACOS_SIGN_PASSWORD: ${{ secrets.MACOS_SIGN_PASSWORD }}
+                  MACOS_NOTARY_ISSUER_ID: ${{ secrets.MACOS_NOTARY_ISSUER_ID }}
+                  MACOS_NOTARY_KEY_ID: ${{ secrets.MACOS_NOTARY_KEY_ID }}
+                  MACOS_NOTARY_KEY: ${{ secrets.MACOS_NOTARY_KEY }}


### PR DESCRIPTION
## Context

When I sync'd the dnscontrol repo into my forked repo it reran these jobs.  The jobs all fail since the credentials are not available.

This also ended up reformatting the yaml.  Let me know if that is an issue.

<!-- PR_BODY_DONE_START -->
## Done

- 🛶 only run GHA release_draft on the main repo

<!-- PR_BODY_DONE_END -->

## Meta

(Automated in `.just/gh-process.just`.)
