### PR TITLE
HOSTINGDE: support init command

### DIFF
--- a/providers/hostingde/hostingdeProvider.go
+++ b/providers/hostingde/hostingdeProvider.go
@@ -48,6 +48,21 @@ func init() {
 	}
 	providers.RegisterDomainServiceProviderType(providerName, fns, features)
 	providers.RegisterMaintainer(providerName, providerMaintainer)
+	providers.RegisterCredsMetadata(providerName, providers.CredsMetadata{
+		DisplayName: "hosting.de",
+		Kind:        providers.KindDNS | providers.KindRegistrar,
+		DocsURL:     "https://docs.dnscontrol.org/provider/hostingde",
+		PortalURL:   "https://secure.hosting.de/", // TODO: Verify
+		Fields: []providers.CredsField{
+			{
+				Key:      "authToken",
+				Label:    "Auth token",
+				Help:     "Your hosting.de API auth token.",
+				Secret:   true,
+				Required: true,
+			},
+		},
+	})
 }
 
 type providerMeta struct {

--- a/providers/hostingde/hostingdeProvider.go
+++ b/providers/hostingde/hostingdeProvider.go
@@ -52,7 +52,7 @@ func init() {
 		DisplayName: "hosting.de",
 		Kind:        providers.KindDNS | providers.KindRegistrar,
 		DocsURL:     "https://docs.dnscontrol.org/provider/hostingde",
-		PortalURL:   "https://secure.hosting.de/", // TODO: Verify
+		PortalURL:   "https://secure.hosting.de/",
 		Fields: []providers.CredsField{
 			{
 				Key:      "authToken",


### PR DESCRIPTION
## Summary

Register `CredsMetadata` for HOSTINGDE so the provider is offered by the `dnscontrol init` wizard.

Fields mirror the entries in `integrationTest/profiles.json`.

CC: @juliusrickert

## Test plan

- [x] `go build ./...` passes
- [x] `dnscontrol init` lists HOSTINGDE as an option
- [x] Verify any `// TODO: Verify` annotations in the diff (e.g. `PortalURL`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)