### PR TITLE
REFACTOR: More efficient SVCB/HTTPS parsing

### DIFF
--- a/models/makers.go
+++ b/models/makers.go
@@ -344,17 +344,20 @@ func MakeSVCB(origin string, _ map[string]string, args ...any) (dnsv2.RDATA, err
 	case []svcbv2.Pair:
 		return dnsrdatav2.SVCB{Priority: mustbe.Uint16(priority), Target: mustbe.TargetHost(origin, target), Value: v}, nil
 	case string:
-		// ech=IGNORE is special. It means "take the ech value from the existing record".  We replace it with the byte sequence 0x10 0x00
-		// here. Later,
+		// ech=IGNORE is special. It means "take the ech value from the existing
+		// record".  We replace it with the byte sequence 0x10 0x00 here. Later,
+		// we look for that value and replace it with the existing record's
+		// value. This works because we can assume there are no ech= values that
+		// are actually 0x10 0x00.  (The ech=IGNORE value is stored as ech=1000
+		// in the wire format.)
 		v = strings.ReplaceAll(v, "IGNORE", "1000")
 
-		// NB(tlim): It's overkill to construct this string just to parse it but dnsv2 doesn't expose the parser in a way to do just the params.
-		line := fmt.Sprintf("%d %s %s", mustbe.Uint16(priority), mustbe.TargetHost(origin, target), v)
-		sr, err := MyNewData(dnsv2.TypeHTTPS, line, origin)
+		pairs, err := stringToSvcbv2Values(origin, v)
 		if err != nil {
 			return nil, err
 		}
-		return sr, nil
+		return dnsrdatav2.SVCB{Priority: mustbe.Uint16(priority), Target: mustbe.TargetHost(origin, target), Value: pairs}, nil
+
 	}
 
 	panic(fmt.Sprintf("BUG: Invalid params type for SVCB/HTTPS record: %T", params))

--- a/models/t_svcb.go
+++ b/models/t_svcb.go
@@ -20,6 +20,7 @@ func (rc *RecordConfig) targetCombinedSVCBRaw() string {
 }
 
 // SetTargetSVCB sets the SVCB fields.
+// FUTURE(tlim): This will either go away or changed such that params is []svcbv2.Pair.
 func (rc *RecordConfig) SetTargetSVCB(priority uint16, target string, params []dnsv1.SVCBKeyValue) error {
 	rc.SvcPriority = priority
 	if err := rc.SetTarget(target); err != nil {
@@ -123,6 +124,41 @@ func (rc *RecordConfig) GetSVCBValue() []dnsv1.SVCBKeyValue {
 	}
 
 	return nil
+}
+
+// stringToSvcbv2Values converts a string to a SVCB value list.
+// TODO(tlim): THIS NEEDS A UNIT TEST!
+func stringToSvcbv2Values(origin string, contents string) ([]svcbv2.Pair, error) {
+	fields := strings.Fields(contents)
+	fmt.Printf("DEBUG: stringToSvcbv2Values: origin=%q contents=%q fields=%v\n", origin, contents, fields)
+
+	var result []svcbv2.Pair
+
+	for _, field := range fields {
+		keyValue := strings.SplitN(field, "=", 2)
+		if len(keyValue) != 2 {
+			return nil, fmt.Errorf("invalid svcb.Pair: %q", field)
+		}
+
+		// Make the pair.
+		pairFn := svcbv2.KeyToPair(svcbv2.StringToKey(keyValue[0]))
+		pair := pairFn()
+
+		// Strip the value of any quotes:
+		v := keyValue[1]
+		if len(v) >= 2 && v[0] == '"' && v[len(v)-1] == '"' { // Strip quotes if present
+			v = v[1 : len(v)-1]
+		}
+
+		// Parse it:
+		err := svcbv2.Parse(pair, v, origin)
+		if err != nil {
+			return nil, err
+		}
+
+		result = append(result, pair)
+	}
+	return result, nil
 }
 
 // svcbv2ValueToString converts a SVCB value list to a string.


### PR DESCRIPTION
# Issue

MakeSVCB() uses an inefficient parser. It builds up a big string, parses it, and tosses most of the results.

# Resolution

Use svcb.Parse() to only parse the parts we need.