### PR TITLE
ROUTE53: Initial AWS European Sovereign Cloud support

### DIFF
--- a/documentation/provider/route53.md
+++ b/documentation/provider/route53.md
@@ -94,7 +94,7 @@ You can find some other ways to authenticate to Route53 in the [go sdk configura
 
 ## AWS European Sovereign Cloud (aws.eu)
 
-You can use AWS European Sovereign Cloud API endpoints by defining "eusc-de-east-1" to Region variable in `creds.json`. By default global AWS uses region "us-east-1" and you don't need to define it explicitly.
+You can use AWS European Sovereign Cloud API endpoints by setting the `Region` variable to `eusc-de-east-1` in `creds.json`. By default global AWS uses region "us-east-1" if not set explicitly.
 
 Notice that AWS ESC doesn't support domain registration endpoints. Currently you'll need to use global AWS to register domains with Route 53.
 

--- a/documentation/provider/route53.md
+++ b/documentation/provider/route53.md
@@ -94,7 +94,9 @@ You can find some other ways to authenticate to Route53 in the [go sdk configura
 
 ## AWS European Sovereign Cloud (aws.eu)
 
-You can use AWS European Sovereign Cloud API endpoints by defining "eusc-de-east-1" to Region variable in `creds.json`. AWS ESC doesn't support domain registration endpoints. Currently you'll need to use global AWS to register domains with Route 53.
+You can use AWS European Sovereign Cloud API endpoints by defining "eusc-de-east-1" to Region variable in `creds.json`. By default global AWS uses region "us-east-1" and you don't need to define it explicitly.
+
+Notice that AWS ESC doesn't support domain registration endpoints. Currently you'll need to use global AWS to register domains with Route 53.
 
 ## Metadata
 

--- a/documentation/provider/route53.md
+++ b/documentation/provider/route53.md
@@ -10,6 +10,7 @@ Example:
   "r53_main": {
     "TYPE": "ROUTE53",
     "DelegationSet": "optional-delegation-set-id",
+    "Region": "optional-aws-region-id",
     "KeyId": "your-aws-key",
     "SecretKey": "your-aws-secret-key",
     "Token": "optional-sts-token"
@@ -90,6 +91,10 @@ Example:
 {% endcode %}
 
 You can find some other ways to authenticate to Route53 in the [go sdk configuration](https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html).
+
+## AWS European Sovereign Cloud (aws.eu)
+
+You can use AWS European Sovereign Cloud API endpoints by defining "eusc-de-east-1" to Region variable in `creds.json`. AWS ESC doesn't support domain registration endpoints. Currently you'll need to use global AWS to register domains with Route 53.
 
 ## Metadata
 

--- a/providers/route53/route53Provider.go
+++ b/providers/route53/route53Provider.go
@@ -48,11 +48,16 @@ func newRoute53Dsp(conf map[string]string, metadata json.RawMessage) (providers.
 }
 
 func newRoute53(m map[string]string, _ json.RawMessage) (*route53Provider, error) {
-	optFns := []func(*config.LoadOptions) error{
+	optFns := []func(*config.LoadOptions) error{ }
+
+	if m["Region"] != "" {
+		// AWS European Sovereign Cloud (aws.eu) uses its own endpoint and does not support route53domains.
+		optFns = append(optFns, config.WithRegion(m["Region"]))
+	} else {
 		// Route53 uses a global endpoint and route53domains
 		// currently only has a single regional endpoint in us-east-1
 		// https://docs.aws.amazon.com/general/latest/gr/rande.html#r53_region
-		config.WithRegion("us-east-1"),
+		optFns = append(optFns, config.WithRegion("us-east-1"))
 	}
 
 	keyID, secretKey, tokenID, roleArn, externalID := m["KeyId"], m["SecretKey"], m["Token"], m["RoleArn"], m["ExternalId"]

--- a/providers/route53/route53Provider.go
+++ b/providers/route53/route53Provider.go
@@ -41,7 +41,7 @@ type route53Provider struct {
 
 func newRoute53Reg(conf map[string]string) (providers.Registrar, error) {
 	// AWS European Sovereign Cloud (aws.eu) does not support registering domains, at least not yet.
-	// Let us assume only the global AWS is capable of registering domains curerntly.
+	// Let us assume only the global AWS is capable of registering domains currently.
 	if conf["Region"] != "" && conf["Region"] != "us-east-1" {
 		return nil, errors.New("Error! Domain register endpoint is only supported on the global AWS region us-east-1.")
 	} else {

--- a/providers/route53/route53Provider.go
+++ b/providers/route53/route53Provider.go
@@ -180,7 +180,7 @@ func init() {
 			{
 				Key:      "KeyId",
 				Label:    "AWS access key ID",
-			Help:     "The AWS_ACCESS_KEY_ID for an IAM user or role with Route 53 permissions.",
+				Help:     "The AWS_ACCESS_KEY_ID for an IAM user or role with Route 53 permissions.",
 				EnvVar:   "AWS_ACCESS_KEY_ID",
 				Required: true,
 				ShowIf:   map[string]string{"_authMethod": "Static access key"},

--- a/providers/route53/route53Provider.go
+++ b/providers/route53/route53Provider.go
@@ -151,6 +151,12 @@ func init() {
 		Notes:       "Route53 supports several auth methods: a named profile from ~/.aws/config (including AWS IAM Identity Center / SSO), static access keys, or the SDK's default credential chain (environment variables, EC2 instance role, etc.). RoleArn can be layered on top of any of these.",
 		Fields: []providers.CredsField{
 			{
+				Key:    "Region",
+				Label:  "AWS Region to use for Route 53 control plane (optional)",
+				Help:   "Leave blank to use default global Route 53 in us-east-1. Type \"eusc-de-east-1\" for AWS European Sovereign Cloud.",
+				EnvVar: "AWS_DEFAULT_REGION",
+			},
+			{
 				Key:      "_authMethod",
 				Label:    "Which authentication method do you want to use?",
 				Help:     "Named profile reads ~/.aws/config and supports SSO. Static access key uses KeyId/SecretKey. Default credential chain relies on the AWS SDK to discover credentials from the environment or instance role.",
@@ -168,7 +174,7 @@ func init() {
 			{
 				Key:      "KeyId",
 				Label:    "AWS access key ID",
-				Help:     "The AWS_ACCESS_KEY_ID for an IAM user or role with Route 53 permissions.",
+			Help:     "The AWS_ACCESS_KEY_ID for an IAM user or role with Route 53 permissions.",
 				EnvVar:   "AWS_ACCESS_KEY_ID",
 				Required: true,
 				ShowIf:   map[string]string{"_authMethod": "Static access key"},

--- a/providers/route53/route53Provider.go
+++ b/providers/route53/route53Provider.go
@@ -40,7 +40,13 @@ type route53Provider struct {
 }
 
 func newRoute53Reg(conf map[string]string) (providers.Registrar, error) {
-	return newRoute53(conf, nil)
+	// AWS European Sovereign Cloud (aws.eu) does not support registering domains, at least not yet.
+	// Let us assume only the global AWS is capable of registering domains curerntly.
+	if conf["Region"] != "" && conf["Region"] != "us-east-1" {
+		return nil, errors.New("Error! Domain register endpoint is only supported on the global AWS region us-east-1.")
+	} else {
+		return newRoute53(conf, nil)
+	}
 }
 
 func newRoute53Dsp(conf map[string]string, metadata json.RawMessage) (providers.DNSServiceProvider, error) {

--- a/providers/route53/route53Provider.go
+++ b/providers/route53/route53Provider.go
@@ -57,7 +57,7 @@ func newRoute53(m map[string]string, _ json.RawMessage) (*route53Provider, error
 	optFns := []func(*config.LoadOptions) error{ }
 
 	if m["Region"] != "" {
-		// AWS European Sovereign Cloud (aws.eu) uses its own endpoint and does not support route53domains.
+		// AWS European Sovereign Cloud (aws.eu) region eusc-de-east-1 uses a separate Route 53 API endpoint from the global AWS
 		optFns = append(optFns, config.WithRegion(m["Region"]))
 	} else {
 		// Route53 uses a global endpoint and route53domains


### PR DESCRIPTION
# Summary
Route53: Initial support for AWS European Sovereign Cloud (aws.eu)
Domain registration isn't supported in AWS ESC, the code generates an error when tryign to register a domain on the ESC.

# Changes
* `providers/route53/route53Provider.go` Add optional Region variable to creds.json, add init support for Region
* `documentation/provider/route53.md` Update Route53 documentation about AWS European Sovereign Cloud region
