### PR TITLE
NEW PROVIDER: WebSupport (websupport.sk) DNS provider

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -63,6 +63,7 @@ providers/transip @blackshadev
 providers/unifi @zupolgec
 providers/vercel @SukkaW
 providers/vultr @pgaskin
+providers/websupport @mtmn
 
 * @TomOnTime
 .goreleaser.yml @cafferata @TomOnTime

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -193,3 +193,6 @@ provider-VERCEL:
 provider-VULTR:
   - changed-files:
       - any-glob-to-any-file: providers/vultr/**
+provider-WEBSUPPORT:
+  - changed-files:
+      - any-glob-to-any-file: providers/websupport/**

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -37,7 +37,7 @@ changelog:
       regexp: "(?i)^.*(major|new provider|feature)[(\\w)]*:+.*$"
       order: 1
     - title: 'Provider-specific changes:'
-      regexp: "(?i)((adguardhome|akamaiedgedns|alidns|autodns|axfrddns|azure_dns|azure_private_dns|azuredns|bind|bunny_dns|bunnydns|cloudflare|cloudflareapi|cloudns|cnr|cscglobal|desec|digitalocean|dnscale|dnsimple|dnsmadeeasy|dnsoverhttps|doh|domainnameshop|dynadot|easyname|exoscale|fortigate|gandi|gandi_v5|gcloud|gcore|gidinet|hedns|hetzner|hetzner_v2|hexonet|hostingde|huaweicloud|infomaniak|internetbs|inwx|joker|linode|loopia|luadns|mikrotik|mythicbeasts|namecheap|namedotcom|netbird|netcup|netlify|netnod|ns1|opensrs|oracle|ovh|packetframe|porkbun|powerdns|realtimeregister|route53|rwth|sakuracloud|softlayer|tencentdns|transip|unifi|vercel|vultr).*:)+.*"
+      regexp: "(?i)((adguardhome|akamaiedgedns|alidns|autodns|axfrddns|azure_dns|azure_private_dns|azuredns|bind|bunny_dns|bunnydns|cloudflare|cloudflareapi|cloudns|cnr|cscglobal|desec|digitalocean|dnscale|dnsimple|dnsmadeeasy|dnsoverhttps|doh|domainnameshop|dynadot|easyname|exoscale|fortigate|gandi|gandi_v5|gcloud|gcore|gidinet|hedns|hetzner|hetzner_v2|hexonet|hostingde|huaweicloud|infomaniak|internetbs|inwx|joker|linode|loopia|luadns|mikrotik|mythicbeasts|namecheap|namedotcom|netbird|netcup|netlify|netnod|ns1|opensrs|oracle|ovh|packetframe|porkbun|powerdns|realtimeregister|route53|rwth|sakuracloud|softlayer|tencentdns|transip|unifi|vercel|vultr|websupport).*:)+.*"
       order: 2
     - title: 'Documentation:'
       regexp: "(?i)^.*(docs)[(\\w)]*:+.*$"

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ See [Getting Started](https://docs.dnscontrol.org/getting-started/getting-starte
 
 ## Supported Providers
 
-DNSControl supports 63 DNS providers and registrars:
+DNSControl supports 64 DNS providers and registrars:
 
 | | | | | |
 | ----- | ----- | ----- | ----- | ----- |
@@ -59,6 +59,7 @@ DNSControl supports 63 DNS providers and registrars:
 | [Oracle Cloud](https://docs.dnscontrol.org/provider/oracle) | [OVH](https://docs.dnscontrol.org/provider/ovh)¹ | [Packetframe](https://docs.dnscontrol.org/provider/packetframe) | [Porkbun](https://docs.dnscontrol.org/provider/porkbun)¹ | [PowerDNS](https://docs.dnscontrol.org/provider/powerdns) |
 | [Realtime Register](https://docs.dnscontrol.org/provider/realtimeregister)¹ | [RWTH DNS-Admin](https://docs.dnscontrol.org/provider/rwth) | [Sakura Cloud](https://docs.dnscontrol.org/provider/sakuracloud) | [SoftLayer](https://docs.dnscontrol.org/provider/softlayer) | [Tencent Cloud DNS](https://docs.dnscontrol.org/provider/tencentdns)¹ |
 | [TransIP](https://docs.dnscontrol.org/provider/transip) | [UniFi Network](https://docs.dnscontrol.org/provider/unifi) | [Vercel](https://docs.dnscontrol.org/provider/vercel) | [Vultr](https://docs.dnscontrol.org/provider/vultr) | [Netbird](https://docs.dnscontrol.org/provider/netbird) |
+| [WebSupport](https://docs.dnscontrol.org/provider/websupport) | | | | |
 
 ¹also supports registrar functions
 ²registrar only

--- a/documentation/SUMMARY.md
+++ b/documentation/SUMMARY.md
@@ -185,6 +185,7 @@
 * [UniFi Network](provider/unifi.md)
 * [Vercel](provider/vercel.md)
 * [Vultr](provider/vultr.md)
+* [WebSupport](provider/websupport.md)
 
 ## Commands
 

--- a/documentation/provider/index.md
+++ b/documentation/provider/index.md
@@ -87,6 +87,7 @@ Jump to a table:
 | [`UNIFI`](unifi.md) | ❌ | ✅ | ❌ |
 | [`VERCEL`](vercel.md) | ❌ | ✅ | ❌ |
 | [`VULTR`](vultr.md) | ❌ | ✅ | ❌ |
+| [`WEBSUPPORT`](websupport.md) | ❌ | ✅ | ❌ |
 
 
 ### Provider API <!--(table 2/6)-->
@@ -157,6 +158,7 @@ Jump to a table:
 | [`UNIFI`](unifi.md) | ❌ | ❔ | ❌ | ❌ |
 | [`VERCEL`](vercel.md) | ❔ | ❌ | ❌ | ❌ |
 | [`VULTR`](vultr.md) | ❔ | ❔ | ✅ | ✅ |
+| [`WEBSUPPORT`](websupport.md) | ❔ | ❌ | ❌ | ❌ |
 
 
 ### DNS extensions <!--(table 3/6)-->
@@ -222,6 +224,7 @@ Jump to a table:
 | [`UNIFI`](unifi.md) | ❌ | ❔ | ❌ | ❌ | ❔ |
 | [`VERCEL`](vercel.md) | ✅ | ❌ | ❌ | ❌ | ❌ |
 | [`VULTR`](vultr.md) | ❌ | ❔ | ❌ | ❌ | ❔ |
+| [`WEBSUPPORT`](websupport.md) | ❌ | ❔ | ❌ | ❌ | ❌ |
 
 
 ### Service discovery <!--(table 4/6)-->
@@ -286,6 +289,7 @@ Jump to a table:
 | [`UNIFI`](unifi.md) | ❔ | ❔ | ✅ | ❔ |
 | [`VERCEL`](vercel.md) | ❌ | ❌ | ✅ | ❌ |
 | [`VULTR`](vultr.md) | ❔ | ❔ | ✅ | ❔ |
+| [`WEBSUPPORT`](websupport.md) | ❔ | ❌ | ✅ | ❔ |
 
 
 ### Security <!--(table 5/6)-->
@@ -347,6 +351,7 @@ Jump to a table:
 | [`UNIFI`](unifi.md) | ❌ | ❔ | ❔ | ❌ | ❌ |
 | [`VERCEL`](vercel.md) | ✅ | ✅ | ❔ | ❌ | ❌ |
 | [`VULTR`](vultr.md) | ✅ | ❔ | ❔ | ✅ | ❌ |
+| [`WEBSUPPORT`](websupport.md) | ❌ | ❔ | ❔ | ❌ | ❌ |
 
 
 ### DNSSEC <!--(table 6/6)-->
@@ -391,6 +396,7 @@ Jump to a table:
 | [`SAKURACLOUD`](sakuracloud.md) | ❌ | ❌ | ❌ |
 | [`TRANSIP`](transip.md) | ❌ | ❌ | ❌ |
 | [`VERCEL`](vercel.md) | ❌ | ❌ | ❌ |
+| [`WEBSUPPORT`](websupport.md) | ❔ | ❔ | ❌ |
 
 <!-- provider-matrix-end -->
 

--- a/documentation/provider/websupport.md
+++ b/documentation/provider/websupport.md
@@ -1,0 +1,85 @@
+# Configuration
+
+To use this provider, add an entry to `creds.json` with `TYPE` set to `WEBSUPPORT`
+along with your WebSupport API key and secret. Both are generated in the
+[Security section](https://admin.websupport.sk/en/auth/security) of the WebSupport
+admin console.
+
+Example:
+
+{% code title="creds.json" %}
+```json
+{
+  "websupport": {
+    "TYPE": "WEBSUPPORT",
+    "api_key": "your-api-key",
+    "secret": "your-api-secret"
+  }
+}
+```
+{% endcode %}
+
+You can also use environment variables:
+
+{% code title="creds.json" %}
+```json
+{
+  "websupport": {
+    "TYPE": "WEBSUPPORT",
+    "api_key": "$WEBSUPPORT_API_KEY",
+    "secret": "$WEBSUPPORT_SECRET"
+  }
+}
+```
+{% endcode %}
+
+## Metadata
+
+This provider does not recognize any special metadata fields unique to WebSupport.
+
+## Usage
+
+An example configuration:
+
+{% code title="dnsconfig.js" %}
+```javascript
+var REG_NONE = NewRegistrar("none");
+var DSP_WEBSUPPORT = NewDnsProvider("websupport");
+
+D("example.com", REG_NONE, DnsProvider(DSP_WEBSUPPORT),
+    A("@", "1.2.3.4"),
+    CNAME("www", "@"),
+    MX("@", 10, "mail.example.com."),
+);
+```
+{% endcode %}
+
+# Activation
+
+DNSControl uses the [WebSupport REST API v2](https://rest.websupport.sk/v2/docs)
+to manage your DNS records. Generate an API key and secret in the
+[Security section](https://admin.websupport.sk/en/auth/security) of the admin
+console.
+
+Authentication uses HTTP Basic auth where the username is the API key and the
+password is a per-request HMAC-SHA1 signature derived from the secret. The
+secret itself is never transmitted.
+
+## Notes and limitations
+
+* **Zones must already exist.** The API has no endpoint to create a zone or to
+  enumerate all zones, so `create-domains` and `get-zones` are not supported.
+  Add domains through the WebSupport portal first.
+* **Supported record types:** `A`, `AAAA`, `CNAME`, `MX`, `TXT`, and `SRV`.
+* **Unsupported record types**, due to WebSupport v2 API limitations:
+  * `NS` — the API silently ignores attempts to create NS records, so they are
+    rejected to avoid an endless create loop. Apex nameservers are managed by
+    WebSupport and are not exposed through the DNS record API.
+  * `CAA` — the API does not return the `tag`/`flags` of a CAA record on read,
+    so the record cannot be managed without churn.
+  * `ALIAS`/`ANAME` — WebSupport only allows `ANAME` at the apex and rejects it
+    when other apex records exist, so it cannot be supported generically.
+  * `LOC`, `NAPTR`, `PTR`, `SSHFP`, `TLSA`, `DS`.
+* The provider automatically resolves each domain to its numeric WebSupport
+  service id (used internally by the v2 API); you only need to supply
+  `api_key` and `secret`.

--- a/integrationTest/profiles.json
+++ b/integrationTest/profiles.json
@@ -406,5 +406,11 @@
     "TYPE": "VULTR",
     "domain": "$VULTR_DOMAIN",
     "token": "$VULTR_TOKEN"
+  },
+  "WEBSUPPORT": {
+    "TYPE": "WEBSUPPORT",
+    "api_key": "$WEBSUPPORT_API_KEY",
+    "domain": "$WEBSUPPORT_DOMAIN",
+    "secret": "$WEBSUPPORT_SECRET"
   }
 }

--- a/pkg/providers/_all/all.go
+++ b/pkg/providers/_all/all.go
@@ -68,4 +68,5 @@ import (
 	_ "github.com/DNSControl/dnscontrol/v4/providers/unifi"
 	_ "github.com/DNSControl/dnscontrol/v4/providers/vercel"
 	_ "github.com/DNSControl/dnscontrol/v4/providers/vultr"
+	_ "github.com/DNSControl/dnscontrol/v4/providers/websupport"
 )

--- a/providers/websupport/api.go
+++ b/providers/websupport/api.go
@@ -1,0 +1,206 @@
+package websupport
+
+import (
+	"bytes"
+	"crypto/hmac"
+	"crypto/sha1"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	defaultBaseURL = "https://rest.websupport.sk"
+	rowsPerPage    = 1000
+)
+
+// nativeRecord matches the WebSupport REST API v2 DNS record shape. The
+// `name` field is the fully-qualified record name (e.g. "www.example.com",
+// with the apex represented as the bare domain "example.com").
+type nativeRecord struct {
+	ID       int64  `json:"id,omitempty"`
+	Type     string `json:"type,omitempty"`
+	Name     string `json:"name"`
+	Content  string `json:"content"`
+	TTL      uint32 `json:"ttl,omitempty"`
+	Priority *int   `json:"priority,omitempty"`
+	Port     *int   `json:"port,omitempty"`
+	Weight   *int   `json:"weight,omitempty"`
+	Note     string `json:"note,omitempty"`
+}
+
+// recordPage is one page of GET /v2/service/{service}/dns/record.
+type recordPage struct {
+	CurrentPage  int            `json:"currentPage"`
+	TotalPages   int            `json:"totalPages"`
+	TotalRecords int            `json:"totalRecords"`
+	RowsPerPage  int            `json:"rowsPerPage"`
+	Data         []nativeRecord `json:"data"`
+}
+
+// v1Service is one entry of the v1 service listing, used to map a domain
+// name to the numeric service id that the v2 DNS endpoints require.
+type v1Service struct {
+	ID   int64  `json:"id"`
+	Name string `json:"name"`
+}
+
+type v1ServiceList struct {
+	Items []v1Service `json:"items"`
+}
+
+type apiError struct {
+	HTTPStatus int
+	Body       string
+}
+
+func (e *apiError) Error() string {
+	return fmt.Sprintf("WEBSUPPORT: bad API response (%d): %s", e.HTTPStatus, e.Body)
+}
+
+func isNotFound(err error) bool {
+	if e, ok := err.(*apiError); ok {
+		return e.HTTPStatus == http.StatusNotFound
+	}
+	return false
+}
+
+// do performs a signed request against the WebSupport REST API.
+//
+// Authentication is HTTP Basic where the username is the API key and the
+// password is a hex-encoded HMAC-SHA1 signature of the canonical string
+// "{METHOD} {path} {unix-timestamp}" keyed by the API secret. The signed
+// path excludes the query string. A matching date header carries the same
+// timestamp in ISO-8601 basic format (GMT); the header is named "X-Date"
+// for the v2 API and "Date" for the v1 API.
+func (c *websupportProvider) do(dateHeader, method, endpoint string, body, out any, validStatus ...int) error {
+	if len(validStatus) == 0 {
+		validStatus = []int{http.StatusOK}
+	}
+
+	var reqBody io.Reader
+	if body != nil {
+		b, err := json.Marshal(body)
+		if err != nil {
+			return fmt.Errorf("WEBSUPPORT: marshal body: %w", err)
+		}
+		reqBody = bytes.NewReader(b)
+	}
+
+	req, err := http.NewRequest(method, c.baseURL+endpoint, reqBody)
+	if err != nil {
+		return err
+	}
+
+	// The signature covers the path only, never the query string.
+	signPath := endpoint
+	if i := strings.IndexByte(signPath, '?'); i >= 0 {
+		signPath = signPath[:i]
+	}
+
+	ts := time.Now().Unix()
+	canonical := fmt.Sprintf("%s %s %d", method, signPath, ts)
+	mac := hmac.New(sha1.New, []byte(c.secret))
+	mac.Write([]byte(canonical))
+	signature := hex.EncodeToString(mac.Sum(nil))
+
+	req.SetBasicAuth(c.apiKey, signature)
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set(dateHeader, time.Unix(ts, 0).UTC().Format("20060102T150405Z"))
+	if reqBody != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	respBody, _ := io.ReadAll(resp.Body)
+
+	if !slices.Contains(validStatus, resp.StatusCode) {
+		return &apiError{HTTPStatus: resp.StatusCode, Body: string(respBody)}
+	}
+
+	if out != nil && len(respBody) > 0 {
+		if err := json.Unmarshal(respBody, out); err != nil {
+			return fmt.Errorf("WEBSUPPORT: decode response: %w (body: %s)", err, string(respBody))
+		}
+	}
+	return nil
+}
+
+// serviceID resolves a domain name to its numeric WebSupport service id,
+// which the v2 DNS endpoints use as the {service} path segment. The v2 API
+// has no service-listing endpoint, so this uses the v1 service listing.
+func (c *websupportProvider) serviceID(domain string) (int64, error) {
+	if id, ok := c.services[domain]; ok {
+		return id, nil
+	}
+
+	var list v1ServiceList
+	if err := c.do("Date", http.MethodGet, "/v1/user/self/service", nil, &list); err != nil {
+		return 0, fmt.Errorf("WEBSUPPORT: listing services: %w", err)
+	}
+	for _, s := range list.Items {
+		c.services[s.Name] = s.ID
+	}
+
+	id, ok := c.services[domain]
+	if !ok {
+		return 0, fmt.Errorf("WEBSUPPORT: domain %q is not a service in this account", domain)
+	}
+	return id, nil
+}
+
+func recordBasePath(serviceID int64) string {
+	return "/v2/service/" + strconv.FormatInt(serviceID, 10) + "/dns/record"
+}
+
+// getAllRecords returns every record in a zone, walking all pages.
+func (c *websupportProvider) getAllRecords(serviceID int64) ([]nativeRecord, error) {
+	var all []nativeRecord
+	page := 1
+	for {
+		endpoint := fmt.Sprintf("%s?page=%d&rowsPerPage=%d", recordBasePath(serviceID), page, rowsPerPage)
+		var p recordPage
+		if err := c.do("X-Date", http.MethodGet, endpoint, nil, &p); err != nil {
+			return nil, err
+		}
+		all = append(all, p.Data...)
+		if p.TotalPages == 0 || p.CurrentPage >= p.TotalPages || len(p.Data) == 0 {
+			break
+		}
+		page++
+	}
+	return all, nil
+}
+
+func (c *websupportProvider) createRecord(serviceID int64, r nativeRecord) error {
+	// The create endpoint returns 204 with no body, so the new record's id is
+	// not echoed back. That's fine: dnscontrol re-reads the zone on the next
+	// run, and corrections never need the id of a record they just created.
+	return c.do("X-Date", http.MethodPost, recordBasePath(serviceID), r, nil,
+		http.StatusNoContent, http.StatusCreated, http.StatusOK)
+}
+
+func (c *websupportProvider) updateRecord(serviceID, id int64, r nativeRecord) error {
+	endpoint := recordBasePath(serviceID) + "/" + strconv.FormatInt(id, 10)
+	return c.do("X-Date", http.MethodPut, endpoint, r, nil, http.StatusNoContent, http.StatusOK)
+}
+
+func (c *websupportProvider) deleteRecord(serviceID, id int64) error {
+	endpoint := recordBasePath(serviceID) + "/" + strconv.FormatInt(id, 10)
+	err := c.do("X-Date", http.MethodDelete, endpoint, nil, nil, http.StatusNoContent, http.StatusOK)
+	if isNotFound(err) {
+		return nil
+	}
+	return err
+}

--- a/providers/websupport/auditrecords.go
+++ b/providers/websupport/auditrecords.go
@@ -1,0 +1,31 @@
+package websupport
+
+import (
+	"fmt"
+
+	"github.com/DNSControl/dnscontrol/v4/models"
+	"github.com/DNSControl/dnscontrol/v4/pkg/rejectif"
+)
+
+// AuditRecords returns a list of errors corresponding to the records
+// that aren't supported by this provider. If all records are
+// supported, an empty list is returned.
+func AuditRecords(records []*models.RecordConfig) []error {
+	a := rejectif.Auditor{}
+
+	a.Add("TXT", rejectif.TxtIsEmpty) // Last verified 2026-06-17
+
+	a.Add("SRV", rejectif.SrvHasNullTarget) // Last verified 2026-06-17
+
+	// The WebSupport v2 DNS record API silently ignores attempts to create NS
+	// records (it returns success but the record never appears), which would
+	// otherwise cause dnscontrol to loop trying to create them. Reject them
+	// with a clear message instead. Last verified 2026-06-17.
+	a.Add("NS", rejectNS)
+
+	return a.Audit(records)
+}
+
+func rejectNS(rc *models.RecordConfig) error {
+	return fmt.Errorf("WEBSUPPORT does not support managing NS records via its API")
+}

--- a/providers/websupport/auditrecords_test.go
+++ b/providers/websupport/auditrecords_test.go
@@ -1,0 +1,73 @@
+package websupport
+
+import (
+	"testing"
+
+	"github.com/DNSControl/dnscontrol/v4/models"
+)
+
+func makeRC(rtype, label, target string) *models.RecordConfig {
+	rc := &models.RecordConfig{Type: rtype}
+	rc.SetLabel(label, "example.com")
+	switch rtype {
+	case "TXT":
+		_ = rc.SetTargetTXT(target)
+	case "MX":
+		_ = rc.SetTargetMX(10, target)
+	case "SRV":
+		_ = rc.SetTargetSRV(0, 0, 443, target)
+	default:
+		_ = rc.SetTarget(target)
+	}
+	return rc
+}
+
+func TestAuditRecords(t *testing.T) {
+	tests := []struct {
+		name      string
+		records   []*models.RecordConfig
+		wantCount int
+	}{
+		{
+			name:      "empty",
+			records:   []*models.RecordConfig{},
+			wantCount: 0,
+		},
+		{
+			name: "supported types are fine",
+			records: []*models.RecordConfig{
+				makeRC("A", "@", "1.2.3.4"),
+				makeRC("AAAA", "@", "::1"),
+				makeRC("CNAME", "www", "example.net."),
+				makeRC("MX", "@", "mail.example.com."),
+				makeRC("TXT", "@", "hello"),
+				makeRC("SRV", "_sip._tcp", "sip.example.com."),
+			},
+			wantCount: 0,
+		},
+		{
+			name:      "NS is rejected (API silently drops it)",
+			records:   []*models.RecordConfig{makeRC("NS", "deleg", "ns1.example.net.")},
+			wantCount: 1,
+		},
+		{
+			name:      "empty TXT is rejected",
+			records:   []*models.RecordConfig{makeRC("TXT", "@", "")},
+			wantCount: 1,
+		},
+		{
+			name:      "SRV with null target is rejected",
+			records:   []*models.RecordConfig{makeRC("SRV", "_sip._tcp", ".")},
+			wantCount: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			errs := AuditRecords(tt.records)
+			if len(errs) != tt.wantCount {
+				t.Errorf("AuditRecords() = %d errors, want %d: %v", len(errs), tt.wantCount, errs)
+			}
+		})
+	}
+}

--- a/providers/websupport/convert.go
+++ b/providers/websupport/convert.go
@@ -1,0 +1,104 @@
+package websupport
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/DNSControl/dnscontrol/v4/models"
+)
+
+// fqdnTypes are record types whose `content` holds a hostname that dnscontrol
+// represents as a fully-qualified, dot-terminated target. WebSupport stores
+// these without the trailing dot, so it is stripped on write and restored on
+// read.
+var fqdnTypes = map[string]bool{
+	"CNAME": true,
+	"MX":    true,
+	"SRV":   true,
+}
+
+func intPtr(i uint16) *int {
+	v := int(i)
+	return &v
+}
+
+func derefInt(p *int) uint16 {
+	if p == nil {
+		return 0
+	}
+	return uint16(*p)
+}
+
+// toNative converts a dnscontrol RecordConfig into the WebSupport API shape.
+func toNative(rc *models.RecordConfig) (nativeRecord, error) {
+	// The WebSupport API is asymmetric about record names: GET returns the
+	// fully-qualified name, but POST/PUT expect the relative label (the API
+	// appends the zone itself). dnscontrol's GetLabel() returns "@" for the
+	// apex, which the API accepts.
+	r := nativeRecord{
+		Type: rc.Type,
+		Name: rc.GetLabel(),
+		TTL:  rc.TTL,
+	}
+
+	switch rc.Type {
+	case "MX":
+		r.Content = trimDot(rc.GetTargetField())
+		r.Priority = intPtr(rc.MxPreference)
+	case "SRV":
+		r.Content = trimDot(rc.GetTargetField())
+		r.Priority = intPtr(rc.SrvPriority)
+		r.Weight = intPtr(rc.SrvWeight)
+		r.Port = intPtr(rc.SrvPort)
+	case "TXT":
+		r.Content = rc.GetTargetTXTJoined()
+	case "CNAME":
+		r.Content = trimDot(rc.GetTargetField())
+	default:
+		r.Content = rc.GetTargetField()
+	}
+
+	return r, nil
+}
+
+// toRecordConfig converts a WebSupport native record into a dnscontrol RecordConfig.
+func toRecordConfig(domain string, n nativeRecord) (*models.RecordConfig, error) {
+	rc := &models.RecordConfig{
+		Type:     n.Type,
+		TTL:      n.TTL,
+		Original: n,
+	}
+	rc.SetLabelFromFQDN(n.Name, domain)
+
+	content := n.Content
+	if fqdnTypes[n.Type] {
+		content = ensureDot(content)
+	}
+
+	var err error
+	switch n.Type {
+	case "MX":
+		err = rc.SetTargetMX(derefInt(n.Priority), content)
+	case "SRV":
+		err = rc.SetTargetSRV(derefInt(n.Priority), derefInt(n.Weight), derefInt(n.Port), content)
+	case "TXT":
+		err = rc.SetTargetTXT(n.Content)
+	default:
+		err = rc.SetTarget(content)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("WEBSUPPORT: %s record %q: %w", n.Type, n.Name, err)
+	}
+	return rc, nil
+}
+
+func trimDot(s string) string {
+	return strings.TrimSuffix(s, ".")
+}
+
+func ensureDot(s string) string {
+	if s == "" || strings.HasSuffix(s, ".") {
+		return s
+	}
+	return s + "."
+}

--- a/providers/websupport/convert_test.go
+++ b/providers/websupport/convert_test.go
@@ -1,0 +1,104 @@
+package websupport
+
+import (
+	"testing"
+
+	"github.com/DNSControl/dnscontrol/v4/models"
+)
+
+const testDomain = "example.com"
+
+func mkRC(t *testing.T, rtype, label string, build func(rc *models.RecordConfig)) *models.RecordConfig {
+	t.Helper()
+	rc := &models.RecordConfig{Type: rtype, TTL: 3600}
+	rc.SetLabel(label, testDomain)
+	build(rc)
+	return rc
+}
+
+func TestRoundTrip(t *testing.T) {
+	tests := []struct {
+		name        string
+		rc          *models.RecordConfig
+		wantType    string
+		wantName    string
+		wantContent string
+	}{
+		{
+			name:        "A apex",
+			rc:          mkRC(t, "A", "@", func(rc *models.RecordConfig) { _ = rc.SetTarget("1.2.3.4") }),
+			wantType:    "A",
+			wantName:    "@",
+			wantContent: "1.2.3.4",
+		},
+		{
+			name:        "CNAME strips trailing dot",
+			rc:          mkRC(t, "CNAME", "www", func(rc *models.RecordConfig) { _ = rc.SetTarget("ghs.example.net.") }),
+			wantType:    "CNAME",
+			wantName:    "www",
+			wantContent: "ghs.example.net",
+		},
+		{
+			name:        "MX",
+			rc:          mkRC(t, "MX", "@", func(rc *models.RecordConfig) { _ = rc.SetTargetMX(10, "mail.example.com.") }),
+			wantType:    "MX",
+			wantName:    "@",
+			wantContent: "mail.example.com",
+		},
+		{
+			name:        "SRV",
+			rc:          mkRC(t, "SRV", "_sip._tcp", func(rc *models.RecordConfig) { _ = rc.SetTargetSRV(10, 20, 5060, "sip.example.com.") }),
+			wantType:    "SRV",
+			wantName:    "_sip._tcp",
+			wantContent: "sip.example.com",
+		},
+		{
+			name:        "AAAA",
+			rc:          mkRC(t, "AAAA", "ipv6", func(rc *models.RecordConfig) { _ = rc.SetTarget("2a00:4b40:aaaa:2001::6") }),
+			wantType:    "AAAA",
+			wantName:    "ipv6",
+			wantContent: "2a00:4b40:aaaa:2001::6",
+		},
+		{
+			name:        "TXT",
+			rc:          mkRC(t, "TXT", "@", func(rc *models.RecordConfig) { _ = rc.SetTargetTXT("hello world") }),
+			wantType:    "TXT",
+			wantName:    "@",
+			wantContent: "hello world",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			n, err := toNative(tc.rc)
+			if err != nil {
+				t.Fatalf("toNative: %v", err)
+			}
+			if n.Type != tc.wantType {
+				t.Errorf("type = %q, want %q", n.Type, tc.wantType)
+			}
+			if n.Name != tc.wantName {
+				t.Errorf("name = %q, want %q", n.Name, tc.wantName)
+			}
+			if n.Content != tc.wantContent {
+				t.Errorf("content = %q, want %q", n.Content, tc.wantContent)
+			}
+
+			// Round-trip back to a RecordConfig and compare the canonical content.
+			// Simulate the API, which echoes the fully-qualified name on read
+			// even though writes use the relative label.
+			n.ID = 42
+			n.Name = tc.rc.GetLabelFQDN()
+			rc2, err := toRecordConfig(testDomain, n)
+			if err != nil {
+				t.Fatalf("toRecordConfig: %v", err)
+			}
+			if got, want := rc2.GetTargetCombined(), tc.rc.GetTargetCombined(); got != want {
+				t.Errorf("round-trip target = %q, want %q", got, want)
+			}
+			if rc2.Type != tc.rc.Type {
+				t.Errorf("round-trip type = %q, want %q", rc2.Type, tc.rc.Type)
+			}
+		})
+	}
+}

--- a/providers/websupport/records.go
+++ b/providers/websupport/records.go
@@ -1,0 +1,106 @@
+package websupport
+
+import (
+	"fmt"
+
+	"github.com/DNSControl/dnscontrol/v4/models"
+	"github.com/DNSControl/dnscontrol/v4/pkg/diff2"
+)
+
+// GetZoneRecords returns the current records for a zone.
+func (c *websupportProvider) GetZoneRecords(dc *models.DomainConfig) (models.Records, error) {
+	svcID, err := c.serviceID(dc.Name)
+	if err != nil {
+		return nil, err
+	}
+
+	nativeRecs, err := c.getAllRecords(svcID)
+	if err != nil {
+		return nil, err
+	}
+
+	recs := make(models.Records, 0, len(nativeRecs))
+	for _, n := range nativeRecs {
+		rc, err := toRecordConfig(dc.Name, n)
+		if err != nil {
+			return nil, err
+		}
+		recs = append(recs, rc)
+	}
+	return recs, nil
+}
+
+// GetZoneRecordsCorrections computes the changes needed to bring the zone in
+// sync with the desired configuration.
+func (c *websupportProvider) GetZoneRecordsCorrections(dc *models.DomainConfig, existing models.Records) ([]*models.Correction, int, error) {
+	svcID, err := c.serviceID(dc.Name)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	instructions, actualChangeCount, err := diff2.ByRecord(existing, dc, nil)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	var corrections []*models.Correction
+	for _, inst := range instructions {
+		switch inst.Type {
+		case diff2.REPORT:
+			corrections = append(corrections, &models.Correction{Msg: inst.MsgsJoined})
+		case diff2.CREATE:
+			corrections = append(corrections, c.mkCreateCorrection(svcID, inst.New[0], inst.Msgs[0]))
+		case diff2.CHANGE:
+			corrections = append(corrections, c.mkChangeCorrection(svcID, inst.Old[0], inst.New[0], inst.Msgs[0]))
+		case diff2.DELETE:
+			corrections = append(corrections, c.mkDeleteCorrection(svcID, inst.Old[0], inst.Msgs[0]))
+		default:
+			panic(fmt.Sprintf("unhandled inst.Type %s", inst.Type))
+		}
+	}
+
+	return corrections, actualChangeCount, nil
+}
+
+func (c *websupportProvider) mkCreateCorrection(svcID int64, newRec *models.RecordConfig, msg string) *models.Correction {
+	return &models.Correction{
+		Msg: msg,
+		F: func() error {
+			n, err := toNative(newRec)
+			if err != nil {
+				return err
+			}
+			return c.createRecord(svcID, n)
+		},
+	}
+}
+
+func (c *websupportProvider) mkChangeCorrection(svcID int64, oldRec, newRec *models.RecordConfig, msg string) *models.Correction {
+	return &models.Correction{
+		Msg: msg,
+		F: func() error {
+			id := oldRec.Original.(nativeRecord).ID
+			if id == 0 {
+				return fmt.Errorf("WEBSUPPORT: cannot update record without an id")
+			}
+			n, err := toNative(newRec)
+			if err != nil {
+				return err
+			}
+			return c.updateRecord(svcID, id, n)
+		},
+	}
+}
+
+func (c *websupportProvider) mkDeleteCorrection(svcID int64, oldRec *models.RecordConfig, msg string) *models.Correction {
+	return &models.Correction{
+		Msg: msg,
+		F: func() error {
+			id := oldRec.Original.(nativeRecord).ID
+			if id == 0 {
+				return fmt.Errorf("WEBSUPPORT: cannot delete record without an id")
+			}
+			return c.deleteRecord(svcID, id)
+		},
+	}
+}

--- a/providers/websupport/websupportProvider.go
+++ b/providers/websupport/websupportProvider.go
@@ -1,0 +1,122 @@
+// Package websupport implements a DNS provider for WebSupport (websupport.sk),
+// using their REST API v2 (https://rest.websupport.sk/v2/docs).
+package websupport
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/DNSControl/dnscontrol/v4/models"
+	"github.com/DNSControl/dnscontrol/v4/pkg/providers"
+)
+
+var features = providers.DocumentationNotes{
+	// The default for unlisted capabilities is 'Cannot'.
+	// See providers/capabilities.go for the entire list of capabilities.
+	providers.CanGetZones:            providers.Cannot("WebSupport has no list-all-zones endpoint."),
+	providers.CanConcur:              providers.Unimplemented(),
+	providers.CanUseAlias:            providers.Cannot("WebSupport's ANAME is apex-only and conflicts with other apex records."),
+	providers.CanUseCAA:              providers.Cannot("The v2 API does not return CAA tag/flags on read, so records cannot be managed without churn."),
+	providers.CanUseLOC:              providers.Cannot(),
+	providers.CanUseNAPTR:            providers.Cannot(),
+	providers.CanUsePTR:              providers.Cannot(),
+	providers.CanUseSRV:              providers.Can(),
+	providers.CanUseSSHFP:            providers.Cannot(),
+	providers.CanUseTLSA:             providers.Cannot(),
+	providers.CanUseDS:               providers.Cannot(),
+	providers.CanUseSOA:              providers.Cannot(),
+	providers.DocCreateDomains:       providers.Cannot("Zones must be created via the WebSupport portal."),
+	providers.DocDualHost:            providers.Cannot(),
+	providers.DocOfficiallySupported: providers.Cannot(),
+}
+
+type websupportProvider struct {
+	apiKey     string
+	secret     string
+	baseURL    string
+	httpClient *http.Client
+	// services caches the domain -> numeric service id mapping that the v2
+	// DNS endpoints require as their {service} path segment.
+	services map[string]int64
+}
+
+func init() {
+	const providerName = "WEBSUPPORT"
+	const providerMaintainer = "@mtmn"
+	fns := providers.DspFuncs{
+		Initializer:   newWebsupport,
+		RecordAuditor: AuditRecords,
+	}
+	providers.RegisterDomainServiceProviderType(providerName, fns, features)
+	providers.RegisterMaintainer(providerName, providerMaintainer)
+	providers.RegisterCredsMetadata(providerName, providers.CredsMetadata{
+		DisplayName: "WebSupport",
+		Kind:        providers.KindDNS,
+		DocsURL:     "https://docs.dnscontrol.org/provider/websupport",
+		PortalURL:   "https://admin.websupport.sk/en/auth/security",
+		Fields: []providers.CredsField{
+			{
+				Key:      "api_key",
+				Label:    "API key",
+				Help:     "WebSupport API key (generated in the Security section of the admin console).",
+				Secret:   true,
+				Required: true,
+			},
+			{
+				Key:      "secret",
+				Label:    "API secret",
+				Help:     "WebSupport API secret used to sign requests.",
+				Secret:   true,
+				Required: true,
+			},
+		},
+	})
+}
+
+func newWebsupport(settings map[string]string, _ json.RawMessage) (providers.DNSServiceProvider, error) {
+	apiKey := settings["api_key"]
+	secret := settings["secret"]
+	if apiKey == "" || secret == "" {
+		return nil, errors.New("WEBSUPPORT: missing api_key and/or secret")
+	}
+
+	baseURL := settings["base_url"]
+	if baseURL == "" {
+		baseURL = defaultBaseURL
+	}
+
+	return &websupportProvider{
+		apiKey:     apiKey,
+		secret:     secret,
+		baseURL:    baseURL,
+		httpClient: &http.Client{Timeout: 30 * time.Second},
+		services:   map[string]int64{},
+	}, nil
+}
+
+// GetNameservers returns the apex NS records of the zone. WebSupport's zone
+// detail endpoint does not expose nameservers directly, so they are read from
+// the zone's own NS records.
+func (c *websupportProvider) GetNameservers(domain string) ([]*models.Nameserver, error) {
+	svcID, err := c.serviceID(domain)
+	if err != nil {
+		return nil, err
+	}
+
+	records, err := c.getAllRecords(svcID)
+	if err != nil {
+		return nil, err
+	}
+
+	// The v2 API returns fully-qualified record names, so apex NS records
+	// have the bare domain as their name.
+	var ns []string
+	for _, r := range records {
+		if r.Type == "NS" && r.Name == domain {
+			ns = append(ns, trimDot(r.Content))
+		}
+	}
+	return models.ToNameservers(ns)
+}


### PR DESCRIPTION
This change introduces a new DNS provider for [Websupport](https://www.websupport.sk/) that utilizes their public API (v2) that's available [here](https://rest.websupport.sk/v2/docs).

I have tested it with A, AAAA, CNAME, MX, TXT and SRV, though there are some limitations that have been documented.