### PR TITLE
CICD: Auto-generate labeler config for provider labels

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,186 @@
+provider-ADGUARDHOME:
+  - changed-files:
+      - any-glob-to-any-file: providers/adguardhome/**
+provider-AKAMAIEDGEDNS:
+  - changed-files:
+      - any-glob-to-any-file: providers/akamaiedgedns/**
+provider-ALIDNS:
+  - changed-files:
+      - any-glob-to-any-file: providers/alidns/**
+provider-AUTODNS:
+  - changed-files:
+      - any-glob-to-any-file: providers/autodns/**
+provider-AXFRDDNS:
+  - changed-files:
+      - any-glob-to-any-file: providers/axfrddns/**
+provider-AZURE_DNS:
+  - changed-files:
+      - any-glob-to-any-file: providers/azuredns/**
+provider-AZURE_PRIVATE_DNS:
+  - changed-files:
+      - any-glob-to-any-file: providers/azureprivatedns/**
+provider-BIND:
+  - changed-files:
+      - any-glob-to-any-file: providers/bind/**
+provider-BUNNY_DNS:
+  - changed-files:
+      - any-glob-to-any-file: providers/bunnydns/**
+provider-CLOUDFLAREAPI:
+  - changed-files:
+      - any-glob-to-any-file: providers/cloudflare/**
+provider-CLOUDNS:
+  - changed-files:
+      - any-glob-to-any-file: providers/cloudns/**
+provider-CNR:
+  - changed-files:
+      - any-glob-to-any-file: providers/cnr/**
+provider-CSCGLOBAL:
+  - changed-files:
+      - any-glob-to-any-file: providers/cscglobal/**
+provider-DESEC:
+  - changed-files:
+      - any-glob-to-any-file: providers/desec/**
+provider-DIGITALOCEAN:
+  - changed-files:
+      - any-glob-to-any-file: providers/digitalocean/**
+provider-DNSCALE:
+  - changed-files:
+      - any-glob-to-any-file: providers/dnscale/**
+provider-DNSIMPLE:
+  - changed-files:
+      - any-glob-to-any-file: providers/dnsimple/**
+provider-DNSMADEEASY:
+  - changed-files:
+      - any-glob-to-any-file: providers/dnsmadeeasy/**
+provider-DNSOVERHTTPS:
+  - changed-files:
+      - any-glob-to-any-file: providers/doh/**
+provider-DOMAINNAMESHOP:
+  - changed-files:
+      - any-glob-to-any-file: providers/domainnameshop/**
+provider-DYNADOT:
+  - changed-files:
+      - any-glob-to-any-file: providers/dynadot/**
+provider-EASYNAME:
+  - changed-files:
+      - any-glob-to-any-file: providers/easyname/**
+provider-EXOSCALE:
+  - changed-files:
+      - any-glob-to-any-file: providers/exoscale/**
+provider-FORTIGATE:
+  - changed-files:
+      - any-glob-to-any-file: providers/fortigate/**
+provider-GANDI_V5:
+  - changed-files:
+      - any-glob-to-any-file: providers/gandiv5/**
+provider-GCLOUD:
+  - changed-files:
+      - any-glob-to-any-file: providers/gcloud/**
+provider-GCORE:
+  - changed-files:
+      - any-glob-to-any-file: providers/gcore/**
+provider-GIDINET:
+  - changed-files:
+      - any-glob-to-any-file: providers/gidinet/**
+provider-HEDNS:
+  - changed-files:
+      - any-glob-to-any-file: providers/hedns/**
+provider-HETZNER:
+  - changed-files:
+      - any-glob-to-any-file: providers/hetzner/**
+provider-HETZNER_V2:
+  - changed-files:
+      - any-glob-to-any-file: providers/hetznerv2/**
+provider-HOSTINGDE:
+  - changed-files:
+      - any-glob-to-any-file: providers/hostingde/**
+provider-HUAWEICLOUD:
+  - changed-files:
+      - any-glob-to-any-file: providers/huaweicloud/**
+provider-INFOMANIAK:
+  - changed-files:
+      - any-glob-to-any-file: providers/infomaniak/**
+provider-INTERNETBS:
+  - changed-files:
+      - any-glob-to-any-file: providers/internetbs/**
+provider-INWX:
+  - changed-files:
+      - any-glob-to-any-file: providers/inwx/**
+provider-JOKER:
+  - changed-files:
+      - any-glob-to-any-file: providers/joker/**
+provider-LINODE:
+  - changed-files:
+      - any-glob-to-any-file: providers/linode/**
+provider-LOOPIA:
+  - changed-files:
+      - any-glob-to-any-file: providers/loopia/**
+provider-LUADNS:
+  - changed-files:
+      - any-glob-to-any-file: providers/luadns/**
+provider-MIKROTIK:
+  - changed-files:
+      - any-glob-to-any-file: providers/mikrotik/**
+provider-MYTHICBEASTS:
+  - changed-files:
+      - any-glob-to-any-file: providers/mythicbeasts/**
+provider-NAMECHEAP:
+  - changed-files:
+      - any-glob-to-any-file: providers/namecheap/**
+provider-NAMEDOTCOM:
+  - changed-files:
+      - any-glob-to-any-file: providers/namedotcom/**
+provider-NETCUP:
+  - changed-files:
+      - any-glob-to-any-file: providers/netcup/**
+provider-NETLIFY:
+  - changed-files:
+      - any-glob-to-any-file: providers/netlify/**
+provider-NS1:
+  - changed-files:
+      - any-glob-to-any-file: providers/ns1/**
+provider-OPENSRS:
+  - changed-files:
+      - any-glob-to-any-file: providers/opensrs/**
+provider-ORACLE:
+  - changed-files:
+      - any-glob-to-any-file: providers/oracle/**
+provider-OVH:
+  - changed-files:
+      - any-glob-to-any-file: providers/ovh/**
+provider-PACKETFRAME:
+  - changed-files:
+      - any-glob-to-any-file: providers/packetframe/**
+provider-PORKBUN:
+  - changed-files:
+      - any-glob-to-any-file: providers/porkbun/**
+provider-POWERDNS:
+  - changed-files:
+      - any-glob-to-any-file: providers/powerdns/**
+provider-REALTIMEREGISTER:
+  - changed-files:
+      - any-glob-to-any-file: providers/realtimeregister/**
+provider-ROUTE53:
+  - changed-files:
+      - any-glob-to-any-file: providers/route53/**
+provider-RWTH:
+  - changed-files:
+      - any-glob-to-any-file: providers/rwth/**
+provider-SAKURACLOUD:
+  - changed-files:
+      - any-glob-to-any-file: providers/sakuracloud/**
+provider-SOFTLAYER:
+  - changed-files:
+      - any-glob-to-any-file: providers/softlayer/**
+provider-TRANSIP:
+  - changed-files:
+      - any-glob-to-any-file: providers/transip/**
+provider-UNIFI:
+  - changed-files:
+      - any-glob-to-any-file: providers/unifi/**
+provider-VERCEL:
+  - changed-files:
+      - any-glob-to-any-file: providers/vercel/**
+provider-VULTR:
+  - changed-files:
+      - any-glob-to-any-file: providers/vultr/**

--- a/.github/workflows/pr_labeler.yml
+++ b/.github/workflows/pr_labeler.yml
@@ -1,0 +1,19 @@
+name: PR Labeler
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/labeler@v5
+        with:
+          configuration-path: .github/labeler.yml

--- a/build/generate/generate.go
+++ b/build/generate/generate.go
@@ -19,4 +19,7 @@ func main() {
 	if err := generateGoreleaserFile(); err != nil {
 		log.Fatal(err)
 	}
+	if err := generateLabelerFile(); err != nil {
+		log.Fatal(err)
+	}
 }

--- a/build/generate/labelerFile.go
+++ b/build/generate/labelerFile.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"os"
+	"strings"
+
+	"github.com/DNSControl/dnscontrol/v4/pkg/providers"
+)
+
+func generateLabelerFile() error {
+	maintainers := providers.ProviderMaintainers
+	sortedProviderNames := getSortedProviderNames(maintainers)
+
+	var labelerData strings.Builder
+	for _, providerName := range sortedProviderNames {
+		providerDirectory := getProviderDirectory(providerName)
+		labelerData.WriteString("provider-")
+		labelerData.WriteString(providerName)
+		labelerData.WriteString(":\n")
+		labelerData.WriteString("  - changed-files:\n")
+		labelerData.WriteString("      - any-glob-to-any-file: providers/")
+		labelerData.WriteString(providerDirectory)
+		labelerData.WriteString("/**\n")
+	}
+
+	return os.WriteFile(".github/labeler.yml", []byte(labelerData.String()), 0o644)
+}

--- a/main.go
+++ b/main.go
@@ -12,7 +12,7 @@ import (
 	"github.com/fatih/color"
 )
 
-//go:generate go run build/generate/generate.go build/generate/featureMatrix.go build/generate/functionTypes.go build/generate/dtsFile.go build/generate/ownersFile.go build/generate/goreleaserFile.go
+//go:generate go run build/generate/generate.go build/generate/featureMatrix.go build/generate/functionTypes.go build/generate/dtsFile.go build/generate/ownersFile.go build/generate/goreleaserFile.go build/generate/labelerFile.go
 
 func main() {
 	if os.Getenv("CI") == "true" {


### PR DESCRIPTION
The repository has `provider-*` labels that map provider type names (e.g. `CLOUDFLAREAPI`) to issues and pull requests, but these were assigned manually. For pull requests this can be automated by matching changed files against `providers/` directories.

This GitHub pull request adds a `go generate` step that builds `.github/labeler.yml` from the registered provider constants. A `pr_labeler.yml` workflow runs `actions/labeler@v5` on `pull_request_target` to apply the labels automatically. New providers are picked up on the next `go generate` run, similar to #4255 (GoReleaser) and #4245 (integration tests).