### PR TITLE
GIDINET: v5 test fixes and modernize record conversion

### DIFF
--- a/integrationTest/integration_test.go
+++ b/integrationTest/integration_test.go
@@ -486,6 +486,7 @@ func makeTests() []*TestGroup {
 				"DYNU",              // Apex NS records are managed by Dynu.
 				"EXOSCALE",          // Not supported.
 				"GANDI_V5",          // "Gandi does not support changing apex NS records. Ignoring ns1.foo.com."
+				"GIDINET",           // "GIDINET does not support modifying NS records at apex."
 				"JOKER",             // Not supported via the Zone API.
 				"NAMEDOTCOM",        // "Ignores @ for NS records"
 				"NETCUP",            // NS records not currently supported.

--- a/providers/gidinet/auditrecords.go
+++ b/providers/gidinet/auditrecords.go
@@ -13,6 +13,8 @@ func AuditRecords(records []*models.RecordConfig) []error {
 
 	a.Add("MX", rejectif.MxNull) // Last verified 2026-01-24
 
+	a.Add("SRV", rejectif.SrvHasNullTarget) // Last verified 2026-07-07
+
 	a.Add("TXT", rejectif.TxtHasDoubleQuotes) // Last verified 2026-01-24
 
 	a.Add("TXT", rejectif.TxtIsEmpty) // Last verified 2026-01-24

--- a/providers/gidinet/auditrecords_test.go
+++ b/providers/gidinet/auditrecords_test.go
@@ -45,6 +45,20 @@ func TestAuditRecords(t *testing.T) {
 			},
 			wantCount: 1,
 		},
+		{
+			name: "valid SRV record",
+			records: []*models.RecordConfig{
+				makeRC("SRV", "_sip._tcp", "foo.com."),
+			},
+			wantCount: 0,
+		},
+		{
+			name: "SRV with null target should fail",
+			records: []*models.RecordConfig{
+				makeRC("SRV", "_sip._tcp", "."),
+			},
+			wantCount: 1,
+		},
 	}
 
 	for _, tt := range tests {

--- a/providers/gidinet/gidinetProvider.go
+++ b/providers/gidinet/gidinetProvider.go
@@ -258,13 +258,12 @@ func toRecordConfig(domain string, r *DNSRecordListItem) (*models.RecordConfig, 
 	// Handle different record types
 	switch r.RecordType {
 	case "MX":
-		rc.MxPreference = uint16(r.Priority)
 		// MX target should be FQDN with trailing dot
 		target := r.Data
 		if !strings.HasSuffix(target, ".") {
 			target = dnsutil.AddOrigin(target+".", domain)
 		}
-		if err := rc.SetTarget(target); err != nil {
+		if err := rc.SetTargetMX(uint16(r.Priority), target); err != nil {
 			return nil, err
 		}
 
@@ -280,10 +279,7 @@ func toRecordConfig(domain string, r *DNSRecordListItem) (*models.RecordConfig, 
 			if !strings.HasSuffix(target, ".") {
 				target = target + "."
 			}
-			rc.SrvPriority = uint16(priority)
-			rc.SrvWeight = uint16(weight)
-			rc.SrvPort = uint16(port)
-			if err := rc.SetTarget(target); err != nil {
+			if err := rc.SetTargetSRV(uint16(priority), uint16(weight), uint16(port), target); err != nil {
 				return nil, err
 			}
 		} else {


### PR DESCRIPTION
Tested GIDINET against `release_candidate_v5` (#4421). Two fixes so the
integration test passes, plus a small modernization.

- Reject null SRV targets in `AuditRecords` — the Gidinet API errors on them
  (code 4), so the `43:SRV Null Target` case now skips instead of failing.
- Exclude GIDINET from the `NS only APEX` test — the provider already refuses to
  modify apex NS records, so the test expected changes that never come.
- `toRecordConfig`: use `SetTargetMX`/`SetTargetSRV` instead of setting
  the fields by hand (v5 cookbook). No behaviour change.

Integration test green; unit tests pass.
