### PR TITLE
AZURE_DNS: support init command

### DIFF
--- a/documentation/provider/azuredns.md
+++ b/documentation/provider/azuredns.md
@@ -155,6 +155,8 @@ D("example.com", REG_NONE, DnsProvider(DSP_AZURE_MAIN),
 ## Activation
 DNSControl depends on a standard [Client credentials Authentication](https://docs.microsoft.com/en-us/cli/azure/create-an-azure-service-principal-azure-cli?view=azure-cli-latest) with permission to list, create and update hosted zones.
 
+Additional documentation can be found here: https://learn.microsoft.com/en-us/azure/dns/
+
 ## New domains
 If a domain does not exist in your Azure account, DNSControl will *not* automatically add it with the `push` command. You can do that either manually via the control panel, or via the command `dnscontrol create-domains` command.
 

--- a/providers/azuredns/azureDnsProvider.go
+++ b/providers/azuredns/azureDnsProvider.go
@@ -125,7 +125,7 @@ func init() {
 		DisplayName: "Azure DNS",
 		Kind:        providers.KindDNS,
 		DocsURL:     "https://docs.dnscontrol.org/provider/azuredns",
-		PortalURL:   "https://portal.azure.com/", // TODO: Verify
+		PortalURL:   "https://portal.azure.com/",
 		Fields: []providers.CredsField{
 			{
 				Key:      "SubscriptionID",

--- a/providers/azuredns/azureDnsProvider.go
+++ b/providers/azuredns/azureDnsProvider.go
@@ -121,6 +121,45 @@ func init() {
 	providers.RegisterDomainServiceProviderType(providerName, fns, features)
 	providers.RegisterCustomRecordType("AZURE_ALIAS", providerName, "")
 	providers.RegisterMaintainer(providerName, providerMaintainer)
+	providers.RegisterCredsMetadata(providerName, providers.CredsMetadata{
+		DisplayName: "Azure DNS",
+		Kind:        providers.KindDNS,
+		DocsURL:     "https://docs.dnscontrol.org/provider/azuredns",
+		PortalURL:   "https://portal.azure.com/", // TODO: Verify
+		Fields: []providers.CredsField{
+			{
+				Key:      "SubscriptionID",
+				Label:    "Subscription ID",
+				Help:     "Azure subscription ID that contains the DNS zones.",
+				Required: true,
+			},
+			{
+				Key:      "ResourceGroup",
+				Label:    "Resource group",
+				Help:     "Azure resource group that contains the DNS zones.",
+				Required: true,
+			},
+			{
+				Key:      "TenantID",
+				Label:    "Tenant ID",
+				Help:     "Azure AD tenant ID for the service principal.",
+				Required: true,
+			},
+			{
+				Key:      "ClientID",
+				Label:    "Client ID",
+				Help:     "Service principal client (application) ID.",
+				Required: true,
+			},
+			{
+				Key:      "ClientSecret",
+				Label:    "Client secret",
+				Help:     "Service principal client secret.",
+				Secret:   true,
+				Required: true,
+			},
+		},
+	})
 }
 
 func (a *azurednsProvider) getExistingZones() ([]*adns.Zone, error) {

--- a/providers/azuredns/azureDnsProvider.go
+++ b/providers/azuredns/azureDnsProvider.go
@@ -125,7 +125,7 @@ func init() {
 		DisplayName: "Azure DNS",
 		Kind:        providers.KindDNS,
 		DocsURL:     "https://docs.dnscontrol.org/provider/azuredns",
-		PortalURL:   "https://portal.azure.com/",
+		PortalURL:   "https://portal.azure.com/#view/Microsoft_AAD_IAM/ActiveDirectoryMenuBlade/~/RegisteredApps",
 		Fields: []providers.CredsField{
 			{
 				Key:      "SubscriptionID",


### PR DESCRIPTION
## Summary

Register `CredsMetadata` for AZURE_DNS so the provider is offered by the `dnscontrol init` wizard.

Fields mirror the entries in `integrationTest/profiles.json`.

CC: @vatsalyagoel

## Test plan

- [ ] `go build ./...` passes
- [ ] `dnscontrol init` lists AZURE_DNS as an option
- [ ] Verify any `// TODO: Verify` annotations in the diff (e.g. `PortalURL`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)