### PR TITLE
Revert "ROUTE53: Enable SOA record editing (#4402)"

### DIFF
--- a/documentation/provider/index.md
+++ b/documentation/provider/index.md
@@ -218,7 +218,7 @@ Jump to a table:
 | [`PORKBUN`](porkbun.md) | ✅ | ❔ | ❌ | ❌ | ❌ |
 | [`POWERDNS`](powerdns.md) | ✅ | ✅ | ❔ | ✅ | ✅ |
 | [`REALTIMEREGISTER`](realtimeregister.md) | ✅ | ❔ | ✅ | ❌ | ❌ |
-| [`ROUTE53`](route53.md) | ❌ | ❔ | ❌ | ✅ | ✅ |
+| [`ROUTE53`](route53.md) | ❌ | ❔ | ❌ | ✅ | ❔ |
 | [`RWTH`](rwth.md) | ❌ | ❔ | ❌ | ✅ | ❔ |
 | [`SAKURACLOUD`](sakuracloud.md) | ✅ | ❌ | ❌ | ✅ | ❌ |
 | [`SOFTLAYER`](softlayer.md) | ❔ | ❔ | ❌ | ❔ | ❔ |

--- a/providers/route53/route53Provider.go
+++ b/providers/route53/route53Provider.go
@@ -129,7 +129,6 @@ var features = providers.DocumentationNotes{
 	providers.CanUseLOC:              providers.Cannot(),
 	providers.CanUsePTR:              providers.Can(),
 	providers.CanUseRoute53Alias:     providers.Can(),
-	providers.CanUseSOA:              providers.Can(),
 	providers.CanUseSRV:              providers.Can(),
 	providers.CanUseSSHFP:            providers.Can(),
 	providers.CanUseSVCB:             providers.Can(),
@@ -572,6 +571,8 @@ func nativeToRecords(set r53Types.ResourceRecordSet, origin string) ([]*models.R
 	} else {
 		for _, rec := range set.ResourceRecords {
 			switch rtype := set.Type; rtype {
+			case r53Types.RRTypeSoa:
+				continue
 			case r53Types.RRTypeSpf:
 				// route53 uses a custom record type for SPF
 				rtype = "TXT"


### PR DESCRIPTION
This reverts commit b7d62d010a398212628ac43cf5fcf42c2a8bed6c.

<!--
## Before submiting a pull request

Please make sure you've run the following commands from the root directory.

    bin/generate-all.sh

(this runs commands like "go generate", fixes formatting, and so on)

## Release changelog section

Help keep the release changelog clear by pre-naming the proper section in the GitHub pull request title.

Some examples:
* CICD: Add required GHA permissions for goreleaser
* DOCS: Fixed providers with "contributor support" table
* ROUTE53: Allow R53_ALIAS records to enable target health evaluation

More examples/context can be found in the file .goreleaser.yml under the 'build' > 'changelog' key.
!-->
