### PR TITLE
DOCS: Reorganize README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,105 +4,12 @@
 [![Google Group](https://img.shields.io/badge/google%20group-chat-green.svg)](https://groups.google.com/forum/#!forum/dnscontrol-discuss)
 [![PkgGoDev](https://pkg.go.dev/badge/github.com/DNSControl/dnscontrol)](https://pkg.go.dev/github.com/DNSControl/dnscontrol/v4)
 
-[DNSControl](https://docs.dnscontrol.org/) is a system
-for maintaining DNS zones.  It has two parts:
-a domain specific language (DSL) for describing DNS zones plus
-software that processes the DSL and pushes the resulting zones to
-DNS providers such as Route53, Cloudflare, and Gandi.  It can send
-the same DNS records to multiple providers.  It even generates
-the most beautiful BIND zone files ever.  It runs anywhere Go runs (Linux, macOS,
-Windows). The provider model is extensible, so more providers can be added.
-
-Currently supported DNS providers:
-
-- AdGuard Home
-- Akamai Edge DNS
-- Alibaba Cloud DNS (ALIDNS)
-- AutoDNS
-- AWS Route 53
-- AXFR+DDNS
-- Azure DNS
-- Azure Private DNS
-- BIND
-- Bunny DNS
-- CentralNic Reseller (CNR) - formerly RRPProxy
-- Cloudflare
-- ClouDNS
-- CSC Global (*Experimental*)
-- deSEC
-- DigitalOcean
-- DNS Made Easy
-- DNScale
-- DNSimple
-- Domainnameshop (Domeneshop)
-- Exoscale
-- Fortigate
-- Gandi
-- Gcore
-- Gidinet
-- Google DNS
-- Hetzner
-- hosting.de
-- Huawei Cloud DNS
-- Hurricane Electric DNS
-- Infomaniak
-- INWX
-- Joker
-- Linode
-- Loopia
-- LuaDNS
-- Microsoft Windows Server DNS Server
-- MikroTik RouterOS
-- Mythic Beasts
-- Name.com
-- Namecheap
-- Netcup
-- Netlify
-- NS1
-- Oracle Cloud
-- OVH
-- Packetframe
-- Porkbun
-- PowerDNS
-- Realtime Register
-- RWTH DNS-Admin
-- Sakura Cloud
-- SoftLayer
-- TransIP
-- UniFi Network
-- Vercel
-- Vultr
-
-Currently supported Domain Registrars:
-
-- AWS Route 53
-- CentralNic Reseller (CNR) - formerly RRPProxy
-- CSC Global
-- DNSimple
-- DNSOVERHTTPS
-- Dynadot
-- easyname
-- Gandi
-- Gidinet
-- hosting.de
-- Internet.bs
-- INWX
-- Loopia
-- Name.com
-- Namecheap
-- OpenSRS
-- OVH
-- Porkbun
-- Realtime Register
-
-Stack Overflow uses this system to manage hundreds of domains
-and subdomains across multiple registrars and DNS providers.
-
-You can think of it as a DNS compiler.  The configuration files are
-written in a DSL that looks a lot like JavaScript.  It is compiled
-to an intermediate representation (IR).  Compiler back-ends use the
-IR to update your DNS zones on services such as Route53, Cloudflare,
-and Gandi, or systems such as BIND.
+[DNSControl](https://docs.dnscontrol.org/) is Infrastructure as Code for DNS.
+It includes a full-featured configuration language (Javascript-compatible),
+plus "plug-ins" that speak to DNS provider APIs such as AWS Route 53,
+Cloudflare, and Gandi. It can send the same DNS records to multiple providers.
+It runs anywhere Go runs (Linux, macOS, Windows). The provider model is
+extensible, so more providers can be added.
 
 ## An Example
 
@@ -132,6 +39,38 @@ docker run --rm -it -v "$(pwd):/dns"  ghcr.io/dnscontrol/dnscontrol preview
 ```
 
 See [Getting Started](https://docs.dnscontrol.org/getting-started/getting-started) page on documentation site to get started!
+
+## Supported Providers
+
+DNSControl supports 62 DNS providers and registrars:
+
+| | | | | |
+| ----- | ----- | ----- | ----- | ----- |
+| [AdGuard Home](https://docs.dnscontrol.org/provider/adguardhome) | [Akamai Edge DNS](https://docs.dnscontrol.org/provider/akamaiedgedns) | [Alibaba Cloud DNS](https://docs.dnscontrol.org/provider/alidns) | [AutoDNS](https://docs.dnscontrol.org/provider/autodns) | [AWS Route 53](https://docs.dnscontrol.org/provider/route53)¹ |
+| [AXFR+DDNS](https://docs.dnscontrol.org/provider/axfrddns) | [Azure DNS](https://docs.dnscontrol.org/provider/azuredns) | [Azure Private DNS](https://docs.dnscontrol.org/provider/azureprivatedns) | [BIND](https://docs.dnscontrol.org/provider/bind) | [Bunny DNS](https://docs.dnscontrol.org/provider/bunnydns) |
+| [CentralNic Reseller](https://docs.dnscontrol.org/provider/cnr)¹ | [Cloudflare](https://docs.dnscontrol.org/provider/cloudflareapi) | [ClouDNS](https://docs.dnscontrol.org/provider/cloudns) | [CSC Global](https://docs.dnscontrol.org/provider/cscglobal)¹ | [deSEC](https://docs.dnscontrol.org/provider/desec) |
+| [DigitalOcean](https://docs.dnscontrol.org/provider/digitalocean) | [DNS Made Easy](https://docs.dnscontrol.org/provider/dnsmadeeasy) | [DNSOVERHTTPS](https://docs.dnscontrol.org/provider/dnsoverhttps)² | [DNScale](https://docs.dnscontrol.org/provider/dnscale) | [DNSimple](https://docs.dnscontrol.org/provider/dnsimple)¹ |
+| [Domainnameshop](https://docs.dnscontrol.org/provider/domainnameshop) | [Dynadot](https://docs.dnscontrol.org/provider/dynadot)² | [easyname](https://docs.dnscontrol.org/provider/easyname)² | [Exoscale](https://docs.dnscontrol.org/provider/exoscale) | [Fortigate](https://docs.dnscontrol.org/provider/fortigate) |
+| [Gandi](https://docs.dnscontrol.org/provider/gandiv5)¹ | [Gcore](https://docs.dnscontrol.org/provider/gcore) | [Gidinet](https://docs.dnscontrol.org/provider/gidinet)¹ | [Google DNS](https://docs.dnscontrol.org/provider/gcloud) | [Hetzner](https://docs.dnscontrol.org/provider/hetzner) |
+| [hosting.de](https://docs.dnscontrol.org/provider/hostingde)¹ | [Huawei Cloud DNS](https://docs.dnscontrol.org/provider/huaweicloud) | [Hurricane Electric DNS](https://docs.dnscontrol.org/provider/hedns) | [Infomaniak](https://docs.dnscontrol.org/provider/infomaniak) | [Internet.bs](https://docs.dnscontrol.org/provider/internetbs)² |
+| [INWX](https://docs.dnscontrol.org/provider/inwx)¹ | [Joker](https://docs.dnscontrol.org/provider/joker) | [Linode](https://docs.dnscontrol.org/provider/linode) | [Loopia](https://docs.dnscontrol.org/provider/loopia)¹ | [LuaDNS](https://docs.dnscontrol.org/provider/luadns) |
+| Windows Server DNS | [MikroTik RouterOS](https://docs.dnscontrol.org/provider/mikrotik) | [Mythic Beasts](https://docs.dnscontrol.org/provider/mythicbeasts) | [Name.com](https://docs.dnscontrol.org/provider/namedotcom)¹ | [Namecheap](https://docs.dnscontrol.org/provider/namecheap)¹ |
+| [Netcup](https://docs.dnscontrol.org/provider/netcup) | [Netlify](https://docs.dnscontrol.org/provider/netlify) | [NS1](https://docs.dnscontrol.org/provider/ns1) | [OpenSRS](https://docs.dnscontrol.org/provider/opensrs)² | [Oracle Cloud](https://docs.dnscontrol.org/provider/oracle) |
+| [OVH](https://docs.dnscontrol.org/provider/ovh)¹ | [Packetframe](https://docs.dnscontrol.org/provider/packetframe) | [Porkbun](https://docs.dnscontrol.org/provider/porkbun)¹ | [PowerDNS](https://docs.dnscontrol.org/provider/powerdns) | [Realtime Register](https://docs.dnscontrol.org/provider/realtimeregister)¹ |
+| [RWTH DNS-Admin](https://docs.dnscontrol.org/provider/rwth) | [Sakura Cloud](https://docs.dnscontrol.org/provider/sakuracloud) | [SoftLayer](https://docs.dnscontrol.org/provider/softlayer) | [TransIP](https://docs.dnscontrol.org/provider/transip) | [UniFi Network](https://docs.dnscontrol.org/provider/unifi) |
+| [Vercel](https://docs.dnscontrol.org/provider/vercel) | [Vultr](https://docs.dnscontrol.org/provider/vultr) | | | |
+
+¹also supports registrar functions
+²registrar only
+
+Stack Overflow uses this system to manage hundreds of domains
+and subdomains across multiple registrars and DNS providers.
+
+You can think of it as a DNS compiler.  The configuration files are
+written in a DSL that looks a lot like JavaScript.  It is compiled
+to an intermediate representation (IR).  Compiler back-ends use the
+IR to update your DNS zones on services such as Route53, Cloudflare,
+and Gandi, or systems such as BIND.
 
 ## Benefits
 


### PR DESCRIPTION
The opening paragraph now uses "Infrastructure as Code" framing instead of "domain specific language (DSL)". The code example is moved up so readers see working code before the provider list. The two separate provider lists (57 DNS providers and 19 registrars) are combined into a single 5-column table with superscript markers: ¹ for providers that also support registrar functions and ² for registrar-only providers. Each provider links to its documentation page on https://docs.dnscontrol.org.

Addresses #4088.