### PR TITLE
DIGITALOCEAN: support init command

### DIFF
--- a/providers/digitalocean/digitaloceanProvider.go
+++ b/providers/digitalocean/digitaloceanProvider.go
@@ -106,6 +106,21 @@ func init() {
 	}
 	providers.RegisterDomainServiceProviderType(providerName, fns, features)
 	providers.RegisterMaintainer(providerName, providerMaintainer)
+	providers.RegisterCredsMetadata(providerName, providers.CredsMetadata{
+		DisplayName: "DigitalOcean",
+		Kind:        providers.KindDNS,
+		DocsURL:     "https://docs.dnscontrol.org/provider/digitalocean",
+		PortalURL:   "https://cloud.digitalocean.com/account/api/tokens", // TODO: Verify
+		Fields: []providers.CredsField{
+			{
+				Key:      "token",
+				Label:    "API token",
+				Help:     "Your DigitalOcean personal access token.",
+				Secret:   true,
+				Required: true,
+			},
+		},
+	})
 }
 
 // EnsureZoneExists creates a zone if it does not exist.

--- a/providers/digitalocean/digitaloceanProvider.go
+++ b/providers/digitalocean/digitaloceanProvider.go
@@ -110,7 +110,7 @@ func init() {
 		DisplayName: "DigitalOcean",
 		Kind:        providers.KindDNS,
 		DocsURL:     "https://docs.dnscontrol.org/provider/digitalocean",
-		PortalURL:   "https://cloud.digitalocean.com/account/api/tokens", // TODO: Verify
+		PortalURL:   "https://cloud.digitalocean.com/account/api/tokens",
 		Fields: []providers.CredsField{
 			{
 				Key:      "token",


### PR DESCRIPTION
## Summary

Register `CredsMetadata` for DIGITALOCEAN so the provider is offered by the `dnscontrol init` wizard.

Fields mirror the entries in `integrationTest/profiles.json`.

CC: @chicks-net

## Test plan

- [ ] `go build ./...` passes
- [ ] `dnscontrol init` lists DIGITALOCEAN as an option
- [ ] Verify any `// TODO: Verify` annotations in the diff (e.g. `PortalURL`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)