### PR TITLE
HUAWEICLOUD: implement DNSSEC support

### DIFF
--- a/documentation/provider/huaweicloud.md
+++ b/documentation/provider/huaweicloud.md
@@ -88,7 +88,10 @@ The minimum permissions required are as follows:
                 "dns:zone:list",
                 "dns:recordset:update",
                 "dns:recordset:list",
-                "dns:zone:get"
+                "dns:zone:get",
+                "dns:zone:getDnssecConfig",
+                "dns:zone:enableDnssecConfig",
+                "dns:zone:disableDnssecConfig"
             ]
         }
     ]

--- a/documentation/provider/index.md
+++ b/documentation/provider/index.md
@@ -359,7 +359,7 @@ Jump to a table:
 | [`HETZNER`](hetzner.md) | ❌ | ❔ | ✅ |
 | [`HETZNER_V2`](hetznerv2.md) | ❌ | ❔ | ✅ |
 | [`HOSTINGDE`](hostingde.md) | ✅ | ❔ | ✅ |
-| [`HUAWEICLOUD`](huaweicloud.md) | ❔ | ❔ | ❌ |
+| [`HUAWEICLOUD`](huaweicloud.md) | ✅ | ❔ | ❌ |
 | [`INFOMANIAK`](infomaniak.md) | ❔ | ❔ | ✅ |
 | [`INWX`](inwx.md) | ✅ | ❔ | ❔ |
 | [`JOKER`](joker.md) | ❔ | ❌ | ❌ |

--- a/providers/huaweicloud/auditrecords.go
+++ b/providers/huaweicloud/auditrecords.go
@@ -10,9 +10,12 @@ import (
 // supported, an empty list is returned.
 func AuditRecords(records []*models.RecordConfig) []error {
 	a := rejectif.Auditor{}
-	a.Add("MX", rejectif.MxNull)              // Last verified 2024-06-14
-	a.Add("TXT", rejectif.TxtHasBackslash)    // Last verified 2024-06-14
-	a.Add("TXT", rejectif.TxtHasDoubleQuotes) // Last verified 2024-06-14
+	// go test -v -run 'TestDNSProviders/.*/.*NullMX(Apex)?:(create|unnull|renull)$' -verbose -profile HUAWEICLOUD
+	a.Add("MX", rejectif.MxNull) // Last verified 2026-05-18
+	// go test -v -run 'TestDNSProviders/.*/.*TXT backslashes:TXT with backslashs$' -verbose -profile HUAWEICLOUD
+	a.Add("TXT", rejectif.TxtHasBackslash) // Last verified 2026-05-18
+	// go test -v -run 'TestDNSProviders/.*/.*complex TXT:TXT with (1 dq-1interior|2 dq-2interior|1 dq-left|1 dq-right)$' -verbose -profile HUAWEICLOUD
+	a.Add("TXT", rejectif.TxtHasDoubleQuotes) // Last verified 2026-05-18
 
 	return a.Audit(records)
 }

--- a/providers/huaweicloud/convert.go
+++ b/providers/huaweicloud/convert.go
@@ -17,11 +17,12 @@ func getRRSetIDFromRecords(rcs models.Records) []string {
 		if r.Original == nil {
 			continue
 		}
-		if r.Original.(*model.ShowRecordSetByZoneResp).Id == nil {
+		rrset := r.Original.(*model.ShowRecordSetByZoneResp)
+		if rrset.Id == nil {
 			printer.Warnf("RecordSet ID is nil for record %+v\n", r)
 			continue
 		}
-		ids = append(ids, *r.Original.(*model.ShowRecordSetByZoneResp).Id)
+		ids = append(ids, *rrset.Id)
 	}
 	slices.Sort(ids)
 	return slices.Compact(ids)

--- a/providers/huaweicloud/dnssec.go
+++ b/providers/huaweicloud/dnssec.go
@@ -1,0 +1,69 @@
+package huaweicloud
+
+import (
+	"github.com/DNSControl/dnscontrol/v4/models"
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/services/dns/v2/model"
+)
+
+func (c *huaweicloudProvider) getDNSSECCorrections(dc *models.DomainConfig) ([]*models.Correction, int, error) {
+	if dc.AutoDNSSEC == "" {
+		return nil, 0, nil
+	}
+
+	zoneID := c.zoneIDByDomain[dc.Name]
+
+	enabled, err := c.isDNSSECEnabled(zoneID)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	if enabled && dc.AutoDNSSEC == "off" {
+		return []*models.Correction{{
+			Msg: "Disable DNSSEC",
+			F:   func() error { return c.disableDNSSEC(zoneID) },
+		}}, 1, nil
+	}
+
+	if !enabled && dc.AutoDNSSEC == "on" {
+		return []*models.Correction{{
+			Msg: "Enable DNSSEC",
+			F:   func() error { return c.enableDNSSEC(zoneID) },
+		}}, 1, nil
+	}
+
+	return nil, 0, nil
+}
+
+func (c *huaweicloudProvider) isDNSSECEnabled(zoneID string) (bool, error) {
+	req := &model.ShowDnssecConfigRequest{ZoneId: zoneID}
+	var resp *model.ShowDnssecConfigResponse
+	var err error
+	withRetry(func() error {
+		resp, err = c.client.ShowDnssecConfig(req)
+		return err
+	})
+	if err != nil {
+		return false, err
+	}
+	return resp.Status != nil && *resp.Status == "ENABLE", nil
+}
+
+func (c *huaweicloudProvider) enableDNSSEC(zoneID string) error {
+	req := &model.EnableDnssecConfigRequest{ZoneId: zoneID}
+	var err error
+	withRetry(func() error {
+		_, err = c.client.EnableDnssecConfig(req)
+		return err
+	})
+	return err
+}
+
+func (c *huaweicloudProvider) disableDNSSEC(zoneID string) error {
+	req := &model.DisableDnssecConfigRequest{ZoneId: zoneID}
+	var err error
+	withRetry(func() error {
+		_, err = c.client.DisableDnssecConfig(req)
+		return err
+	})
+	return err
+}

--- a/providers/huaweicloud/huaweicloudProvider.go
+++ b/providers/huaweicloud/huaweicloudProvider.go
@@ -82,7 +82,7 @@ func newHuaweicloud(m map[string]string, metadata json.RawMessage) (providers.DN
 var features = providers.DocumentationNotes{
 	// The default for unlisted capabilities is 'Cannot'.
 	// See providers/capabilities.go for the entire list of capabilities.
-	providers.CanAutoDNSSEC:          providers.Unimplemented("No public api provided, but can be turned on manually in the console."),
+	providers.CanAutoDNSSEC:          providers.Can(),
 	providers.CanGetZones:            providers.Can(),
 	providers.CanUseAlias:            providers.Cannot(),
 	providers.CanUseCAA:              providers.Can(),

--- a/providers/huaweicloud/records.go
+++ b/providers/huaweicloud/records.go
@@ -72,9 +72,7 @@ func (c *huaweicloudProvider) GetZoneRecordsCorrections(dc *models.DomainConfig,
 		switch change.Type {
 		case diff2.REPORT:
 			reports = append(reports, &models.Correction{Msg: change.MsgsJoined})
-		case diff2.CREATE:
-			fallthrough
-		case diff2.CHANGE:
+		case diff2.CREATE, diff2.CHANGE:
 			newRecordsColl := collectRecordsByLineAndWeightAndKey(change.New)
 			oldRecordsColl := collectRecordsByLineAndWeightAndKey(change.Old)
 			corrections = append(corrections, &models.Correction{
@@ -219,10 +217,7 @@ func (c *huaweicloudProvider) createRRSet(zoneID string, rc *model.ShowRecordSet
 		_, err = c.client.CreateRecordSetWithLine(createPayload)
 		return err
 	})
-	if err != nil {
-		return err
-	}
-	return nil
+	return err
 }
 
 func (c *huaweicloudProvider) updateRRSet(zoneID, rrsetID string, rc *model.ShowRecordSetByZoneResp) error {
@@ -243,10 +238,7 @@ func (c *huaweicloudProvider) updateRRSet(zoneID, rrsetID string, rc *model.Show
 		_, err = c.client.UpdateRecordSets(updatePayload)
 		return err
 	})
-	if err != nil {
-		return err
-	}
-	return nil
+	return err
 }
 
 func parseMarkerFromURL(link string) (string, error) {

--- a/providers/huaweicloud/records.go
+++ b/providers/huaweicloud/records.go
@@ -131,9 +131,15 @@ func (c *huaweicloudProvider) GetZoneRecordsCorrections(dc *models.DomainConfig,
 		}
 	}
 
+	dnssecCorrections, dnssecChangeCount, err := c.getDNSSECCorrections(dc)
+	if err != nil {
+		return nil, 0, err
+	}
+
 	result := append(reports, deletions...)
 	result = append(result, corrections...)
-	return result, actualChangeCount, nil
+	result = append(result, dnssecCorrections...)
+	return result, actualChangeCount + dnssecChangeCount, nil
 }
 
 func collectRecordsByLineAndWeightAndKey(records models.Records) map[string]models.Records {


### PR DESCRIPTION
This PR aims to introduce DNSSEC[ON/OFF] support for Huawei Cloud DNS.

- Implement AUTODNSSEC support for the Huawei Cloud DNS provider
- Integrate DNSSEC corrections
- Update capability DNSSEC from Unimplemented to Can()
- Update required IAM permissions to documentation

AUTODNSSEC_[ON/OFF] has been tested manually.

and integration test result:

```
--- PASS: TestDualProviders (8.18s)
=== RUN   TestNameserverDots
Testing Profile="HUAWEICLOUD" (TYPE="HUAWEICLOUD")
=== RUN   TestNameserverDots/No_trailing_dot_in_nameserver
--- PASS: TestNameserverDots (1.35s)
    --- PASS: TestNameserverDots/No_trailing_dot_in_nameserver (0.00s)
=== RUN   TestDuplicateNameservers
Testing Profile="HUAWEICLOUD" (TYPE="HUAWEICLOUD")
    provider_test.go:145: Skipping. Deduplication logic is not implemented for this provider.
--- SKIP: TestDuplicateNameservers (1.51s)
PASS
ok      github.com/DNSControl/dnscontrol/v4/integrationTest     640.645s
```