### PR TITLE
DOCS: Homebrew-tap GitHub fine-grained PAT

### DIFF
--- a/documentation/developer-info/goreleaser.md
+++ b/documentation/developer-info/goreleaser.md
@@ -6,23 +6,35 @@ GoReleaser automatically publishes a Homebrew Cask to [DNSControl/homebrew-tap](
 
 ### Homebrew TAP GitHub PAT
 
-GoReleaser needs a GitHub Personal Access Token to push the Homebrew Cask formula to the `DNSControl/homebrew-tap` repository.
+GoReleaser needs a GitHub Personal Access Token to push the Homebrew Cask formula to the `DNSControl/homebrew-tap` repository. This is a fine-grained PAT scoped to the `DNSControl` organization with minimal permissions.
 
 | Item | Value |
 |------|-------|
-| **Secret name** | `HOMEBREW_TAP_GITHUB_TOKEN` (repository secret) |
-| **Scope** | `repo` access on `DNSControl` org |
+| **Secret name** | `HOMEBREW_TAP_TOKEN` (repository secret) |
+| **Token type** | Fine-grained PAT |
+| **Resource owner** | `DNSControl` (organization) |
+| **Repository access** | `DNSControl/homebrew-tap` only |
+| **Permissions** | Contents: Read and write |
 | **Expires** | February 6, 2027 |
 | **Action needed before** | ~January 18, 2027 |
 
 **Links:**
 - [GitHub Issue (tracking): Rotate Homebrew TAP GitHub PAT before Feb 6, 2027](https://github.com/DNSControl/dnscontrol/issues/4071)
-- [Secret setting](https://github.com/DNSControl/dnscontrol/settings/secrets/actions/HOMEBREW_TAP_GITHUB_TOKEN)
+- [Secret setting](https://github.com/DNSControl/dnscontrol/settings/secrets/actions/HOMEBREW_TAP_TOKEN)
 
 #### Rotation procedure
 
-1. Generate a new PAT with the same scopes (`repo` on `DNSControl` org)
-2. Update the repository secret [`HOMEBREW_TAP_GITHUB_TOKEN`](https://github.com/DNSControl/dnscontrol/settings/secrets/actions/HOMEBREW_TAP_GITHUB_TOKEN)
+1. Generate a new fine-grained PAT at [github.com/settings/personal-access-tokens/new](https://github.com/settings/personal-access-tokens/new):
+   - **Resource owner**: `DNSControl`
+   - **Repository access**: Only select repositories > `DNSControl/homebrew-tap`
+   - **Permissions**: Contents > Read and write
+   - **Expiration**: 1 year
+2. Update the repository secret:
+   ```bash
+   gh secret set HOMEBREW_TAP_TOKEN \
+     --repo DNSControl/dnscontrol \
+     --body "<the-new-token>"
+   ```
 3. Verify that the next GoReleaser release successfully updates the Homebrew tap
 4. Create a new tracking issue for the next rotation cycle
 


### PR DESCRIPTION
The v4.36.5 release failed at the Homebrew cask step with a 404 when pushing to `DNSControl/homebrew-tap` (https://github.com/DNSControl/dnscontrol/actions/runs/25402728783/job/74506128761). The `HOMEBREW_TAP_TOKEN` secret contained a classic PAT that was scoped to the old `StackExchange` organization and no longer had access after the migration to `DNSControl`. It has been rotated to a fine-grained PAT scoped to `DNSControl/homebrew-tap` only, with Contents read/write permission. The release has been re-run successfully: https://github.com/DNSControl/dnscontrol/actions/runs/25402728783/job/74759829144

This PR updates the rotation procedure in the docs to reflect the new token type, corrects the secret name from `HOMEBREW_TAP_GITHUB_TOKEN` to `HOMEBREW_TAP_TOKEN`, and adds the `gh secret set` command to the rotation steps.