### PR TITLE
CLOUDFLAREAPI: Reduce integration tests to match the free tier

### DIFF
--- a/.github/workflows/pr_integration_tests.yml
+++ b/.github/workflows/pr_integration_tests.yml
@@ -259,7 +259,6 @@ jobs:
         run: |
           END=3
           echo "END: Default set to $END"
-          DO_WORKERS=false
 
           # Only for PRs
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
@@ -268,7 +267,6 @@ jobs:
             if [[ " $LABELS " =~ " longtest " ]]; then
               END=999
               echo "END: Pull request + longtest label. END=$END"
-              DO_WORKERS=true
             else
               echo "END: longtest not set. No change."
             fi
@@ -283,7 +281,6 @@ jobs:
           if [[ "${{ github.ref_name }}" == "main" ]]; then
             END=999
             echo "END: github.ref_name is main. END=$END"
-            DO_WORKERS=true
           fi
           # VERCEL it limited to 100 updates per hour. Therefore we never run more than the first few tests.
           if [[ "${{ matrix.provider }}" == "VERCEL" ]]; then
@@ -292,7 +289,6 @@ jobs:
           fi
           echo "END: Final value: END=$END"
           echo "END=$END" >> $GITHUB_ENV
-          echo "DO_WORKERS=$DO_WORKERS" >> $GITHUB_ENV
 
       - name: Run integration tests for ${{ matrix.provider }} provider
         run: |-
@@ -306,8 +302,8 @@ jobs:
                 -timeout 40m -v \
                 -verbose \
                 -profile ${{ matrix.provider }} \
-                -cfworkers=$DO_WORKERS \
-                -cfredirect=false \
+                -cfworkers=true \
+                -cfredirect=true \
                 -cfflatten=false \
                 -cftags=false \
                 -end $END \

--- a/documentation/provider/cloudflareapi.md
+++ b/documentation/provider/cloudflareapi.md
@@ -2,6 +2,10 @@ This is the provider for [Cloudflare](https://www.cloudflare.com/).
 
 ## Important notes
 
+* The following features are not regularly tested: (free tier accounts don't support these features. Contact the project if you'd like to sponsor a higher tier)
+  * CNAME flattening
+  * Tags
+  * "Single redirects" that use the "Matches" subcommand
 * SPF records are silently converted to RecordType `TXT` as Cloudflare API fails otherwise. See [DNSControl/dnscontrol#446](https://github.com/DNSControl/dnscontrol/issues/446).
 * This provider currently fails if there are more than 1000 corrections on one domain. This only affects "push". This usually when moving a domain with many records to Cloudflare.  Try commenting out most records, then uncomment groups of 999. Typical updates are less than 1000 corrections and will not trigger this bug. See [DNSControl/dnscontrol#1440](https://github.com/DNSControl/dnscontrol/issues/1440).
 * DNS records that Cloudflare injects and maintains are ignored. That includes SOA records, NS records at the domain's apex, and the MX/DKIM records created as part of Cloudflare mail routing.

--- a/integrationTest/helpers_integration_test.go
+++ b/integrationTest/helpers_integration_test.go
@@ -447,27 +447,27 @@ func bunnyPullZone(name, pullZoneID string) *models.RecordConfig {
 	return makeRec(name, pullZoneID, "BUNNY_DNS_PZ")
 }
 
-func cfRedir(pattern, target string) *models.RecordConfig {
-	rec, err := rtypecontrol.NewRecordConfigFromRaw(rtypecontrol.FromRawOpts{
-		Type: "CF_REDIRECT",
-		TTL:  1,
-		Args: []any{pattern, target},
-		DCN:  globalDCN,
-	})
-	panicOnErr(err)
-	return rec
-}
+// func cfRedir(pattern, target string) *models.RecordConfig {
+// 	rec, err := rtypecontrol.NewRecordConfigFromRaw(rtypecontrol.FromRawOpts{
+// 		Type: "CF_REDIRECT",
+// 		TTL:  1,
+// 		Args: []any{pattern, target},
+// 		DCN:  globalDCN,
+// 	})
+// 	panicOnErr(err)
+// 	return rec
+// }
 
-func cfRedirTemp(pattern, target string) *models.RecordConfig {
-	rec, err := rtypecontrol.NewRecordConfigFromRaw(rtypecontrol.FromRawOpts{
-		Type: "CF_TEMP_REDIRECT",
-		TTL:  1,
-		Args: []any{pattern, target},
-		DCN:  globalDCN,
-	})
-	panicOnErr(err)
-	return rec
-}
+// func cfRedirTemp(pattern, target string) *models.RecordConfig {
+// 	rec, err := rtypecontrol.NewRecordConfigFromRaw(rtypecontrol.FromRawOpts{
+// 		Type: "CF_TEMP_REDIRECT",
+// 		TTL:  1,
+// 		Args: []any{pattern, target},
+// 		DCN:  globalDCN,
+// 	})
+// 	panicOnErr(err)
+// 	return rec
+// }
 
 func aghAPassthrough(pattern, target string) *models.RecordConfig {
 	r := makeRec(pattern, target, "ADGUARDHOME_A_PASSTHROUGH")

--- a/integrationTest/helpers_test.go
+++ b/integrationTest/helpers_test.go
@@ -17,7 +17,7 @@ import (
 var (
 	providerFlag         = flag.String("provider", "", "Provider to run (if empty, deduced from -profile)")
 	profileFlag          = flag.String("profile", "", "Entry in profiles.json to use (if empty, copied from -provider)")
-	enableCFWorkers      = flag.Bool("cfworkers", true, "enable CF worker tests (default true)")
+	enableCFWorkers      = flag.Bool("cfworkers", false, "enable CF worker tests (default false)")
 	enableCFRedirectMode = flag.Bool("cfredirect", false, "enable CF SingleRedirect tests (default false)")
 	enableCFFlatten      = flag.Bool("cfflatten", false, "enable CF CNAME flattening tests (requires paid plan, default false)")
 	enableCFTags         = flag.Bool("cftags", false, "enable CF tag tests (requires paid plan, default false)")

--- a/integrationTest/integration_test.go
+++ b/integrationTest/integration_test.go
@@ -1231,12 +1231,15 @@ func makeTests() []*TestGroup {
 
 		// go test -v -verbose -profile CLOUDFLAREAPI -cfredirect=true  // Convert: Test Single Redirects
 
-		testgroup("CF_REDIRECT_CONVERT",
-			only("CLOUDFLAREAPI"),
-			alltrue(cfSingleRedirectEnabled()),
-			tc("start301", cfRedir("cnn.**current-domain**/*", "https://www.cnn.com/$1")),
-			tc("convert302", cfRedirTemp("cnn.**current-domain**/*", "https://www.cnn.com/$1")),
-		),
+		// This test is commented out because of this error:
+		// "helpers_integration_test.go:241: not entitled: the use of operator Matches is not allowed, a Business plan or a WAF Advanced plan is required"
+		// There's no obvious way to have this test only run when a Business plan is used.
+		// testgroup("CF_REDIRECT_CONVERT",
+		// 	only("CLOUDFLAREAPI"),
+		// 	alltrue(cfSingleRedirectEnabled()),
+		// 	tc("start301", cfRedir("cnn.**current-domain**/*", "https://www.cnn.com/$1")),
+		// 	tc("convert302", cfRedirTemp("cnn.**current-domain**/*", "https://www.cnn.com/$1")),
+		// ),
 
 		testgroup("CLOUDFLAREAPI_SINGLE_REDIRECT",
 			only("CLOUDFLAREAPI"),


### PR DESCRIPTION
CC @tresni @allixsenos @jzhang-sre 

# Issue

Some tests fail because they use features that are not available in the "free tier" account we use for testing.

# Resolution

Reduce the tests to avoid them.

The following features will no longer be regularly tested:

  * CNAME flattening
  * Tags
  * "Single redirects" that use the "Matches" subcommand

NOTE: Would you like these features to be tested regularly?  We'd gladly accept the donation to enable us to buy a "business plan"-level account.  (Cloudflare, if you're listening, we'd love a partnership!)