### PR TITLE
NAMECHEAP: support init command

### DIFF
--- a/providers/namecheap/namecheapProvider.go
+++ b/providers/namecheap/namecheapProvider.go
@@ -60,7 +60,7 @@ func init() {
 		DisplayName: "Namecheap",
 		Kind:        providers.KindDNS | providers.KindRegistrar,
 		DocsURL:     "https://docs.dnscontrol.org/provider/namecheap",
-		PortalURL:   "https://ap.www.namecheap.com/settings/tools/apiaccess/", // TODO: Verify
+		PortalURL:   "https://ap.www.namecheap.com/settings/tools/apiaccess/",
 		Fields: []providers.CredsField{
 			{
 				Key:      "apiuser",

--- a/providers/namecheap/namecheapProvider.go
+++ b/providers/namecheap/namecheapProvider.go
@@ -56,6 +56,32 @@ func init() {
 	providers.RegisterCustomRecordType("URL301", providerName, "")
 	providers.RegisterCustomRecordType("FRAME", providerName, "")
 	providers.RegisterMaintainer(providerName, providerMaintainer)
+	providers.RegisterCredsMetadata(providerName, providers.CredsMetadata{
+		DisplayName: "Namecheap",
+		Kind:        providers.KindDNS | providers.KindRegistrar,
+		DocsURL:     "https://docs.dnscontrol.org/provider/namecheap",
+		PortalURL:   "https://ap.www.namecheap.com/settings/tools/apiaccess/", // TODO: Verify
+		Fields: []providers.CredsField{
+			{
+				Key:      "apiuser",
+				Label:    "API user",
+				Help:     "Your Namecheap API username (usually your account login).",
+				Required: true,
+			},
+			{
+				Key:      "apikey",
+				Label:    "API key",
+				Help:     "The Namecheap API key generated from the API Access page.",
+				Secret:   true,
+				Required: true,
+			},
+			{
+				Key:   "BaseURL",
+				Label: "Base URL (optional)",
+				Help:  "Override the API base URL (for example to use the sandbox). Leave blank to use the production URL.",
+			},
+		},
+	})
 }
 
 func newDsp(conf map[string]string, metadata json.RawMessage) (providers.DNSServiceProvider, error) {


### PR DESCRIPTION
## Summary

Register `CredsMetadata` for NAMECHEAP so the provider is offered by the `dnscontrol init` wizard.

Fields mirror the entries in `integrationTest/profiles.json`.

CC: @willpower232

## Test plan

- [ ] `go build ./...` passes
- [ ] `dnscontrol init` lists NAMECHEAP as an option
- [ ] Verify any `// TODO: Verify` annotations in the diff (e.g. `PortalURL`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)