### PR TITLE
CICD: Do not run all tests on VERCEL in GHA

### DIFF
--- a/.github/workflows/pr_integration_tests.yml
+++ b/.github/workflows/pr_integration_tests.yml
@@ -281,7 +281,7 @@ jobs:
             DO_WORKERS=true
           fi
           # VERCEL it limited to 100 updates per hour. Therefore we never run more than the first few tests.
-          if "${{ matrix.provider }}" == "VERCEL" ; then
+          if [[ "${{ matrix.provider }}" == "VERCEL" ]]; then
             END=3
             echo "END: Exception for VERCEL: Run fewer tests. END=$END"
           fi

--- a/.github/workflows/pr_integration_tests.yml
+++ b/.github/workflows/pr_integration_tests.yml
@@ -282,8 +282,8 @@ jobs:
           fi
           # VERCEL it limited to 100 updates per hour. Therefore we never run more than the first few tests.
           if "${{ matrix.provider }}" == "VERCEL" ; then
-            echo "END: Exception for VERCEL: Never run more than the first few tests. END=$END"
             END=3
+            echo "END: Exception for VERCEL: Run fewer tests. END=$END"
           fi
           echo "END: Final value: END=$END"
           echo "END=$END" >> $GITHUB_ENV

--- a/.github/workflows/pr_integration_tests.yml
+++ b/.github/workflows/pr_integration_tests.yml
@@ -8,7 +8,7 @@ permissions:
 # 2. On a schedule (currently set to run every day at 4am UTC).
 
 # When are "smoke tests" vs "full tests" run?
-# 1. Is this a PR?  If the label "longtest" exists, run full tests.  Otherwise, run smoke tests.
+# 1. Is this a PR?  If the label "longtest" exists, run full tests. Otherwise, run smoke tests.
 # 1. Is this a scheduled run? Run all the tests.
 # 2. Manually triggered? Run all the tests.
 
@@ -40,7 +40,7 @@ env:
 
 jobs:
   # integration-test-providers: Determine which providers have a _DOMAIN variable set.
-  # That variable enables testing for the provider.  The results are
+  # That variable enables testing for the provider. The results are
   # stored in a JSON blob stashed in # needs.integration-test-providers.outputs.integration_test_providers
   # where integration-tests can pick it up.
   integration-test-providers:
@@ -262,6 +262,8 @@ jobs:
             #if [[ "${{ github.event.pull_request.labels.*.name }}" =~ "longtest" ]]; then
             if [[ " $LABELS " =~ " longtest " ]]; then
               END=999
+              # VERCEL it limited to 100 updates per hour. Therefore we don't run it for the long tests. Sigh.
+              unset VERCEL_DOMAIN
               echo "END: Pull request + longtest label. END=$END"
               DO_WORKERS=true
             else
@@ -277,6 +279,8 @@ jobs:
           #           wrong.
           if [[ "${{ github.ref_name }}" == "main" ]]; then
             END=999
+            # VERCEL it limited to 100 updates per hour. Therefore we don't run it for the long tests. Sigh.
+            unset VERCEL_DOMAIN
             echo "END: github.ref_name is main. END=$END"
             DO_WORKERS=true
           fi

--- a/.github/workflows/pr_integration_tests.yml
+++ b/.github/workflows/pr_integration_tests.yml
@@ -262,8 +262,6 @@ jobs:
             #if [[ "${{ github.event.pull_request.labels.*.name }}" =~ "longtest" ]]; then
             if [[ " $LABELS " =~ " longtest " ]]; then
               END=999
-              # VERCEL it limited to 100 updates per hour. Therefore we don't run it for the long tests. Sigh.
-              VERCEL_DOMAIN=""
               echo "END: Pull request + longtest label. END=$END"
               DO_WORKERS=true
             else
@@ -279,10 +277,13 @@ jobs:
           #           wrong.
           if [[ "${{ github.ref_name }}" == "main" ]]; then
             END=999
-            # VERCEL it limited to 100 updates per hour. Therefore we don't run it for the long tests. Sigh.
-            VERCEL_DOMAIN=""
             echo "END: github.ref_name is main. END=$END"
             DO_WORKERS=true
+          fi
+          # VERCEL it limited to 100 updates per hour. Therefore we never run more than the first few tests.
+          if "${{ matrix.provider }}" == "VERCEL" ; then
+            echo "END: Exception for VERCEL: Never run more than the first few tests. END=$END"
+            END=3
           fi
           echo "END: Final value: END=$END"
           echo "END=$END" >> $GITHUB_ENV
@@ -290,6 +291,7 @@ jobs:
 
       - name: Run integration tests for ${{ matrix.provider }} provider
         run: |-
+          #
           echo "END: Running tests 0 to $END"
           go install gotest.tools/gotestsum@latest
           if [ -n "$${{ matrix.provider }}_DOMAIN" ] ; then

--- a/.github/workflows/pr_integration_tests.yml
+++ b/.github/workflows/pr_integration_tests.yml
@@ -263,7 +263,7 @@ jobs:
             if [[ " $LABELS " =~ " longtest " ]]; then
               END=999
               # VERCEL it limited to 100 updates per hour. Therefore we don't run it for the long tests. Sigh.
-              unset VERCEL_DOMAIN
+              VERCEL_DOMAIN=""
               echo "END: Pull request + longtest label. END=$END"
               DO_WORKERS=true
             else
@@ -280,7 +280,7 @@ jobs:
           if [[ "${{ github.ref_name }}" == "main" ]]; then
             END=999
             # VERCEL it limited to 100 updates per hour. Therefore we don't run it for the long tests. Sigh.
-            unset VERCEL_DOMAIN
+            VERCEL_DOMAIN=""
             echo "END: github.ref_name is main. END=$END"
             DO_WORKERS=true
           fi


### PR DESCRIPTION
# Issue

The VERCEL free account used for testing is limited to 100 create/update calls per hour. Therefore, the tests would take literally hours (days?) to complete if all tests were run.

# Resolution

Hard-code that VERCEL tests are disabled when running in "longtest" mode.