### PR TITLE
CNR: Skip ALIAS on DNSSEC-signed zones, add SMIMEA + AUTODNSSEC support, and enhance SVCB handling

### DIFF
--- a/documentation/provider/index.md
+++ b/documentation/provider/index.md
@@ -310,7 +310,7 @@ Jump to a table:
 | [`BUNNY_DNS`](bunnydns.md) | ✅ | ✅ | ❔ | ❌ | ✅ |
 | [`CLOUDFLAREAPI`](cloudflareapi.md) | ✅ | ✅ | ❔ | ✅ | ✅ |
 | [`CLOUDNS`](cloudns.md) | ✅ | ❌ | ❔ | ✅ | ✅ |
-| [`CNR`](cnr.md) | ✅ | ❌ | ❔ | ✅ | ✅ |
+| [`CNR`](cnr.md) | ✅ | ❌ | ✅ | ✅ | ✅ |
 | [`CSCGLOBAL`](cscglobal.md) | ✅ | ❔ | ❔ | ❔ | ❔ |
 | [`DESEC`](desec.md) | ✅ | ✅ | ✅ | ✅ | ✅ |
 | [`DIGITALOCEAN`](digitalocean.md) | ✅ | ❌ | ❌ | ❌ | ❌ |
@@ -371,6 +371,7 @@ Jump to a table:
 | [`BUNNY_DNS`](bunnydns.md) | ✅ | ❔ | ❌ |
 | [`CLOUDFLAREAPI`](cloudflareapi.md) | ❔ | ❌ | ✅ |
 | [`CLOUDNS`](cloudns.md) | ✅ | ❌ | ❌ |
+| [`CNR`](cnr.md) | ✅ | ❔ | ❔ |
 | [`DESEC`](desec.md) | ✅ | ✅ | ✅ |
 | [`DIGITALOCEAN`](digitalocean.md) | ❌ | ❌ | ❌ |
 | [`DNSIMPLE`](dnsimple.md) | ✅ | ❔ | ❌ |

--- a/providers/cnr/auditrecords.go
+++ b/providers/cnr/auditrecords.go
@@ -2,6 +2,7 @@ package cnr
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 
 	"github.com/DNSControl/dnscontrol/v4/models"
@@ -20,7 +21,29 @@ func AuditRecords(records []*models.RecordConfig) []error {
 
 	a.Add("SRV", rejectif.SrvHasNullTarget) // Last verified 2020-12-28
 
-	a.Add("DNAME", dnameHasWildcardLabel) // Last verified 2026-02-10
+	a.Add("DNAME", dnameHasWildcardLabel)               // Last verified 2026-02-10
+	a.Add("SVCB", func(rc *models.RecordConfig) error { // Last verified 2026-06-29
+		for param := range strings.FieldsSeq(rc.SvcParams) {
+			key, value, _ := strings.Cut(param, "=")
+			key = strings.ToLower(strings.TrimSpace(key))
+			value = strings.Trim(value, `"`)
+			switch key {
+			case "dohpath", "ohttp", "tls-supported-groups":
+				return fmt.Errorf("SVCB parameter %q is not supported", key)
+			case "alpn":
+				for protocol := range strings.SplitSeq(value, ",") {
+					if protocol == "h2" || protocol == "h3" {
+						return errors.New("SVCB alpn h2/h3 requires dohpath, which is not supported")
+					}
+				}
+			case "ech":
+				if value != "IGNORE" {
+					return errors.New("SVCB parameter \"ech\" is not supported")
+				}
+			}
+		}
+		return nil
+	})
 
 	return a.Audit(records)
 }

--- a/providers/cnr/cnrProvider.go
+++ b/providers/cnr/cnrProvider.go
@@ -24,7 +24,7 @@ var features = providers.DocumentationNotes{
 	// See providers/capabilities.go for the entire list of capabilities.
 	// The default for unlisted capabilities is 'Cannot'.
 	// --- Supported Features ---
-	providers.CanAutoDNSSEC:          providers.Unimplemented("Ask for this feature."),
+	providers.CanAutoDNSSEC:          providers.Can(),
 	providers.CanConcur:              providers.Can(),
 	providers.CanGetZones:            providers.Can(),
 	providers.CanOnlyDiff1Features:   providers.Can(),
@@ -33,7 +33,7 @@ var features = providers.DocumentationNotes{
 	providers.DocOfficiallySupported: providers.Cannot("Actively maintained provider module."),
 	// --- Supported record types ---
 	// providers.CanUseAKAMAICDN: 	      providers.Cannot(), // can only be supported by Akamai EdgeDns provider
-	providers.CanUseAlias: providers.Can(),
+	providers.CanUseAlias: providers.Can("ALIAS records require an unsigned zone served through RCodeZero and cannot be used with DNSSEC-signed zones."),
 	// providers.CanUseAzureAlias:		  providers.Cannot(), // can only be supported by Azure provider
 	providers.CanUseCAA:           providers.Can(),
 	providers.CanUseDHCID:         providers.Can(),
@@ -46,11 +46,12 @@ var features = providers.DocumentationNotes{
 	providers.CanUseNAPTR:         providers.Can(),
 	providers.CanUsePTR:           providers.Can(),
 	// providers.CanUseRoute53Alias:	  providers.Cannot(), // can only be supported by AWS Route53 provider
-	providers.CanUseSOA:   providers.Cannot("The SOA record is managed on the DNSZone directly. Data only accessible via StatusDNSZone Request, not via the resource records list. Hard to integrate this into DNSControl by that."), // supported by bind, honstingde
-	providers.CanUseSRV:   providers.Can("SRV records with empty targets are not supported"),
-	providers.CanUseSSHFP: providers.Can(),
-	providers.CanUseSVCB:  providers.Can(),
-	providers.CanUseTLSA:  providers.Can(),
+	providers.CanUseSMIMEA: providers.Can(),
+	providers.CanUseSOA:    providers.Cannot("The SOA record is managed on the DNSZone directly. Data only accessible via StatusDNSZone Request, not via the resource records list. Hard to integrate this into DNSControl by that."), // supported by bind, honstingde
+	providers.CanUseSRV:    providers.Can("SRV records with empty targets are not supported"),
+	providers.CanUseSSHFP:  providers.Can(),
+	providers.CanUseSVCB:   providers.Can(),
+	providers.CanUseTLSA:   providers.Can(),
 }
 
 func newProvider(conf map[string]string) (*Client, error) {

--- a/providers/cnr/dnssec.go
+++ b/providers/cnr/dnssec.go
@@ -1,0 +1,62 @@
+package cnr
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/DNSControl/dnscontrol/v4/models"
+)
+
+// isZoneSigned reports whether the DNS zone is DNSSEC-signed, based on the
+// SIGNED property returned by StatusDNSZone.
+func (n *Client) isZoneSigned(domain string) (bool, error) {
+	r := n.client.Request(map[string]any{
+		"COMMAND": "StatusDNSZone",
+		"DNSZONE": domain,
+	})
+	if !r.IsSuccess() {
+		return false, n.GetAPIError("Could not get status for DNS zone", domain, r)
+	}
+	signed, err := r.GetColumnIndex("SIGNED", 0)
+	if err != nil {
+		return false, fmt.Errorf("could not determine signed status for DNS zone %q: %w", domain, err)
+	}
+	return strings.TrimSpace(signed) == "1", nil
+}
+
+// getDNSSECCorrections returns the corrections needed to reconcile the zone's
+// DNSSEC signing state with dc.AutoDNSSEC ("on", "off", or "" for no change).
+func (n *Client) getDNSSECCorrections(dc *models.DomainConfig) ([]*models.Correction, error) {
+	if dc.AutoDNSSEC == "" {
+		return nil, nil
+	}
+	signed, err := n.isZoneSigned(dc.Name)
+	if err != nil {
+		return nil, err
+	}
+	switch {
+	case signed && dc.AutoDNSSEC == "off":
+		return []*models.Correction{{
+			Msg: fmt.Sprintf("Disable DNSSEC signing for zone %s", dc.Name),
+			F:   n.setZoneSigned(dc.Name, false),
+		}}, nil
+	case !signed && dc.AutoDNSSEC == "on":
+		return []*models.Correction{{
+			Msg: fmt.Sprintf("Enable DNSSEC signing for zone %s", dc.Name),
+			F:   n.setZoneSigned(dc.Name, true),
+		}}, nil
+	}
+	return nil, nil
+}
+
+// setZoneSigned returns a function that enables or disables DNSSEC signing for
+// the zone via ModifyDNSZone.
+func (n *Client) setZoneSigned(domain string, signed bool) func() error {
+	return func() error {
+		value := "0"
+		if signed {
+			value = "1"
+		}
+		return n.updateZoneBy(map[string]any{"SIGNED": value}, domain)
+	}
+}

--- a/providers/cnr/domains.go
+++ b/providers/cnr/domains.go
@@ -35,7 +35,6 @@ func (n *Client) ListZones() ([]string, error) {
 		}
 		zoneColumn := r.GetColumn("DNSZONE")
 		if zoneColumn != nil {
-			// return nil, fmt.Errorf("failed getting DNSZONE BASIC column")
 			zones = append(zones, zoneColumn.GetData()...)
 		}
 	}

--- a/providers/cnr/nameservers.go
+++ b/providers/cnr/nameservers.go
@@ -53,7 +53,6 @@ func (n *Client) getNameserversRaw(domain string) ([]string, error) {
 	}
 	nsColumn := r.GetColumn("NAMESERVER")
 	if nsColumn == nil {
-		fmt.Println("No nameservers found")
 		return []string{}, nil // No nameserver assigned
 	}
 	ns := nsColumn.GetData()

--- a/providers/cnr/records.go
+++ b/providers/cnr/records.go
@@ -61,12 +61,85 @@ func (n *Client) GetZoneRecords(dc *models.DomainConfig) (models.Records, error)
 
 // GetZoneRecordsCorrections returns a list of corrections that will turn existing records into dc.Records.
 func (n *Client) GetZoneRecordsCorrections(dc *models.DomainConfig, actual models.Records) ([]*models.Correction, int, error) {
+	for _, rc := range actual {
+		if rc.Type == "SVCB" {
+			rc.SvcParams = strings.Join(strings.Fields(rc.SvcParams), " ")
+		}
+	}
+	for _, rc := range dc.Records {
+		if rc.Type != "SVCB" {
+			continue
+		}
+		fields := strings.Fields(rc.SvcParams)
+		params := make([]string, 0, len(fields))
+		for _, field := range fields {
+			key, value, _ := strings.Cut(field, "=")
+			if strings.EqualFold(strings.TrimSpace(key), "ech") && strings.Trim(value, `"`) == "IGNORE" {
+				continue
+			}
+			params = append(params, field)
+		}
+		rc.SvcParams = strings.Join(params, " ")
+	}
+
+	var aliasSkip *models.Correction
+	hasAlias := false
+	for _, rc := range dc.Records {
+		if rc.Type == "ALIAS" {
+			hasAlias = true
+			break
+		}
+	}
+	if !hasAlias {
+		for _, rc := range actual {
+			if rc.Type == "ALIAS" {
+				hasAlias = true
+				break
+			}
+		}
+	}
+	if hasAlias {
+		signed, err := n.isZoneSigned(dc.Name)
+		if err != nil {
+			return nil, 0, err
+		}
+		if signed {
+			skipped := 0
+			desired := make(models.Records, 0, len(dc.Records))
+			for _, rc := range dc.Records {
+				if rc.Type == "ALIAS" {
+					skipped++
+					continue
+				}
+				desired = append(desired, rc)
+			}
+			dc.Records = desired
+
+			filteredActual := make(models.Records, 0, len(actual))
+			for _, rc := range actual {
+				if rc.Type != "ALIAS" {
+					filteredActual = append(filteredActual, rc)
+				}
+			}
+			actual = filteredActual
+
+			if skipped != 0 {
+				aliasSkip = &models.Correction{
+					Msg: fmt.Sprintf("SKIP ALIAS records in DNSSEC-signed CNR zone %s", dc.Name),
+					F:   func() error { return nil },
+				}
+			}
+		}
+	}
 	toReport, create, del, mod, actualChangeCount, err := diff.NewCompat(dc).IncrementalDiff(actual)
 	if err != nil {
 		return nil, 0, err
 	}
 	// Start corrections with the reports
 	corrections := diff.GenerateMessageCorrections(toReport)
+	if aliasSkip != nil {
+		corrections = append(corrections, aliasSkip)
+	}
 
 	buf := &bytes.Buffer{}
 	// Print a list of changes. Generate an actual change that is the zone
@@ -130,6 +203,13 @@ func (n *Client) GetZoneRecordsCorrections(dc *models.DomainConfig, actual model
 		})
 	}
 
+	dnssecCorrections, err := n.getDNSSECCorrections(dc)
+	if err != nil {
+		return nil, 0, err
+	}
+	corrections = append(corrections, dnssecCorrections...)
+	actualChangeCount += len(dnssecCorrections)
+
 	return corrections, actualChangeCount, nil
 }
 
@@ -166,7 +246,7 @@ func toRecord(r *Record, origin string) *models.RecordConfig {
 		if err := rc.PopulateFromStringFunc(r.Type, r.Answer, strings.TrimSuffix(r.Fqdn, "."), txtutil.ParseQuoted); err != nil {
 			panic(fmt.Errorf("unparsable %s record received from centralnic reseller API: %w", r.Type, err))
 		}
-	default: // "A", "AAAA", "ANAME", "ALIAS", "CNAME", "NS", "TXT", "CAA", "TLSA", "PTR"
+	default: // "A", "AAAA", "ANAME", "ALIAS", "CNAME", "NS", "TXT", "CAA", "TLSA", "SMIMEA", "PTR"
 		if err := rc.PopulateFromStringFunc(r.Type, r.Answer, fqdn, txtutil.ParseQuoted); err != nil {
 			panic(fmt.Errorf("unparsable record received from centralnic reseller API: %w", err))
 		}
@@ -231,7 +311,6 @@ func (n *Client) getRecords(domain string) ([]*Record, error) {
 	rrs := r.GetRecords()
 	for i := range len(rrs) {
 		data := rrs[i].GetData()
-		// fmt.Printf("Data: %+v\n", data)
 		if _, exists := data["NAME"]; !exists {
 			continue
 		}
@@ -272,8 +351,6 @@ func (n *Client) getRecords(domain string) ([]*Record, error) {
 			TTL:        uint32(ttl),
 			Priority:   uint32(priority),
 		}
-		// fmt.Printf("Record: %+v\n", record)
-
 		// Append the record to the records slice
 		records = append(records, record)
 	}
@@ -313,6 +390,8 @@ func (n *Client) createRecordString(rc *models.RecordConfig, domain string) (str
 		answer = fmt.Sprintf(`%v %v "%v" "%v" "%v" %v`, rc.NaptrOrder, rc.NaptrPreference, rc.NaptrFlags, rc.NaptrService, rc.NaptrRegexp, rc.GetTargetField())
 	case "TLSA":
 		answer = fmt.Sprintf(`%v %v %v %s`, rc.TlsaUsage, rc.TlsaSelector, rc.TlsaMatchingType, rc.GetTargetField())
+	case "SMIMEA":
+		answer = fmt.Sprintf(`%v %v %v %s`, rc.SmimeaUsage, rc.SmimeaSelector, rc.SmimeaMatchingType, rc.GetTargetField())
 	case "CAA":
 		answer = fmt.Sprintf(`%v %s "%s"`, rc.CaaFlag, rc.CaaTag, rc.GetTargetField())
 	case "TXT":
@@ -362,8 +441,6 @@ func (n *Client) deleteRecordString(record *Record) string {
 		values = append(values, strconv.FormatUint(uint64(record.Priority), 10))
 	}
 	values = append(values, record.Answer)
-
-	// fmt.Printf("Values: %+v\n", values)
 
 	// Remove IN if the record type is "NS" TODO
 	if record.Type == "NS" {


### PR DESCRIPTION
<!--
## Before submiting a pull request

Please make sure you've run the following commands from the root directory.

    bin/generate-all.sh

(this runs commands like "go generate", fixes formatting, and so on)

## Release changelog section

Help keep the release changelog clear by pre-naming the proper section in the GitHub pull request title.

Some examples:
* CICD: Add required GHA permissions for goreleaser
* DOCS: Fixed providers with "contributor support" table
* ROUTE53: Allow R53_ALIAS records to enable target health evaluation

More examples/context can be found in the file .goreleaser.yml under the 'build' > 'changelog' key.
!-->

Thank you @TomOnTime  for bringing this into our attention.

CNR API does not accept ALIAS records when a dns zone is DNSSEC-signed.

Fixes the issue #4400 