### PR TITLE
GCORE: support init command

### DIFF
--- a/providers/gcore/gcoreProvider.go
+++ b/providers/gcore/gcoreProvider.go
@@ -77,6 +77,21 @@ func init() {
 	}
 	providers.RegisterDomainServiceProviderType(providerName, fns, features)
 	providers.RegisterMaintainer(providerName, providerMaintainer)
+	providers.RegisterCredsMetadata(providerName, providers.CredsMetadata{
+		DisplayName: "G-Core Labs",
+		Kind:        providers.KindDNS,
+		DocsURL:     "https://docs.dnscontrol.org/provider/gcore",
+		PortalURL:   "https://accounts.gcore.com/profile/api-tokens", // TODO: Verify
+		Fields: []providers.CredsField{
+			{
+				Key:      "api-key",
+				Label:    "API key",
+				Help:     "G-Core Labs permanent API key.",
+				Secret:   true,
+				Required: true,
+			},
+		},
+	})
 }
 
 // GetNameservers returns the nameservers for a domain.


### PR DESCRIPTION
## Summary

Register `CredsMetadata` for GCORE so the provider is offered by the `dnscontrol init` wizard.

Fields mirror the entries in `integrationTest/profiles.json`.

CC: @xddxdd

## Test plan

- [ ] `go build ./...` passes
- [ ] `dnscontrol init` lists GCORE as an option
- [ ] Verify any `// TODO: Verify` annotations in the diff (e.g. `PortalURL`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)