### PR TITLE
CI: run scripts and format files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,7 +9,7 @@ providers/bind @TomOnTime
 providers/bunnydns @ppmathis
 providers/cloudflare @tresni
 providers/cloudns @pragmaton
-providers/cnr @KaiSchwarz-cnic @AsifNawaz-cnic
+providers/cnr @AsifNawaz-cnic
 providers/cscglobal @mikenz
 providers/desec @D3luxee
 providers/digitalocean @chicks-net

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -130,6 +130,9 @@ provider-NAMECHEAP:
 provider-NAMEDOTCOM:
   - changed-files:
       - any-glob-to-any-file: providers/namedotcom/**
+provider-NETBIRD:
+  - changed-files:
+      - any-glob-to-any-file: providers/netbird/**
 provider-NETCUP:
   - changed-files:
       - any-glob-to-any-file: providers/netcup/**

--- a/commands/init.go
+++ b/commands/init.go
@@ -798,7 +798,6 @@ func askDomains(asker Asker) ([]string, error) {
 	return domains, nil
 }
 
-
 // loadExistingCreds reads an existing creds.json, returning an empty map if
 // the file does not exist. Parse errors are fatal so we never silently drop
 // a broken file.


### PR DESCRIPTION
Run `bin/generate-all.sh` to format files and make CI happy again
