### PR TITLE
ORACLE: Upgrade to diff2 and change to RRSet API

### DIFF
--- a/providers/oracle/oracleProvider.go
+++ b/providers/oracle/oracleProvider.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"strings"
 	"time"
 
 	"github.com/DNSControl/dnscontrol/v4/models"
-	"github.com/DNSControl/dnscontrol/v4/pkg/diff"
+	"github.com/DNSControl/dnscontrol/v4/pkg/diff2"
 	"github.com/DNSControl/dnscontrol/v4/pkg/printer"
 	"github.com/DNSControl/dnscontrol/v4/pkg/providers"
 	"github.com/oracle/oci-go-sdk/v65/common"
@@ -22,7 +23,6 @@ var features = providers.DocumentationNotes{
 	// See providers/capabilities.go for the entire list of capabilities.
 	providers.CanConcur:              providers.Unimplemented(),
 	providers.CanGetZones:            providers.Can(),
-	providers.CanOnlyDiff1Features:   providers.Can(),
 	providers.CanUseAlias:            providers.Can(),
 	providers.CanUseCAA:              providers.Can(),
 	providers.CanUseDS:               providers.Cannot(), // should be supported, but getting 500s in tests
@@ -259,17 +259,18 @@ func (o *oracleProvider) GetZoneRecordsCorrections(dc *models.DomainConfig, exis
 		}
 
 		if rec.GetLabel() == "@" && rec.TTL != 86400 {
-			printer.Warnf("Oracle Cloud forces TTL=86400 for NS records. Ignoring configured TTL of %d for %s\n", rec.TTL, recNS)
+			// printer.Warnf("Oracle Cloud forces TTL=86400 for NS records. Ignoring configured TTL of %d for %s\n", rec.TTL, recNS)
 			rec.TTL = 86400
 		}
 	}
 
-	toReport, create, dels, modify, actualChangeCount, err := diff.NewCompat(dc).IncrementalDiff(existingRecords)
+	changes, actualChangeCount, err := diff2.ByRecord(existingRecords, dc, nil)
 	if err != nil {
 		return nil, 0, err
 	}
-	// Start corrections with the reports
-	corrections := diff.GenerateMessageCorrections(toReport)
+	if changes == nil {
+		return nil, 0, nil
+	}
 
 	/*
 		Oracle's API doesn't have a way to update an existing record.
@@ -277,76 +278,64 @@ func (o *oracleProvider) GetZoneRecordsCorrections(dc *models.DomainConfig, exis
 		the entire desired state, or you can patch specifying ADD/REMOVE actions.
 		Oracle's API is also increadibly slow, so updating individual RRSets is unbearably slow
 		for any size zone.
+
+		Using this method means we need to handle the add/delete functions manually in this function
+		rather than passing a function attached to the correction like every other provider.
+		This cannot be the most elegant way to handle this issue, but I have not come up with better yet...
 	*/
 
-	var desc strings.Builder
-	createRecords := models.Records{}
-	deleteRecords := models.Records{}
+	var corrections []*models.Correction
 
-	if len(create) > 0 {
-		for _, rec := range create {
-			createRecords = append(createRecords, rec.Desired)
-			desc.WriteString(rec.String() + "\n")
+	ops := make([]dns.RecordOperation, 0, actualChangeCount)
+
+	for _, change := range changes {
+		switch change.Type {
+			case diff2.REPORT:
+				corrections = append(corrections, &models.Correction{Msg: change.MsgsJoined})
+			case diff2.CREATE:
+				ops = append(ops, convertToRecordOperation(change.New[0], dns.RecordOperationOperationAdd))
+				corrections = append(corrections, &models.Correction{
+					Msg: change.MsgsJoined,
+					F: func() error { return nil},
+				})
+			case diff2.DELETE:
+				ops = append(ops, convertToRecordOperation(change.Old[0], dns.RecordOperationOperationRemove))
+				corrections = append(corrections, &models.Correction{
+					Msg: change.MsgsJoined,
+					F: func() error { return nil},
+				})
+			case diff2.CHANGE:
+				ops = append(ops, convertToRecordOperation(change.Old[0], dns.RecordOperationOperationRemove))
+				ops = append(ops, convertToRecordOperation(change.New[0], dns.RecordOperationOperationAdd))
+				corrections = append(corrections, &models.Correction{
+					Msg: change.MsgsJoined,
+					F: func() error { return nil},
+				})
+			default:
+				panic(fmt.Sprintf("unhandled change.Type %s", change.Type))
 		}
 	}
 
-	if len(dels) > 0 {
-		for _, rec := range dels {
-			deleteRecords = append(deleteRecords, rec.Existing)
-			desc.WriteString(rec.String() + "\n")
-		}
-	}
-
-	if len(modify) > 0 {
-		for _, rec := range modify {
-			createRecords = append(createRecords, rec.Desired)
-			deleteRecords = append(deleteRecords, rec.Existing)
-			desc.WriteString(rec.String() + "\n")
-		}
-	}
-
-	// There were corrections. Send them as one big batch:
-	if len(createRecords) > 0 || len(deleteRecords) > 0 {
-		corrections = append(corrections, &models.Correction{
-			Msg: desc.String(),
-			F: func() error {
-				return o.patch(createRecords, deleteRecords, dc.Name)
-			},
-		})
-	}
-
-	return corrections, actualChangeCount, nil
-}
-
-func (o *oracleProvider) patch(createRecords, deleteRecords models.Records, domain string) error {
+	// Prepare batched operation
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
-
 	patchReq := dns.PatchZoneRecordsRequest{
-		ZoneNameOrId:  &domain,
+		ZoneNameOrId:  &dc.Name,
 		CompartmentId: &o.compartment,
 	}
 
-	ops := make([]dns.RecordOperation, 0, len(createRecords)+len(deleteRecords))
-
-	for _, rec := range deleteRecords {
-		ops = append(ops, convertToRecordOperation(rec, dns.RecordOperationOperationRemove))
-	}
-	for _, rec := range createRecords {
-		ops = append(ops, convertToRecordOperation(rec, dns.RecordOperationOperationAdd))
-	}
-
+	// Send batched corrections
 	for batchStart := 0; batchStart < len(ops); batchStart += 100 {
 		batchEnd := min(batchStart+100, len(ops))
 		patchReq.Items = ops[batchStart:batchEnd]
 
 		_, err := o.client.PatchZoneRecords(ctx, patchReq)
 		if err != nil {
-			return err
+			return nil, 0, err
 		}
 	}
 
-	return nil
+	return corrections, actualChangeCount, nil
 }
 
 func convertToRecordOperation(rec *models.RecordConfig, op dns.RecordOperationOperationEnum) dns.RecordOperation {

--- a/providers/oracle/oracleProvider.go
+++ b/providers/oracle/oracleProvider.go
@@ -259,12 +259,12 @@ func (o *oracleProvider) GetZoneRecordsCorrections(dc *models.DomainConfig, exis
 		}
 
 		if rec.GetLabel() == "@" && rec.TTL != 86400 {
-			printer.Warnf("Oracle Cloud forces TTL=86400 for NS records. Ignoring configured TTL of %d for %s\n", rec.TTL, recNS)
+			// printer.Warnf("Oracle Cloud forces TTL=86400 for NS records. Ignoring configured TTL of %d for %s\n", rec.TTL, recNS)
 			rec.TTL = 86400
 		}
 	}
 
-	changes, actualChangeCount, err := diff2.ByRecord(existingRecords, dc, nil)
+	changes, actualChangeCount, err := diff2.ByRecordSet(existingRecords, dc, nil)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -286,76 +286,126 @@ func (o *oracleProvider) GetZoneRecordsCorrections(dc *models.DomainConfig, exis
 
 	var corrections []*models.Correction
 
-	ops := make([]dns.RecordOperation, 0, actualChangeCount)
-
 	for _, change := range changes {
 		switch change.Type {
-		case diff2.REPORT:
-			corrections = append(corrections, &models.Correction{Msg: change.MsgsJoined})
-		case diff2.CREATE:
-			ops = append(ops, convertToRecordOperation(change.New[0], dns.RecordOperationOperationAdd))
-			corrections = append(corrections, &models.Correction{
-				Msg: change.MsgsJoined,
-				F:   func() error { return nil },
-			})
-		case diff2.DELETE:
-			ops = append(ops, convertToRecordOperation(change.Old[0], dns.RecordOperationOperationRemove))
-			corrections = append(corrections, &models.Correction{
-				Msg: change.MsgsJoined,
-				F:   func() error { return nil },
-			})
-		case diff2.CHANGE:
-			ops = append(ops, convertToRecordOperation(change.Old[0], dns.RecordOperationOperationRemove))
-			ops = append(ops, convertToRecordOperation(change.New[0], dns.RecordOperationOperationAdd))
-			corrections = append(corrections, &models.Correction{
-				Msg: change.MsgsJoined,
-				F:   func() error { return nil },
-			})
-		default:
-			panic(fmt.Sprintf("unhandled change.Type %s", change.Type))
-		}
-	}
-
-	// Prepare batched operation
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
-	defer cancel()
-	patchReq := dns.PatchZoneRecordsRequest{
-		ZoneNameOrId:  &dc.Name,
-		CompartmentId: &o.compartment,
-	}
-
-	// Send batched corrections
-	for batchStart := 0; batchStart < len(ops); batchStart += 100 {
-		batchEnd := min(batchStart+100, len(ops))
-		patchReq.Items = ops[batchStart:batchEnd]
-
-		_, err := o.client.PatchZoneRecords(ctx, patchReq)
-		if err != nil {
-			return nil, 0, err
+			case diff2.REPORT:
+				corrections = append(corrections, &models.Correction{Msg: change.MsgsJoined})
+			case diff2.CREATE:
+				corrections = append(corrections, &models.Correction{
+					Msg: change.MsgsJoined,
+					F:   func() error {
+						return o.addRecords(dc.Name, change)
+					},
+				})
+			case diff2.DELETE:
+				corrections = append(corrections, &models.Correction{
+					Msg: change.MsgsJoined,
+					F:   func() error {
+						return o.deleteRecord(dc.Name, change)
+					},
+				})
+			case diff2.CHANGE:
+				corrections = append(corrections, &models.Correction{
+					Msg: change.MsgsJoined,
+					F:   func() error {
+						return o.updateRecords(dc.Name, change)
+					},
+				})
+			default:
+				panic(fmt.Sprintf("unhandled change.Type %s", change.Type))
 		}
 	}
 
 	return corrections, actualChangeCount, nil
 }
 
-func convertToRecordOperation(rec *models.RecordConfig, op dns.RecordOperationOperationEnum) dns.RecordOperation {
-	if rec.Original != nil {
-		return dns.RecordOperation{
-			RecordHash: rec.Original.(dns.Record).RecordHash,
-			Operation:  op,
-		}
+func (o *oracleProvider) addRecords(zoneName string, change diff2.Change) error {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+
+	fqdn := change.Key.NameFQDN
+	rtype:= change.Key.Type
+
+	var records []dns.RecordOperation
+	for _, rec := range change.New {
+		rdata := rec.GetTargetCombined()
+		ttl := int(rec.TTL)
+
+		records = append(records, dns.RecordOperation{
+			Domain:    &fqdn,
+			Rtype:     &rtype,
+			Rdata:     &rdata,
+			Ttl:       &ttl,
+			Operation: dns.RecordOperationOperationAdd,
+			},
+		)
 	}
 
-	fqdn := rec.GetLabelFQDN()
-	rtype := rec.Type
-	rdata := rec.GetTargetCombined()
-	ttl := int(rec.TTL)
-
-	return dns.RecordOperation{
-		Domain:    &fqdn,
-		Rtype:     &rtype,
-		Rdata:     &rdata,
-		Ttl:       &ttl,
-		Operation: op,
+	patchReq := dns.PatchRRSetRequest{
+		ZoneNameOrId:  &zoneName,
+		CompartmentId: &o.compartment,
+		Domain: &fqdn,
+		Rtype: &rtype,
+		PatchRrSetDetails: dns.PatchRrSetDetails{
+			Items: records,
+		},
 	}
+
+	_, err := o.client.PatchRRSet(ctx, patchReq)
+	return err
+}
+
+
+func (o *oracleProvider) updateRecords(zoneName string, change diff2.Change) error {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+
+	fqdn := change.Key.NameFQDN
+	rtype := change.Key.Type
+
+	var records []dns.RecordDetails
+	for _, rec := range change.New {
+		rdata := rec.GetTargetCombined()
+		ttl := int(rec.TTL)
+
+		records = append(records, dns.RecordDetails{
+			Domain:    &fqdn,
+			Rtype:     &rtype,
+			Rdata:     &rdata,
+			Ttl:       &ttl,
+			},
+		)
+	}
+
+
+	updateReq := dns.UpdateRRSetRequest{
+		ZoneNameOrId:  &zoneName,
+		CompartmentId: &o.compartment,
+		Domain: &fqdn,
+		Rtype: &rtype,
+		UpdateRrSetDetails: dns.UpdateRrSetDetails{
+			Items: records,
+		},
+	}
+
+	_, err := o.client.UpdateRRSet(ctx, updateReq)
+	return err
+}
+
+func (o *oracleProvider) deleteRecord(zoneName string, change diff2.Change) error {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+	
+	fqdn := change.Old[0].GetLabelFQDN()
+	rtype := change.Old[0].Type
+
+	patchReq := dns.DeleteRRSetRequest{
+		ZoneNameOrId:  &zoneName,
+		CompartmentId: &o.compartment,
+		Domain: &fqdn,
+		Rtype: &rtype,
+	}
+
+	_, err := o.client.DeleteRRSet(ctx, patchReq)
+	return err
 }

--- a/providers/oracle/oracleProvider.go
+++ b/providers/oracle/oracleProvider.go
@@ -259,7 +259,7 @@ func (o *oracleProvider) GetZoneRecordsCorrections(dc *models.DomainConfig, exis
 		}
 
 		if rec.GetLabel() == "@" && rec.TTL != 86400 {
-			// printer.Warnf("Oracle Cloud forces TTL=86400 for NS records. Ignoring configured TTL of %d for %s\n", rec.TTL, recNS)
+			printer.Warnf("Oracle Cloud forces TTL=86400 for NS records. Ignoring configured TTL of %d for %s\n", rec.TTL, recNS)
 			rec.TTL = 86400
 		}
 	}
@@ -273,15 +273,9 @@ func (o *oracleProvider) GetZoneRecordsCorrections(dc *models.DomainConfig, exis
 	}
 
 	/*
-		Oracle's API doesn't have a way to update an existing record.
-		You can either update an existing RRSet, Domain (FQDN), or Zone in which you have to supply
-		the entire desired state, or you can patch specifying ADD/REMOVE actions.
-		Oracle's API is also increadibly slow, so updating individual RRSets is unbearably slow
-		for any size zone.
-
-		Using this method means we need to handle the add/delete functions manually in this function
-		rather than passing a function attached to the correction like every other provider.
-		This cannot be the most elegant way to handle this issue, but I have not come up with better yet...
+		Oracle's API has Zone or RRSet APIs available.
+		Using RRSet as it feels more natural way to propagate changes
+		rather than sending individual changes as add/delete into a patch zone request.
 	*/
 
 	var corrections []*models.Correction

--- a/providers/oracle/oracleProvider.go
+++ b/providers/oracle/oracleProvider.go
@@ -259,7 +259,7 @@ func (o *oracleProvider) GetZoneRecordsCorrections(dc *models.DomainConfig, exis
 		}
 
 		if rec.GetLabel() == "@" && rec.TTL != 86400 {
-			// printer.Warnf("Oracle Cloud forces TTL=86400 for NS records. Ignoring configured TTL of %d for %s\n", rec.TTL, recNS)
+			printer.Warnf("Oracle Cloud forces TTL=86400 for NS records. Ignoring configured TTL of %d for %s\n", rec.TTL, recNS)
 			rec.TTL = 86400
 		}
 	}
@@ -290,29 +290,29 @@ func (o *oracleProvider) GetZoneRecordsCorrections(dc *models.DomainConfig, exis
 
 	for _, change := range changes {
 		switch change.Type {
-			case diff2.REPORT:
-				corrections = append(corrections, &models.Correction{Msg: change.MsgsJoined})
-			case diff2.CREATE:
-				ops = append(ops, convertToRecordOperation(change.New[0], dns.RecordOperationOperationAdd))
-				corrections = append(corrections, &models.Correction{
-					Msg: change.MsgsJoined,
-					F: func() error { return nil},
-				})
-			case diff2.DELETE:
-				ops = append(ops, convertToRecordOperation(change.Old[0], dns.RecordOperationOperationRemove))
-				corrections = append(corrections, &models.Correction{
-					Msg: change.MsgsJoined,
-					F: func() error { return nil},
-				})
-			case diff2.CHANGE:
-				ops = append(ops, convertToRecordOperation(change.Old[0], dns.RecordOperationOperationRemove))
-				ops = append(ops, convertToRecordOperation(change.New[0], dns.RecordOperationOperationAdd))
-				corrections = append(corrections, &models.Correction{
-					Msg: change.MsgsJoined,
-					F: func() error { return nil},
-				})
-			default:
-				panic(fmt.Sprintf("unhandled change.Type %s", change.Type))
+		case diff2.REPORT:
+			corrections = append(corrections, &models.Correction{Msg: change.MsgsJoined})
+		case diff2.CREATE:
+			ops = append(ops, convertToRecordOperation(change.New[0], dns.RecordOperationOperationAdd))
+			corrections = append(corrections, &models.Correction{
+				Msg: change.MsgsJoined,
+				F:   func() error { return nil },
+			})
+		case diff2.DELETE:
+			ops = append(ops, convertToRecordOperation(change.Old[0], dns.RecordOperationOperationRemove))
+			corrections = append(corrections, &models.Correction{
+				Msg: change.MsgsJoined,
+				F:   func() error { return nil },
+			})
+		case diff2.CHANGE:
+			ops = append(ops, convertToRecordOperation(change.Old[0], dns.RecordOperationOperationRemove))
+			ops = append(ops, convertToRecordOperation(change.New[0], dns.RecordOperationOperationAdd))
+			corrections = append(corrections, &models.Correction{
+				Msg: change.MsgsJoined,
+				F:   func() error { return nil },
+			})
+		default:
+			panic(fmt.Sprintf("unhandled change.Type %s", change.Type))
 		}
 	}
 


### PR DESCRIPTION
I want Oracle provider to use diff2 package,
So that Oracle can reliably support NO_PURGE and IGNORE()

Related to https://github.com/DNSControl/dnscontrol/issues/4309

I also changed the API calls to use the RRSet API instead of Zone.

There does seem to be quite a difference (~40%)  between both methods when running the current test suite :
Tests with RRSet API = ~415-425 sec
Tests with batched zone API (see #4310 ) = ~300-305 sec

I will improve on the zone update method ( #4310 ) with a couple of things I learned when working on this PR, I keep this PR as a record of testing with RRSet and its impact on performance.