### PR TITLE
ALIDNS: audit punycoded CNAME targets

### DIFF
--- a/providers/alidns/auditrecords.go
+++ b/providers/alidns/auditrecords.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/DNSControl/dnscontrol/v4/models"
 	"github.com/DNSControl/dnscontrol/v4/pkg/rejectif"
+	"golang.org/x/net/idna"
 )
 
 // isValidAliDNSString checks if a string contains only ASCII or Chinese characters.
@@ -35,7 +36,11 @@ func labelConstraint(rc *models.RecordConfig) error {
 // targetConstraint detects target values that contain non-ASCII characters except Chinese characters.
 // This applies to CNAME, MX, NS, SRV targets.
 func targetConstraint(rc *models.RecordConfig) error {
-	if !isValidAliDNSString(rc.GetTargetField()) {
+	target, err := idna.ToUnicode(rc.GetTargetField())
+	if err != nil {
+		target = rc.GetTargetField()
+	}
+	if !isValidAliDNSString(target) {
 		return errors.New("target contains non-ASCII characters (only Chinese is allowed)")
 	}
 	return nil

--- a/providers/alidns/auditrecords_test.go
+++ b/providers/alidns/auditrecords_test.go
@@ -1,0 +1,53 @@
+package alidns
+
+import (
+	"testing"
+
+	"github.com/DNSControl/dnscontrol/v4/models"
+)
+
+func TestTargetConstraint(t *testing.T) {
+	tests := []struct {
+		name    string
+		target  string
+		wantErr bool
+	}{
+		{
+			name:   "ascii target",
+			target: "www.example.com.",
+		},
+		{
+			name:   "chinese target",
+			target: "xn--55qx5d.",
+		},
+		{
+			name:    "non-chinese idn target",
+			target:  "xn--ndaaa.com.",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rc := &models.RecordConfig{Type: "CNAME"}
+			rc.SetLabel("a", "example.com")
+			rc.MustSetTarget(tt.target)
+
+			err := targetConstraint(rc)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("targetConstraint() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestAuditRecordsRejectsNonChineseIDNCNAMETarget(t *testing.T) {
+	rc := &models.RecordConfig{Type: "CNAME"}
+	rc.SetLabel("a", "example.com")
+	rc.MustSetTarget("xn--ndaaa.com.")
+
+	errs := AuditRecords([]*models.RecordConfig{rc})
+	if len(errs) != 1 {
+		t.Fatalf("AuditRecords() returned %d errors, want 1", len(errs))
+	}
+}


### PR DESCRIPTION
## Summary

Fixes the AliDNS audit path for internationalized CNAME targets that have already been converted to ACE/punycode before `AuditRecords` runs.

AliDNS supports ASCII and Chinese IDN values, but rejects non-Chinese IDN targets such as `ööö.com.`. During integration testing, that target reaches the provider audit as `xn--ndaaa.com.`, so the existing ASCII/Chinese check sees only ASCII and allows it through. The AliDNS API then rejects the create request with `SubDomainInvalid.Value`.

This changes `targetConstraint` to decode the target with `idna.ToUnicode` before applying the existing AliDNS string validation. That preserves support for ASCII and Chinese IDN targets while rejecting non-Chinese IDN targets during audit, so the integration test is skipped as provider-unsupported instead of failing at the API call.

related to: https://github.com/DNSControl/dnscontrol/issues/4421

## Tests

```bash
go test ./providers/alidns
go test ./integrationTest -run TestNonExistent -count=0
```
