### PR TITLE
CLOUDFLAREAPI: support init command

### DIFF
--- a/providers/cloudflare/cloudflareProvider.go
+++ b/providers/cloudflare/cloudflareProvider.go
@@ -76,6 +76,51 @@ func init() {
 	providers.RegisterDomainServiceProviderType(providerName, fns, features)
 	providers.RegisterCustomRecordType("CF_WORKER_ROUTE", providerName, "")
 	providers.RegisterMaintainer(providerName, providerMaintainer)
+	providers.RegisterCredsMetadata(providerName, providers.CredsMetadata{
+		DisplayName: "Cloudflare",
+		Kind:        providers.KindDNS,
+		DocsURL:     "https://docs.dnscontrol.org/provider/cloudflareapi",
+		PortalURL:   "https://dash.cloudflare.com/profile/api-tokens", // TODO: Verify
+		Notes:       "Cloudflare supports two auth methods: a scoped API token (recommended) or the legacy global API key paired with the account email.",
+		Fields: []providers.CredsField{
+			{
+				Key:      "_authMethod",
+				Label:    "Which authentication method do you want to use?",
+				Help:     "API token is scoped and recommended; the global API key requires the account email.",
+				Choices:  []string{"API token", "Global API key + email"},
+				Required: true,
+				Internal: true,
+			},
+			{
+				Key:      "apitoken",
+				Label:    "API token",
+				Help:     "Cloudflare API token with the required permissions.",
+				Secret:   true,
+				Required: true,
+				ShowIf:   map[string]string{"_authMethod": "API token"},
+			},
+			{
+				Key:      "apiuser",
+				Label:    "API user (email)",
+				Help:     "Account email used with the global API key.",
+				Required: true,
+				ShowIf:   map[string]string{"_authMethod": "Global API key + email"},
+			},
+			{
+				Key:      "apikey",
+				Label:    "API key",
+				Help:     "Cloudflare global API key.",
+				Secret:   true,
+				Required: true,
+				ShowIf:   map[string]string{"_authMethod": "Global API key + email"},
+			},
+			{
+				Key:   "accountid",
+				Label: "Account ID (optional)",
+				Help:  "Cloudflare account ID. Required to manage zones in a specific account when the credentials have access to more than one.",
+			},
+		},
+	})
 }
 
 // cloudflareProvider is the handle for API calls.


### PR DESCRIPTION
## Summary

Register `CredsMetadata` for CLOUDFLAREAPI so the provider is offered by the `dnscontrol init` wizard.

Fields mirror the entries in `integrationTest/profiles.json`.

CC: @tresni

## Test plan

- [ ] `go build ./...` passes
- [ ] `dnscontrol init` lists CLOUDFLAREAPI as an option
- [ ] Verify any `// TODO: Verify` annotations in the diff (e.g. `PortalURL`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)