### PR TITLE
CICD: only release in DNSControl/dnscontrol repo, fixes #4238

### DIFF
--- a/.github/workflows/release_draft.yml
+++ b/.github/workflows/release_draft.yml
@@ -10,6 +10,7 @@ jobs:
   draft_release:
     name: draft release
     runs-on: ubuntu-latest
+    if: github.repository == 'DNSControl/dnscontrol'
     permissions:
       packages: write
       contents: write


### PR DESCRIPTION
<!-- PR_BODY_DONE_START -->
## Done

- CICD: only release in DNSControl/dnscontrol repo, fixes #4238

<!-- PR_BODY_DONE_END -->

## Meta

(Automated in `.just/gh-process.just`.)
