### PR TITLE
POWERDNS: Add support for automatic address hints in SVCB/HTTPS records

### DIFF
--- a/documentation/provider/powerdns.md
+++ b/documentation/provider/powerdns.md
@@ -66,6 +66,16 @@ D("example.com", REG_NONE, DnsProvider(DSP_POWERDNS),
 ## Activation
 See the [PowerDNS documentation](https://doc.powerdns.com/authoritative/http-api/index.html) how the API can be enabled.
 
+## HTTPS/SVCB Automatic Hints
+
+PowerDNS supports automatic address hints for `HTTPS` and `SVCB` records. DNSControl preserves the PowerDNS-specific `ipv4hint=auto` and `ipv6hint=auto` parameters when using this provider:
+
+{% code title="dnsconfig.js" %}
+```javascript
+HTTPS("foo", 1, ".", "alpn=h3,h2 ipv4hint=auto ipv6hint=auto");
+```
+{% endcode %}
+
 ## Tags and Variants
 If you use a dnscontrol *tag* (like `example.com!internal`) it will be mapped to a powerdns *variant* (like `example.com..internal`) when `use_views` is enabled in the provider metadata.
 

--- a/models/dns_test.go
+++ b/models/dns_test.go
@@ -49,6 +49,23 @@ func TestRR(t *testing.T) {
 	}
 }
 
+func TestSvcbAutoHintsTargetCombined(t *testing.T) {
+	experiment := RecordConfig{
+		Type:        "HTTPS",
+		Name:        "foo",
+		NameFQDN:    "foo.example.com",
+		SvcPriority: 1,
+		SvcParams:   "alpn=h3,h2 ipv4hint=auto ipv6hint=auto",
+		TTL:         300,
+	}
+	experiment.MustSetTarget(".")
+
+	expected := "1 . alpn=h3,h2 ipv4hint=auto ipv6hint=auto"
+	if found := experiment.ToComparableNoTTL(); found != expected {
+		t.Errorf("ToComparableNoTTL expected (%#v) got (%#v)\n", expected, found)
+	}
+}
+
 func TestDowncase(t *testing.T) {
 	dc := DomainConfig{Records: Records{
 		&RecordConfig{Type: "MX", Name: "lower", target: "targetmx"},

--- a/models/record.go
+++ b/models/record.go
@@ -351,6 +351,8 @@ func (rc *RecordConfig) ToComparableNoTTL() string {
 		return rc.luaCombined()
 	case "UNKNOWN":
 		return fmt.Sprintf("rtype=%s rdata=%s", rc.UnknownTypeName, rc.target)
+	case "HTTPS", "SVCB":
+		return rc.targetCombinedSVCBRaw()
 	}
 	return rc.GetTargetCombined()
 }

--- a/models/t_svcb.go
+++ b/models/t_svcb.go
@@ -7,6 +7,13 @@ import (
 	dnsv1 "github.com/miekg/dns"
 )
 
+func (rc *RecordConfig) targetCombinedSVCBRaw() string {
+	if rc.SvcParams == "" {
+		return fmt.Sprintf("%d %s", rc.SvcPriority, rc.target)
+	}
+	return fmt.Sprintf("%d %s %s", rc.SvcPriority, rc.target, rc.SvcParams)
+}
+
 // SetTargetSVCB sets the SVCB fields.
 func (rc *RecordConfig) SetTargetSVCB(priority uint16, target string, params []dnsv1.SVCBKeyValue) error {
 	rc.SvcPriority = priority

--- a/providers/powerdns/auditrecords.go
+++ b/providers/powerdns/auditrecords.go
@@ -13,6 +13,8 @@ func AuditRecords(records []*models.RecordConfig) []error {
 
 	a.Add("TXT", rejectif.TxtHasDoubleQuotes) // Last verified 2023-11-11
 	a.Add("TXT", rejectif.TxtHasBackslash)    // Last verified 2023-11-11
+	a.Add("HTTPS", rejectPowerDNSSVCBAutoHintsUnsorted)
+	a.Add("SVCB", rejectPowerDNSSVCBAutoHintsUnsorted)
 
 	return a.Audit(records)
 }

--- a/providers/powerdns/auditrecords_test.go
+++ b/providers/powerdns/auditrecords_test.go
@@ -1,0 +1,63 @@
+package powerdns
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/DNSControl/dnscontrol/v4/models"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAuditRecordsSvcbAutoHintOrder(t *testing.T) {
+	tests := []struct {
+		name    string
+		params  string
+		wantErr bool
+	}{
+		{
+			name:    "sorted auto hints",
+			params:  "alpn=h3,h2 ipv4hint=auto ipv6hint=auto",
+			wantErr: false,
+		},
+		{
+			name:    "ipv6hint before ipv4hint",
+			params:  "alpn=h3,h2 ipv6hint=auto ipv4hint=auto",
+			wantErr: true,
+		},
+		{
+			name:    "non auto hints use regular validation path",
+			params:  "alpn=h3,h2 ipv6hint=2001:db8::1 ipv4hint=192.0.2.1",
+			wantErr: false,
+		},
+		{
+			name:    "unknown params ignored",
+			params:  "alpn=h3,h2 key65400=value ipv4hint=auto ipv6hint=auto",
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			record := powerDNSSVCBRecord("HTTPS", tt.params)
+			errs := AuditRecords(models.Records{record})
+
+			if tt.wantErr {
+				assert.Len(t, errs, 1)
+				assert.True(t, strings.Contains(errs[0].Error(), "ipv4hint must appear before ipv6hint"))
+			} else {
+				assert.Empty(t, errs)
+			}
+		})
+	}
+}
+
+func powerDNSSVCBRecord(rtype, params string) *models.RecordConfig {
+	rc := &models.RecordConfig{
+		Type:        rtype,
+		SvcPriority: 1,
+		SvcParams:   params,
+	}
+	rc.SetLabel("auto", "example.com")
+	rc.MustSetTarget(".")
+	return rc
+}

--- a/providers/powerdns/convert.go
+++ b/providers/powerdns/convert.go
@@ -1,6 +1,8 @@
 package powerdns
 
 import (
+	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/DNSControl/dnscontrol/v4/models"
@@ -35,9 +37,31 @@ func toRecordConfig(domain string, r zones.Record, ttl int, name string, rtype s
 			return nil, err
 		}
 		return rc, rc.SetTargetTXT(value)
+	case "HTTPS", "SVCB":
+		if contentHasPowerDNSSVCBAutoHints(r.Content) {
+			return rc, setTargetSVCBPowerDNS(rc, r.Content)
+		}
+		return rc, rc.PopulateFromString(rtype, r.Content, domain)
 	default:
 		return rc, rc.PopulateFromString(rtype, r.Content, domain)
 	}
+}
+
+func setTargetSVCBPowerDNS(rc *models.RecordConfig, content string) error {
+	fields := strings.Fields(content)
+	if len(fields) < 2 {
+		return fmt.Errorf("could not parse PowerDNS SVCB record: %s", content)
+	}
+	priority, err := strconv.ParseUint(fields[0], 10, 16)
+	if err != nil {
+		return fmt.Errorf("could not parse PowerDNS SVCB priority %q: %w", fields[0], err)
+	}
+	rc.SvcPriority = uint16(priority)
+	if err := rc.SetTarget(fields[1]); err != nil {
+		return err
+	}
+	rc.SvcParams = strings.Join(fields[2:], " ")
+	return nil
 }
 
 func parseTxt(content string) (result []string) {

--- a/providers/powerdns/convert_test.go
+++ b/providers/powerdns/convert_test.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/DNSControl/dnscontrol/v4/models"
+	"github.com/DNSControl/dnscontrol/v4/pkg/diff2"
 	"github.com/mittwald/go-powerdns/apis/zones"
 	"github.com/stretchr/testify/assert"
 )
@@ -46,6 +48,37 @@ func TestToRecordConfig(t *testing.T) {
 	assert.Equal(t, "return 'Hello, world!'", recordConfig.GetTargetTXTJoined())
 	assert.Equal(t, "TXT \"return 'Hello, world!'\"", recordConfig.GetTargetCombined())
 	assert.Equal(t, uint32(3600), recordConfig.TTL)
+
+	autoHintRecord := zones.Record{
+		Content: "1 . alpn=h3,h2 ipv4hint=auto ipv6hint=auto",
+	}
+	recordConfig, err = toRecordConfig("example.com", autoHintRecord, 300, "auto", "HTTPS")
+
+	assert.NoError(t, err)
+	assert.Equal(t, "auto.example.com", recordConfig.NameFQDN)
+	assert.Equal(t, "HTTPS", recordConfig.Type)
+	assert.Equal(t, uint16(1), recordConfig.SvcPriority)
+	assert.Equal(t, ".", recordConfig.GetTargetField())
+	assert.Equal(t, "alpn=h3,h2 ipv4hint=auto ipv6hint=auto", recordConfig.SvcParams)
+	assert.Equal(t, "1 . alpn=h3,h2 ipv4hint=auto ipv6hint=auto", powerDNSTargetCombined(recordConfig))
+	assert.Equal(t, uint32(300), recordConfig.TTL)
+}
+
+func TestBuildRecordListSvcbAutoHints(t *testing.T) {
+	recordConfig := &models.RecordConfig{
+		Type:        "HTTPS",
+		Name:        "auto",
+		NameFQDN:    "auto.example.com",
+		SvcPriority: 1,
+		SvcParams:   "alpn=h3,h2 ipv4hint=auto ipv6hint=auto",
+		TTL:         300,
+	}
+	recordConfig.MustSetTarget(".")
+
+	records := buildRecordList(diff2.Change{New: models.Records{recordConfig}})
+
+	assert.Len(t, records, 1)
+	assert.Equal(t, "1 . alpn=h3,h2 ipv4hint=auto ipv6hint=auto", records[0].Content)
 }
 
 func TestParseText(t *testing.T) {

--- a/providers/powerdns/diff.go
+++ b/providers/powerdns/diff.go
@@ -84,7 +84,7 @@ func (dsp *powerdnsProvider) getDiff2DomainCorrections(dc *models.DomainConfig, 
 func buildRecordList(change diff2.Change) (records []zones.Record) {
 	for _, recordContent := range change.New {
 		record := zones.Record{
-			Content: recordContent.GetTargetCombined(),
+			Content: powerDNSTargetCombined(recordContent),
 		}
 		if recordContent.Type == "HTTPS" || recordContent.Type == "SVCB" {
 			// PowerDNS API will return HTTP 422 error if record content contains double quotes.

--- a/providers/powerdns/svcb.go
+++ b/providers/powerdns/svcb.go
@@ -10,7 +10,7 @@ import (
 // contentHasPowerDNSSVCBAutoHints reports whether SVCB/HTTPS rdata contains
 // PowerDNS's provider-specific automatic address hinting parameters.
 func contentHasPowerDNSSVCBAutoHints(content string) bool {
-	for _, field := range strings.Fields(content) {
+	for field := range strings.FieldsSeq(content) {
 		if field == "ipv4hint=auto" || field == "ipv6hint=auto" {
 			return true
 		}

--- a/providers/powerdns/svcb.go
+++ b/providers/powerdns/svcb.go
@@ -1,6 +1,7 @@
 package powerdns
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -35,8 +36,59 @@ func powerDNSTargetCombined(rc *models.RecordConfig) string {
 		if rc.SvcParams == "" {
 			return fmt.Sprintf("%d %s", rc.SvcPriority, rc.GetTargetField())
 		}
-		fmt.Printf("%d %s %s", rc.SvcPriority, rc.GetTargetField(), rc.SvcParams)
 		return fmt.Sprintf("%d %s %s", rc.SvcPriority, rc.GetTargetField(), rc.SvcParams)
 	}
 	return rc.GetTargetCombined()
+}
+
+// rejectPowerDNSSVCBAutoHintsUnsorted rejects PowerDNS auto hint records with
+// params that are not sorted by SvcParamKey number.
+func rejectPowerDNSSVCBAutoHintsUnsorted(rc *models.RecordConfig) error {
+	if !recordHasPowerDNSSVCBAutoHints(rc) {
+		return nil
+	}
+
+	lastOrder := -1
+	for field := range strings.FieldsSeq(rc.SvcParams) {
+		order := powerDNSSVCBParamOrder(field)
+		if order == -1 {
+			continue
+		}
+		if order < lastOrder {
+			return errors.New("PowerDNS SVCB/HTTPS auto hint params must be sorted by SvcParamKey number; ipv4hint must appear before ipv6hint")
+		}
+		lastOrder = order
+	}
+	return nil
+}
+
+// powerDNSSVCBParamOrder returns the SvcParamKey number for known SVCB params.
+func powerDNSSVCBParamOrder(field string) int {
+	key := field
+	if before, _, ok := strings.Cut(field, "="); ok {
+		key = before
+	}
+
+	switch key {
+	case "mandatory":
+		return 0
+	case "alpn":
+		return 1
+	case "no-default-alpn":
+		return 2
+	case "port":
+		return 3
+	case "ipv4hint":
+		return 4
+	case "ech":
+		return 5
+	case "ipv6hint":
+		return 6
+	case "dohpath":
+		return 7
+	case "ohttp":
+		return 8
+	default:
+		return -1
+	}
 }

--- a/providers/powerdns/svcb.go
+++ b/providers/powerdns/svcb.go
@@ -1,0 +1,42 @@
+package powerdns
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/DNSControl/dnscontrol/v4/models"
+)
+
+// contentHasPowerDNSSVCBAutoHints reports whether SVCB/HTTPS rdata contains
+// PowerDNS's provider-specific automatic address hinting parameters.
+func contentHasPowerDNSSVCBAutoHints(content string) bool {
+	for _, field := range strings.Fields(content) {
+		if field == "ipv4hint=auto" || field == "ipv6hint=auto" {
+			return true
+		}
+	}
+	return false
+}
+
+// recordHasPowerDNSSVCBAutoHints reports whether a RecordConfig is an
+// SVCB/HTTPS record using PowerDNS automatic address hinting.
+func recordHasPowerDNSSVCBAutoHints(rc *models.RecordConfig) bool {
+	if rc.Type != "SVCB" && rc.Type != "HTTPS" {
+		return false
+	}
+	return contentHasPowerDNSSVCBAutoHints(rc.SvcParams)
+}
+
+// powerDNSTargetCombined returns PowerDNS API content for a RecordConfig,
+// preserving provider-specific SVCB/HTTPS auto hint values that miekg/dns
+// cannot parse.
+func powerDNSTargetCombined(rc *models.RecordConfig) string {
+	if recordHasPowerDNSSVCBAutoHints(rc) {
+		if rc.SvcParams == "" {
+			return fmt.Sprintf("%d %s", rc.SvcPriority, rc.GetTargetField())
+		}
+		fmt.Printf("%d %s %s", rc.SvcPriority, rc.GetTargetField(), rc.SvcParams)
+		return fmt.Sprintf("%d %s %s", rc.SvcPriority, rc.GetTargetField(), rc.SvcParams)
+	}
+	return rc.GetTargetCombined()
+}


### PR DESCRIPTION
Add support for PowerDNS specific automatic address hints in SVCB/HTTPS records. Add tests for this as well.

Fixes #4187 
