### PR TITLE
BUGFIX: Avoid panic in ToRR when A/AAAA target is an invalid IP

### DIFF
--- a/models/dns_test.go
+++ b/models/dns_test.go
@@ -49,6 +49,20 @@ func TestRR(t *testing.T) {
 	}
 }
 
+func TestRRInvalidIPNoPanic(t *testing.T) {
+	// A malformed AAAA target (e.g. an incomplete IPv6 address) leaves the
+	// stored target unparseable. ToRR must not panic while building the RR so
+	// that normalize validation can report the error to the user.
+	experiment := RecordConfig{
+		Type:     "AAAA",
+		Name:     "@",
+		NameFQDN: "example.com",
+		target:   "2a00:1450:4003:809:1",
+		TTL:      300,
+	}
+	experiment.ToRR()
+}
+
 func TestSvcbAutoHintsTargetCombined(t *testing.T) {
 	experiment := RecordConfig{
 		Type:        "HTTPS",

--- a/models/record.go
+++ b/models/record.go
@@ -393,12 +393,14 @@ func (rc *RecordConfig) ToRR() dnsv1.RR {
 	switch rdtype { // #rtype_variations
 	case dnsv1.TypeA:
 		addr := rc.GetTargetIP()
-		s := addr.AsSlice()
-		rr.(*dnsv1.A).A = s[0:4]
+		if s := addr.AsSlice(); len(s) == 4 {
+			rr.(*dnsv1.A).A = s
+		}
 	case dnsv1.TypeAAAA:
 		addr := rc.GetTargetIP()
-		s := addr.AsSlice()
-		rr.(*dnsv1.AAAA).AAAA = s[0:16]
+		if s := addr.AsSlice(); len(s) == 16 {
+			rr.(*dnsv1.AAAA).AAAA = s
+		}
 	case dnsv1.TypeCAA:
 		rr.(*dnsv1.CAA).Flag = rc.CaaFlag
 		rr.(*dnsv1.CAA).Tag = rc.CaaTag


### PR DESCRIPTION
An AAAA (or A) record whose target is a malformed IP, such as the incomplete `2a00:1450:4003:809:1` from #4375, leaves the stored target unparseable. `GetTargetIP` then returns the zero `netip.Addr`, whose `AsSlice()` is empty, and `ToRR` slices it with `s[0:16]`, panicking with "slice bounds out of range" before normalize validation can report the bad IP.

This guards the A/AAAA cases so the slice is only assigned when it has the expected length, letting the existing "invalid IP" validation error surface instead of crashing. Added a regression test that builds an RR from an invalid AAAA target.

Fixes #4375