### PR TITLE
BUGFIX: LOC record latitude/longitude overflow on 32 bit archs

### DIFF
--- a/models/record.go
+++ b/models/record.go
@@ -172,8 +172,8 @@ func (rc *RecordConfig) UnmarshalJSON(b []byte) error {
 		LocSize            uint8             `json:"locsize,omitempty"`
 		LocHorizPre        uint8             `json:"lochorizpre,omitempty"`
 		LocVertPre         uint8             `json:"locvertpre,omitempty"`
-		LocLatitude        int               `json:"loclatitude,omitempty"`
-		LocLongitude       int               `json:"loclongitude,omitempty"`
+		LocLatitude        uint32            `json:"loclatitude,omitempty"`
+		LocLongitude       uint32            `json:"loclongitude,omitempty"`
 		LocAltitude        uint32            `json:"localtitude,omitempty"`
 		LuaRType           string            `json:"luartype,omitempty"`
 		NaptrOrder         uint16            `json:"naptrorder,omitempty"`

--- a/pkg/js/helpers.js
+++ b/pkg/js/helpers.js
@@ -874,8 +874,8 @@ function locStringBuilder(record, args) {
 // Renders LOC type internal properties from D˚M'S" parameters.
 // Change anything here at your peril.
 function locDMSBuilder(record, args) {
-    LOCEquator = 1 << 31; // RFC 1876, Section 2.
-    LOCPrimeMeridian = 1 << 31; // RFC 1876, Section 2.
+    LOCEquator = Math.pow(2, 31); // RFC 1876, Section 2.
+    LOCPrimeMeridian = Math.pow(2, 31); // RFC 1876, Section 2.
     LOCHours = 60 * 1000;
     LOCDegrees = 60 * LOCHours;
     LOCAltitudeBase = 100000;


### PR DESCRIPTION
The 045-loc.js test fails for me on i686:
```
--- FAIL: TestParsedFiles (0.55s)
    --- FAIL: TestParsedFiles/045-loc.js (0.02s)
        js_test.go:51: json: cannot unmarshal number -2403461648 into Go struct field DomainConfig.domains.records.loclongitude of type int
FAIL
FAIL	github.com/StackExchange/dnscontrol/v4/pkg/js	0.553s
FAIL
```

So in pkg/js/helpers.js, I found out that the bit shift operator always returns a signed int32 which means `1 << 31` evaluates to -2147483648 whereas `Math.pow(2, 31)` gives the correct value of +2147483648 for the equator and prime meridian.

And in models/record.go, `LocLatitude` and `LocLongitude` in `UnmarshalJSON` were typed as `int` which didn't match the main struct or RFC 1876 apparently and on 32 bit architectures, `int` ends up as a signed 32 bit integer and any lat/lon coordinates north of the equator or east of the prime meridian can overflow that which causes `json.Unmarshal` to fail.