### PR TITLE
HUAWEICLOUD: support init command

### DIFF
--- a/providers/huaweicloud/huaweicloudProvider.go
+++ b/providers/huaweicloud/huaweicloudProvider.go
@@ -123,7 +123,7 @@ func init() {
 		DisplayName: "Huawei Cloud DNS",
 		Kind:        providers.KindDNS,
 		DocsURL:     "https://docs.dnscontrol.org/provider/huaweicloud",
-		PortalURL:   "https://console-intl.huaweicloud.com/iam/?locale=en-us#/mine/accessKey", // TODO: Verify
+		PortalURL:   "https://console-intl.huaweicloud.com/iam/?locale=en-us#/iam/users",
 		Fields: []providers.CredsField{
 			{
 				Key:      "KeyId",

--- a/providers/huaweicloud/huaweicloudProvider.go
+++ b/providers/huaweicloud/huaweicloudProvider.go
@@ -119,6 +119,33 @@ func init() {
 	}
 	providers.RegisterDomainServiceProviderType(providerName, fns, features)
 	providers.RegisterMaintainer(providerName, providerMaintainer)
+	providers.RegisterCredsMetadata(providerName, providers.CredsMetadata{
+		DisplayName: "Huawei Cloud DNS",
+		Kind:        providers.KindDNS,
+		DocsURL:     "https://docs.dnscontrol.org/provider/huaweicloud",
+		PortalURL:   "https://console-intl.huaweicloud.com/iam/?locale=en-us#/mine/accessKey", // TODO: Verify
+		Fields: []providers.CredsField{
+			{
+				Key:      "KeyId",
+				Label:    "Access key ID",
+				Help:     "Your Huawei Cloud Access Key ID (AK).",
+				Required: true,
+			},
+			{
+				Key:      "SecretKey",
+				Label:    "Secret access key",
+				Help:     "Your Huawei Cloud Secret Access Key (SK).",
+				Secret:   true,
+				Required: true,
+			},
+			{
+				Key:      "Region",
+				Label:    "Region",
+				Help:     "The Huawei Cloud region the DNS API call is routed through (for example ap-southeast-1).",
+				Required: true,
+			},
+		},
+	})
 }
 
 // huaweicloud has request limiting like above.


### PR DESCRIPTION
## Summary

Register `CredsMetadata` for HUAWEICLOUD so the provider is offered by the `dnscontrol init` wizard.

Fields mirror the entries in `integrationTest/profiles.json`.

CC: @huihuimoe

## Test plan

- [x] `go build ./...` passes
- [x] `dnscontrol init` lists HUAWEICLOUD as an option
- [x] Verify any `// TODO: Verify` annotations in the diff (e.g. `PortalURL`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)