### PR TITLE
ROUTE53: support named AWS profiles (including SSO) and init command

### DIFF
--- a/documentation/provider/route53.md
+++ b/documentation/provider/route53.md
@@ -58,6 +58,21 @@ Example:
 ```
 {% endcode %}
 
+You can also select a named profile on a per-provider basis using the `Profile` field. This reads from `~/.aws/config` and supports AWS IAM Identity Center (SSO) profiles — run `aws sso login` first so a valid SSO session is cached. `Profile` is mutually exclusive with `KeyId`/`SecretKey` (setting both will return an error), but composes with `RoleArn`: the profile provides the source credentials and `RoleArn` is then assumed on top. This lets a single `dnscontrol push` target multiple AWS accounts in one run.
+
+Example:
+
+{% code title="creds.json" %}
+```json
+{
+  "r53_main": {
+    "TYPE": "ROUTE53",
+    "Profile": "my-aws-profile"
+  }
+}
+```
+{% endcode %}
+
 Alternatively, this provider also supports `RoleArn` with an optional `ExternalId`
 
 Example:

--- a/providers/route53/route53Provider.go
+++ b/providers/route53/route53Provider.go
@@ -138,6 +138,70 @@ func init() {
 	providers.RegisterRegistrarType(providerName, newRoute53Reg)
 	providers.RegisterCustomRecordType("R53_ALIAS", providerName, "")
 	providers.RegisterMaintainer(providerName, providerMaintainer)
+	providers.RegisterCredsMetadata(providerName, providers.CredsMetadata{
+		DisplayName: "Amazon Route 53",
+		Kind:        providers.KindDNS | providers.KindRegistrar,
+		DocsURL:     "https://docs.dnscontrol.org/provider/route53",
+		PortalURL:   "https://console.aws.amazon.com/route53/",
+		Notes:       "Route53 supports several auth methods: a named profile from ~/.aws/config (including AWS IAM Identity Center / SSO), static access keys, or the SDK's default credential chain (environment variables, EC2 instance role, etc.). RoleArn can be layered on top of any of these.",
+		Fields: []providers.CredsField{
+			{
+				Key:      "_authMethod",
+				Label:    "Which authentication method do you want to use?",
+				Help:     "Named profile reads ~/.aws/config and supports SSO. Static access key uses KeyId/SecretKey. Default credential chain relies on the AWS SDK to discover credentials from the environment or instance role.",
+				Choices:  []string{"Named profile (~/.aws/config, including SSO)", "Static access key", "Default credential chain"},
+				Required: true,
+				Internal: true,
+			},
+			{
+				Key:      "Profile",
+				Label:    "AWS profile name",
+				Help:     "Name of the profile in ~/.aws/config to use. For SSO profiles, run `aws sso login` before invoking dnscontrol.",
+				Required: true,
+				ShowIf:   map[string]string{"_authMethod": "Named profile (~/.aws/config, including SSO)"},
+			},
+			{
+				Key:      "KeyId",
+				Label:    "AWS access key ID",
+				Help:     "The AWS_ACCESS_KEY_ID for an IAM user or role with Route 53 permissions.",
+				EnvVar:   "AWS_ACCESS_KEY_ID",
+				Required: true,
+				ShowIf:   map[string]string{"_authMethod": "Static access key"},
+			},
+			{
+				Key:      "SecretKey",
+				Label:    "AWS secret access key",
+				Help:     "The AWS_SECRET_ACCESS_KEY paired with the access key ID.",
+				EnvVar:   "AWS_SECRET_ACCESS_KEY",
+				Secret:   true,
+				Required: true,
+				ShowIf:   map[string]string{"_authMethod": "Static access key"},
+			},
+			{
+				Key:    "Token",
+				Label:  "AWS session token (optional)",
+				Help:   "STS session token. Leave blank unless you are using temporary credentials.",
+				EnvVar: "AWS_SESSION_TOKEN",
+				Secret: true,
+				ShowIf: map[string]string{"_authMethod": "Static access key"},
+			},
+			{
+				Key:   "RoleArn",
+				Label: "Role ARN to assume (optional)",
+				Help:  "If set, dnscontrol will call sts:AssumeRole on this ARN using the source credentials selected above. Leave blank to use the source credentials directly.",
+			},
+			{
+				Key:   "ExternalId",
+				Label: "External ID for AssumeRole (optional)",
+				Help:  "External ID required by some trust policies. Only relevant when RoleArn is set.",
+			},
+			{
+				Key:   "DelegationSet",
+				Label: "Reusable delegation set ID (optional)",
+				Help:  "Existing Route 53 reusable delegation set ID (the value after /delegationset/). Only applied when creating new domains.",
+			},
+		},
+	})
 }
 
 func withRetry(f func() error) {

--- a/providers/route53/route53Provider.go
+++ b/providers/route53/route53Provider.go
@@ -61,6 +61,14 @@ func newRoute53(m map[string]string, _ json.RawMessage) (*route53Provider, error
 		optFns = append(optFns, config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(keyID, secretKey, tokenID)))
 	}
 
+	profile := m["Profile"]
+	if profile != "" && (keyID != "" || secretKey != "") {
+		return nil, fmt.Errorf("route53: cannot set both Profile and KeyId/SecretKey")
+	}
+	if profile != "" {
+		optFns = append(optFns, config.WithSharedConfigProfile(profile))
+	}
+
 	config, err := config.LoadDefaultConfig(context.Background(), optFns...)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary

Two related additions to the Route 53 provider:

1. **`Profile` field** in `creds.json` — point each provider entry at a specific named profile from `~/.aws/config`, including AWS IAM Identity Center (SSO) profiles. Enables managing multiple AWS accounts from a single `dnscontrol push`.
2. **`init` command support** — `RegisterCredsMetadata` so the `dnscontrol init` wizard offers `ROUTE53` and walks the user through picking an auth method.

## Motivation

Today the provider only accepts `KeyId`/`SecretKey`/`Token` and (optionally) `RoleArn`/`ExternalId`. Operators who use AWS Identity Center to manage multiple AWS accounts can't point each Route53 provider entry at a different SSO profile — the SDK's default chain only honors a single `AWS_PROFILE` env var, so a single `dnscontrol push` across multiple accounts is impossible without manually exporting temporary credentials between runs.

Going through `RoleArn` doesn't help here: AWS-reserved SSO roles (`AWSReservedSSO_*`) have SAML-federation trust policies and cannot be reached via `sts:AssumeRole` from a regular IAM identity.

## `Profile` behavior

- New `Profile` field is read from `m` and, when set, appended to the SDK load options as `config.WithSharedConfigProfile(profile)`.
- `Profile` is **mutually exclusive** with `KeyId`/`SecretKey`. Setting both returns an explicit error.
- `Profile` **composes with `RoleArn`**: the profile supplies the source credentials, and `RoleArn` is then assumed on top via STS — matching the existing flow.

Example `creds.json`:

```json
{
  "r53_prod":  { "TYPE": "ROUTE53", "Profile": "aws-prod"  },
  "r53_dev":   { "TYPE": "ROUTE53", "Profile": "aws-dev"   },
  "r53_stage": { "TYPE": "ROUTE53", "Profile": "aws-stage" }
}
```

With `aws sso login --sso-session <session>` cached, a single `dnscontrol push` can now operate across all three accounts.

## `init` command behavior

`RegisterCredsMetadata` is called with `Kind: KindDNS | KindRegistrar` (Route 53 acts as both) and an `_authMethod` selector offering three branches:

- **Named profile (`~/.aws/config`, including SSO)** → prompts for `Profile`.
- **Static access key** → prompts for `KeyId`, `SecretKey`, and optional `Token`, each pre-filled from the matching `AWS_*` env var when present.
- **Default credential chain** → writes a minimal entry; the SDK discovers credentials from the environment or instance role.

Optional fields shown for all branches: `RoleArn`, `ExternalId`, `DelegationSet`.

## Scope

Only `providers/route53/` uses `config.LoadDefaultConfig` — `grep -r LoadDefaultConfig providers/` returns just the Route53 file — so no other provider is affected.

## Test plan

- [x] `go build ./...` succeeds
- [x] `go vet ./providers/route53/...` clean
- [x] `bin/generate-all.sh` produces no diff
- [ ] `dnscontrol init` lists ROUTE53 and writes a valid entry for each of the three auth methods
- [ ] Manual: `aws sso login --sso-session <session>` then `dnscontrol check-creds r53_prod ROUTE53` against an SSO-backed profile
- [ ] Manual: `Profile` + `KeyId` in the same entry returns the mutual-exclusion error
- [ ] Manual: `Profile` + `RoleArn` chains correctly (source creds from profile, STS assume on top)