### PR TITLE
TEST: Add validations and tests for SOA records to reject multiple SOAs

### DIFF
--- a/pkg/normalize/validate.go
+++ b/pkg/normalize/validate.go
@@ -558,6 +558,8 @@ func ValidateAndNormalizeConfig(config *models.DNSConfig) (errs []error) {
 	for _, d := range config.Domains {
 		// Check that CNAMES don't have to co-exist with any other records
 		errs = append(errs, checkCNAMEs(d)...)
+		// Check that only one SOA record exist for a zone
+		errs = append(errs, checkMultipleSOAs(d)...)
 		// Check that if any advanced record types are used in a domain, every provider for that domain supports them
 		err := checkProviderCapabilities(d)
 		if err != nil {
@@ -663,6 +665,19 @@ func checkCNAMEs(dc *models.DomainConfig) (errs []error) {
 				continue
 			}
 			errs = append(errs, fmt.Errorf("%s: cannot have CNAME and %s record with same name: %s", r.FilePos, r.Type, r.GetLabelFQDN()))
+		}
+	}
+	return
+}
+
+func checkMultipleSOAs(dc *models.DomainConfig) (errs []error) {
+	soas := map[string]bool{}
+	for _, r := range dc.Records {
+		if r.Type == "SOA" {
+			if soas[r.GetLabel()] {
+				errs = append(errs, fmt.Errorf("%s: cannot have multiple SOAs with same name: %s", r.FilePos, r.GetLabelFQDN()))
+			}
+			soas[r.GetLabel()] = true
 		}
 	}
 	return

--- a/pkg/normalize/validate_test.go
+++ b/pkg/normalize/validate_test.go
@@ -76,6 +76,42 @@ func TestCheckSoa(t *testing.T) {
 	}
 }
 
+func TestCheckMultipleSOAs(t *testing.T) {
+	dcSingleSoa := &models.DomainConfig{
+		Name:          "foo.com",
+		RegistrarName: "BIND",
+		Records: []*models.RecordConfig{
+			makeRC("@", "foo.com", "ns1.foo.com.", models.RecordConfig{
+				Type:      "SOA",
+				SoaExpire: 1, SoaMinttl: 1, SoaRefresh: 1, SoaRetry: 1, SoaSerial: 1, SoaMbox: "bar.foo.com",
+			}),
+		},
+	}
+
+	t.Run("single_SOA", func(t *testing.T) {
+		errs := checkMultipleSOAs(dcSingleSoa)
+		if errs != nil {
+			t.Error("checkMultipleSOAs function failed with single SOA record")
+		}
+	})
+
+	dcTwoSoas := dcSingleSoa
+	// Add another SOA record to DC
+	dcTwoSoas.Records = append(dcTwoSoas.Records,
+		makeRC("@", "foo.com", "ns2.foo.com.", models.RecordConfig{
+			Type:      "SOA",
+			SoaExpire: 1, SoaMinttl: 1, SoaRefresh: 1, SoaRetry: 1, SoaSerial: 1, SoaMbox: "bar.foo.com",
+		}),
+	)
+
+	t.Run("two_SOAs", func(t *testing.T) {
+		errs := checkMultipleSOAs(dcTwoSoas)
+		if len(errs) < 1 {
+			t.Error("checkMultipleSOAs function failed to catch two SOAs")
+		}
+	})
+}
+
 func TestCheckLabel(t *testing.T) {
 	tests := []struct {
 		label       string


### PR DESCRIPTION
This PR adds validations to reject multipel SOA records. Also unit tests for new function checkMultipleSOAs added.

I did run integration tests only for Route 53 but there isn't anything Route 53 provider spesific.
