### PR TITLE
HEDNS: Re-enable HTTPS/SVCB test that was failing

### DIFF
--- a/.github/workflows/pr_integration_tests.yml
+++ b/.github/workflows/pr_integration_tests.yml
@@ -300,7 +300,7 @@ jobs:
             # NB(tlim): THe output of gotestsum needs to go to stdout AND the
             # gotestsum-output.txt file. That's why "tee" is used.
             gotestsum --junitfile ${TEST_RESULTS}/gotestsum-report.xml -- \
-                -timeout 40m -v \
+                -timeout 70m -v \
                 -verbose \
                 -profile ${{ matrix.provider }} \
                 -cfworkers=true \

--- a/integrationTest/integration_test.go
+++ b/integrationTest/integration_test.go
@@ -317,7 +317,6 @@ func makeTests() []*TestGroup {
 				//
 				// Let's just ignore ECH test for Vercel for now.
 				"VERCEL",
-				"HEDNS", // BUG: https://github.com/DNSControl/dnscontrol/issues/4328
 			),
 			tc("Create a HTTPS record", https("@", 1, "example.com.", "alpn=h2,h3")),
 			tc("Add an ECH key", https("@", 1, "example.com.", "alpn=h2,h3 ech=some+base64+encoded+value///")),


### PR DESCRIPTION
Fixes https://github.com/DNSControl/dnscontrol/issues/4328

# Issue

Test was failing

# Resolution

It no longer fails.  Was probably fixed by https://github.com/DNSControl/dnscontrol/pull/4329