### PR TITLE
CHORE: Add CODEOWNERS for documentation and GoReleaser config

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -62,3 +62,5 @@ providers/vercel @SukkaW
 providers/vultr @pgaskin
 
 * @TomOnTime
+.goreleaser.yml @cafferata @TomOnTime
+documentation/ @cafferata @TomOnTime

--- a/build/generate/ownersFile.go
+++ b/build/generate/ownersFile.go
@@ -28,6 +28,8 @@ func generateOwnersFile() error {
 	// Overall maintainer
 	ownersData.WriteString("\n")
 	ownersData.WriteString("* @TomOnTime\n")
+	ownersData.WriteString(".goreleaser.yml @cafferata @TomOnTime\n")
+	ownersData.WriteString("documentation/ @cafferata @TomOnTime\n")
 
 	file, err := os.Create(".github/CODEOWNERS")
 	if err != nil {


### PR DESCRIPTION
Reviews for documentation and `.goreleaser.yml` changes are regularly requested manually. This adds me as a code owner alongside @TomOnTime for these paths, so GitHub automatically assigns reviewers when a pull request touches them.