### PR TITLE
BUGFIX: preview should display long TXT records as one string

### DIFF
--- a/models/record.go
+++ b/models/record.go
@@ -344,7 +344,7 @@ func (rc *RecordConfig) ToComparableNoTTL() string {
 		// SoaSerial is not included because it isn't used in comparisons.
 	case "TXT":
 		// fmt.Fprintf(os.Stdout, "DEBUG: ToComNoTTL raw txts=%s q=%q\n", rc.target, rc.target)
-		r := txtutil.EncodeQuoted(rc.target)
+		r := txtutil.EncodeSingle(rc.target)
 		// fmt.Fprintf(os.Stdout, "DEBUG: ToComNoTTL cmp txts=%s q=%q\n", r, r)
 		return r
 	case "LUA":

--- a/pkg/txtutil/txtcode.go
+++ b/pkg/txtutil/txtcode.go
@@ -36,6 +36,13 @@ func EncodeQuoted(t string) string {
 	return txtEncode(ToChunks(t))
 }
 
+// EncodeSingle encodes a string as a single quoted value without splitting
+// into 255-octet chunks. This is intended for user-facing display (e.g., diff
+// preview) where the chunked representation is confusing.
+func EncodeSingle(t string) string {
+	return txtEncode([]string{t})
+}
+
 // State denotes the parser state.
 type State int
 


### PR DESCRIPTION
### Description

Fixes the confusing display of long TXT records in the preview/diff output. Previously, TXT records longer than 255 octets were shown as chunked segments:

```
"v=DKIM1; k=rsa; p=MIIB...long..." "remaining..."
```

Now they are displayed as a single string per [Opinion #8](https://docs.dnscontrol.org/developer-info/opinions#opinion-8-txt-records-are-one-long-string):

```
"v=DKIM1; k=rsa; p=MIIB...long...remaining..."
```

### Root Cause

`ToComparableNoTTL()` (used by the diff engine for both comparison and display) called `txtutil.EncodeQuoted()`, which splits TXT values into 255-octet chunks before quoting.

### Fix

- Added `txtutil.EncodeSingle()` that quotes the TXT value as a single string without chunking
- Changed `ToComparableNoTTL()` to use `EncodeSingle()` instead of `EncodeQuoted()`
- Zone file output (`prettyzone`) continues to use `EncodeQuoted()` with chunking, as that format is required for DNS wire compatibility

### Tests

All existing txtutil, diff2, and models tests pass.

Fixes #2834