### PR TITLE
DOCS: Use the "-args" flag with "go test" when appropriate

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,7 +72,7 @@ These prefixes are used by GoReleaser to categorize the release changelog. See `
 Integration tests run real DNS operations against a provider's API. They require credentials and a dedicated test zone. See the [integration test documentation](https://docs.dnscontrol.org/developer-info/integration-tests) for setup instructions.
 
 ```shell
-go test ./integrationTest/ -v -provider PROVIDERNAME
+go test ./integrationTest/ -v -args -provider PROVIDERNAME
 ```
 
 ## Writing a new provider

--- a/documentation/advanced-features/adding-new-rtypes.md
+++ b/documentation/advanced-features/adding-new-rtypes.md
@@ -188,7 +188,7 @@ To run the integration test with the BIND provider:
 
 ```shell
 pushd integrationTest
-go test -v -verbose -profile BIND
+go test -v -args -verbose -profile BIND
 popd
 ```
 
@@ -207,7 +207,7 @@ export R53_DOMAIN=dnscontroltest-r53.com  # Use a test domain.
 export R53_KEY_ID=CHANGE_TO_THE_ID
 export R53_KEY='CHANGE_TO_THE_KEY'
 pushd integrationTest
-go test -v -verbose -profile ROUTE53
+go test -v -args -verbose -profile ROUTE53
 popd
 ```
 

--- a/documentation/advanced-features/debugging-with-dlv.md
+++ b/documentation/advanced-features/debugging-with-dlv.md
@@ -34,14 +34,14 @@ If you are using VSCode, the equivalent configuration is:
                 "-verbose",
                 "-profile",
                 "BIND",
-                "-start",
-                "7",
-                "-end",
-                "7"
+                "-start", "7",
+                "-end", "7"
             ],
             "buildFlags": "",
             "env": {},
-            "showLog": true
+            "showLog": false,
+            "console": "integratedTerminal",
+            "internalConsoleOptions": "neverOpen"
         }
 
     ]

--- a/documentation/advanced-features/debugging-with-dlv.md
+++ b/documentation/advanced-features/debugging-with-dlv.md
@@ -32,8 +32,7 @@ If you are using VSCode, the equivalent configuration is:
                 "-test.run",
                 "^TestDNSProviders",
                 "-verbose",
-                "-profile",
-                "BIND",
+                "-profile", "BIND",
                 "-start", "7",
                 "-end", "7"
             ],

--- a/documentation/advanced-features/integration-tests.md
+++ b/documentation/advanced-features/integration-tests.md
@@ -14,7 +14,7 @@ For each step, it will run the config once and expect changes. It will run it ag
 
 1. The integration tests need a test domain to run on. All the records of this domain will be deleted!
 2. Define all environment variables expected for the provider you wish to run.
-3. run `cd integrationTest && go test -v -profile $NAME` where $NAME is the name of the provider you wish to run.
+3. run `cd integrationTest && go test -v -args -profile $NAME` where $NAME is the name of the provider you wish to run.
 
 Example:
 
@@ -36,15 +36,15 @@ export ROUTE53_DOMAIN="testdomain.tld"
 
 ```shell
 cd integrationTest              # NOTE: Not needed if already in that subdirectory
-go test -v -verbose -profile ROUTE53
+go test -v -args -verbose -profile ROUTE53
 ```
 
 The `-start` and `-end` flags allow you to run just a portion of the tests.
 
 ```shell
-go test -v -verbose -profile ROUTE53 -start 16
-go test -v -verbose -profile ROUTE53 -end 5
-go test -v -verbose -profile ROUTE53 -start 16 -end 20
+go test -v -args -verbose -profile ROUTE53 -start 16
+go test -v -args -verbose -profile ROUTE53 -end 5
+go test -v -args -verbose -profile ROUTE53 -start 16 -end 20
 ```
 
 The `start` and `end` flags are both inclusive (i.e. `-start 16 -end 20` will run `[16, 17, 18, 19, 20]`).
@@ -52,7 +52,7 @@ The `start` and `end` flags are both inclusive (i.e. `-start 16 -end 20` will ru
 For some providers it may be necessary to increase the test timeout using `-test`. The default is 10 minutes.  `0` is "no limit".  Typical Go durations work too (`1h` for 1 hour, etc).
 
 ```shell
-go test -timeout 0 -v -verbose -profile CLOUDNS
+go test -timeout 0 -v -args -verbose -profile CLOUDNS
 ```
 
 FYI: The order of the flags matters.  Flags native to the Go testing suite (`-timeout` and `-v`) must come before flags that are part of the DNSControl integration tests (`-verbose`, `-profile`). Yeah, that sucks and is confusing.

--- a/documentation/advanced-features/test-a-branch.md
+++ b/documentation/advanced-features/test-a-branch.md
@@ -28,7 +28,7 @@ as usual. The directory to be in is `/go/dnscontrol/integrationTest`.
 
 ```shell
 cd /go/dnscontrol/integrationTest
-go test -v -verbose -profile INSERT_PROVIDER_NAME -start 1 -end 3
+go test -v -args -verbose -profile INSERT_PROVIDER_NAME -start 1 -end 3
 ```
 
 Change `INSERT_PROVIDER_NAME` to the name of your provider (`BIND`, `ROUTE53`, `GCLOUD`, etc.)

--- a/documentation/advanced-features/writing-providers.md
+++ b/documentation/advanced-features/writing-providers.md
@@ -173,7 +173,7 @@ For example, test BIND:
 ```shell
 cd integrationTest              # NOTE: Not needed if already there
 export BIND_DOMAIN='example.com'
-go test -v -verbose -profile BIND
+go test -v -args -verbose -profile BIND
 ```
 
 (BIND is a good place to start since it doesn't require API keys.)
@@ -185,22 +185,23 @@ export R53_DOMAIN='dnscontroltest-r53.com'    # Use a test domain.
 export R53_KEY_ID='CHANGE_TO_THE_ID'
 export R53_KEY='CHANGE_TO_THE_KEY'
 cd integrationTest              # NOTE: Not needed if already there
-go test -v -verbose -profile ROUTE53
+go test -v -args -verbose -profile ROUTE53
 ```
 
 Some useful `go test` flags:
 
+* Flags before `-args` go to the `go test` program. Flags after `-args` go to the program being tested.
 * Run only certain tests using the `-start` and `-end` flags.
   * Rather than running all the tests, run just the tests you want.
   * These flags must be *after* the `-profile FOO` flag.
-  * Example: `go test -v -verbose -profile ROUTE53 -start 10 -end 20` run tests 10-20 inclusive.
-  * Example: `go test -v -verbose -profile ROUTE53 -start 5 -end 5` runs only test 5.
-  * Example: `go test -v -verbose -profile ROUTE53 -start 20` skip the first 19 tests.
-  * Example: `go test -v -verbose -profile ROUTE53 -end 20` only run the first 20 tests.
+  * Example: `go test -v -args -verbose -profile ROUTE53 -start 10 -end 20` run tests 10-20 inclusive.
+  * Example: `go test -v -args -verbose -profile ROUTE53 -start 5 -end 5` runs only test 5.
+  * Example: `go test -v -args -verbose -profile ROUTE53 -start 20` skip the first 19 tests.
+  * Example: `go test -v -args -verbose -profile ROUTE53 -end 20` only run the first 20 tests.
 * Slow tests? Add `-timeout n` to increase the timeout for tests
   * `go test` kills the tests after 10 minutes by default.  Some providers need more time.
-  * This flag must be *before* the `-verbose` flag.  Usually it is the first flag after `go test`.
-  * Example:  `go test -timeout 20m -v -verbose -profile CLOUDFLAREAPI`
+  * This flag must be *before* the `-args` flag.
+  * Example:  `go test -timeout 20m -v -args -verbose -profile CLOUDFLAREAPI`
 * If a test will always fail because the provider doesn't support the feature, you can opt out of the test.  Look at `func makeTests()` in [integrationTest/integration_test.go](https://github.com/DNSControl/dnscontrol/blob/2f65533e1b92c2967229a92a304fff7c14f7f4b6/integrationTest/integration_test.go#L675) for more details.
 
 ## Step 8: Manual tests

--- a/documentation/provider/cloudflareapi.md
+++ b/documentation/provider/cloudflareapi.md
@@ -571,7 +571,7 @@ The integration tests assume that Cloudflare Workers are enabled and the credent
 
 ```shell
 cd integrationTest              # NOTE: Not needed if already in that subdirectory
-go test -v -verbose -profile CLOUDFLAREAPI -cfworkers=false
+go test -v -args -verbose -profile CLOUDFLAREAPI -cfworkers=false
 ```
 
 When `-cfworkers=false` is set, tests related to Workers are skipped.  The Account ID is not required.
@@ -582,7 +582,7 @@ Tests for per-record CNAME flattening (`CF_CNAME_FLATTEN_ON`/`CF_CNAME_FLATTEN_O
 
 ```shell
 cd integrationTest
-go test -v -verbose -profile CLOUDFLAREAPI -cfflatten=true
+go test -v -args -verbose -profile CLOUDFLAREAPI -cfflatten=true
 ```
 
 If you run with `-cfflatten=true` on a free zone, the tests will fail with an error from the Cloudflare API.
@@ -594,13 +594,13 @@ Tests for record comments (`CF_COMMENT`) always run since comments work on all p
 ```shell
 cd integrationTest
 # Tags disabled by default:
-go test -v -verbose -profile CLOUDFLAREAPI
+go test -v -args -verbose -profile CLOUDFLAREAPI
 
 # Enable tag tests (requires paid plan):
-go test -v -verbose -profile CLOUDFLAREAPI -cftags=true
+go test -v -args -verbose -profile CLOUDFLAREAPI -cftags=true
 
 # Enable all paid features:
-go test -v -verbose -profile CLOUDFLAREAPI -cfflatten=true -cftags=true
+go test -v -args -verbose -profile CLOUDFLAREAPI -cfflatten=true -cftags=true
 ```
 
 ## Cloudflare special TTLs

--- a/documentation/provider/cnr.md
+++ b/documentation/provider/cnr.md
@@ -58,7 +58,7 @@ export CNR_UID=test.user
 export CNR_PW=test.passw0rd
 export CNR_DEBUGMODE=2
 cd integrationTest              # NOTE: Not needed if already in that subdirectory
-go test -v -verbose -profile CNR
+go test -v -args -verbose -profile CNR
 ```
 
 ## Usage

--- a/integrationTest/integration_test.go
+++ b/integrationTest/integration_test.go
@@ -1234,7 +1234,7 @@ func makeTests() []*TestGroup {
 
 		// CLOUDFLAREAPI: Redirects:
 
-		// go test -v -verbose -profile CLOUDFLAREAPI -cfredirect=true  // Convert: Test Single Redirects
+		// go test -v -args -verbose -profile CLOUDFLAREAPI -cfredirect=true  // Convert: Test Single Redirects
 
 		// This test is commented out because of this error:
 		// "helpers_integration_test.go:241: not entitled: the use of operator Matches is not allowed, a Business plan or a WAF Advanced plan is required"

--- a/providers/huaweicloud/auditrecords.go
+++ b/providers/huaweicloud/auditrecords.go
@@ -10,11 +10,11 @@ import (
 // supported, an empty list is returned.
 func AuditRecords(records []*models.RecordConfig) []error {
 	a := rejectif.Auditor{}
-	// go test -v -run 'TestDNSProviders/.*/.*NullMX(Apex)?:(create|unnull|renull)$' -verbose -profile HUAWEICLOUD
+	// go test -v -run 'TestDNSProviders/.*/.*NullMX(Apex)?:(create|unnull|renull)$' -args -verbose -profile HUAWEICLOUD
 	a.Add("MX", rejectif.MxNull) // Last verified 2026-05-18
-	// go test -v -run 'TestDNSProviders/.*/.*TXT backslashes:TXT with backslashs$' -verbose -profile HUAWEICLOUD
+	// go test -v -run 'TestDNSProviders/.*/.*TXT backslashes:TXT with backslashs$' -args -verbose -profile HUAWEICLOUD
 	a.Add("TXT", rejectif.TxtHasBackslash) // Last verified 2026-05-18
-	// go test -v -run 'TestDNSProviders/.*/.*complex TXT:TXT with (1 dq-1interior|2 dq-2interior|1 dq-left|1 dq-right)$' -verbose -profile HUAWEICLOUD
+	// go test -v -run 'TestDNSProviders/.*/.*complex TXT:TXT with (1 dq-1interior|2 dq-2interior|1 dq-left|1 dq-right)$' -args -verbose -profile HUAWEICLOUD
 	a.Add("TXT", rejectif.TxtHasDoubleQuotes) // Last verified 2026-05-18
 
 	return a.Audit(records)

--- a/providers/route53/route53Provider.go
+++ b/providers/route53/route53Provider.go
@@ -43,7 +43,7 @@ func newRoute53Reg(conf map[string]string) (providers.Registrar, error) {
 	// AWS European Sovereign Cloud (aws.eu) does not support registering domains, at least not yet.
 	// Let us assume only the global AWS is capable of registering domains currently.
 	if conf["Region"] != "" && conf["Region"] != "us-east-1" {
-		return nil, errors.New("Error! Domain register endpoint is only supported on the global AWS region us-east-1.")
+		return nil, errors.New("Error! Domain register endpoint is only supported on the global AWS region us-east-1")
 	} else {
 		return newRoute53(conf, nil)
 	}
@@ -54,7 +54,7 @@ func newRoute53Dsp(conf map[string]string, metadata json.RawMessage) (providers.
 }
 
 func newRoute53(m map[string]string, _ json.RawMessage) (*route53Provider, error) {
-	optFns := []func(*config.LoadOptions) error{ }
+	optFns := []func(*config.LoadOptions) error{}
 
 	if m["Region"] != "" {
 		// AWS European Sovereign Cloud (aws.eu) region eusc-de-east-1 uses a separate Route 53 API endpoint from the global AWS


### PR DESCRIPTION
# Issue

When running integration tests, it is a bit confusing which flags are for the "go test" command and which are for the "dnscontrol" command.

# Resolution

Use the `-args` flag to separate the two types of flags.
