### PR TITLE
AUTODNS: reject TXT values that AutoDNS cannot store losslessly

### DIFF
--- a/providers/autodns/auditrecords.go
+++ b/providers/autodns/auditrecords.go
@@ -14,5 +14,18 @@ func AuditRecords(records []*models.RecordConfig) []error {
 	a.Add("MX", rejectif.MxNull)      // Last verified 2022-03-25
 	a.Add("TXT", rejectif.TxtIsEmpty) // Last verified 2025-05-13
 
+	// Last verified 2026-06-22: AutoDNS drops interior double quotes from TXT
+	// values (e.g. `in"side` is stored as `inside`).
+	a.Add("TXT", rejectif.TxtHasDoubleQuotes)
+
+	// Last verified 2026-06-22: AutoDNS strips an odd (unpaired) run of
+	// backslashes from TXT values (e.g. `1back\slash` is stored as
+	// `1backslash`); even runs are preserved.
+	a.Add("TXT", rejectif.TxtHasUnpairedBackslash)
+
+	// Last verified 2026-06-22: AutoDNS trims surrounding whitespace from TXT
+	// values (e.g. a trailing space in `trailingws ` is stripped).
+	a.Add("TXT", rejectif.TxtStartsOrEndsWithSpaces)
+
 	return a.Audit(records)
 }


### PR DESCRIPTION
## What

AutoDNS silently mangles certain TXT values, so `get-zones`/`push` round-trips never converge — DNSControl keeps re-issuing the same correction every run. Reject the unsupported shapes in `AuditRecords` so they're skipped cleanly.

Observed (verified live against a real AutoDNS account):

| TXT value | stored by AutoDNS |
| --- | --- |
| `in"side` (interior double quote) | `inside` |
| `1back\slash` (odd/unpaired backslash run) | `1backslash` |
| `trailingws ` (surrounding whitespace) | `trailingws` |

Even backslash runs (`2back\\slash`) are preserved, so this uses `TxtHasUnpairedBackslash` (odd-count only) rather than rejecting all backslashes.

## Change

```go
a.Add("TXT", rejectif.TxtHasDoubleQuotes)
a.Add("TXT", rejectif.TxtHasUnpairedBackslash)
a.Add("TXT", rejectif.TxtStartsOrEndsWithSpaces)
```

These were the only failures in the AUTODNS integration suite; with them the suite is fully green. Results posted in a comment below.

## ⚠️ Migration note (behaviour change)

Previously these malformed TXT values were accepted by DNSControl but **silently normalised by AutoDNS on store**, producing a *perpetual no-op `± MODIFY`* every run (the value never round-trips). After this change, such records are **rejected at validation time** with a clear error instead.

That's better diagnostics, but it means existing configs that contain one of these shapes will start to **error** until the offending TXT record is corrected. The most common real-world case is an **accidental leading/trailing space** in a DKIM/SPF value, e.g. `" v=DKIM1; p=..."` → fix to `"v=DKIM1; p=..."`. If you see a new rejection after upgrading, search your `dnsconfig.js` for TXT values with surrounding whitespace, interior `"`, or a lone `\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
