### PR TITLE
CICD: Integration test output not visible

### DIFF
--- a/.github/workflows/pr_integration_tests.yml
+++ b/.github/workflows/pr_integration_tests.yml
@@ -271,6 +271,7 @@ jobs:
           echo "END: Using: END=$END"
           go install gotest.tools/gotestsum@latest
           if [ -n "$${{ matrix.provider }}_DOMAIN" ] ; then
+            echo "DEBUG: matrix.provider=$${{ matrix.provider }}_DOMAIN"
             gotestsum --junitfile ${TEST_RESULTS}/gotestsum-report.xml -- \
                 -timeout 30m -v \
                 -verbose \
@@ -279,7 +280,9 @@ jobs:
                 -cfredirect=false \
                 -cfflatten=false \
                 -cftags=false \
-                -end $END ./... > ${TEST_RESULTS}/gotestsum-output.txt
+                -end $END \
+                ./... \
+                > ${TEST_RESULTS}/gotestsum-output.txt
           else
             echo "Skip test for ${{ matrix.provider }} provider"
           fi

--- a/.github/workflows/pr_integration_tests.yml
+++ b/.github/workflows/pr_integration_tests.yml
@@ -246,10 +246,8 @@ jobs:
           DO_WORKERS=false
 
           # Only for PRs
-          echo "DEBUG: ONLY FOR PRs: ${{ github.event_name }} == pull_request"
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
             # Check for 'longtest' label
-            echo "DEBUG: check label: ${{ github.event.pull_request.labels.*.name }}"
             #if [[ "${{ github.event.pull_request.labels.*.name }}" =~ "longtest" ]]; then
             if [[ " $LABELS " =~ " longtest " ]]; then
               END=999

--- a/.github/workflows/pr_integration_tests.yml
+++ b/.github/workflows/pr_integration_tests.yml
@@ -241,6 +241,7 @@ jobs:
           END=3
           echo "END: Default set to $END"
           DO_WORKERS=false
+
           # Only for PRs
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
             # Check for 'longtest' label
@@ -248,12 +249,17 @@ jobs:
               END=999
               echo "END: Pull request + longtest label. END=$END"
               DO_WORKERS=true
+            else
+              echo "END: longtest not set. No change."
             fi
+          else
+              echo "END: Not a pull request. No change."
           fi
           # Check if branch is main
           if [[ "${{ github.base_ref }}" == "main" ]]; then
             END=999
-            echo "END: Branch is main.  END=$END"
+            echo "END: DEBUG: base_ref=${{ github.base_ref }}" 
+            echo "END: github.base_ref is main.  END=$END"
             DO_WORKERS=true
           fi
           echo "END: Final value: END=$END"

--- a/.github/workflows/pr_integration_tests.yml
+++ b/.github/workflows/pr_integration_tests.yml
@@ -281,7 +281,7 @@ jobs:
             # NB(tlim): THe output of gotestsum needs to go to stdout AND the
             # gotestsum-output.txt file. That's why "tee" is used.
             gotestsum --junitfile ${TEST_RESULTS}/gotestsum-report.xml -- \
-                -timeout 30m -v \
+                -timeout 40m -v \
                 -verbose \
                 -profile ${{ matrix.provider }} \
                 -cfworkers=$DO_WORKERS \

--- a/.github/workflows/pr_integration_tests.yml
+++ b/.github/workflows/pr_integration_tests.yml
@@ -270,8 +270,9 @@ jobs:
         run: |-
           echo "END: Using: END=$END"
           go install gotest.tools/gotestsum@latest
+          echo "DEBUG: matrix.provider=$${{ matrix.provider }}_DOMAIN"
           if [ -n "$${{ matrix.provider }}_DOMAIN" ] ; then
-            echo "DEBUG: matrix.provider=$${{ matrix.provider }}_DOMAIN"
+            echo "DEBUG: running gotestsum"
             gotestsum --junitfile ${TEST_RESULTS}/gotestsum-report.xml -- \
                 -timeout 30m -v \
                 -verbose \
@@ -283,6 +284,7 @@ jobs:
                 -end $END \
                 ./... \
                 > ${TEST_RESULTS}/gotestsum-output.txt
+                ls -lad ${TEST_RESULTS}/gotestsum-output.txt
           else
             echo "Skip test for ${{ matrix.provider }} provider"
           fi

--- a/.github/workflows/pr_integration_tests.yml
+++ b/.github/workflows/pr_integration_tests.yml
@@ -243,8 +243,10 @@ jobs:
           DO_WORKERS=false
 
           # Only for PRs
+          echo "DEBUG: ONLY FOR PRs: ${{ github.event_name }} == pull_request"
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
             # Check for 'longtest' label
+            echo "DEBUG: check label: ${{ github.event.pull_request.labels.*.name }}"
             if [[ "${{ github.event.pull_request.labels.*.name }}" =~ "longtest" ]]; then
               END=999
               echo "END: Pull request + longtest label. END=$END"

--- a/.github/workflows/pr_integration_tests.yml
+++ b/.github/workflows/pr_integration_tests.yml
@@ -256,9 +256,13 @@ jobs:
               echo "END: Not a pull request. No change."
           fi
           # Check if branch is main
+          # NB(tlim): This used to be github.base_ref but it was changed to
+          #           github.ref_name in 2026-05-07 because that seemed more correct.
+          #           The original statement was created by an LLM and might have been
+          #           wrong.
           if [[ "${{ github.ref_name }}" == "main" ]]; then
             END=999
-            echo "END: github.ref_name is main.  END=$END"
+            echo "END: github.ref_name is main. END=$END"
             DO_WORKERS=true
           fi
           echo "END: Final value: END=$END"
@@ -267,7 +271,7 @@ jobs:
 
       - name: Run integration tests for ${{ matrix.provider }} provider
         run: |-
-          echo "END: Using: END=$END"
+          echo "END: Running tests 0 to $END"
           go install gotest.tools/gotestsum@latest
           if [ -n "$${{ matrix.provider }}_DOMAIN" ] ; then
             # NB(tlim): THe output of gotestsum needs to go to stdout AND the

--- a/.github/workflows/pr_integration_tests.yml
+++ b/.github/workflows/pr_integration_tests.yml
@@ -239,29 +239,41 @@ jobs:
         shell: bash
         run: |
           END=3
+          echo "END: Default set to $END"
           DO_WORKERS=false
           # Only for PRs
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
             # Check for 'longtest' label
             if [[ "${{ github.event.pull_request.labels.*.name }}" =~ "longtest" ]]; then
               END=999
+              echo "END: Pull request + longtest label. END=$END"
               DO_WORKERS=true
             fi
           fi
           # Check if branch is main
           if [[ "${{ github.base_ref }}" == "main" ]]; then
             END=999
+            echo "END: Branch is main.  END=$END"
             DO_WORKERS=true
           fi
+          echo "END: Final value: END=$END"
           echo "END=$END" >> $GITHUB_ENV
           echo "DO_WORKERS=$DO_WORKERS" >> $GITHUB_ENV
 
       - name: Run integration tests for ${{ matrix.provider }} provider
         run: |-
-          echo END=$END
+          echo "END: Using: END=$END"
           go install gotest.tools/gotestsum@latest
           if [ -n "$${{ matrix.provider }}_DOMAIN" ] ; then
-            gotestsum --junitfile ${TEST_RESULTS}/gotestsum-report.xml -- -timeout 30m -v -verbose -profile ${{ matrix.provider }} -cfworkers=$DO_WORKERS -cfredirect=false -cfflatten=false -cftags=false -end $END ./... > ${TEST_RESULTS}/gotestsum-output.txt
+            gotestsum --junitfile ${TEST_RESULTS}/gotestsum-report.xml -- \
+                -timeout 30m -v \
+                -verbose \
+                -profile ${{ matrix.provider }} \
+                -cfworkers=$DO_WORKERS \
+                -cfredirect=false \
+                -cfflatten=false \
+                -cftags=false \
+                -end $END ./... > ${TEST_RESULTS}/gotestsum-output.txt
           else
             echo "Skip test for ${{ matrix.provider }} provider"
           fi

--- a/.github/workflows/pr_integration_tests.yml
+++ b/.github/workflows/pr_integration_tests.yml
@@ -237,6 +237,9 @@ jobs:
         # For pushes to main or if the PR has the 'longtest' label, we run all tests.
         id: set_end
         shell: bash
+        env:
+          # Converts label names into a single string for easier grep/matching
+          LABELS: ${{ join(github.event.pull_request.labels.*.name, ' ') }}
         run: |
           END=3
           echo "END: Default set to $END"
@@ -247,7 +250,8 @@ jobs:
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
             # Check for 'longtest' label
             echo "DEBUG: check label: ${{ github.event.pull_request.labels.*.name }}"
-            if [[ "${{ github.event.pull_request.labels.*.name }}" =~ "longtest" ]]; then
+            #if [[ "${{ github.event.pull_request.labels.*.name }}" =~ "longtest" ]]; then
+            if [[ " $LABELS " =~ " longtest " ]]; then
               END=999
               echo "END: Pull request + longtest label. END=$END"
               DO_WORKERS=true

--- a/.github/workflows/pr_integration_tests.yml
+++ b/.github/workflows/pr_integration_tests.yml
@@ -258,7 +258,6 @@ jobs:
           # Check if branch is main
           if [[ "${{ github.ref_name }}" == "main" ]]; then
             END=999
-            echo "END: DEBUG: ref_name=${{ github.ref_name }}" 
             echo "END: github.ref_name is main.  END=$END"
             DO_WORKERS=true
           fi
@@ -270,9 +269,9 @@ jobs:
         run: |-
           echo "END: Using: END=$END"
           go install gotest.tools/gotestsum@latest
-          echo "DEBUG: matrix.provider=$${{ matrix.provider }}_DOMAIN"
           if [ -n "$${{ matrix.provider }}_DOMAIN" ] ; then
-            echo "DEBUG: running gotestsum"
+            # NB(tlim): THe output of gotestsum needs to go to stdout AND the
+            # gotestsum-output.txt file. That's why "tee" is used.
             gotestsum --junitfile ${TEST_RESULTS}/gotestsum-report.xml -- \
                 -timeout 30m -v \
                 -verbose \
@@ -282,9 +281,8 @@ jobs:
                 -cfflatten=false \
                 -cftags=false \
                 -end $END \
-                ./... \
-                > ${TEST_RESULTS}/gotestsum-output.txt
-                ls -lad ${TEST_RESULTS}/gotestsum-output.txt
+                ./... >&1 | \
+                tee ${TEST_RESULTS}/gotestsum-output.txt
           else
             echo "Skip test for ${{ matrix.provider }} provider"
           fi

--- a/.github/workflows/pr_integration_tests.yml
+++ b/.github/workflows/pr_integration_tests.yml
@@ -256,10 +256,10 @@ jobs:
               echo "END: Not a pull request. No change."
           fi
           # Check if branch is main
-          if [[ "${{ github.base_ref }}" == "main" ]]; then
+          if [[ "${{ github.ref_name }}" == "main" ]]; then
             END=999
-            echo "END: DEBUG: base_ref=${{ github.base_ref }}" 
-            echo "END: github.base_ref is main.  END=$END"
+            echo "END: DEBUG: ref_name=${{ github.ref_name }}" 
+            echo "END: github.ref_name is main.  END=$END"
             DO_WORKERS=true
           fi
           echo "END: Final value: END=$END"

--- a/.github/workflows/pr_integration_tests.yml
+++ b/.github/workflows/pr_integration_tests.yml
@@ -236,6 +236,7 @@ jobs:
         # For PRs we only run a smoke test (the first 3 tests) to save time.
         # For pushes to main or if the PR has the 'longtest' label, we run all tests.
         id: set_end
+        shell: bash
         run: |
           END=3
           DO_WORKERS=false
@@ -257,6 +258,7 @@ jobs:
 
       - name: Run integration tests for ${{ matrix.provider }} provider
         run: |-
+          echo END=$END
           go install gotest.tools/gotestsum@latest
           if [ -n "$${{ matrix.provider }}_DOMAIN" ] ; then
             gotestsum --junitfile ${TEST_RESULTS}/gotestsum-report.xml -- -timeout 30m -v -verbose -profile ${{ matrix.provider }} -cfworkers=$DO_WORKERS -cfredirect=false -cfflatten=false -cftags=false -end $END ./... > ${TEST_RESULTS}/gotestsum-output.txt


### PR DESCRIPTION
Fixes https://github.com/DNSControl/dnscontrol/issues/4233
Fixes https://github.com/DNSControl/dnscontrol/issues/4227
Fixes https://github.com/DNSControl/dnscontrol/issues/4220

# Issue

Issue 1: The output of the integration tests isn't displayed anywhere. It seems that the output is generated (provider tests take the right amount of time) but I don't see anyplace in the UI that I can view the results.
- Example: 
https://github.com/DNSControl/dnscontrol/actions/runs/25500999681/job/74833580403

Issue 2: The code that sets "END" is failing with a `if [[ not found` error.

# Resolution

- Issue 2:  It turns out the code to generate `$END` is using `if [[` which is a bash-ism, and this GHA defaults to `sh`.  Change to the `bash` shell for that step.


