### PR TITLE
DNSIMPLE: support init command

### DIFF
--- a/providers/dnsimple/dnsimpleProvider.go
+++ b/providers/dnsimple/dnsimpleProvider.go
@@ -53,6 +53,26 @@ func init() {
 	}
 	providers.RegisterDomainServiceProviderType(providerName, fns, features)
 	providers.RegisterMaintainer(providerName, providerMaintainer)
+	providers.RegisterCredsMetadata(providerName, providers.CredsMetadata{
+		DisplayName: "DNSimple",
+		Kind:        providers.KindDNS | providers.KindRegistrar,
+		DocsURL:     "https://docs.dnscontrol.org/provider/dnsimple",
+		PortalURL:   "https://dnsimple.com/user", // TODO: Verify
+		Fields: []providers.CredsField{
+			{
+				Key:      "token",
+				Label:    "Account access token",
+				Help:     "DNSimple account access token (must be an account token, not a user token).",
+				Secret:   true,
+				Required: true,
+			},
+			{
+				Key:   "baseurl",
+				Label: "Base URL (optional)",
+				Help:  "Override the API base URL (for example, the sandbox URL https://api.sandbox.dnsimple.com). Leave blank to use the production endpoint.",
+			},
+		},
+	})
 }
 
 const stateRegistered = "registered"

--- a/providers/dnsimple/dnsimpleProvider.go
+++ b/providers/dnsimple/dnsimpleProvider.go
@@ -57,7 +57,7 @@ func init() {
 		DisplayName: "DNSimple",
 		Kind:        providers.KindDNS | providers.KindRegistrar,
 		DocsURL:     "https://docs.dnscontrol.org/provider/dnsimple",
-		PortalURL:   "https://dnsimple.com/user", // TODO: Verify
+		PortalURL:   "https://dnsimple.com/user",
 		Fields: []providers.CredsField{
 			{
 				Key:      "token",


### PR DESCRIPTION
## Summary

Register `CredsMetadata` for DNSIMPLE so the provider is offered by the `dnscontrol init` wizard.

Fields mirror the entries in `integrationTest/profiles.json`.

CC: @onlyhavecans

## Test plan

- [ ] `go build ./...` passes
- [ ] `dnscontrol init` lists DNSIMPLE as an option
- [ ] Verify any `// TODO: Verify` annotations in the diff (e.g. `PortalURL`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)