### PR TITLE
LOOPIA: support init command

### DIFF
--- a/providers/loopia/loopiaProvider.go
+++ b/providers/loopia/loopiaProvider.go
@@ -43,6 +43,27 @@ func init() {
 	providers.RegisterDomainServiceProviderType(providerName, fns, features)
 	providers.RegisterRegistrarType(providerName, newReg)
 	providers.RegisterMaintainer(providerName, providerMaintainer)
+	providers.RegisterCredsMetadata(providerName, providers.CredsMetadata{
+		DisplayName: "Loopia",
+		Kind:        providers.KindDNS | providers.KindRegistrar,
+		DocsURL:     "https://docs.dnscontrol.org/provider/loopia",
+		PortalURL:   "https://customerzone.loopia.com/api/", // TODO: Verify
+		Fields: []providers.CredsField{
+			{
+				Key:      "username",
+				Label:    "API username",
+				Help:     "Your Loopia API username.",
+				Required: true,
+			},
+			{
+				Key:      "password",
+				Label:    "API password",
+				Help:     "Your Loopia API password.",
+				Secret:   true,
+				Required: true,
+			},
+		},
+	})
 }
 
 // features declares which features and options are available.

--- a/providers/loopia/loopiaProvider.go
+++ b/providers/loopia/loopiaProvider.go
@@ -47,7 +47,7 @@ func init() {
 		DisplayName: "Loopia",
 		Kind:        providers.KindDNS | providers.KindRegistrar,
 		DocsURL:     "https://docs.dnscontrol.org/provider/loopia",
-		PortalURL:   "https://customerzone.loopia.com/api/", // TODO: Verify
+		PortalURL:   "https://support.loopia.com/wiki/loopiaapi/",
 		Fields: []providers.CredsField{
 			{
 				Key:      "username",


### PR DESCRIPTION
## Summary

Register `CredsMetadata` for LOOPIA so the provider is offered by the `dnscontrol init` wizard.

Fields mirror the entries in `integrationTest/profiles.json`.

CC: @systemcrash

## Test plan

- [ ] `go build ./...` passes
- [ ] `dnscontrol init` lists LOOPIA as an option
- [ ] Verify any `// TODO: Verify` annotations in the diff (e.g. `PortalURL`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)