### PR TITLE
v5 - add non-porkbun compatibility to url301

### DIFF
--- a/pkg/privatetypes/rdata/rdata_url301.go
+++ b/pkg/privatetypes/rdata/rdata_url301.go
@@ -28,6 +28,16 @@ func (rd URL301) String() string {
 
 func MakeURL301(origin string, _ map[string]string, args ...any) (dnsv2.RDATA, error) {
 	mustbe.ValidArgs(args)
+
+	// backwards compatibility for providers which aren't porkbun
+	if len(args) == 1 {
+		return URL301{
+			Location:           mustbe.TargetHost(origin, args[0]),
+			PorkbunIncludePath: false,
+			PorkbunWildCard:    false,
+		}, nil
+	}
+
 	if len(args) != 3 {
 		return nil, fmt.Errorf("URL301 expects 3 arguments, got %d: %+v", len(args), args)
 	}


### PR DESCRIPTION
https://github.com/DNSControl/dnscontrol/issues/4421#issuecomment-4887078054

https://github.com/DNSControl/dnscontrol/issues/4421#issuecomment-4890438490

not sure if there is a neat way of detecting the provider or not, probably preferable to making a second kind of URL301 type
