### PR TITLE
AUTODNS: optionally include sub-user (children) zones in get-zones

### DIFF
--- a/documentation/provider/autodns.md
+++ b/documentation/provider/autodns.md
@@ -18,6 +18,27 @@ Example:
 ```
 {% endcode %}
 
+### Including sub-user zones
+
+By default DNSControl only sees zones owned directly by the configured user. If
+you authenticate as a master/admin user and want `get-zones` (and the `all`
+keyword) to also include zones owned by sub-users — the same optional "include
+subusers" toggle the AutoDNS web UI offers — set `children` to `"true"`:
+
+{% code title="creds.json" %}
+```json
+{
+  "autodns": {
+    "TYPE": "AUTODNS",
+    "username": "autodns.service-account@example.com",
+    "password": "[***]",
+    "context": "33004",
+    "children": "true"
+  }
+}
+```
+{% endcode %}
+
 ## Usage
 
 An example configuration:

--- a/providers/autodns/api.go
+++ b/providers/autodns/api.go
@@ -98,6 +98,12 @@ func (api *autoDNSProvider) request(method string, requestPath string, data any)
 func (api *autoDNSProvider) findZoneSystemNameServer(domain string) (*models.Nameserver, error) {
 	request := &ZoneListRequest{}
 
+	// When opted in, request child zones so master/admin users can locate
+	// zones owned by sub-users (the optional "include subusers" UI toggle).
+	if api.includeChildren {
+		request.View = &ZoneListView{Limit: 1, Offset: 0, Children: true}
+	}
+
 	request.Filter = append(request.Filter, &ZoneListFilter{
 		Key:      "name",
 		Value:    domain,
@@ -186,7 +192,7 @@ func (api *autoDNSProvider) getZones() ([]string, error) {
 		View: &ZoneListView{
 			Limit:    0,
 			Offset:   0,
-			Children: false,
+			Children: api.includeChildren,
 		},
 	}
 
@@ -206,7 +212,7 @@ func (api *autoDNSProvider) getZones() ([]string, error) {
 			View: &ZoneListView{
 				Limit:    100,
 				Offset:   i * 100,
-				Children: false,
+				Children: api.includeChildren,
 			},
 		}
 

--- a/providers/autodns/autoDnsProvider.go
+++ b/providers/autodns/autoDnsProvider.go
@@ -36,8 +36,9 @@ var features = providers.DocumentationNotes{
 }
 
 type autoDNSProvider struct {
-	baseURL        url.URL
-	defaultHeaders http.Header
+	baseURL         url.URL
+	defaultHeaders  http.Header
+	includeChildren bool
 }
 
 func init() {
@@ -74,6 +75,10 @@ func newAutoDNSProvider(settings map[string]string) *autoDNSProvider {
 		"Content-Type":          []string{"application/json; charset=UTF-8"},
 		"X-Domainrobot-Context": []string{settings["context"]},
 	}
+
+	// AutoDNS hides zones owned by sub-users unless "children" is requested
+	// (the same optional toggle the web UI offers). Opt-in via creds.json.
+	api.includeChildren = settings["children"] == "true"
 
 	return api
 }


### PR DESCRIPTION
## What

Fixes #4210 — `get-zones` skipped zones owned by sub-users on AutoDNS.

AutoDNS hides zones owned by sub-users unless the search explicitly requests children (the optional **"include subusers"** toggle the web UI offers). DNSControl always sent `children: false`, so a master/admin user could neither list (`get-zones … all`) nor fetch (`get-zones … <zone>`) sub-user-owned zones.

## Change

Add a `children` creds option (default **off**, opt-in) that, when set to `"true"`, requests child zones in the `zone/_search` calls behind `ListZones()` and `findZoneSystemNameServer()`.

```json
{
  "autodns": {
    "TYPE": "AUTODNS",
    "username": "…",
    "password": "…",
    "context": "…",
    "children": "true"
  }
}
```

With the option **off**, behaviour is byte-for-byte unchanged (`findZoneSystemNameServer` sends no `view`, exactly as before).

The default is opt-in rather than always-on because "include subusers" is an *optional* toggle in the AutoDNS UI — defaulting it on would flood master/reseller accounts (potentially thousands of sub-user zones) for everyone.

## Testing

Verified live against an AutoDNS account (both `get-zones … all` and direct `get-zones … <zone>`), with the option off (no regression) and on (works). Integration test results posted in a comment below.

> ⚠️ I could not *demonstrate* the child-surfacing itself: my test account is itself a sub-user (so it can't create sub-users), and the master account enforces 2FA (unusable with the tool). @dkorunic — if you can, please confirm `"children": "true"` now surfaces your sub-user zones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
