### PR TITLE
BUNNY_DNS: support init command

### DIFF
--- a/providers/bunnydns/bunnydnsProvider.go
+++ b/providers/bunnydns/bunnydnsProvider.go
@@ -55,7 +55,7 @@ func init() {
 		DisplayName: "Bunny DNS",
 		Kind:        providers.KindDNS,
 		DocsURL:     "https://docs.dnscontrol.org/provider/bunnydns",
-		PortalURL:   "https://dash.bunny.net/account/api-key", // TODO: Verify
+		PortalURL:   "https://dash.bunny.net/account/api-key",
 		Fields: []providers.CredsField{
 			{
 				Key:      "api_key",

--- a/providers/bunnydns/bunnydnsProvider.go
+++ b/providers/bunnydns/bunnydnsProvider.go
@@ -50,6 +50,22 @@ func init() {
 
 	providers.RegisterCustomRecordType("BUNNY_DNS_RDR", providerName, "")
 	providers.RegisterCustomRecordType("BUNNY_DNS_PZ", providerName, "")
+
+	providers.RegisterCredsMetadata(providerName, providers.CredsMetadata{
+		DisplayName: "Bunny DNS",
+		Kind:        providers.KindDNS,
+		DocsURL:     "https://docs.dnscontrol.org/provider/bunnydns",
+		PortalURL:   "https://dash.bunny.net/account/api-key", // TODO: Verify
+		Fields: []providers.CredsField{
+			{
+				Key:      "api_key",
+				Label:    "API key",
+				Help:     "Bunny.net account API key.",
+				Secret:   true,
+				Required: true,
+			},
+		},
+	})
 }
 
 func newBunnydns(settings map[string]string, _ json.RawMessage) (providers.DNSServiceProvider, error) {


### PR DESCRIPTION
## Summary

Register `CredsMetadata` for BUNNY_DNS so the provider is offered by the `dnscontrol init` wizard.

Fields mirror the entries in `integrationTest/profiles.json`.

CC: @ppmathis

## Test plan

- [ ] `go build ./...` passes
- [ ] `dnscontrol init` lists BUNNY_DNS as an option
- [ ] Verify any `// TODO: Verify` annotations in the diff (e.g. `PortalURL`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)