### PR TITLE
NAMECHEAP: Fix paginate zone listing to work with more than 20 items

### DIFF
--- a/providers/namecheap/namecheapProvider.go
+++ b/providers/namecheap/namecheapProvider.go
@@ -1,10 +1,16 @@
 package namecheap
 
 import (
+	"bytes"
 	"encoding/json"
+	"encoding/xml"
 	"errors"
 	"fmt"
+	"io"
+	"net/http"
+	"net/url"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -24,6 +30,30 @@ type namecheapProvider struct {
 	APIKEY  string
 	APIUser string
 	client  *nc.Client
+}
+
+const namecheapListZonesPageSize = 100
+
+type domainsGetListResponse struct {
+	Status  string                        `xml:"Status,attr"`
+	Domains []nc.DomainGetListResult      `xml:"CommandResponse>DomainGetListResult>Domain"`
+	Paging  domainsGetListResponsePaging  `xml:"CommandResponse>Paging"`
+	Errors  []domainsGetListResponseError `xml:"Errors>Error"`
+}
+
+type domainsGetListResponsePaging struct {
+	TotalItems  int `xml:"TotalItems"`
+	CurrentPage int `xml:"CurrentPage"`
+	PageSize    int `xml:"PageSize"`
+}
+
+type domainsGetListResponseError struct {
+	Number  int    `xml:"Number,attr"`
+	Message string `xml:",innerxml"`
+}
+
+func (e domainsGetListResponseError) Error() string {
+	return fmt.Sprintf("Error %d: %s", e.Number, e.Message)
 }
 
 var features = providers.DocumentationNotes{
@@ -269,17 +299,79 @@ func (n *namecheapProvider) GetNameservers(domainName string) ([]*models.Nameser
 }
 
 func (n *namecheapProvider) ListZones() ([]string, error) {
-	zones, err := n.client.DomainsGetList()
-	if err != nil {
-		return nil, err
-	}
-
 	var zoneList []string
-	for _, zone := range zones {
-		zoneList = append(zoneList, zone.Name)
+	page := 1
+	for {
+		zones, paging, err := n.listZonesPage(page)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, zone := range zones {
+			zoneList = append(zoneList, zone.Name)
+		}
+
+		if paging.TotalItems == 0 || paging.PageSize == 0 || len(zoneList) >= paging.TotalItems {
+			return zoneList, nil
+		}
+
+		page++
+	}
+}
+
+func (n *namecheapProvider) listZonesPage(page int) ([]nc.DomainGetListResult, domainsGetListResponsePaging, error) {
+	params := url.Values{}
+	params.Set("ApiUser", n.client.ApiUser)
+	params.Set("ApiKey", n.client.ApiToken)
+	params.Set("UserName", n.client.UserName)
+	params.Set("ClientIp", n.client.ClientIp)
+	params.Set("Command", "namecheap.domains.getList")
+	params.Set("Page", strconv.Itoa(page))
+	params.Set("PageSize", strconv.Itoa(namecheapListZonesPageSize))
+
+	encodedParams := params.Encode()
+	var err error
+	var resp *http.Response
+	doWithRetry(func() error {
+		req, reqErr := http.NewRequest(http.MethodPost, n.client.BaseURL, strings.NewReader(encodedParams))
+		if reqErr != nil {
+			err = reqErr
+			return reqErr
+		}
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		req.Header.Set("Content-Length", strconv.Itoa(len(encodedParams)))
+		resp, err = n.client.HttpClient.Do(req)
+		return err
+	})
+	if err != nil {
+		return nil, domainsGetListResponsePaging{}, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, domainsGetListResponsePaging{}, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, domainsGetListResponsePaging{}, fmt.Errorf("unexpected status code from api: %d", resp.StatusCode)
 	}
 
-	return zoneList, nil
+	parsed := domainsGetListResponse{}
+	if err := xml.Unmarshal(body, &parsed); err != nil {
+		return nil, domainsGetListResponsePaging{}, err
+	}
+	if parsed.Status == "ERROR" {
+		messages := make([]string, 0, len(parsed.Errors))
+		for _, apiErr := range parsed.Errors {
+			messages = append(messages, apiErr.Error())
+		}
+		return nil, domainsGetListResponsePaging{}, errors.New(strings.Join(messages, "\n"))
+	}
+	if parsed.Status == "" {
+		return nil, domainsGetListResponsePaging{}, fmt.Errorf("failed to parse xml from api: %s", bytes.TrimSpace(body))
+	}
+
+	return parsed.Domains, parsed.Paging, nil
 }
 
 // GetRegistrarCorrections returns corrections to update nameservers.

--- a/providers/namecheap/namecheapProvider_test.go
+++ b/providers/namecheap/namecheapProvider_test.go
@@ -1,0 +1,95 @@
+package namecheap
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"reflect"
+	"testing"
+
+	nc "github.com/billputer/go-namecheap"
+)
+
+func TestListZonesPaginates(t *testing.T) {
+	requests := []string{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("ParseForm() error = %v", err)
+		}
+		requests = append(requests, r.Form.Get("Page"))
+
+		want := url.Values{
+			"ApiUser":  []string{"api-user"},
+			"ApiKey":   []string{"api-key"},
+			"UserName": []string{"api-user"},
+			"ClientIp": []string{"127.0.0.1"},
+			"Command":  []string{"namecheap.domains.getList"},
+			"PageSize": []string{"100"},
+		}
+
+		for key, values := range want {
+			if got := r.Form[key]; !reflect.DeepEqual(got, values) {
+				t.Fatalf("form[%q] = %v, want %v", key, got, values)
+			}
+		}
+
+		page := r.Form.Get("Page")
+		switch page {
+		case "1":
+			fmt.Fprint(w, `<?xml version="1.0" encoding="utf-8"?>
+<ApiResponse Status="OK" xmlns="http://api.namecheap.com/xml.response">
+  <Errors />
+  <CommandResponse Type="namecheap.domains.getList">
+    <DomainGetListResult>
+      <Domain ID="1" Name="alpha.example" User="api-user" Created="11/04/2014" Expires="11/04/2015" IsExpired="false" IsLocked="false" AutoRenew="false" WhoisGuard="ENABLED" />
+      <Domain ID="2" Name="beta.example" User="api-user" Created="11/04/2014" Expires="11/04/2015" IsExpired="false" IsLocked="false" AutoRenew="false" WhoisGuard="ENABLED" />
+    </DomainGetListResult>
+    <Paging>
+      <TotalItems>3</TotalItems>
+      <CurrentPage>1</CurrentPage>
+      <PageSize>2</PageSize>
+    </Paging>
+  </CommandResponse>
+</ApiResponse>`)
+		case "2":
+			fmt.Fprint(w, `<?xml version="1.0" encoding="utf-8"?>
+<ApiResponse Status="OK" xmlns="http://api.namecheap.com/xml.response">
+  <Errors />
+  <CommandResponse Type="namecheap.domains.getList">
+    <DomainGetListResult>
+      <Domain ID="3" Name="gamma.example" User="api-user" Created="11/04/2014" Expires="11/04/2015" IsExpired="false" IsLocked="false" AutoRenew="false" WhoisGuard="ENABLED" />
+    </DomainGetListResult>
+    <Paging>
+      <TotalItems>3</TotalItems>
+      <CurrentPage>2</CurrentPage>
+      <PageSize>2</PageSize>
+    </Paging>
+  </CommandResponse>
+</ApiResponse>`)
+		default:
+			t.Fatalf("unexpected page %q", page)
+		}
+	}))
+	defer server.Close()
+
+	provider := &namecheapProvider{
+		client: nc.NewClient("api-user", "api-key", "api-user"),
+	}
+	provider.client.BaseURL = server.URL
+
+	zones, err := provider.ListZones()
+	if err != nil {
+		t.Fatalf("ListZones() error = %v", err)
+	}
+
+	wantZones := []string{"alpha.example", "beta.example", "gamma.example"}
+	if !reflect.DeepEqual(zones, wantZones) {
+		t.Fatalf("ListZones() = %v, want %v", zones, wantZones)
+	}
+
+	wantRequests := []string{"1", "2"}
+	if !reflect.DeepEqual(requests, wantRequests) {
+		t.Fatalf("pages requested = %v, want %v", requests, wantRequests)
+	}
+}


### PR DESCRIPTION
Provides a fix for the issue #3824. If the user has more than 20 domains at Namecheap then dnscontrol only gets the first 20. This patch performs paging such that all the domains can be retrieved.

* Fetch all the pages from Namecheap when listing zones so get-zones and zone existence checks do not miss domains beyond the default first page of 20 results.
* Add regression test covering multi-page domains.getList responses.

Assisted-by: OpenCode gpt-5.4 via OpenCode

Fixes: #3824
