### PR TITLE
CNR: support init command

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,7 +9,7 @@ providers/bind @TomOnTime
 providers/bunnydns @ppmathis
 providers/cloudflare @tresni
 providers/cloudns @pragmaton
-providers/cnr @KaiSchwarz-cnic
+providers/cnr @KaiSchwarz-cnic @AsifNawaz-cnic
 providers/cscglobal @mikenz
 providers/desec @D3luxee
 providers/digitalocean @chicks-net

--- a/providers/cnr/cnrProvider.go
+++ b/providers/cnr/cnrProvider.go
@@ -86,7 +86,7 @@ func newDsp(conf map[string]string, meta json.RawMessage) (providers.DNSServiceP
 
 func init() {
 	const providerName = "CNR"
-	const providerMaintainer = "@KaiSchwarz-cnic"
+	const providerMaintainer = "@AsifNawaz-cnic"
 	fns := providers.DspFuncs{
 		Initializer:   newDsp,
 		RecordAuditor: AuditRecords,
@@ -98,7 +98,7 @@ func init() {
 		DisplayName: "CentralNic Reseller",
 		Kind:        providers.KindDNS | providers.KindRegistrar,
 		DocsURL:     "https://docs.dnscontrol.org/provider/cnr",
-		PortalURL:   "https://www.rrpproxy.net/", // TODO: Verify
+		PortalURL:   "https://www.rrpproxy.net/",
 		Fields: []providers.CredsField{
 			{
 				Key:      "apilogin",

--- a/providers/cnr/cnrProvider.go
+++ b/providers/cnr/cnrProvider.go
@@ -94,4 +94,37 @@ func init() {
 	providers.RegisterRegistrarType(providerName, newReg)
 	providers.RegisterDomainServiceProviderType(providerName, fns, features)
 	providers.RegisterMaintainer(providerName, providerMaintainer)
+	providers.RegisterCredsMetadata(providerName, providers.CredsMetadata{
+		DisplayName: "CentralNic Reseller",
+		Kind:        providers.KindDNS | providers.KindRegistrar,
+		DocsURL:     "https://docs.dnscontrol.org/provider/cnr",
+		PortalURL:   "https://www.rrpproxy.net/", // TODO: Verify
+		Fields: []providers.CredsField{
+			{
+				Key:      "apilogin",
+				Label:    "API login",
+				Help:     "Your CNR API login username.",
+				Required: true,
+			},
+			{
+				Key:      "apipassword",
+				Label:    "API password",
+				Help:     "Your CNR API password.",
+				Secret:   true,
+				Required: true,
+			},
+			{
+				Key:      "apientity",
+				Label:    "API entity",
+				Help:     "Use \"OTE\" for the test (OT&E) system or \"LIVE\" for the production system.",
+				Choices:  []string{"OTE", "LIVE"},
+				Required: true,
+			},
+			{
+				Key:   "debugmode",
+				Label: "Debug mode (optional)",
+				Help:  "Set to \"2\" to enable verbose API debug logging. Leave blank to disable.",
+			},
+		},
+	})
 }


### PR DESCRIPTION
## Summary

Register `CredsMetadata` for CNR so the provider is offered by the `dnscontrol init` wizard.

Fields mirror the entries in `integrationTest/profiles.json`.

CC: @KaiSchwarz-cnic

## Test plan

- [ ] `go build ./...` passes
- [ ] `dnscontrol init` lists CNR as an option
- [ ] Verify any `// TODO: Verify` annotations in the diff (e.g. `PortalURL`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)