### PR TITLE
CLOUDFLAREAPI: allow CNAME + other records when Cloudflare proxy is enabled

### DIFF
--- a/pkg/normalize/validate.go
+++ b/pkg/normalize/validate.go
@@ -636,18 +636,28 @@ func checkAutoDNSSEC(dc *models.DomainConfig) (errs []error) {
 
 func checkCNAMEs(dc *models.DomainConfig) (errs []error) {
 	cnames := map[string]bool{}
+	proxiedCnames := map[string]bool{}
 	for _, r := range dc.Records {
 		if r.Type == "CNAME" {
 			if cnames[r.GetLabel()] {
 				errs = append(errs, fmt.Errorf("%s: cannot have multiple CNAMEs with same name: %s", r.FilePos, r.GetLabelFQDN()))
 			}
 			cnames[r.GetLabel()] = true
+			if p, ok := r.Metadata["cloudflare_proxy"]; ok && (p == "on" || p == "full") {
+				proxiedCnames[r.GetLabel()] = true
+			}
 		}
 	}
 	for _, r := range dc.Records {
 		if cnames[r.GetLabel()] && r.Type != "CNAME" {
 			// Allow AKAMAICDN and CNAME to have same name
 			if r.Type == "AKAMAICDN" {
+				continue
+			}
+			// Cloudflare proxied (flattened) CNAMEs are resolved internally
+			// and never served as actual CNAME records, so the RFC 1034 §3.6.2
+			// restriction does not apply.
+			if proxiedCnames[r.GetLabel()] {
 				continue
 			}
 			errs = append(errs, fmt.Errorf("%s: cannot have CNAME and %s record with same name: %s", r.FilePos, r.Type, r.GetLabelFQDN()))

--- a/pkg/normalize/validate_test.go
+++ b/pkg/normalize/validate_test.go
@@ -342,6 +342,40 @@ func TestCNAMEMutex(t *testing.T) {
 	}
 }
 
+func TestCNAMECloudflareProxied(t *testing.T) {
+	// A proxied (flattened) CNAME should be allowed alongside other record types.
+	recCNAME := &models.RecordConfig{
+		Type:     "CNAME",
+		Metadata: map[string]string{"cloudflare_proxy": "on"},
+	}
+	recCNAME.SetLabel("mail", "mail.example.com")
+	recCNAME.MustSetTarget("example.com.")
+	recMX := &models.RecordConfig{Type: "MX"}
+	recMX.SetLabel("mail", "mail.example.com")
+	recMX.MustSetTarget("smtp.example.com.")
+	dc := &models.DomainConfig{
+		Name:    "example.com",
+		Records: []*models.RecordConfig{recCNAME, recMX},
+	}
+	errs := checkCNAMEs(dc)
+	if len(errs) != 0 {
+		t.Errorf("Expected no errors for proxied CNAME + MX, got: %v", errs)
+	}
+
+	// A non-proxied CNAME should still fail.
+	recCNAME2 := &models.RecordConfig{Type: "CNAME"}
+	recCNAME2.SetLabel("mail", "mail.example.com")
+	recCNAME2.MustSetTarget("example.com.")
+	dc2 := &models.DomainConfig{
+		Name:    "example.com",
+		Records: []*models.RecordConfig{recCNAME2, recMX},
+	}
+	errs2 := checkCNAMEs(dc2)
+	if len(errs2) == 0 {
+		t.Error("Expected error for non-proxied CNAME + MX, got none")
+	}
+}
+
 func TestCAAValidation(t *testing.T) {
 	config := &models.DNSConfig{
 		Domains: []*models.DomainConfig{


### PR DESCRIPTION
### Description

Fixes the CNAME + other record type validation to allow coexistence when the CNAME is proxied through Cloudflare (`CF_PROXY_ON` or `CF_PROXY_FULL`).

### Problem

When using the Cloudflare provider with `CF_PROXY_ON`, dnscontrol rejects configurations that have a CNAME and another record type (e.g., MX) on the same name:

```
cannot have CNAME and MX record with same name: mailscanner.example.com
```

However, when a CNAME is proxied, Cloudflare flattens it internally and returns A/AAAA records to resolvers. The CNAME is never served to the public, so the RFC 1034 §3.6.2 restriction does not apply. Cloudflare itself allows this configuration and it works correctly.

### Root Cause

The `checkCNAMEs` function in `pkg/normalize/validate.go` unconditionally rejects any record type (except AKAMAICDN) that shares a label with a CNAME, without checking whether the CNAME uses Cloudflare proxy flattening.

### Fix

When building the CNAME label map, also track which CNAMEs have `cloudflare_proxy` metadata set to `"on"` or `"full"`. Skip the conflict error for those labels, following the same pattern as the existing AKAMAICDN exception.

### Tests

Added `TestCNAMECloudflareProxied` that verifies:
- Proxied CNAME + MX on the same label produces no error
- Non-proxied CNAME + MX on the same label still produces an error

Fixes #4181