### PR TITLE
BUG: Fix CAA_BUILDER type declarations

### DIFF
--- a/commands/types/dnscontrol.d.ts
+++ b/commands/types/dnscontrol.d.ts
@@ -541,21 +541,21 @@ declare function CAA(name: string, tag: "issue" | "issuewild" | "iodef" | "conta
  * ### Parameters
  *
  * * `label:` The label of the CAA record. (Optional. Default: `"@"`)
- * * `iodef:` Report all violation to configured mail address.
+ * * `iodef:` Report all violation to configured mail address. (Optional. Default: `""`)
  * * `iodef_critical:` This can be `true` or `false`. If enabled and CA does not support this record, then certificate issue will be refused. (Optional. Default: `false`)
- * * `issue:` An array of CAs which are allowed to issue certificates. (Use `"none"` to refuse all CAs)
+ * * `issue:` An array of CAs which are allowed to issue certificates. (Optional. Default: `[]`. Use `"none"` to refuse all CAs)
  * * `issue_critical:` This can be `true` or `false`. If enabled and CA does not support this record, then certificate issue will be refused. (Optional. Default: `false`)
- * * `issuewild:` An array of CAs which are allowed to issue wildcard certificates. (Can be simply `"none"` to refuse issuing wildcard certificates for all CAs)
+ * * `issuewild:` An array of CAs which are allowed to issue wildcard certificates. (Optional. Default: `[]`. Can be simply `"none"` to refuse issuing wildcard certificates for all CAs)
  * * `issuewild_critical:` This can be `true` or `false`. If enabled and CA does not support this record, then certificate issue will be refused. (Optional. Default: `false`)
- * * `issuevmc:` An array of CAs which are allowed to issue VMC certificates. (Use `"none"` to refuse all CAs)
+ * * `issuevmc:` An array of CAs which are allowed to issue VMC certificates. (Optional. Default: `[]`. Use `"none"` to refuse all CAs)
  * * `issuevmc_critical:` This can be `true` or `false`. If enabled and CA does not support this record, then certificate issue will be refused. (Optional. Default: `false`)
- * * `issuemail:` An array of CAs which are allowed to issue email certificates. (Use `"none"` to refuse all CAs)
+ * * `issuemail:` An array of CAs which are allowed to issue email certificates. (Optional. Default: `[]`. Use `"none"` to refuse all CAs)
  * * `issuemail_critical:` This can be `true` or `false`. If enabled and CA does not support this record, then certificate issue will be refused. (Optional. Default: `false`)
  * * `ttl:` Input for `TTL` method (optional)
  *
  * @see https://docs.dnscontrol.org/language-reference/domain-modifiers/caa_builder
  */
-declare function CAA_BUILDER(opts: { label?: string; iodef: string; iodef_critical?: boolean; issue: string[]|string; issue_critical?: boolean; issuewild: string[]|string; issuewild_critical?: boolean; issuevmc: string[]|string; issuevmc_critical?: boolean; issuemail: string[]|string; issuemail_critical?: boolean; ttl?: Duration }): DomainModifier;
+declare function CAA_BUILDER(opts: { label?: string; iodef?: string; iodef_critical?: boolean; issue?: string[]|'none'; issue_critical?: boolean; issuewild?: string[]|'none'; issuewild_critical?: boolean; issuevmc?: string[]|'none'; issuevmc_critical?: boolean; issuemail?: string[]|'none'; issuemail_critical?: boolean; ttl?: Duration }): DomainModifier;
 
 /**
  * **WARNING:** Cloudflare is removing this feature and replacing it with a new

--- a/documentation/language-reference/domain-modifiers/CAA_BUILDER.md
+++ b/documentation/language-reference/domain-modifiers/CAA_BUILDER.md
@@ -16,15 +16,15 @@ parameters:
 parameters_object: true
 parameter_types:
   label: string?
-  iodef: string
+  iodef: string?
   iodef_critical: boolean?
-  issue: string[]|string
+  issue: "string[]|'none'?"
   issue_critical: boolean?
-  issuewild: string[]|string
+  issuewild: "string[]|'none'?"
   issuewild_critical: boolean?
-  issuevmc: string[]|string
+  issuevmc: "string[]|'none'?"
   issuevmc_critical: boolean?
-  issuemail: string[]|string
+  issuemail: "string[]|'none'?"
   issuemail_critical: boolean?
   ttl: Duration?
 ---
@@ -126,14 +126,14 @@ which in turns yield the following records:
 ### Parameters
 
 * `label:` The label of the CAA record. (Optional. Default: `"@"`)
-* `iodef:` Report all violation to configured mail address.
+* `iodef:` Report all violation to configured mail address. (Optional. Default: `""`)
 * `iodef_critical:` This can be `true` or `false`. If enabled and CA does not support this record, then certificate issue will be refused. (Optional. Default: `false`)
-* `issue:` An array of CAs which are allowed to issue certificates. (Use `"none"` to refuse all CAs)
+* `issue:` An array of CAs which are allowed to issue certificates. (Optional. Default: `[]`. Use `"none"` to refuse all CAs)
 * `issue_critical:` This can be `true` or `false`. If enabled and CA does not support this record, then certificate issue will be refused. (Optional. Default: `false`)
-* `issuewild:` An array of CAs which are allowed to issue wildcard certificates. (Can be simply `"none"` to refuse issuing wildcard certificates for all CAs)
+* `issuewild:` An array of CAs which are allowed to issue wildcard certificates. (Optional. Default: `[]`. Can be simply `"none"` to refuse issuing wildcard certificates for all CAs)
 * `issuewild_critical:` This can be `true` or `false`. If enabled and CA does not support this record, then certificate issue will be refused. (Optional. Default: `false`)
-* `issuevmc:` An array of CAs which are allowed to issue VMC certificates. (Use `"none"` to refuse all CAs)
+* `issuevmc:` An array of CAs which are allowed to issue VMC certificates. (Optional. Default: `[]`. Use `"none"` to refuse all CAs)
 * `issuevmc_critical:` This can be `true` or `false`. If enabled and CA does not support this record, then certificate issue will be refused. (Optional. Default: `false`)
-* `issuemail:` An array of CAs which are allowed to issue email certificates. (Use `"none"` to refuse all CAs)
+* `issuemail:` An array of CAs which are allowed to issue email certificates. (Optional. Default: `[]`. Use `"none"` to refuse all CAs)
 * `issuemail_critical:` This can be `true` or `false`. If enabled and CA does not support this record, then certificate issue will be refused. (Optional. Default: `false`)
 * `ttl:` Input for `TTL` method (optional)


### PR DESCRIPTION
<!--
## Before submiting a pull request

Please make sure you've run the following commands from the root directory.

    bin/generate-all.sh

(this runs commands like "go generate", fixes formatting, and so on)

## Release changelog section

Help keep the release changelog clear by pre-naming the proper section in the GitHub pull request title.

Some examples:
* CICD: Add required GHA permissions for goreleaser
* DOCS: Fixed providers with "contributor support" table
* ROUTE53: Allow R53_ALIAS records to enable target health evaluation

More examples/context can be found in the file .goreleaser.yml under the 'build' > 'changelog' key.
!-->
# Summary
The type declarations for the `CAA_BUILDER` currently require several fields, that the underlying function does not actually require. In addition to that, the `issue*` fields do not actually take any string, like the type currently describes, but only either a list of strings or `"none"`. This PR updates the type declarations and documentation in accordance with the current implementation.

# Changes
I updated the `documentation/language-reference/domain-modifiers/CAA_BUILDER.md` to include the correct types of the fields. Also updated the description of the parameters to document, that they are optional and what their default values are.

`./bin/generate-all.sh` was used to regenerate the `commands/types/dnscontrol.d.ts`.

# Testing
I ran `go run main.go write-types` to generate the new `types-dnscontrol.d.ts`. I then tested the generated declaration file in my own DNSControl configuration repository and verified that valid `CAA_BUILDER` invocations, such as the following, now type-check correctly:
```ts
CAA_BUILDER({
  issue: ["letsencrypt.org;validationmethods=dns-01"],
  issue_critical: true,
})
```