### PR TITLE
AXFRDDNS: Support for Technitium Conditional Forwarder Zones (Ignore TYPE65281)

### DIFF
--- a/providers/axfrddns/axfrddnsProvider.go
+++ b/providers/axfrddns/axfrddnsProvider.go
@@ -322,9 +322,11 @@ func (c *axfrddnsProvider) GetZoneRecords(dc *models.DomainConfig) (models.Recor
 			dnsv1.TypeNSEC3,
 			dnsv1.TypeNSEC3PARAM,
 			dnsv1.TypeZONEMD,
+			65281,
 			65534:
 			// Ignoring DNSSec RRs, but replacing it with a single
 			// "TXT" placeholder
+			// Ignoring TYPE65281 Technitium Conditional Forwarder Zone Record
 			// Also ignoring spurious TYPE65534, see:
 			// https://bind9-users.isc.narkive.com/zX29ay0j/rndc-signing-list-not-working#post2
 			if foundDNSSecRecords == nil {


### PR DESCRIPTION
This is a small edit for the AXFRDDNS Provider to ignore TYPE65281 records during parse. 

Technitium adds a single TYPE65281 record for Conditional Forwarder Zones. The provider already had a similar ignore implementation for BIND TYPE65534.

* unit tests passed with 'ok' or '?'
* generate-all.sh did not generate any git changes.

**Sample Error**:
```
******************** Domain: jadorno.com!private
INFO#1: Domain "jadorno.com" provider technitium20 Error: rrToRecord: Unimplemented zone record type= (jadorno.com.   0       CLASS1  TYPE65281       \# 16 000b746869732d736572766572000000)
```

