### PR TITLE
POWERDNS: Fix DNSSEC corrections handling for unset AutoDNSSEC

### DIFF
--- a/providers/powerdns/dnssec.go
+++ b/providers/powerdns/dnssec.go
@@ -10,10 +10,15 @@ import (
 
 // getDNSSECCorrections returns corrections that update a domain's DNSSEC state.
 func (dsp *powerdnsProvider) getDNSSECCorrections(dc *models.DomainConfig) ([]*models.Correction, error) {
+	// Ignore if AutoDNSSEC is not set
+	if dc.AutoDNSSEC == "" {
+		return nil, nil
+	}
+
 	domainVariant := dsp.zoneName(dc.Name, dc.Tag)
 	zoneCryptokeys, getErr := dsp.client.Cryptokeys().ListCryptokeys(context.Background(), dsp.ServerName, domainVariant)
 	if getErr != nil {
-		if _, ok := getErr.(pdnshttp.ErrNotFound); ok {
+		if pdnshttp.IsNotFound(getErr) {
 			// Zone doesn't exist, this is okay as no corrections are needed
 			return nil, nil
 		}

--- a/providers/powerdns/dnssec_test.go
+++ b/providers/powerdns/dnssec_test.go
@@ -1,0 +1,47 @@
+package powerdns
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/DNSControl/dnscontrol/v4/models"
+	pdns "github.com/mittwald/go-powerdns"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetDNSSECCorrectionsSkipsCryptokeysWhenAutoDNSSECUnset(t *testing.T) {
+	dsp := &powerdnsProvider{}
+
+	corrections, err := dsp.getDNSSECCorrections(&models.DomainConfig{
+		Name: "example.com",
+	})
+
+	require.NoError(t, err)
+	assert.Empty(t, corrections)
+}
+
+func TestGetDNSSECCorrectionsIgnoresMissingCryptokeysEndpoint(t *testing.T) {
+	server := httptest.NewServer(http.NotFoundHandler())
+	t.Cleanup(server.Close)
+
+	client, err := pdns.New(
+		pdns.WithBaseURL(server.URL),
+		pdns.WithAPIKeyAuthentication("secret"),
+	)
+	require.NoError(t, err)
+
+	dsp := &powerdnsProvider{
+		client:     client,
+		ServerName: "localhost",
+	}
+
+	corrections, err := dsp.getDNSSECCorrections(&models.DomainConfig{
+		Name:       "example.com",
+		AutoDNSSEC: "on",
+	})
+
+	require.NoError(t, err)
+	assert.Empty(t, corrections)
+}


### PR DESCRIPTION
Fix DNSSEC corrections handling for unset AutoDNSSEC, this way the cryptokeys endpoint from PowerDNS wont be called.
This also adds tests for it.

Fixes issue #3773 
