### PR TITLE
CHORE: Replace parser.ParseDir with golang.org/x/tools/go/packages

### DIFF
--- a/pkg/normalize/capabilities_test.go
+++ b/pkg/normalize/capabilities_test.go
@@ -1,12 +1,13 @@
 package normalize
 
 import (
-	"go/ast"
-	"go/parser"
-	"go/token"
+	"go/constant"
+	"go/types"
 	"sort"
 	"strings"
 	"testing"
+
+	"golang.org/x/tools/go/packages"
 )
 
 const (
@@ -20,38 +21,42 @@ func TestCapabilitiesAreFiltered(t *testing.T) {
 	skipCheckCapabilities := make(map[string]struct{})
 	// skipCheckCapabilities["CanUseBlahBlahBlah"] = struct{}{}
 
-	fset := token.NewFileSet()
-	pkgs, err := parser.ParseDir(fset, providersImportDir, nil, 0) //nolint:staticcheck
-	/* FIXME(tlim):
-	pkg/normalize/capabilities_test.go:24:15: SA1019: parser.ParseDir has been deprecated since Go 1.25 and an alternative has been available since Go 1.11: ParseDir does not consider build tags when associating files with packages. For precise information about the relationship between packages and files, use golang.org/x/tools/go/packages, which can also optionally parse and type-check the files too. (staticcheck)
-	pkgs, err := parser.ParseDir(fset, providersImportDir, nil, 0)
-	*/
-	if err != nil {
-		t.Fatalf("unable to load Go code from providers: %s", err)
+	cfg := &packages.Config{
+		Mode: packages.NeedName | packages.NeedTypes | packages.NeedTypesInfo,
+		Dir:  providersImportDir,
 	}
-	providers, ok := pkgs[providersPackageName]
-	if !ok {
+	pkgs, err := packages.Load(cfg, ".")
+	if err != nil || len(pkgs) == 0 {
+		t.Fatalf("unable to load Go code from providers: %v", err)
+	}
+	var providers *packages.Package
+	for _, pkg := range pkgs {
+		if pkg.Name == providersPackageName {
+			providers = pkg
+			break
+		}
+	}
+	if providers == nil {
 		t.Fatalf("did not find package %q in %q", providersPackageName, providersImportDir)
 	}
 
 	constantNames := make([]string, 0, 50)
 	capabilityInts := make(map[string]int, 50)
 
-	// providers.Scope was nil in my testing
-	for fileName := range providers.Files {
-		scope := providers.Files[fileName].Scope
-		for itemName, obj := range scope.Objects {
-			if obj.Kind != ast.Con {
-				continue
-			}
-			// In practice, the object.Type is nil here so we can't filter for
-			// capabilities so easily.
-			if !strings.HasPrefix(itemName, "CanUse") {
-				continue
-			}
-			constantNames = append(constantNames, itemName)
-			capabilityInts[itemName] = obj.Data.(int)
+	for ident, obj := range providers.TypesInfo.Defs {
+		if !strings.HasPrefix(ident.Name, "CanUse") {
+			continue
 		}
+		c, ok := obj.(*types.Const)
+		if !ok {
+			continue
+		}
+		val, exact := constant.Int64Val(c.Val())
+		if !exact {
+			t.Fatalf("unable to get int value for %s", ident.Name)
+		}
+		constantNames = append(constantNames, ident.Name)
+		capabilityInts[ident.Name] = int(val)
 	}
 	sort.Strings(constantNames)
 


### PR DESCRIPTION
parser.ParseDir is deprecated since Go 1.25. Use packages.Load with NeedTypes and NeedTypesInfo to correctly extract CanUse* constant integer values via TypesInfo.Defs, preserving the test's ability to detect missing providerCapabilityChecks entries.

---

This is a *replacement* PR for #4154.  I took my review feedback from that PR, copied the markdown into two local files, and prompted Claude Code (using Sonnet 4.6) with:

> Branch sx-pr/4154 contains one commit, which purports to "Replace parser.ParseDir, which is deprecated".  But it is broken.  This is a test of the codebase, via AST checks, that various providers.CanUse* checks are called appropriately.  Files `local.pdp.review1.1` and `local.pdp.review1.2` (git-ignored) contain my review feedback, pointing out how the change is broken and how it can be validated.  You are on a new git branch based off current main; please provide a correct replacement, and validate that it works.

The next section is choice quotes from Claude's analysis while working, and the final section was Claude's summary at end-of-work.

I have independently reviewed the code, it looks good, and I've validated that the tests look reasonable and correctly fail when a test is commented out (to ensure the AI did not fabricate that).  I think this is a sane way forward.

I thought it would be amusing to use Claude to critique Claude's earlier work.

---

Now I understand the problem clearly. The broken PR sets `capabilityInts[name.Name] = 0` for all constants (the comment even admits it), which means every `CanUse*` constant maps to `int 0`, and since `capIntsToNames[0]` finds the first entry, all checks pass trivially. The test is completely neutered.

The fix is to use `packages.NeedTypes`/`NeedTypesInfo` (already requested in the config) to actually read the integer values of the constants. Let me look at the providers package to understand the constants:

[...]

The problem is clear. The broken PR:
  1. Uses `packages.Load` correctly to get type info (`NeedTypes`, `NeedTypesInfo`)
  2. But then abandons the type info and sets all `capabilityInts` to `0`, making every `CanUse*` constant map to `CanAutoDNSSEC` (which is in `capIntsToNames[0]`), so all checks pass trivially

The fix is to use `providers.TypesInfo.Defs` to look up the actual `*types.Const` value for each constant. Let me write the corrected test file:
  
--- 

Both validations from the review pass:

  1. Correct output: integer values are real (`(4)`, `(9)`, etc.) and each is paired with its correct record type — matches the "before" output exactly.
  2. Test actually catches omissions: commenting out the DNAME entry causes `FAIL` with `MISSING: providers.CanUseDNAME (9)`.

What was wrong in the PR: The code switched from `parser.ParseDir` to `packages.Load` correctly, but the author gave up on extracting real integer values and wrote `capabilityInts[name.Name] = 0` for everything. Since all constants got value `0`, they all matched `capIntsToNames[0] = AUTODNSSEC`, making the test trivially pass regardless of what was in `providerCapabilityChecks`.

The fix: Instead of iterating the raw AST and guessing values, use `providers.TypesInfo.Defs` (which is what `NeedTypesInfo` provides) to look up each identifier's `*types.Const` object and call `constant.Int64Val(c.Val())` to get the actual iota integer.
