### PR TITLE
DOCS: Homebrew install requires `brew trust` since Homebrew 5.1.15

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -175,6 +175,7 @@ release:
     ##### Install with [Homebrew](https://brew.sh) (recommended)
 
     ```shell
+    brew trust --formula dnscontrol/tap/dnscontrol
     brew install DNSControl/tap/dnscontrol
     ```
 

--- a/documentation/getting-started/getting-started.md
+++ b/documentation/getting-started/getting-started.md
@@ -14,6 +14,7 @@ Choose one of the following installation methods:
 On macOS (or Linux) you can install it using [Homebrew](https://brew.sh).
 
 ```shell
+brew trust --formula dnscontrol/tap/dnscontrol
 brew install DNSControl/tap/dnscontrol
 ```
 


### PR DESCRIPTION
Since [Homebrew 5.1.15](https://github.com/Homebrew/brew/releases/tag/5.1.15) (May 30, 2026), third-party taps are marked as untrusted. Starting with Homebrew 6.0.0 (or 5.2.0, whichever comes first), untrusted taps will be blocked by default. This means users installing DNSControl via `brew install DNSControl/tap/dnscontrol` need to explicitly trust the tap first with `brew trust --formula dnscontrol/tap/dnscontrol`. See [Tap Trust](https://docs.brew.sh/Tap-Trust) for details.

This adds the `brew trust` command to the Homebrew install instructions in the Getting Started documentation and the GoReleaser release notes template that appears on every GitHub Release.