### PR TITLE
TYPES: Allow RecordModifier to accept arrays

### DIFF
--- a/commands/types/base-types.d.ts
+++ b/commands/types/base-types.d.ts
@@ -25,7 +25,8 @@ type DomainModifier =
 
 type RecordModifier =
     | ((record: DNSRecord) => void)
-    | Partial<DNSRecord['meta']>;
+    | Partial<DNSRecord['meta']>
+    | RecordModifier[];
 
 type Duration =
     | `${number}${'s' | 'm' | 'h' | 'd' | 'w' | 'n' | 'y' | ''}`

--- a/commands/types/dnscontrol.d.ts
+++ b/commands/types/dnscontrol.d.ts
@@ -27,7 +27,8 @@ type DomainModifier =
 
 type RecordModifier =
     | ((record: DNSRecord) => void)
-    | Partial<DNSRecord['meta']>;
+    | Partial<DNSRecord['meta']>
+    | RecordModifier[];
 
 type Duration =
     | `${number}${'s' | 'm' | 'h' | 'd' | 'w' | 'n' | 'y' | ''}`


### PR DESCRIPTION
`DomainModifier` already includes `| DomainModifier[]`, but `RecordModifier` did not — even though dnscontrol flattens nested modifier arrays at runtime. This is why the common `ttl ? TTL(ttl) : []` no-op idiom works at runtime but errors under the type definitions. Added `| RecordModifier[]` to restore the symmetry.

```diff
 type RecordModifier =
     | ((record: DNSRecord) => void)
-    | Partial<DNSRecord['meta']>;
+    | Partial<DNSRecord['meta']>
+    | RecordModifier[];
```

`commands/types/dnscontrol.d.ts` was regenerated via `go generate` from `base-types.d.ts`.