### PR TITLE
cicd(golangci): Exclude govet false positive

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,3 +12,9 @@ linters:
     - durationcheck
     - godot
     - predeclared
+# 2026-05-02: Temporary exclusions
+  exclusions:
+    rules:
+      - linters:
+          - govet
+        text: "inline: cannot inline: type parameter inference is not yet supported"


### PR DESCRIPTION
This is a false positive.

```
$ golangci-lint run ./...
providers/bunnydns/api.go:225:21: inline: cannot inline: type parameter inference is not yet supported (govet)
	if !slices.Contains(validStatus, resp.StatusCode) {
	                   ^
providers/bunnydns/convert.go:55:33: inline: cannot inline: type parameter inference is not yet supported (govet)
	isNullRecord := slices.Contains(nullTypes, r.Type) && r.Value == "."
	                               ^
providers/bunnydns/convert.go:56:20: inline: cannot inline: type parameter inference is not yet supported (govet)
	if slices.Contains(fqdnTypes, r.Type) && strings.HasSuffix(r.Value, ".") && !isNullRecord {
```