### PR TITLE
BUILD: Fix typo in GoReleaser GHCR image path

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -96,7 +96,7 @@ nfpms:
 dockers_v2:
   - images:
       - "dnscontrol/{{.ProjectName}}"
-      - "ghcr.io/dnscontrodnscontrol/{{.ProjectName}}"
+      - "ghcr.io/dnscontrol/{{.ProjectName}}"
     tags:
       - "{{ .Version }}"
       - "{{ if not .IsSnapshot }}latest{{ end }}"
@@ -183,7 +183,7 @@ release:
     You can use the Docker image from [Docker hub](https://hub.docker.com/r/dnscontrol/dnscontrol/) or [GitHub Container Registry](https://github.com/dnscontrol/dnscontrol/pkgs/container/dnscontrol).
 
     ```shell
-    docker run --rm -it -v "$(pwd):/dns" ghcr.io/dnscontrodnscontrol/dnscontrol preview
+    docker run --rm -it -v "$(pwd):/dns" ghcr.io/dnscontrol/dnscontrol preview
     ```
 
     #### Anywhere else

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Running `dnscontrol push` will make those changes with the provider and my dns r
 
 The easiest way to run DNSControl is to use the Docker container:
 
-```
+```shell
 docker run --rm -it -v "$(pwd):/dns"  ghcr.io/dnscontrol/dnscontrol preview
 ```
 


### PR DESCRIPTION
The GHCR image path contained 'dnscontrodnscontrol' instead of 'dnscontrol', causing pushes to be written under the wrong namespace. The same typo also appeared in the release notes Docker example.