### PR TITLE
HEDNS: Performance improvements

### DIFF
--- a/documentation/provider/index.md
+++ b/documentation/provider/index.md
@@ -120,7 +120,7 @@ Jump to a table:
 | [`GCLOUD`](gcloud.md) | ✅ | ✅ | ✅ | ✅ |
 | [`GCORE`](gcore.md) | ✅ | ✅ | ✅ | ✅ |
 | [`GIDINET`](gidinet.md) | ✅ | ✅ | ❌ | ✅ |
-| [`HEDNS`](hedns.md) | ❔ | ✅ | ✅ | ✅ |
+| [`HEDNS`](hedns.md) | ✅ | ✅ | ✅ | ✅ |
 | [`HETZNER`](hetzner.md) | ✅ | ✅ | ✅ | ✅ |
 | [`HETZNER_V2`](hetznerv2.md) | ✅ | ✅ | ✅ | ✅ |
 | [`HOSTINGDE`](hostingde.md) | ❔ | ✅ | ✅ | ✅ |

--- a/providers/hedns/hednsProvider.go
+++ b/providers/hedns/hednsProvider.go
@@ -11,7 +11,6 @@ import (
 	"net/url"
 	"os"
 	"path"
-	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -24,6 +23,7 @@ import (
 	"github.com/DNSControl/dnscontrol/v4/pkg/rtypecontrol"
 	"github.com/DNSControl/dnscontrol/v4/pkg/rtypeinfo"
 	"github.com/DNSControl/dnscontrol/v4/pkg/txtutil"
+	"github.com/DNSControl/dnscontrol/v4/pkg/zonecache"
 	"github.com/PuerkitoBio/goquery"
 	"github.com/pquerna/otp/totp"
 )
@@ -155,6 +155,7 @@ type hednsProvider struct {
 	SessionFilePath string
 
 	httpClient http.Client
+	zoneCache  zonecache.ZoneCache[uint64]
 }
 
 // Record stores the HEDNS specific zone and record IDs.
@@ -197,6 +198,7 @@ func newHEDNSProvider(cfg map[string]string, _ json.RawMessage) (providers.DNSSe
 	// Create storage for the cookies
 	cookieJar, _ := cookiejar.New(nil)
 	client.httpClient = http.Client{Jar: cookieJar}
+	client.zoneCache = zonecache.New(client.listDomains)
 
 	err := client.authenticate()
 	return client, err
@@ -204,33 +206,23 @@ func newHEDNSProvider(cfg map[string]string, _ json.RawMessage) (providers.DNSSe
 
 // ListZones list all zones on this provider.
 func (c *hednsProvider) ListZones() ([]string, error) {
-	domainsMap, err := c.listDomains()
+	domains, err := c.zoneCache.GetZoneNames()
 	if err != nil {
 		return nil, err
 	}
-
-	domains := make([]string, 0, len(domainsMap))
-	for domain := range domainsMap {
-		domains = append(domains, domain)
-	}
-
-	// Ensure the order is deterministic
 	sort.Strings(domains)
-
-	return domains, err
+	return domains, nil
 }
 
 // EnsureZoneExists creates a zone if it does not exist.
 func (c *hednsProvider) EnsureZoneExists(domain string, metadata map[string]string) error {
-	domains, err := c.ListZones()
+	ok, err := c.zoneCache.HasZone(domain)
 	if err != nil {
 		return err
 	}
-
-	if slices.Contains(domains, domain) {
+	if ok {
 		return nil
 	}
-
 	return c.createDomain(domain)
 }
 
@@ -273,13 +265,9 @@ func (c *hednsProvider) GetZoneRecordsCorrections(dc *models.DomainConfig, recor
 		return nil, 0, err
 	}
 
-	// Get the SOA record to get the ZoneID, then remove it from the list.
-	zoneID := uint64(0)
-	var prunedRecords models.Records
+	prunedRecords := make(models.Records, 0, len(records))
 	for _, r := range records {
-		if r.Type == "SOA" {
-			zoneID = r.Original.(Record).ZoneID
-		} else {
+		if r.Type != "SOA" {
 			prunedRecords = append(prunedRecords, r)
 		}
 	}
@@ -308,7 +296,7 @@ func (c *hednsProvider) GetZoneRecordsCorrections(dc *models.DomainConfig, recor
 		}
 	}
 
-	return c.getDiff2DomainCorrections(dc, zoneID, prunedRecords)
+	return c.getDiff2DomainCorrections(dc, prunedRecords)
 }
 
 // resolveDynamic determines the desired dynamic flag for a record.
@@ -329,7 +317,12 @@ func resolveDynamic(newRec *models.RecordConfig, oldRec *Record) bool {
 	return false
 }
 
-func (c *hednsProvider) getDiff2DomainCorrections(dc *models.DomainConfig, zoneID uint64, records models.Records) ([]*models.Correction, int, error) {
+func (c *hednsProvider) getDiff2DomainCorrections(dc *models.DomainConfig, records models.Records) ([]*models.Correction, int, error) {
+	zoneID, err := c.zoneCache.GetZone(dc.Name)
+	if err != nil {
+		return nil, 0, err
+	}
+
 	// DDNS keys are write-only: HE DNS does not expose them for reading.
 	// Strip hedns_ddns_key from desired metadata before the diff so that it
 	// does not cause perpetual spurious changes, but save the intents so we
@@ -424,14 +417,12 @@ func (c *hednsProvider) GetZoneRecords(dc *models.DomainConfig) (models.Records,
 	var zoneRecords []*models.RecordConfig
 
 	// Get Domain ID
-	domains, err := c.listDomains()
+	domainID, err := c.zoneCache.GetZone(domain)
 	if err != nil {
+		if errors.Is(err, zonecache.ErrZoneNotFound) {
+			return nil, fmt.Errorf("domain %s does not exist", domain)
+		}
 		return nil, err
-	}
-
-	domainID, domainExists := domains[domain]
-	if !domainExists {
-		return nil, fmt.Errorf("domain %s does not exist", domain)
 	}
 
 	queryURL, _ := url.Parse(apiEndpoint)
@@ -678,8 +669,10 @@ func (c *hednsProvider) listDomains() (map[string]uint64, error) {
 	if err != nil {
 		return nil, err
 	}
+	return parseDomainsTable(document)
+}
 
-	// Check there are any domains in this account
+func parseDomainsTable(document *goquery.Document) (map[string]uint64, error) {
 	domains := make(map[string]uint64)
 	if document.Find("#domains_table").Size() == 0 {
 		return domains, nil
@@ -691,6 +684,7 @@ func (c *hednsProvider) listDomains() (map[string]uint64, error) {
 		"#tabs-advanced .generic_table > tbody > tr > td:last-child > img", // Reverse records
 	}, ", ")
 
+	var err error
 	document.Find(recordsSelector).EachWithBreak(func(index int, element *goquery.Selection) bool {
 		domainID, idExists := element.Attr("value")
 		domainName, nameExists := element.Attr("name")
@@ -718,8 +712,18 @@ func (c *hednsProvider) createDomain(domain string) error {
 	}
 	defer response.Body.Close()
 
-	_, err = c.parseResponseForDocumentAndErrors(response)
-	return err
+	document, err := c.parseResponseForDocumentAndErrors(response)
+	if err != nil {
+		return err
+	}
+	domains, err := parseDomainsTable(document)
+	if err != nil {
+		return err
+	}
+	if id, ok := domains[domain]; ok {
+		c.zoneCache.SetZone(domain, id)
+	}
+	return nil
 }
 
 func (c *hednsProvider) editZoneRecord(zoneID uint64, recordID uint64, rc *models.RecordConfig, create bool, dynamic bool) error {

--- a/providers/hedns/hednsProvider.go
+++ b/providers/hedns/hednsProvider.go
@@ -186,7 +186,6 @@ func newHEDNSProvider(cfg map[string]string, _ json.RawMessage) (providers.DNSSe
 		return nil, errors.New("totp and totp-key must not be specified at the same time")
 	}
 
-	// Perform the initial login
 	client := &hednsProvider{
 		Username:        username,
 		Password:        password,
@@ -195,13 +194,17 @@ func newHEDNSProvider(cfg map[string]string, _ json.RawMessage) (providers.DNSSe
 		SessionFilePath: sessionFilePath,
 	}
 
-	// Create storage for the cookies
+	// Create storage for the cookies.
 	cookieJar, _ := cookiejar.New(nil)
 	client.httpClient = http.Client{Jar: cookieJar}
 	client.zoneCache = zonecache.New(client.listDomains)
 
-	err := client.authenticate()
-	return client, err
+	// Reuse cached session file if one is set.
+	if client.SessionFilePath != "" {
+		_ = client.loadSessionFile()
+	}
+
+	return client, nil
 }
 
 // ListZones list all zones on this provider.
@@ -529,29 +532,6 @@ func (c *hednsProvider) GetZoneRecords(dc *models.DomainConfig) (models.Records,
 	return zoneRecords, err
 }
 
-func (c *hednsProvider) authResumeSession() (authenticated bool, requiresTfa bool, err error) {
-	response, err := c.httpClient.Get(apiEndpoint)
-	if err != nil {
-		return false, false, err
-	}
-	defer response.Body.Close()
-
-	document, err := c.parseResponseForDocumentAndErrors(response)
-	if err != nil {
-		// Deal with the edge case where we have attempted to use the same authentication token more than two times
-		if err.Error() == errorTotpTokenRequired {
-			return false, true, nil
-		}
-		return false, false, err
-	}
-
-	// Look for the presence of the login button or the TFA input
-	authenticated = document.Find("#_tlogout").Size() > 0
-	requiresTfa = document.Find("input#tfacode").Size() > 0
-
-	return authenticated, requiresTfa, err
-}
-
 func (c *hednsProvider) authUsernameAndPassword() (authenticated bool, requiresTfa bool, err error) {
 	// Login with username and password
 	response, err := c.httpClient.PostForm(apiEndpoint, url.Values{
@@ -620,56 +600,66 @@ func (c *hednsProvider) auth2FA() (authenticated bool, err error) {
 }
 
 func (c *hednsProvider) authenticate() error {
-	if c.SessionFilePath != "" {
-		_ = c.loadSessionFile()
-	}
-
-	authenticated, requiresTfa, err := c.authResumeSession()
+	authenticated, requiresTfa, err := c.authUsernameAndPassword()
 	if err != nil {
 		return err
 	}
 
-	if !authenticated {
-		// Only perform username and password login if two-factor authentication is not required at this stage
-		if !requiresTfa {
-			authenticated, requiresTfa, err = c.authUsernameAndPassword()
-			if err != nil {
-				return err
-			}
-		}
-
-		// Only perform two-factor authentication if required
-		if requiresTfa {
-			authenticated, err = c.auth2FA()
-			if err != nil {
-				return err
-			}
+	if requiresTfa {
+		authenticated, err = c.auth2FA()
+		if err != nil {
+			return err
 		}
 	}
 
 	if !authenticated {
-		err = errors.New("unknown authentication failure")
-	} else {
-		if c.SessionFilePath != "" {
-			err = c.saveSessionFile()
-		}
+		return errors.New("unknown authentication failure")
 	}
 
-	return err
+	if c.SessionFilePath != "" {
+		return c.saveSessionFile()
+	}
+	return nil
 }
 
 func (c *hednsProvider) listDomains() (map[string]uint64, error) {
-	response, err := c.httpClient.Get(apiEndpoint)
-	if err != nil {
+	fetchRoot := func() (*goquery.Document, error) {
+		response, err := c.httpClient.Get(apiEndpoint)
+		if err != nil {
+			return nil, err
+		}
+		defer response.Body.Close()
+		return goquery.NewDocumentFromReader(response.Body)
+	}
+
+	// With a cached session, try it first; the page reveals if it is still valid.
+	if c.hasSession() {
+		document, err := fetchRoot()
+		if err != nil {
+			return nil, err
+		}
+		// #_tlogout is only present once the session is authenticated.
+		if document.Find("#_tlogout").Size() > 0 {
+			return parseDomainsTable(document)
+		}
+	}
+
+	if err := c.authenticate(); err != nil {
 		return nil, err
 	}
-	defer response.Body.Close()
-
-	document, err := goquery.NewDocumentFromReader(response.Body)
+	document, err := fetchRoot()
 	if err != nil {
 		return nil, err
 	}
 	return parseDomainsTable(document)
+}
+
+func (c *hednsProvider) hasSession() bool {
+	u, err := url.Parse(apiEndpoint)
+	if err != nil {
+		return false
+	}
+	return len(c.httpClient.Jar.Cookies(u)) > 0
 }
 
 func parseDomainsTable(document *goquery.Document) (map[string]uint64, error) {

--- a/providers/hedns/hednsProvider.go
+++ b/providers/hedns/hednsProvider.go
@@ -52,7 +52,7 @@ var features = providers.DocumentationNotes{
 	// See providers/capabilities.go for the entire list of capabilities.
 	providers.CanAutoDNSSEC:          providers.Cannot(),
 	providers.CanGetZones:            providers.Can(),
-	providers.CanConcur:              providers.Unimplemented(),
+	providers.CanConcur:              providers.Can(),
 	providers.CanUseAlias:            providers.Can(),
 	providers.CanUseCAA:              providers.Can(),
 	providers.CanUseDHCID:            providers.Cannot(),


### PR DESCRIPTION
## Issue

HEDNS has no API, so this provider scrapes its web UI and every request costs ~2s.

These changes cut redundant requests, allow zones to be processed in parallel, and stop the constructor from doing network I/O.

This should help with https://github.com/DNSControl/dnscontrol/issues/4345.

## Changes

- **Cache the zone list** via the shared `pkg/zonecache`.
- **Enable `CanConcur`** so multiple HEDNS zones are processed concurrently.
- **Defer authentication out of the constructor** to first use, reusing the persisted `.hedns-session` optimistically.

## Performance

Measured on integration testgroups 0-9 (single zone, identical range, same live account, only the provider code differing):

| | Before | After | Improvement |
|---|--:|--:|--:|
| Wall-clock (testgroups 0-9) | 333.6s | 210.0s | 37% (1.59×) |

## Testing

- Integration tests pass against a live HE account.
- Concurrency checked with a `-race` probe: concurrent `GetZoneRecords` returned identical record sets with no data races.
- Warm session reuse verified (no re-login when a valid `.hedns-session` exists).