### PR TITLE
REFACTOR: Backport changes from release_candidate_v5

### DIFF
--- a/bin/generate-all.sh
+++ b/bin/generate-all.sh
@@ -37,3 +37,8 @@ if command -v staticcheck >/dev/null 2>&1; then
 else
   echo "staticcheck not found, skipping"
 fi
+
+# NOTE:
+# This is one way to make sure Unicode chars haven't crept into pkg/js/parse_tests
+# pcre2grep --color='auto' -n '[^\x00-\x7F]' $(find * . -type f -name \*.json)
+

--- a/integrationTest/helpers_integration_test.go
+++ b/integrationTest/helpers_integration_test.go
@@ -30,6 +30,10 @@ var (
 	printElapsed = flag.Bool("elapsed", false, "Print elapsed time for each testgroup")
 )
 
+// Global variable to hold the current DomainConfig for use in NewRecordConfig calls.
+// This is an ugly, ugly, hack. We have to find something better.
+var globalDC *models.DomainConfig
+
 // Global variable to hold the current DomainConfig	for use in FromRaw calls.
 var globalDCN *domaintags.DomainNameVarieties
 
@@ -93,9 +97,7 @@ func CfFlattenOn() *TestCase {
 }
 
 func getDomainConfigWithNameservers(t *testing.T, prv providers.DNSServiceProvider, domainName string) *models.DomainConfig {
-	dc := &models.DomainConfig{
-		Name: domainName,
-	}
+	dc, _ := models.NewDomainConfig(domainName)
 	dc.PostProcess()
 	rtypecontrol.FixLegacyDC(dc)
 
@@ -265,6 +267,7 @@ func makeChanges(t *testing.T, prv providers.DNSServiceProvider, dc *models.Doma
 
 func runTests(t *testing.T, prv providers.DNSServiceProvider, domainName string, origConfig map[string]string) {
 	dc := getDomainConfigWithNameservers(t, prv, domainName)
+	globalDC = dc
 	globalDCN = dc.DomainNameVarieties()
 
 	testGroups := makeTests()

--- a/integrationTest/helpers_test.go
+++ b/integrationTest/helpers_test.go
@@ -17,8 +17,8 @@ import (
 var (
 	providerFlag         = flag.String("provider", "", "Provider to run (if empty, deduced from -profile)")
 	profileFlag          = flag.String("profile", "", "Entry in profiles.json to use (if empty, copied from -provider)")
-	enableCFWorkers      = flag.Bool("cfworkers", false, "enable CF worker tests (default false)")
-	enableCFRedirectMode = flag.Bool("cfredirect", false, "enable CF SingleRedirect tests (default false)")
+	enableCFWorkers      = flag.Bool("cfworkers", true, "enable CF worker tests (default false)")
+	enableCFRedirectMode = flag.Bool("cfredirect", true, "enable CF SingleRedirect tests (default false)")
 	enableCFFlatten      = flag.Bool("cfflatten", false, "enable CF CNAME flattening tests (requires paid plan, default false)")
 	enableCFTags         = flag.Bool("cftags", false, "enable CF tag tests (requires paid plan, default false)")
 )

--- a/integrationTest/integration_test.go
+++ b/integrationTest/integration_test.go
@@ -3,15 +3,18 @@ package main
 // Data-driven tests that exercize the DNS Provider APIs.
 
 import (
+	"runtime/debug"
 	"strings"
 	"testing"
 
+	"github.com/DNSControl/dnscontrol/v4/models"
 	"github.com/DNSControl/dnscontrol/v4/pkg/providers"
 	_ "github.com/DNSControl/dnscontrol/v4/pkg/providers/_all"
 	_ "github.com/DNSControl/dnscontrol/v4/pkg/rtype"
 )
 
 func TestDNSProviders(t *testing.T) {
+	debug.SetTraceback("all")
 	provider, domain, cfg := getProvider(t)
 	if provider == nil {
 		return
@@ -23,6 +26,19 @@ func TestDNSProviders(t *testing.T) {
 	t.Run(domain, func(t *testing.T) {
 		runTests(t, provider, domain, cfg)
 	})
+}
+
+func TestMakeTests(t *testing.T) {
+	dc, err := models.NewDomainConfig("example.com")
+	if err != nil {
+		t.FailNow()
+	}
+	globalDC = dc
+	globalDCN = dc.DomainNameVarieties()
+
+	debug.SetTraceback("all")
+
+	_ = makeTests()
 }
 
 func makeTests() []*TestGroup {
@@ -306,6 +322,7 @@ func makeTests() []*TestGroup {
 		testgroup("HTTPS-Ech",
 			requires(providers.CanUseHTTPS),
 			not(
+				"SAKURACLOUD", // NB(tlim): rejectif code is broken.
 				// Last tested in 2025-12-04. Turns out that Vercel implements an unknown validation
 				// on the `ech` parameter, and our dummy base64 string are being rejected with:
 				//
@@ -316,15 +333,20 @@ func makeTests() []*TestGroup {
 				//
 				// Let's just ignore ECH test for Vercel for now.
 				"VERCEL",
+				"HEDNS", // BUG: https://github.com/DNSControl/dnscontrol/issues/4328
 			),
-			tc("Create a HTTPS record", https("@", 1, "example.com.", "alpn=h2,h3")),
-			tc("Add an ECH key", https("@", 1, "example.com.", "alpn=h2,h3 ech=some+base64+encoded+value///")),
-			tc("Ignore the ECH key while changing other values", https("@", 1, "example.net.", "port=80 ech=IGNORE")),
-			// tc("Should be a no-op", https("@", 1, "example.net.", "port=80 ech=some+base64+encoded+value///")),
-			tc("Change the ECH key and other values", https("@", 1, "example.org.", "port=80 ipv4hint=127.0.0.1 ech=another+base64+encoded+value")),
-			// tc("Ignore the ECH key while not changing anything", https("@", 1, "example.org.", "port=80 ipv4hint=127.0.0.1 ech=IGNORE")),
-			// tc("Should be a no-op", https("@", 1, "example.org.", "port=80 ipv4hint=127.0.0.1 ech=another+base64+encoded+value")),
-			tc("Another domain with a different ECH value", https("ech", 1, "example.com.", "ech=some+base64+encoded+value///")),
+			tc("Start",
+				https("@", 3, "example.com.", "alpn=h2,h3 port=999")),
+			tc("Add an ECH key",
+				https("@", 3, "example.com.", "alpn=h2,h3 port=999 ech=some+base64+encoded+value///")),
+			tc("IGNORE ECH",
+				https("@", 3, "example.com.", "alpn=h2,h3 port=999 ech=IGNORE")).ExpectNoChanges(),
+			tc("Ignore the ECH key while changing other values",
+				https("@", 3, "example.com.", "alpn=h2 port=80 ech=IGNORE")),
+			tc("Change the ECH key and other values",
+				https("@", 3, "example.com.", "alpn=h2 port=80 ech=another+base64+encoded+value")),
+			tc("Another domain with a same ECH value",
+				https("@", 3, "yetanother.com.", "alpn=h2 port=80 ech=another+base64+encoded+value")),
 		),
 
 		testgroup("SVCB",
@@ -339,6 +361,7 @@ func makeTests() []*TestGroup {
 		testgroup("SVCB-Ech",
 			requires(providers.CanUseSVCB),
 			not(
+				"SAKURACLOUD", // NB(tlim): rejectif code is broken.
 				// Last tested in 2025-12-04. Turns out that Vercel implements an unknown validation
 				// on the `ech` parameter, and our dummy base64 string are being rejected with:
 				//
@@ -349,15 +372,20 @@ func makeTests() []*TestGroup {
 				//
 				// Let's just ignore ECH test for Vercel for now.
 				"VERCEL",
+				"HEDNS", // BUG: https://github.com/DNSControl/dnscontrol/issues/4328
 			),
-			tc("Create a SVCB record", svcb("@", 1, "example.com.", "alpn=h2,h3")),
-			tc("Add an ECH key", svcb("@", 1, "example.com.", "alpn=h2,h3 ech=some+base64+encoded+value///")),
-			tc("Ignore the ECH key while changing other values", svcb("@", 1, "example.net.", "port=80 ech=IGNORE")),
-			// tc("Should be a no-op", svcb("@", 1, "example.net.", "port=80 ech=some+base64+encoded+value///")),
-			tc("Change the ECH key and other values", svcb("@", 1, "example.org.", "port=80 ipv4hint=127.0.0.1 ech=another+base64+encoded+value")),
-			// tc("Ignore the ECH key while not changing anything", svcb("@", 1, "example.org.", "port=80 ipv4hint=127.0.0.1 ech=IGNORE")),
-			// tc("Should be a no-op", svcb("@", 1, "example.org.", "port=80 ipv4hint=127.0.0.1 ech=another+base64+encoded+value")),
-			tc("Another domain with a different ECH value", svcb("ech", 1, "example.com.", "ech=some+base64+encoded+value///")),
+			tc("Start",
+				svcb("@", 3, "example.com.", "alpn=h2,h3 port=999")),
+			tc("Add an ECH key",
+				svcb("@", 3, "example.com.", "alpn=h2,h3 port=999 ech=some+base64+encoded+value///")),
+			tc("IGNORE ECH",
+				svcb("@", 3, "example.com.", "alpn=h2,h3 port=999 ech=IGNORE")).ExpectNoChanges(),
+			tc("Ignore the ECH key while changing other values",
+				svcb("@", 3, "example.com.", "alpn=h2 port=80 ech=IGNORE")),
+			tc("Change the ECH key and other values",
+				svcb("@", 3, "example.com.", "alpn=h2 port=80 ech=another+base64+encoded+value")),
+			tc("Another domain with a same ECH value",
+				svcb("@", 3, "yetanother.com.", "alpn=h2 port=80 ech=another+base64+encoded+value")),
 		),
 
 		//// Test edge cases from various types.

--- a/models/domain.go
+++ b/models/domain.go
@@ -95,6 +95,16 @@ func (dc *DomainConfig) PostProcess() {
 	dc.Metadata[DomainUniqueName] = dc.UniqueName
 }
 
+func (dc *DomainConfig) PopulateNamesFromRaw(rawname string) {
+	dcn := domaintags.MakeDomainNameVarieties(rawname)
+	dc.Name = dcn.NameASCII
+	dc.Tag = dcn.Tag
+	dc.NameRaw = dcn.NameRaw
+	dc.NameUnicode = dcn.NameUnicode
+	dc.DisplayName = dcn.DisplayName
+	dc.UniqueName = dcn.UniqueName
+}
+
 // GetSplitHorizonNames returns the domain's name, uniquename, and tag.
 // Deprecated: use .Name, .Uniquename, and .Tag directly instead.
 func (dc *DomainConfig) GetSplitHorizonNames() (name, uniquename, tag string) {
@@ -242,6 +252,7 @@ func NewDomainConfig(name string) (*DomainConfig, error) {
 	dc := &DomainConfig{
 		Metadata: map[string]string{}, // Initialize so that nil checking is not required later.
 	}
+	dc.PopulateNamesFromRaw(name)
 
 	return dc, nil
 }

--- a/models/domain.go
+++ b/models/domain.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"fmt"
+	"strings"
 	"sync"
 
 	"github.com/DNSControl/dnscontrol/v4/pkg/domaintags"
@@ -24,6 +25,7 @@ const (
 )
 
 // DomainConfig describes a DNS domain (technically a DNS zone).
+// Do not create your own `&models.DomainConfig{}`.  Use `models.NewDomainConfig(name)`.
 type DomainConfig struct {
 	NameRaw     string `json:"-"`    // name as entered by user in dnsconfig.js
 	Name        string `json:"name"` // NO trailing "."   Converted to IDN (punycode) early in the pipeline.
@@ -128,6 +130,7 @@ func (dc *DomainConfig) Filter(f func(r *RecordConfig) bool) {
 // - Name
 // - NameFQDN
 // - Target (CNAME and MX only).
+// NOTE: This will go away when RCv3 is adopted.
 func (dc *DomainConfig) Punycode() error {
 	for _, rec := range dc.Records {
 		if rec.IsModernType() {
@@ -230,6 +233,17 @@ func (dc *DomainConfig) StorePopulateCorrections(providerName string, correction
 		dc.pendingPopulateCorrections = make(map[string][]*Correction, 1)
 	}
 	dc.pendingPopulateCorrections[providerName] = append(dc.pendingPopulateCorrections[providerName], corrections...)
+}
+
+func NewDomainConfig(name string) (*DomainConfig, error) {
+	if strings.HasSuffix(name, ".") {
+		return nil, fmt.Errorf("do not call NewDomainName with trailing dot: %q", name)
+	}
+	dc := &DomainConfig{
+		Metadata: map[string]string{}, // Initialize so that nil checking is not required later.
+	}
+
+	return dc, nil
 }
 
 // GetPopulateCorrections returns zone corrections in a thread-safe way.

--- a/pkg/rejectif/srv.go
+++ b/pkg/rejectif/srv.go
@@ -11,7 +11,7 @@ import (
 // SrvHasNullTarget detects SRV records that has a null target.
 func SrvHasNullTarget(rc *models.RecordConfig) error {
 	if rc.GetTargetField() == "." {
-		return errors.New("srv has null target")
+		return errors.New("srv has empty target") // Same msg as SrvHasEmptyTarget to make testing easier.
 	}
 	return nil
 }

--- a/providers/alidns/auditrecords.go
+++ b/providers/alidns/auditrecords.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/DNSControl/dnscontrol/v4/models"
 	"github.com/DNSControl/dnscontrol/v4/pkg/rejectif"
+	"golang.org/x/net/idna"
 )
 
 // isValidAliDNSString checks if a string contains only ASCII or Chinese characters.
@@ -35,7 +36,11 @@ func labelConstraint(rc *models.RecordConfig) error {
 // targetConstraint detects target values that contain non-ASCII characters except Chinese characters.
 // This applies to CNAME, MX, NS, SRV targets.
 func targetConstraint(rc *models.RecordConfig) error {
-	if !isValidAliDNSString(rc.GetTargetField()) {
+	target, err := idna.ToUnicode(rc.GetTargetField())
+	if err != nil {
+		target = rc.GetTargetField()
+	}
+	if !isValidAliDNSString(target) {
 		return errors.New("target contains non-ASCII characters (only Chinese is allowed)")
 	}
 	return nil

--- a/providers/alidns/auditrecords_test.go
+++ b/providers/alidns/auditrecords_test.go
@@ -1,0 +1,53 @@
+package alidns
+
+import (
+	"testing"
+
+	"github.com/DNSControl/dnscontrol/v4/models"
+)
+
+func TestTargetConstraint(t *testing.T) {
+	tests := []struct {
+		name    string
+		target  string
+		wantErr bool
+	}{
+		{
+			name:   "ascii target",
+			target: "www.example.com.",
+		},
+		{
+			name:   "chinese target",
+			target: "xn--55qx5d.",
+		},
+		{
+			name:    "non-chinese idn target",
+			target:  "xn--ndaaa.com.",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rc := &models.RecordConfig{Type: "CNAME"}
+			rc.SetLabel("a", "example.com")
+			rc.MustSetTarget(tt.target)
+
+			err := targetConstraint(rc)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("targetConstraint() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestAuditRecordsRejectsNonChineseIDNCNAMETarget(t *testing.T) {
+	rc := &models.RecordConfig{Type: "CNAME"}
+	rc.SetLabel("a", "example.com")
+	rc.MustSetTarget("xn--ndaaa.com.")
+
+	errs := AuditRecords([]*models.RecordConfig{rc})
+	if len(errs) != 1 {
+		t.Fatalf("AuditRecords() returned %d errors, want 1", len(errs))
+	}
+}

--- a/providers/hedns/hednsProvider.go
+++ b/providers/hedns/hednsProvider.go
@@ -410,7 +410,7 @@ func (c *hednsProvider) getDiff2DomainCorrections(dc *models.DomainConfig, recor
 }
 
 // setDDNSKeyForNewRecord sets the DDNS key on a newly created record.
-func (c *hednsProvider) setDDNSKeyForNewRecord(zoneID uint64, domain string, record *models.RecordConfig, key string) error {
+func (c *hednsProvider) setDDNSKeyForNewRecord(zoneID uint64, _ string, record *models.RecordConfig, key string) error {
 	return c.setRecordDDNSKey(zoneID, record.GetLabelFQDN(), key)
 }
 

--- a/providers/mikrotik/mikrotikProvider_test.go
+++ b/providers/mikrotik/mikrotikProvider_test.go
@@ -577,7 +577,8 @@ func TestGetZoneRecords_FiltersAndConverts(t *testing.T) {
 	})
 	defer srv.Close()
 
-	rcs, err := p.GetZoneRecords(&models.DomainConfig{Name: "example.com"})
+	dc, _ := models.NewDomainConfig("example.com")
+	rcs, err := p.GetZoneRecords(dc)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -602,7 +603,8 @@ func TestGetZoneRecords_ForwarderZone(t *testing.T) {
 	})
 	defer srv.Close()
 
-	rcs, err := p.GetZoneRecords(&models.DomainConfig{Name: ForwarderZone})
+	dc, _ := models.NewDomainConfig(ForwarderZone)
+	rcs, err := p.GetZoneRecords(dc)
 
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/providers/porkbun/porkbunProvider.go
+++ b/providers/porkbun/porkbunProvider.go
@@ -165,6 +165,47 @@ func genComparable(rec *models.RecordConfig) string {
 	return ""
 }
 
+func porkbunURLForwardingMetadata(recordType string, metadata map[string]string) (string, string, string) {
+	t := metadata[metaType]
+	if t == "" {
+		if recordType == "URL301" {
+			t = "permanent"
+		} else {
+			t = "temporary"
+		}
+	}
+	includePath := metadata[metaIncludePath]
+	if includePath == "" {
+		includePath = "no"
+	}
+	wildcard := metadata[metaWildcard]
+	if wildcard == "" {
+		wildcard = "yes"
+	}
+	return t, includePath, wildcard
+}
+
+func normalizeURLForwardingRecord(record *models.RecordConfig, origin string) {
+	if !isURLForwardingType(record.Type) {
+		return
+	}
+	record.TTL = 0
+	if record.Metadata == nil {
+		record.Metadata = make(map[string]string)
+	}
+	t, includePath, wildcard := porkbunURLForwardingMetadata(record.Type, record.Metadata)
+	record.Metadata[metaType] = t
+	record.Metadata[metaIncludePath] = includePath
+	record.Metadata[metaWildcard] = wildcard
+	if record.Type == "PORKBUN_URLFWD" {
+		if record.Metadata[metaType] == "permanent" {
+			record.Type = "URL301"
+		} else {
+			record.Type = "URL"
+		}
+	}
+}
+
 // GetZoneRecordsCorrections returns a list of corrections that will turn existing records into dc.Records.
 func (c *porkbunProvider) GetZoneRecordsCorrections(dc *models.DomainConfig, existingRecords models.Records) ([]*models.Correction, int, error) {
 	var corrections []*models.Correction
@@ -175,35 +216,7 @@ func (c *porkbunProvider) GetZoneRecordsCorrections(dc *models.DomainConfig, exi
 	// Make sure TTL larger than the minimum TTL
 	for _, record := range dc.Records {
 		record.TTL = fixTTL(record.TTL)
-		if isURLForwardingType(record.Type) {
-			record.TTL = 0
-			if record.Metadata == nil {
-				record.Metadata = make(map[string]string)
-			}
-			// Set metadata type based on record type
-			if record.Metadata[metaType] == "" {
-				if record.Type == "URL301" {
-					record.Metadata[metaType] = "permanent"
-				} else {
-					// Default for URL and PORKBUN_URLFWD
-					record.Metadata[metaType] = "temporary"
-				}
-			}
-			if record.Metadata[metaIncludePath] == "" {
-				record.Metadata[metaIncludePath] = "no"
-			}
-			if record.Metadata[metaWildcard] == "" {
-				record.Metadata[metaWildcard] = "yes"
-			}
-			if record.Type == "PORKBUN_URLFWD" {
-				printer.Warnf("`PORKBUN_URLFWD` is deprecated. Please use `URL` or `URL301` instead.\n")
-				if record.Metadata[metaType] == "permanent" {
-					record.Type = "URL301"
-				} else {
-					record.Type = "URL"
-				}
-			}
-		}
+		normalizeURLForwardingRecord(record, dc.Name)
 	}
 
 	changes, actualChangeCount, err := diff2.ByRecord(existingRecords, dc, genComparable)

--- a/providers/powerdns/dnssec_test.go
+++ b/providers/powerdns/dnssec_test.go
@@ -14,9 +14,8 @@ import (
 func TestGetDNSSECCorrectionsSkipsCryptokeysWhenAutoDNSSECUnset(t *testing.T) {
 	dsp := &powerdnsProvider{}
 
-	corrections, err := dsp.getDNSSECCorrections(&models.DomainConfig{
-		Name: "example.com",
-	})
+	dc, _ := models.NewDomainConfig("example.com")
+	corrections, err := dsp.getDNSSECCorrections(dc)
 
 	require.NoError(t, err)
 	assert.Empty(t, corrections)
@@ -37,10 +36,9 @@ func TestGetDNSSECCorrectionsIgnoresMissingCryptokeysEndpoint(t *testing.T) {
 		ServerName: "localhost",
 	}
 
-	corrections, err := dsp.getDNSSECCorrections(&models.DomainConfig{
-		Name:       "example.com",
-		AutoDNSSEC: "on",
-	})
+	dc, _ := models.NewDomainConfig("example.com")
+	dc.AutoDNSSEC = "on"
+	corrections, err := dsp.getDNSSECCorrections(dc)
 
 	require.NoError(t, err)
 	assert.Empty(t, corrections)

--- a/providers/tencentdns/auditrecords_test.go
+++ b/providers/tencentdns/auditrecords_test.go
@@ -28,6 +28,6 @@ func TestAuditRecords(t *testing.T) {
 	assert.Len(t, errs, 4)
 	assert.Contains(t, errs[0].Error(), "mx has null target")
 	assert.Contains(t, errs[1].Error(), "txtstring is empty")
-	assert.Contains(t, errs[2].Error(), "srv has null target")
+	assert.Contains(t, errs[2].Error(), "srv has empty target")
 	assert.Contains(t, errs[3].Error(), "srv has empty target")
 }

--- a/providers/tencentdns/tencentdnsProvider_test.go
+++ b/providers/tencentdns/tencentdnsProvider_test.go
@@ -113,13 +113,12 @@ func TestSiteConfigForSite(t *testing.T) {
 }
 
 func TestPrepDesiredRecordsRewritesLowTTL(t *testing.T) {
-	dc := &models.DomainConfig{
-		Records: models.Records{
-			{TTL: 0},
-			{TTL: 300},
-			{TTL: 600},
-			{TTL: 3600},
-		},
+	dc, _ := models.NewDomainConfig("example.com")
+	dc.Records = models.Records{
+		{TTL: 0},
+		{TTL: 300},
+		{TTL: 600},
+		{TTL: 3600},
 	}
 
 	prepDesiredRecords(dc, 600)
@@ -131,10 +130,9 @@ func TestPrepDesiredRecordsRewritesLowTTL(t *testing.T) {
 }
 
 func TestPrepDesiredRecordsAllowsPaidDomainTTL(t *testing.T) {
-	dc := &models.DomainConfig{
-		Records: models.Records{
-			{TTL: 300},
-		},
+	dc, _ := models.NewDomainConfig("example.com")
+	dc.Records = models.Records{
+		{TTL: 300},
 	}
 
 	prepDesiredRecords(dc, 1)

--- a/providers/vultr/convert_test.go
+++ b/providers/vultr/convert_test.go
@@ -8,9 +8,7 @@ import (
 )
 
 func TestConversion(t *testing.T) {
-	dc := &models.DomainConfig{
-		Name: "example.com",
-	}
+	dc, _ := models.NewDomainConfig("example.com")
 
 	records := []govultr.DomainRecord{
 		{


### PR DESCRIPTION
* Backport and use models.NewDomainConfig() when possible
* Change defaults for -cfworkers and -cfredirect
* Backport integrationTest/integration_test.go
