### PR TITLE
DNSIMPLE: Update to new NS1 & NS3 nameservers

### DIFF
--- a/providers/dnsimple/dnsimpleProvider.go
+++ b/providers/dnsimple/dnsimpleProvider.go
@@ -58,9 +58,9 @@ func init() {
 const stateRegistered = "registered"
 
 var defaultNameServerNames = []string{
-	"ns1.dnsimple.com",
+	"ns1.dnsimple-edge.com",
 	"ns2.dnsimple-edge.net",
-	"ns3.dnsimple.com",
+	"ns3.dnsimple-edge.io",
 	"ns4.dnsimple-edge.org",
 }
 


### PR DESCRIPTION
This updates the nameservers for the DNSimple dns provider per the migration documented here.

https://support.dnsimple.com/articles/announcement-ns1-ns3-ip-addresses/

All domains that use the DNSimple DnsProvider will be switched to the up-to-date list of nameservers here, there should be no disruptions for this change.

https://support.dnsimple.com/articles/dnsimple-nameservers/

> The legacy `ns1.dnsimple.com` and `ns3.dnsimple.com` hostnames will continue to resolve after the migration but they are no longer recommended.