### PR TITLE
UNIFI: fix errors on version 10.2.105

### DIFF
--- a/providers/unifi/api.go
+++ b/providers/unifi/api.go
@@ -245,26 +245,40 @@ func (c *unifiClient) getSiteID() (string, error) {
 	return "", fmt.Errorf("site '%s' not found", c.site)
 }
 
-// getRecordsNew fetches all DNS policy records using the NEW API.
+// dnsPoliciesPageLimit is the number of records to request per page when listing DNS policies.
+const dnsPoliciesPageLimit = 200
+
+// getRecordsNew fetches all DNS policy records using the NEW API, paginating as needed.
 func (c *unifiClient) getRecordsNew() ([]dnsPolicyRecord, error) {
 	siteID, err := c.getSiteID()
 	if err != nil {
 		return nil, err
 	}
 
-	path := fmt.Sprintf("/integration/v1/sites/%s/dns/policies", siteID)
+	var allRecords []dnsPolicyRecord
+	offset := 0
+	for {
+		path := fmt.Sprintf("/integration/v1/sites/%s/dns/policies?offset=%d&limit=%d", siteID, offset, dnsPoliciesPageLimit)
 
-	respBytes, err := c.do("GET", path, nil)
-	if err != nil {
-		return nil, fmt.Errorf("failed to fetch records: %w", err)
+		respBytes, err := c.do("GET", path, nil)
+		if err != nil {
+			return nil, fmt.Errorf("failed to fetch records: %w", err)
+		}
+
+		var response dnsPolicyResponse
+		if err := json.Unmarshal(respBytes, &response); err != nil {
+			return nil, fmt.Errorf("failed to parse records: %w", err)
+		}
+
+		allRecords = append(allRecords, response.Data...)
+
+		if len(response.Data) < dnsPoliciesPageLimit {
+			break
+		}
+		offset += dnsPoliciesPageLimit
 	}
 
-	var response dnsPolicyResponse
-	if err := json.Unmarshal(respBytes, &response); err != nil {
-		return nil, fmt.Errorf("failed to parse records: %w", err)
-	}
-
-	return response.Data, nil
+	return allRecords, nil
 }
 
 // createRecordNew creates a new DNS record using the NEW API.
@@ -298,8 +312,8 @@ func (c *unifiClient) updateRecordNew(id string, r *dnsPolicyRecord) (*dnsPolicy
 
 	path := fmt.Sprintf("/integration/v1/sites/%s/dns/policies/%s", siteID, id)
 
-	// Ensure the ID is set in the record
-	r.ID = id
+	// The ID is in the URL path; the API rejects it if included in the request body.
+	r.ID = ""
 
 	respBytes, err := c.do("PUT", path, r)
 	if err != nil {
@@ -346,7 +360,7 @@ func (c *unifiClient) detectAPIAvailability() {
 	if _, err := c.getSiteID(); err == nil {
 		// Site ID fetched successfully, try to get records
 		siteID := c.siteID
-		path := fmt.Sprintf("/integration/v1/sites/%s/dns/policies", siteID)
+		path := fmt.Sprintf("/integration/v1/sites/%s/dns/policies?limit=1", siteID)
 		if _, err := c.do("GET", path, nil); err == nil {
 			newAvailable = true
 		}

--- a/providers/unifi/types.go
+++ b/providers/unifi/types.go
@@ -40,14 +40,14 @@ type dnsPolicyMetadata struct {
 // This API is available in UniFi Network 10.1+.
 // The record is polymorphic - different fields are used depending on the type.
 type dnsPolicyRecord struct {
-	Type     string            `json:"type"`         // A_RECORD, AAAA_RECORD, CNAME_RECORD, MX_RECORD, TXT_RECORD, SRV_RECORD
-	ID       string            `json:"id,omitempty"` // UUID
-	Enabled  bool              `json:"enabled"`      // Whether the record is enabled
-	Metadata dnsPolicyMetadata `json:"metadata"`     // Metadata (origin)
-	Domain   string            `json:"domain"`       // FQDN (e.g., "test.example.com")
+	Type     string             `json:"type"`               // A_RECORD, AAAA_RECORD, CNAME_RECORD, MX_RECORD, TXT_RECORD, SRV_RECORD
+	ID       string             `json:"id,omitempty"`       // UUID
+	Enabled  bool               `json:"enabled"`            // Whether the record is enabled
+	Metadata *dnsPolicyMetadata `json:"metadata,omitempty"` // Metadata (origin, read-only in API responses)
+	Domain   string             `json:"domain"`             // FQDN (e.g., "test.example.com")
 
-	// TTL (optional, 0 = default)
-	TTLSeconds int `json:"ttlSeconds,omitempty"`
+	// TTL in seconds (required by the API, always sent)
+	TTLSeconds int `json:"ttlSeconds"`
 
 	// Type-specific fields
 	IPv4Address      string `json:"ipv4Address,omitempty"`      // A record
@@ -289,14 +289,13 @@ func recordToNew(rc *models.RecordConfig) (*dnsPolicyRecord, error) {
 	r := &dnsPolicyRecord{
 		Enabled: true,
 		Domain:  rc.NameFQDN,
-		Metadata: dnsPolicyMetadata{
-			Origin: "USER_DEFINED",
-		},
 	}
 
-	// Set TTL if non-default
-	if rc.TTL > 0 && rc.TTL != 300 {
+	// Always send TTL; the API requires ttlSeconds to be non-null.
+	if rc.TTL > 0 {
 		r.TTLSeconds = int(rc.TTL)
+	} else {
+		r.TTLSeconds = 300
 	}
 
 	switch rc.Type {


### PR DESCRIPTION
When using the Unifi provider with Unifi Network 10.2.105, a number of errors cause DNSControl to fail to apply changes.

## Metadata in payload

```
FAILURE! failed to create record: [UNIFI] POST /integration/v1/sites/88f7af54-98f8-306a-a1c7-c9349722b1f6/dns/policies -> 400: {"statusCode":400,"statusName":"BAD_REQUEST","code":"api.request.unknown-property","message":"Unknown request body property '$.metadata'","timestamp":"2026-04-18T20:41:19.600263489Z","requestPath":"/integration/v1/sites/88f7af54-98f8-306a-a1c7-c9349722b1f6/dns/policies","requestId":"f9cceb4c-4e6d-4119-a6a6-e29fa2211b40"}
```

Looking over the documentation at https://developer.ui.com/network/v10.1.84/creatednspolicy, it seems the `metadata` field this provider was attempting to write to is documented as read-only.

This PR updates the provider to no longer set the `metadata` field when making requests to the API:
```
#3: + CREATE auth.domain.uk A 10.1.1.2 ttl=1
[UNIFI] [DEBUG] POST https://10.1.1.1/proxy/network/integration/v1/sites/88f7af54-98f8-306a-a1c7-c9349722b1f6/dns/policies
Payload: {"type":"A_RECORD","enabled":true,"domain":"auth.domain.uk","ttlSeconds":1,"ipv4Address":"10.1.1.2"}
[UNIFI] [DEBUG] Response (201): {"type":"A_RECORD","id":"a9238946-8cbe-4be5-b65e-1b5106e049c9","enabled":true,"metadata":{"origin":"USER_DEFINED"},"domain":"auth.domain.uk","ipv4Address":"10.1.1.2","ttlSeconds":1}
SUCCESS!
```

## ID in payload
The ID was provided in the path (as expected), but also the request payload, which Unifi's validation did not like.
```
Payload: {"type":"A_RECORD","id":"e90619e0-3bce-46b3-a79e-27440ca3bb58","enabled":true,"domain":"auth.domain.uk","ipv4Address":"10.1.1.2"}
[UNIFI] [DEBUG] Response (400): {"statusCode":400,"statusName":"BAD_REQUEST","code":"api.request.unknown-property","message":"Unknown request body property '$.id'","timestamp":"2026-04-22T18:13:30.314225148Z","requestPath":"/integration/v1/sites/88f7af54-98f8-306a-a1c7-c9349722b1f6/dns/policies/e90619e0-3bce-46b3-a79e-27440ca3bb58","requestId":"003508a3-1da7-47a8-9b16-7faba232fa66"}
```

## Omitted TTL
The documentation on the Unifi site doesn't list this field as required so I'm somewhat confused by this, however, the provider omitted this field for a value of 300s, and this resulted in the following error:

```
[UNIFI] [DEBUG] POST https://10.1.1.1/proxy/network/integration/v1/sites/88f7af54-98f8-306a-a1c7-c9349722b1f6/dns/policies
Payload: {"type":"A_RECORD","enabled":true,"domain":"auth.domain.uk","ipv4Address":"10.1.1.2"}
[UNIFI] [DEBUG] Response (400): {"statusCode":400,"statusName":"BAD_REQUEST","code":"api.request.error","message":"ttlSeconds must not be null","timestamp":"2026-04-22T18:13:30.393200035Z","requestPath":"/integration/v1/sites/88f7af54-98f8-306a-a1c7-c9349722b1f6/dns/policies","requestId":"327b03ae-7793-476b-bedf-353c6d30bd64"}
```

I don't see any harm including it even if it matches the default (if anything, I think it's a marginal improvement - in the event unifi changed defaults, the config from DNSControl should be the source of truth).

## Record pagination
When checking existing DNS record state, the existing implementation made a single call to  `GET `/v1/sites/{siteId}/dns/policies`. This had a default limit of 25 records, so could cause errors when re-creating existing records:
```
[UNIFI] [DEBUG] POST https://10.1.1.1/proxy/network/integration/v1/sites/88f7af54-98f8-306a-a1c7-c9349722b1f6/dns/policies
Payload: {"type":"A_RECORD","enabled":true,"domain":"auth.domain.uk","ttlSeconds":300,"ipv4Address":"10.1.1.2"}
[UNIFI] [DEBUG] Response (400): {"statusCode":400,"statusName":"BAD_REQUEST","code":"api.dns.policy.validation.record-already-exists","message":"DNS policy with the same type and properties already exists","timestamp":"2026-04-22T18:36:29.445574077Z","requestPath":"/integration/v1/sites/88f7af54-98f8-306a-a1c7-c9349722b1f6/dns/policies","requestId":"f45e7ecf-ae97-468b-9be2-1fee036c380b"}
FAILURE! failed to create record: [UNIFI] POST /integration/v1/sites/88f7af54-98f8-306a-a1c7-c9349722b1f6/dns/policies -> 400: {"statusCode":400,"statusName":"BAD_REQUEST","code":"api.dns.policy.validation.record-already-exists","message":"DNS policy with the same type and properties already exists","timestamp":"2026-04-22T18:36:29.445574077Z","requestPath":"/integration/v1/sites/88f7af54-98f8-306a-a1c7-c9349722b1f6/dns/policies","requestId":"f45e7ecf-ae97-468b-9be2-1fee036c380b"}
```
I've updated this to paginate results to ensure all records are fetched.
<!--
## Before submiting a pull request

Please make sure you've run the following commands from the root directory.

    bin/generate-all.sh

(this runs commands like "go generate", fixes formatting, and so on)

## Release changelog section

Help keep the release changelog clear by pre-naming the proper section in the GitHub pull request title.

Some examples:
* CICD: Add required GHA permissions for goreleaser
* DOCS: Fixed providers with "contributor support" table
* ROUTE53: Allow R53_ALIAS records to enable target health evaluation

More examples/context can be found in the file .goreleaser.yml under the 'build' > 'changelog' key.
!-->
