### PR TITLE
DOCS: Add CONTRIBUTING.md with developer onboarding guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,82 @@
+# Contributing to DNSControl
+
+Thank you for your interest in contributing to DNSControl! This guide will help you get started.
+
+## Prerequisites
+
+- **Go 1.26+** (see `go.mod` for the exact version)
+- **golangci-lint** (optional, used by CI and `bin/generate-all.sh`)
+- **staticcheck** (optional, used by `bin/generate-all.sh`)
+
+## Building and testing
+
+Build the binary:
+
+```shell
+go build .
+```
+
+Run all unit tests:
+
+```shell
+go test ./...
+```
+
+Run tests for a specific package:
+
+```shell
+go test ./pkg/spflib/
+```
+
+Run a single test:
+
+```shell
+go test ./pkg/spflib/ -run TestParseQualifiedMechanisms
+```
+
+Run the linter:
+
+```shell
+golangci-lint run
+```
+
+## Before committing
+
+Run `bin/generate-all.sh` from the repository root. This script handles formatting, code generation, linting, and keeping generated files in sync:
+
+```shell
+bin/generate-all.sh
+```
+
+It runs `go fmt`, `go generate`, `go mod tidy`, JSON formatting, and optionally `golangci-lint` and `staticcheck` if they are installed.
+
+## Commit message conventions
+
+Prefix your commit message title with one of the following categories:
+
+| Prefix | Use for |
+| --- | --- |
+| `FEATURE:` | New functionality |
+| `BUG:` | Bug fixes |
+| `DOCS:` | Documentation changes |
+| `CHORE:` or `MAINT:` | Maintenance, dependency updates |
+| `BUILD:` or `CICD:` | CI/CD and build changes |
+| `REFACTOR:` | Code refactoring |
+| `TEST:` | Test additions or changes |
+| `PROVIDERNAME:` | Provider-specific changes (e.g. `CLOUDFLAREAPI:`, `ROUTE53:`) |
+
+These prefixes are used by GoReleaser to categorize the release changelog. See `.goreleaser.yml` for the full list of recognized patterns.
+
+## Integration tests
+
+Integration tests run real DNS operations against a provider's API. They require credentials and a dedicated test zone. See the [integration test documentation](https://docs.dnscontrol.org/developer-info/integration-tests) for setup instructions.
+
+```shell
+go test ./integrationTest/ -v -provider PROVIDERNAME
+```
+
+## Writing a new provider
+
+See [Writing new DNS providers](https://docs.dnscontrol.org/developer-info/writing-providers) for a step-by-step guide on implementing a new DNS provider.
+
+Additional developer resources are available in the [developer info](https://docs.dnscontrol.org/developer-info/styleguide-code) section of the documentation.

--- a/README.md
+++ b/README.md
@@ -179,6 +179,10 @@ See [dnscontrol-action](https://github.com/koenrh/dnscontrol-action) or [gacts/i
 - **REV() will switch from RFC2317 to RFC4183 in v5.0.**  This is a breaking change. Warnings are output if your configuration is affected. No date has been announced for v5.0. See https://docs.dnscontrol.org/language-reference/top-level-functions/revcompat
 - **NAMEDOTCOM, OPENSRS, and SOFTLAYER need maintainers!** These providers have no maintainer. Maintainers respond to PRs and fix bugs in a timely manner, and try to stay on top of protocol changes. Interested in being a hero and adopting them?  Contact tal at what exit dot org.
 
+## Contributing
+
+Want to contribute? Whether it's fixing a bug, adding a new DNS provider, or improving documentation, contributions are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for how to get started.
+
 ## More info at our website
 
 The website: [https://docs.dnscontrol.org/](https://docs.dnscontrol.org/)


### PR DESCRIPTION
DNSControl had no `CONTRIBUTING.md` in the repository root. This is typically the first file new contributors look for when they want to get involved.

This adds a `CONTRIBUTING.md` that brings the essentials together in one place: prerequisites (Go 1.26+, optional golangci-lint and staticcheck), common build and test commands, the `bin/generate-all.sh` pre-commit workflow, commit message prefix conventions as used by GoReleaser's changelog grouping, and links to the existing developer documentation on docs.dnscontrol.org. A "Contributing" section in `README.md` now points to this file.
