### PR TITLE
GCLOUD: support init command

### DIFF
--- a/providers/gcloud/gcloudProvider.go
+++ b/providers/gcloud/gcloudProvider.go
@@ -62,6 +62,41 @@ func init() {
 	}
 	providers.RegisterDomainServiceProviderType(providerName, fns, features)
 	providers.RegisterMaintainer(providerName, providerMaintainer)
+	providers.RegisterCredsMetadata(providerName, providers.CredsMetadata{
+		DisplayName: "Google Cloud DNS",
+		Kind:        providers.KindDNS,
+		DocsURL:     "https://docs.dnscontrol.org/provider/gcloud",
+		PortalURL:   "https://console.cloud.google.com/iam-admin/serviceaccounts", // TODO: Verify
+		Notes:       "These values come from a Google Cloud service account JSON key file.",
+		Fields: []providers.CredsField{
+			{
+				Key:      "project_id",
+				Label:    "Project ID",
+				Help:     "GCP project ID that owns the Cloud DNS zones.",
+				Required: true,
+			},
+			{
+				Key:      "client_email",
+				Label:    "Client email",
+				Help:     "Service account email from the JSON key.",
+				Required: true,
+			},
+			{
+				Key:       "private_key",
+				Label:     "Private key (opens $EDITOR)",
+				Help:      "Paste the full PEM block (including BEGIN/END lines) from the service account JSON, then save and close the editor.",
+				Multiline: true,
+				Required:  true,
+			},
+			{
+				Key:      "type",
+				Label:    "Credential type",
+				Help:     "Credential type from the service account JSON. Typically \"service_account\".",
+				Default:  "service_account",
+				Required: true,
+			},
+		},
+	})
 }
 
 type gcloudProvider struct {


### PR DESCRIPTION
## Summary

Register `CredsMetadata` for GCLOUD so the provider is offered by the `dnscontrol init` wizard.

Fields mirror the entries in `integrationTest/profiles.json`.

CC: @riyadhalnur

## Test plan

- [ ] `go build ./...` passes
- [ ] `dnscontrol init` lists GCLOUD as an option
- [ ] Verify any `// TODO: Verify` annotations in the diff (e.g. `PortalURL`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)