### PR TITLE
CLOUDNS: map CLOUD_WR to CLOUDNS_WR so redirect records are not recreated every push

### DIFF
--- a/providers/cloudns/cloudnsProvider.go
+++ b/providers/cloudns/cloudnsProvider.go
@@ -406,7 +406,7 @@ func toRc(domain string, r *domainRecord) (*models.RecordConfig, error) {
 		rc.DsDigest = r.Target
 		err = rc.SetTarget(r.Target)
 	case "CLOUD_WR":
-		rc.Type = "WR"
+		rc.Type = "CLOUDNS_WR"
 		err = rc.SetTarget(r.Target)
 	case "LOC":
 		loc := fmt.Sprintf("%s %s %s %s %s %s %s %s %s %s %s %s",
@@ -459,7 +459,7 @@ func toReq(rc *models.RecordConfig) (requestParams, error) {
 	}
 
 	switch rc.Type { // #rtype_variations
-	case "A", "AAAA", "NS", "PTR", "TXT", "SOA", "ALIAS", "CNAME", "WR", "DNAME":
+	case "A", "AAAA", "NS", "PTR", "TXT", "SOA", "ALIAS", "CNAME", "DNAME":
 		// Nothing special.
 	case "CLOUDNS_WR":
 		req["record-type"] = "WR"

--- a/providers/cloudns/cloudnsProvider_test.go
+++ b/providers/cloudns/cloudnsProvider_test.go
@@ -1,0 +1,27 @@
+package cloudns
+
+import (
+	"testing"
+)
+
+func TestToRcConvertsCloudWRToCloudnsWR(t *testing.T) {
+	// ClouDNS API returns "CLOUD_WR" as the type for web redirect records.
+	// dnscontrol uses "CLOUDNS_WR" as the custom record type.
+	// Verify that toRc maps "CLOUD_WR" -> "CLOUDNS_WR" so that fetched
+	// records match desired records and are not destroyed/recreated every push.
+	r := &domainRecord{
+		ID:     "123",
+		Type:   "CLOUD_WR",
+		Host:   "www",
+		Target: "https://example.com",
+		TTL:    "3600",
+	}
+
+	rc, err := toRc("example.com", r)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rc.Type != "CLOUDNS_WR" {
+		t.Errorf("expected type CLOUDNS_WR, got %s", rc.Type)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #3972

CLOUDNS_WR (web redirect) records are destroyed and recreated on every `dnscontrol push` even when nothing has changed.

## Root Cause

When records are **fetched** from the ClouDNS API, the `toRc` function converts the API type `CLOUD_WR` to `WR`. However, dnscontrol registers the custom record type as `CLOUDNS_WR` (line 85). This means:

- Fetched records have type `WR`
- Desired records (from user config) have type `CLOUDNS_WR`

The diff algorithm sees them as different record types and generates a DELETE + CREATE on every push.

## Fix

1. In `toRc()`: Map `CLOUD_WR` → `CLOUDNS_WR` (instead of → `WR`) so fetched records match the registered custom type
2. In the request builder: Remove `WR` from the "nothing special" case since the type is now always `CLOUDNS_WR` (which was already handled in the case below)

## Testing

- Added `TestToRcConvertsCloudWRToCloudnsWR` unit test that verifies the type mapping
- Build passes cleanly