### PR TITLE
HETZNER_V2: support init command

### DIFF
--- a/providers/hetznerv2/hetznerv2Provider.go
+++ b/providers/hetznerv2/hetznerv2Provider.go
@@ -51,7 +51,7 @@ func init() {
 	providers.RegisterDomainServiceProviderType(providerName, fns, features)
 	providers.RegisterMaintainer(providerName, providerMaintainer)
 	providers.RegisterCredsMetadata(providerName, providers.CredsMetadata{
-		DisplayName: "Hetzner DNS Console (v2)",
+		DisplayName: "Hetzner DNS",
 		Kind:        providers.KindDNS,
 		DocsURL:     "https://docs.dnscontrol.org/provider/hetzner_v2",
 		PortalURL:   "https://dns.hetzner.com/settings/api-token", // TODO: Verify

--- a/providers/hetznerv2/hetznerv2Provider.go
+++ b/providers/hetznerv2/hetznerv2Provider.go
@@ -59,7 +59,7 @@ func init() {
 			{
 				Key:      "api_token",
 				Label:    "API token",
-				Help:     "Your Hetzner DNS Console API token.",
+				Help:     "Your Hetzner Cloud API token.",
 				Secret:   true,
 				Required: true,
 			},

--- a/providers/hetznerv2/hetznerv2Provider.go
+++ b/providers/hetznerv2/hetznerv2Provider.go
@@ -50,6 +50,21 @@ func init() {
 	}
 	providers.RegisterDomainServiceProviderType(providerName, fns, features)
 	providers.RegisterMaintainer(providerName, providerMaintainer)
+	providers.RegisterCredsMetadata(providerName, providers.CredsMetadata{
+		DisplayName: "Hetzner DNS Console (v2)",
+		Kind:        providers.KindDNS,
+		DocsURL:     "https://docs.dnscontrol.org/provider/hetzner_v2",
+		PortalURL:   "https://dns.hetzner.com/settings/api-token", // TODO: Verify
+		Fields: []providers.CredsField{
+			{
+				Key:      "api_token",
+				Label:    "API token",
+				Help:     "Your Hetzner DNS Console API token.",
+				Secret:   true,
+				Required: true,
+			},
+		},
+	})
 }
 
 // New creates a new API handle.


### PR DESCRIPTION
## Summary

Register `CredsMetadata` for HETZNER_V2 so the provider is offered by the `dnscontrol init` wizard.

Fields mirror the entries in `integrationTest/profiles.json`.

CC: @das7pad

## Test plan

- [ ] `go build ./...` passes
- [ ] `dnscontrol init` lists HETZNER_V2 as an option
- [ ] Verify any `// TODO: Verify` annotations in the diff (e.g. `PortalURL`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)