### PR TITLE
AXFRDDNS: support unix domain sockets in update-mode/transfer-mode

### DIFF
--- a/documentation/provider/axfrddns.md
+++ b/documentation/provider/axfrddns.md
@@ -10,10 +10,12 @@ To use this provider, add an entry to `creds.json` with `TYPE` set to `AXFRDDNS`
 
 Zone transfers and DDNS updates default to TCP when using this provider.
 
-The following two parameters in `creds.json` allow switching to TCP or TCP over TLS.
+The following two parameters in `creds.json` allow switching to TCP, TCP over TLS, or Unix domain sockets.
 
-* `update-mode`: May contain `tcp` (the default), `udp`, or `tcp-tls`.
-* `transfer-mode`: May contain `tcp` (the default), or `tcp-tls`.
+* `update-mode`: May contain `tcp` (the default), `udp`, `tcp-tls`, or `unix`.
+* `transfer-mode`: May contain `tcp` (the default), `tcp-tls`, or `unix`.
+
+When using `unix` mode, `master` and/or `transfer-server` should be set to the path of the Unix domain socket.
 
 ### Authentication
 

--- a/providers/axfrddns/axfrddnsProvider.go
+++ b/providers/axfrddns/axfrddnsProvider.go
@@ -113,7 +113,7 @@ func initAxfrDdns(config map[string]string, providermeta json.RawMessage) (provi
 	}
 	if config["update-mode"] != "" {
 		switch config["update-mode"] {
-		case "tcp", "tcp-tls":
+		case "tcp", "tcp-tls", "unix":
 			api.updateMode = config["update-mode"]
 		case "udp":
 			api.updateMode = ""
@@ -125,7 +125,7 @@ func initAxfrDdns(config map[string]string, providermeta json.RawMessage) (provi
 	}
 	if config["transfer-mode"] != "" {
 		switch config["transfer-mode"] {
-		case "tcp", "tcp-tls":
+		case "tcp", "tcp-tls", "unix":
 			api.transferMode = config["transfer-mode"]
 		default:
 			printer.Printf("[Warning] AXFRDDNS: Unknown transfer-mode in `creds.json` (%s)\n", config["transfer-mode"])
@@ -135,7 +135,7 @@ func initAxfrDdns(config map[string]string, providermeta json.RawMessage) (provi
 	}
 	if config["master"] != "" {
 		api.master = config["master"]
-		if !strings.Contains(api.master, ":") {
+		if api.updateMode != "unix" && !strings.Contains(api.master, ":") {
 			api.master = api.master + ":53"
 		}
 	} else if len(api.nameservers) != 0 {
@@ -145,7 +145,7 @@ func initAxfrDdns(config map[string]string, providermeta json.RawMessage) (provi
 	}
 	if config["transfer-server"] != "" {
 		api.transferServer = config["transfer-server"]
-		if !strings.Contains(api.transferServer, ":") {
+		if api.transferMode != "unix" && !strings.Contains(api.transferServer, ":") {
 			api.transferServer = api.transferServer + ":53"
 		}
 	} else {
@@ -247,10 +247,13 @@ func (c *axfrddnsProvider) GetNameservers(domain string) ([]*models.Nameserver, 
 func (c *axfrddnsProvider) getAxfrConnection() (*dnsv1.Transfer, error) {
 	var con net.Conn
 	var err error
-	if c.transferMode == "tcp-tls" {
+	switch c.transferMode {
+	case "tcp-tls":
 		// RFC 9103 "DNS Zone Transfer over TLS" section 7.1 requires "dot"
 		con, err = tls.Dial("tcp", c.transferServer, &tls.Config{NextProtos: []string{"dot"}})
-	} else {
+	case "unix":
+		con, err = net.Dial("unix", c.transferServer)
+	default:
 		con, err = net.Dial("tcp", c.transferServer)
 	}
 	if err != nil {


### PR DESCRIPTION
My usecase is doing AXFR/DDNS via DNS-over-TLS with PKCS11, and to a server that has a self-signed cert whose [pubkey pin](https://datatracker.ietf.org/doc/html/rfc7858#section-4.2) I want to verify. This could plausibly be natively added to dnscontrol, but it would be a fiddly amount of config in the AXFRDDNS provider.

Unix domain sockets allow connecting via another program, that already exposes lots of the above configuration (stunnel/ghostunnel).

Why not just have that other program listen on a localhost port? That's then exposed to all processes on the host. Unix domain sockets are restricted by file ACLs.
