### PR TITLE
UNIFI: new API compatibility fixes + tests

### DIFF
--- a/integrationTest/integration_test.go
+++ b/integrationTest/integration_test.go
@@ -892,6 +892,7 @@ func makeTests() []*TestGroup {
 		// https://github.com/DNSControl/dnscontrol/issues/2066
 		testgroup("SRV",
 			requires(providers.CanUseSRV),
+			not("UNIFI"), // UniFi has no per-record TTL for SRV records.
 			tc("Create SRV333", ttl(srv("_sip._tcp", 5, 6, 7, "foo.com."), 333)),
 			tc("Change TTL999", ttl(srv("_sip._tcp", 5, 6, 7, "foo.com."), 999)),
 		),

--- a/providers/unifi/api.go
+++ b/providers/unifi/api.go
@@ -350,9 +350,14 @@ func (c *unifiClient) deleteRecordNew(id string) error {
 // ============================================================================
 
 // detectAPIAvailability probes both APIs to determine which are available.
+// Only positive results are cached: a transient probe failure must not
+// permanently mark an API unavailable for the life of the client (otherwise a
+// single network blip poisons every later request). If no API is found yet, the
+// next call re-probes.
 func (c *unifiClient) detectAPIAvailability() {
-	if c.newAPIAvailable != nil && c.legacyAPIAvailable != nil {
-		return // Already detected
+	if (c.newAPIAvailable != nil && *c.newAPIAvailable) ||
+		(c.legacyAPIAvailable != nil && *c.legacyAPIAvailable) {
+		return // Already found a working API.
 	}
 
 	// Try new API first
@@ -365,7 +370,9 @@ func (c *unifiClient) detectAPIAvailability() {
 			newAvailable = true
 		}
 	}
-	c.newAPIAvailable = &newAvailable
+	if newAvailable {
+		c.newAPIAvailable = &newAvailable
+	}
 
 	// Try legacy API
 	legacyAvailable := false
@@ -373,7 +380,9 @@ func (c *unifiClient) detectAPIAvailability() {
 	if _, err := c.do("GET", path, nil); err == nil {
 		legacyAvailable = true
 	}
-	c.legacyAPIAvailable = &legacyAvailable
+	if legacyAvailable {
+		c.legacyAPIAvailable = &legacyAvailable
+	}
 
 	if c.debug {
 		fmt.Printf("[UNIFI] [DEBUG] API availability - New: %v, Legacy: %v\n", newAvailable, legacyAvailable)

--- a/providers/unifi/auditrecords.go
+++ b/providers/unifi/auditrecords.go
@@ -27,6 +27,7 @@ func AuditRecords(records []*models.RecordConfig) []error {
 	// TXT records have limitations
 	a.Add("TXT", rejectif.TxtIsEmpty)
 	a.Add("TXT", rejectif.TxtLongerThan(255)) // UniFi limits TXT to 255 chars per record
+	a.Add("TXT", rejectif.TxtHasDoubleQuotes) // New API rejects interior double quotes ("incorrectly quoted value")
 
 	// MX records cannot have null/empty target
 	a.Add("MX", rejectif.MxNull)

--- a/providers/unifi/types.go
+++ b/providers/unifi/types.go
@@ -46,8 +46,9 @@ type dnsPolicyRecord struct {
 	Metadata *dnsPolicyMetadata `json:"metadata,omitempty"` // Metadata (origin, read-only in API responses)
 	Domain   string             `json:"domain"`             // FQDN (e.g., "test.example.com")
 
-	// TTL in seconds (required by the API, always sent)
-	TTLSeconds int `json:"ttlSeconds"`
+	// TTL in seconds. Only A/AAAA/CNAME accept it in the new API; for
+	// MX/TXT/SRV the property is rejected, so it is omitted when zero.
+	TTLSeconds int `json:"ttlSeconds,omitempty"`
 
 	// Type-specific fields
 	IPv4Address      string `json:"ipv4Address,omitempty"`      // A record
@@ -283,11 +284,15 @@ func recordToNew(rc *models.RecordConfig) (*dnsPolicyRecord, error) {
 		Domain:  rc.NameFQDN,
 	}
 
-	// Always send TTL; the API requires ttlSeconds to be non-null.
-	if rc.TTL > 0 {
-		r.TTLSeconds = int(rc.TTL)
-	} else {
-		r.TTLSeconds = 300
+	// The new API only accepts ttlSeconds for A/AAAA/CNAME; sending it for
+	// MX/TXT/SRV is rejected with "Unknown request body property '$.ttlSeconds'".
+	switch rc.Type {
+	case "A", "AAAA", "CNAME":
+		if rc.TTL > 0 {
+			r.TTLSeconds = int(rc.TTL)
+		} else {
+			r.TTLSeconds = 300
+		}
 	}
 
 	switch rc.Type {

--- a/providers/unifi/types.go
+++ b/providers/unifi/types.go
@@ -61,9 +61,12 @@ type dnsPolicyRecord struct {
 	// MX/SRV specific
 	Priority int `json:"priority,omitempty"` // MX/SRV priority
 
-	// SRV specific
-	Weight int `json:"weight,omitempty"` // SRV weight
-	Port   int `json:"port,omitempty"`   // SRV port
+	// SRV specific. The new API splits the "_service._proto.name" label into
+	// separate fields; service/protocol keep their leading underscore.
+	Service  string `json:"service,omitempty"`  // SRV service, e.g. "_sip"
+	Protocol string `json:"protocol,omitempty"` // SRV protocol, e.g. "_tcp"
+	Weight   int    `json:"weight,omitempty"`   // SRV weight
+	Port     int    `json:"port,omitempty"`     // SRV port
 }
 
 // dnsPolicyResponse wraps the response from the new API list endpoint.
@@ -238,8 +241,13 @@ func newToRecord(domain string, r *dnsPolicyRecord) (*models.RecordConfig, error
 		rc.TTL = 300
 	}
 
-	// Set label from FQDN
-	rc.SetLabelFromFQDN(r.Domain, domain)
+	// Set label from FQDN. For SRV the new API splits the label, so rebuild
+	// "_service._proto.name" from the separate fields.
+	fqdn := r.Domain
+	if r.Type == NewAPITypeSRV && r.Service != "" && r.Protocol != "" {
+		fqdn = r.Service + "." + r.Protocol + "." + r.Domain
+	}
+	rc.SetLabelFromFQDN(fqdn, domain)
 
 	var err error
 	switch r.Type {
@@ -319,6 +327,16 @@ func recordToNew(rc *models.RecordConfig) (*dnsPolicyRecord, error) {
 
 	case "SRV":
 		r.Type = NewAPITypeSRV
+		// The new API wants the "_service._proto.name" label split apart, e.g.
+		// "_sip._tcp.example.com" => service="_sip", protocol="_tcp",
+		// domain="example.com".
+		labels := strings.SplitN(rc.NameFQDN, ".", 3)
+		if len(labels) < 3 {
+			return nil, fmt.Errorf("SRV record %q is not in _service._proto.name form", rc.NameFQDN)
+		}
+		r.Service = labels[0]
+		r.Protocol = labels[1]
+		r.Domain = labels[2]
 		r.Priority = int(rc.SrvPriority)
 		r.Weight = int(rc.SrvWeight)
 		r.Port = int(rc.SrvPort)

--- a/providers/unifi/types.go
+++ b/providers/unifi/types.go
@@ -107,25 +107,21 @@ func legacyToRecord(domain string, r *legacyDNSRecord) (*models.RecordConfig, er
 		err = rc.SetTarget(target)
 
 	case "MX":
-		rc.MxPreference = uint16(r.Priority)
 		target := r.Value
 		if !strings.HasSuffix(target, ".") {
 			target = target + "."
 		}
-		err = rc.SetTarget(target)
+		err = rc.SetTargetMX(uint16(r.Priority), target)
 
 	case "TXT":
 		err = rc.SetTargetTXT(r.Value)
 
 	case "SRV":
-		rc.SrvPriority = uint16(r.Priority)
-		rc.SrvWeight = uint16(r.Weight)
-		rc.SrvPort = uint16(r.Port)
 		target := r.Value
 		if !strings.HasSuffix(target, ".") {
 			target = target + "."
 		}
-		err = rc.SetTarget(target)
+		err = rc.SetTargetSRV(uint16(r.Priority), uint16(r.Weight), uint16(r.Port), target)
 
 	default:
 		err = fmt.Errorf("unsupported record type: %s", r.RecordType)
@@ -260,25 +256,21 @@ func newToRecord(domain string, r *dnsPolicyRecord) (*models.RecordConfig, error
 		err = rc.SetTarget(target)
 
 	case NewAPITypeMX:
-		rc.MxPreference = uint16(r.Priority)
 		target := r.MailServerDomain
 		if !strings.HasSuffix(target, ".") {
 			target = target + "."
 		}
-		err = rc.SetTarget(target)
+		err = rc.SetTargetMX(uint16(r.Priority), target)
 
 	case NewAPITypeTXT:
 		err = rc.SetTargetTXT(r.Text)
 
 	case NewAPITypeSRV:
-		rc.SrvPriority = uint16(r.Priority)
-		rc.SrvWeight = uint16(r.Weight)
-		rc.SrvPort = uint16(r.Port)
 		target := r.ServerDomain
 		if !strings.HasSuffix(target, ".") {
 			target = target + "."
 		}
-		err = rc.SetTarget(target)
+		err = rc.SetTargetSRV(uint16(r.Priority), uint16(r.Weight), uint16(r.Port), target)
 	}
 
 	return rc, err

--- a/providers/unifi/types_test.go
+++ b/providers/unifi/types_test.go
@@ -355,7 +355,7 @@ func TestRecordToNew(t *testing.T) {
 			name: "MX",
 			in:   &dnsPolicyRecord{Type: NewAPITypeMX, Domain: "example.com", MailServerDomain: "mail.example.com", Priority: 10, TTLSeconds: 300},
 			check: func(t *testing.T, r *dnsPolicyRecord) {
-				if r.Type != NewAPITypeMX || r.MailServerDomain != "mail.example.com" || r.Priority != 10 {
+				if r.Type != NewAPITypeMX || r.MailServerDomain != "mail.example.com" || r.Priority != 10 || r.TTLSeconds != 0 {
 					t.Errorf("unexpected MX record: %+v", r)
 				}
 			},
@@ -364,7 +364,7 @@ func TestRecordToNew(t *testing.T) {
 			name: "SRV",
 			in:   &dnsPolicyRecord{Type: NewAPITypeSRV, Domain: "_sip._tcp.example.com", ServerDomain: "sip.example.com", Priority: 1, Weight: 5, Port: 5060, TTLSeconds: 300},
 			check: func(t *testing.T, r *dnsPolicyRecord) {
-				if r.Type != NewAPITypeSRV || r.ServerDomain != "sip.example.com" || r.Priority != 1 || r.Weight != 5 || r.Port != 5060 {
+				if r.Type != NewAPITypeSRV || r.ServerDomain != "sip.example.com" || r.Priority != 1 || r.Weight != 5 || r.Port != 5060 || r.TTLSeconds != 0 {
 					t.Errorf("unexpected SRV record: %+v", r)
 				}
 			},

--- a/providers/unifi/types_test.go
+++ b/providers/unifi/types_test.go
@@ -1,0 +1,438 @@
+package unifi
+
+import (
+	"testing"
+
+	"github.com/DNSControl/dnscontrol/v4/models"
+)
+
+const testDomain = "example.com"
+
+func TestLegacyToRecord(t *testing.T) {
+	tests := []struct {
+		name       string
+		in         *legacyDNSRecord
+		wantType   string
+		wantLabel  string
+		wantTTL    uint32
+		wantTarget string
+		wantMX     uint16
+		wantSrvPri uint16
+		wantSrvWgt uint16
+		wantSrvPrt uint16
+	}{
+		{
+			name:       "A",
+			in:         &legacyDNSRecord{Key: "www.example.com", RecordType: "A", Value: "1.2.3.4", TTL: 3600},
+			wantType:   "A",
+			wantLabel:  "www",
+			wantTTL:    3600,
+			wantTarget: "1.2.3.4",
+		},
+		{
+			name:       "AAAA",
+			in:         &legacyDNSRecord{Key: "www.example.com", RecordType: "AAAA", Value: "2001:db8::1", TTL: 3600},
+			wantType:   "AAAA",
+			wantLabel:  "www",
+			wantTTL:    3600,
+			wantTarget: "2001:db8::1",
+		},
+		{
+			name:       "CNAME gets trailing dot",
+			in:         &legacyDNSRecord{Key: "alias.example.com", RecordType: "CNAME", Value: "target.example.com", TTL: 300},
+			wantType:   "CNAME",
+			wantLabel:  "alias",
+			wantTTL:    300,
+			wantTarget: "target.example.com.",
+		},
+		{
+			name:       "NS gets trailing dot",
+			in:         &legacyDNSRecord{Key: "example.com", RecordType: "NS", Value: "ns1.example.com", TTL: 300},
+			wantType:   "NS",
+			wantLabel:  "@",
+			wantTTL:    300,
+			wantTarget: "ns1.example.com.",
+		},
+		{
+			name:       "MX keeps priority and dot",
+			in:         &legacyDNSRecord{Key: "example.com", RecordType: "MX", Value: "mail.example.com", Priority: 10, TTL: 300},
+			wantType:   "MX",
+			wantLabel:  "@",
+			wantTTL:    300,
+			wantTarget: "mail.example.com.",
+			wantMX:     10,
+		},
+		{
+			name:       "TXT",
+			in:         &legacyDNSRecord{Key: "example.com", RecordType: "TXT", Value: "v=spf1 -all", TTL: 300},
+			wantType:   "TXT",
+			wantLabel:  "@",
+			wantTTL:    300,
+			wantTarget: "v=spf1 -all",
+		},
+		{
+			name:       "SRV",
+			in:         &legacyDNSRecord{Key: "_sip._tcp.example.com", RecordType: "SRV", Value: "sip.example.com", Priority: 1, Weight: 5, Port: 5060, TTL: 300},
+			wantType:   "SRV",
+			wantLabel:  "_sip._tcp",
+			wantTTL:    300,
+			wantTarget: "sip.example.com.",
+			wantSrvPri: 1,
+			wantSrvWgt: 5,
+			wantSrvPrt: 5060,
+		},
+		{
+			name:       "TTL 0 defaults to 300",
+			in:         &legacyDNSRecord{Key: "www.example.com", RecordType: "A", Value: "1.2.3.4", TTL: 0},
+			wantType:   "A",
+			wantLabel:  "www",
+			wantTTL:    300,
+			wantTarget: "1.2.3.4",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rc, err := legacyToRecord(testDomain, tt.in)
+			if err != nil {
+				t.Fatalf("legacyToRecord() unexpected error: %v", err)
+			}
+			if rc.Type != tt.wantType {
+				t.Errorf("Type = %q, want %q", rc.Type, tt.wantType)
+			}
+			if rc.Name != tt.wantLabel {
+				t.Errorf("Name = %q, want %q", rc.Name, tt.wantLabel)
+			}
+			if rc.TTL != tt.wantTTL {
+				t.Errorf("TTL = %d, want %d", rc.TTL, tt.wantTTL)
+			}
+			if got := rc.GetTargetField(); got != tt.wantTarget {
+				t.Errorf("target = %q, want %q", got, tt.wantTarget)
+			}
+			if rc.MxPreference != tt.wantMX {
+				t.Errorf("MxPreference = %d, want %d", rc.MxPreference, tt.wantMX)
+			}
+			if rc.SrvPriority != tt.wantSrvPri || rc.SrvWeight != tt.wantSrvWgt || rc.SrvPort != tt.wantSrvPrt {
+				t.Errorf("SRV = (%d,%d,%d), want (%d,%d,%d)",
+					rc.SrvPriority, rc.SrvWeight, rc.SrvPort, tt.wantSrvPri, tt.wantSrvWgt, tt.wantSrvPrt)
+			}
+			// The raw provider record must be retained for later ID lookups.
+			if rc.Original != tt.in {
+				t.Errorf("Original not preserved")
+			}
+		})
+	}
+}
+
+func TestLegacyToRecordUnsupported(t *testing.T) {
+	_, err := legacyToRecord(testDomain, &legacyDNSRecord{Key: "example.com", RecordType: "CAA", Value: "0 issue \"ca.example.net\""})
+	if err == nil {
+		t.Fatal("expected error for unsupported record type, got nil")
+	}
+}
+
+func TestNewToRecord(t *testing.T) {
+	tests := []struct {
+		name       string
+		in         *dnsPolicyRecord
+		wantType   string
+		wantLabel  string
+		wantTTL    uint32
+		wantTarget string
+		wantMX     uint16
+		wantSrvPri uint16
+		wantSrvWgt uint16
+		wantSrvPrt uint16
+	}{
+		{
+			name:       "A",
+			in:         &dnsPolicyRecord{Type: NewAPITypeA, Domain: "www.example.com", IPv4Address: "1.2.3.4", TTLSeconds: 3600},
+			wantType:   "A",
+			wantLabel:  "www",
+			wantTTL:    3600,
+			wantTarget: "1.2.3.4",
+		},
+		{
+			name:       "AAAA",
+			in:         &dnsPolicyRecord{Type: NewAPITypeAAAA, Domain: "www.example.com", IPv6Address: "2001:db8::1", TTLSeconds: 3600},
+			wantType:   "AAAA",
+			wantLabel:  "www",
+			wantTTL:    3600,
+			wantTarget: "2001:db8::1",
+		},
+		{
+			name:       "CNAME gets trailing dot",
+			in:         &dnsPolicyRecord{Type: NewAPITypeCNAME, Domain: "alias.example.com", TargetDomain: "target.example.com", TTLSeconds: 300},
+			wantType:   "CNAME",
+			wantLabel:  "alias",
+			wantTTL:    300,
+			wantTarget: "target.example.com.",
+		},
+		{
+			name:       "MX keeps priority and dot",
+			in:         &dnsPolicyRecord{Type: NewAPITypeMX, Domain: "example.com", MailServerDomain: "mail.example.com", Priority: 10, TTLSeconds: 300},
+			wantType:   "MX",
+			wantLabel:  "@",
+			wantTTL:    300,
+			wantTarget: "mail.example.com.",
+			wantMX:     10,
+		},
+		{
+			name:       "TXT",
+			in:         &dnsPolicyRecord{Type: NewAPITypeTXT, Domain: "example.com", Text: "v=spf1 -all", TTLSeconds: 300},
+			wantType:   "TXT",
+			wantLabel:  "@",
+			wantTTL:    300,
+			wantTarget: "v=spf1 -all",
+		},
+		{
+			name:       "SRV",
+			in:         &dnsPolicyRecord{Type: NewAPITypeSRV, Domain: "_sip._tcp.example.com", ServerDomain: "sip.example.com", Priority: 1, Weight: 5, Port: 5060, TTLSeconds: 300},
+			wantType:   "SRV",
+			wantLabel:  "_sip._tcp",
+			wantTTL:    300,
+			wantTarget: "sip.example.com.",
+			wantSrvPri: 1,
+			wantSrvWgt: 5,
+			wantSrvPrt: 5060,
+		},
+		{
+			name:       "TTL 0 defaults to 300",
+			in:         &dnsPolicyRecord{Type: NewAPITypeA, Domain: "www.example.com", IPv4Address: "1.2.3.4", TTLSeconds: 0},
+			wantType:   "A",
+			wantLabel:  "www",
+			wantTTL:    300,
+			wantTarget: "1.2.3.4",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rc, err := newToRecord(testDomain, tt.in)
+			if err != nil {
+				t.Fatalf("newToRecord() unexpected error: %v", err)
+			}
+			if rc.Type != tt.wantType {
+				t.Errorf("Type = %q, want %q", rc.Type, tt.wantType)
+			}
+			if rc.Name != tt.wantLabel {
+				t.Errorf("Name = %q, want %q", rc.Name, tt.wantLabel)
+			}
+			if rc.TTL != tt.wantTTL {
+				t.Errorf("TTL = %d, want %d", rc.TTL, tt.wantTTL)
+			}
+			if got := rc.GetTargetField(); got != tt.wantTarget {
+				t.Errorf("target = %q, want %q", got, tt.wantTarget)
+			}
+			if rc.MxPreference != tt.wantMX {
+				t.Errorf("MxPreference = %d, want %d", rc.MxPreference, tt.wantMX)
+			}
+			if rc.SrvPriority != tt.wantSrvPri || rc.SrvWeight != tt.wantSrvWgt || rc.SrvPort != tt.wantSrvPrt {
+				t.Errorf("SRV = (%d,%d,%d), want (%d,%d,%d)",
+					rc.SrvPriority, rc.SrvWeight, rc.SrvPort, tt.wantSrvPri, tt.wantSrvWgt, tt.wantSrvPrt)
+			}
+			if rc.Original != tt.in {
+				t.Errorf("Original not preserved")
+			}
+		})
+	}
+}
+
+func TestNewToRecordUnsupported(t *testing.T) {
+	_, err := newToRecord(testDomain, &dnsPolicyRecord{Type: "CAA_RECORD", Domain: "example.com"})
+	if err == nil {
+		t.Fatal("expected error for unsupported new API record type, got nil")
+	}
+}
+
+// TestRecordToLegacyMap converts a provider record to a RecordConfig and back to
+// the legacy API map, verifying the API is given exactly the fields it expects.
+func TestRecordToLegacyMap(t *testing.T) {
+	tests := []struct {
+		name  string
+		in    *legacyDNSRecord
+		check func(t *testing.T, m map[string]any)
+	}{
+		{
+			name: "A includes ttl",
+			in:   &legacyDNSRecord{Key: "www.example.com", RecordType: "A", Value: "1.2.3.4", TTL: 3600},
+			check: func(t *testing.T, m map[string]any) {
+				wantMapKV(t, m, "record_type", "A")
+				wantMapKV(t, m, "key", "www.example.com")
+				wantMapKV(t, m, "value", "1.2.3.4")
+				wantMapKV(t, m, "ttl", 3600)
+			},
+		},
+		{
+			name: "CNAME strips trailing dot",
+			in:   &legacyDNSRecord{Key: "alias.example.com", RecordType: "CNAME", Value: "target.example.com", TTL: 300},
+			check: func(t *testing.T, m map[string]any) {
+				wantMapKV(t, m, "value", "target.example.com")
+			},
+		},
+		{
+			name: "MX carries priority and no ttl",
+			in:   &legacyDNSRecord{Key: "example.com", RecordType: "MX", Value: "mail.example.com", Priority: 10, TTL: 300},
+			check: func(t *testing.T, m map[string]any) {
+				wantMapKV(t, m, "value", "mail.example.com")
+				wantMapKV(t, m, "priority", 10)
+				if _, ok := m["ttl"]; ok {
+					t.Errorf("MX map should not carry a ttl field, got %v", m["ttl"])
+				}
+			},
+		},
+		{
+			name: "TXT uses joined value",
+			in:   &legacyDNSRecord{Key: "example.com", RecordType: "TXT", Value: "v=spf1 -all", TTL: 300},
+			check: func(t *testing.T, m map[string]any) {
+				wantMapKV(t, m, "value", "v=spf1 -all")
+			},
+		},
+		{
+			name: "SRV carries priority weight port",
+			in:   &legacyDNSRecord{Key: "_sip._tcp.example.com", RecordType: "SRV", Value: "sip.example.com", Priority: 1, Weight: 5, Port: 5060, TTL: 300},
+			check: func(t *testing.T, m map[string]any) {
+				wantMapKV(t, m, "value", "sip.example.com")
+				wantMapKV(t, m, "priority", 1)
+				wantMapKV(t, m, "weight", 5)
+				wantMapKV(t, m, "port", 5060)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rc, err := legacyToRecord(testDomain, tt.in)
+			if err != nil {
+				t.Fatalf("legacyToRecord() error: %v", err)
+			}
+			m, err := recordToLegacyMap(rc)
+			if err != nil {
+				t.Fatalf("recordToLegacyMap() error: %v", err)
+			}
+			if m["enabled"] != true {
+				t.Errorf("enabled = %v, want true", m["enabled"])
+			}
+			tt.check(t, m)
+		})
+	}
+}
+
+func TestRecordToLegacyMapUnsupported(t *testing.T) {
+	_, err := recordToLegacyMap(&models.RecordConfig{Type: "CAA"})
+	if err == nil {
+		t.Fatal("expected error for unsupported record type, got nil")
+	}
+}
+
+// TestRecordToNew converts a provider record to a RecordConfig and back to the
+// new API record, verifying the type-specific fields are populated.
+func TestRecordToNew(t *testing.T) {
+	tests := []struct {
+		name  string
+		in    *dnsPolicyRecord
+		check func(t *testing.T, r *dnsPolicyRecord)
+	}{
+		{
+			name: "A",
+			in:   &dnsPolicyRecord{Type: NewAPITypeA, Domain: "www.example.com", IPv4Address: "1.2.3.4", TTLSeconds: 3600},
+			check: func(t *testing.T, r *dnsPolicyRecord) {
+				if r.Type != NewAPITypeA || r.IPv4Address != "1.2.3.4" || r.Domain != "www.example.com" || r.TTLSeconds != 3600 {
+					t.Errorf("unexpected A record: %+v", r)
+				}
+			},
+		},
+		{
+			name: "CNAME strips trailing dot",
+			in:   &dnsPolicyRecord{Type: NewAPITypeCNAME, Domain: "alias.example.com", TargetDomain: "target.example.com", TTLSeconds: 300},
+			check: func(t *testing.T, r *dnsPolicyRecord) {
+				if r.Type != NewAPITypeCNAME || r.TargetDomain != "target.example.com" {
+					t.Errorf("unexpected CNAME record: %+v", r)
+				}
+			},
+		},
+		{
+			name: "MX",
+			in:   &dnsPolicyRecord{Type: NewAPITypeMX, Domain: "example.com", MailServerDomain: "mail.example.com", Priority: 10, TTLSeconds: 300},
+			check: func(t *testing.T, r *dnsPolicyRecord) {
+				if r.Type != NewAPITypeMX || r.MailServerDomain != "mail.example.com" || r.Priority != 10 {
+					t.Errorf("unexpected MX record: %+v", r)
+				}
+			},
+		},
+		{
+			name: "SRV",
+			in:   &dnsPolicyRecord{Type: NewAPITypeSRV, Domain: "_sip._tcp.example.com", ServerDomain: "sip.example.com", Priority: 1, Weight: 5, Port: 5060, TTLSeconds: 300},
+			check: func(t *testing.T, r *dnsPolicyRecord) {
+				if r.Type != NewAPITypeSRV || r.ServerDomain != "sip.example.com" || r.Priority != 1 || r.Weight != 5 || r.Port != 5060 {
+					t.Errorf("unexpected SRV record: %+v", r)
+				}
+			},
+		},
+		{
+			name: "TTL 0 defaults to 300",
+			in:   &dnsPolicyRecord{Type: NewAPITypeA, Domain: "www.example.com", IPv4Address: "1.2.3.4", TTLSeconds: 0},
+			check: func(t *testing.T, r *dnsPolicyRecord) {
+				if r.TTLSeconds != 300 {
+					t.Errorf("TTLSeconds = %d, want 300", r.TTLSeconds)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rc, err := newToRecord(testDomain, tt.in)
+			if err != nil {
+				t.Fatalf("newToRecord() error: %v", err)
+			}
+			r, err := recordToNew(rc)
+			if err != nil {
+				t.Fatalf("recordToNew() error: %v", err)
+			}
+			if !r.Enabled {
+				t.Errorf("Enabled = false, want true")
+			}
+			tt.check(t, r)
+		})
+	}
+}
+
+func TestRecordToNewUnsupported(t *testing.T) {
+	_, err := recordToNew(&models.RecordConfig{Type: "CAA"})
+	if err == nil {
+		t.Fatal("expected error for unsupported record type, got nil")
+	}
+}
+
+func TestGetRecordID(t *testing.T) {
+	legacy := &models.RecordConfig{Original: &legacyDNSRecord{ID: "legacy-123"}}
+	if got := getRecordID(legacy); got != "legacy-123" {
+		t.Errorf("getRecordID(legacy) = %q, want %q", got, "legacy-123")
+	}
+
+	newRec := &models.RecordConfig{Original: &dnsPolicyRecord{ID: "new-456"}}
+	if got := getRecordID(newRec); got != "new-456" {
+		t.Errorf("getRecordID(new) = %q, want %q", got, "new-456")
+	}
+
+	if got := getRecordID(&models.RecordConfig{}); got != "" {
+		t.Errorf("getRecordID(nil Original) = %q, want empty", got)
+	}
+
+	if got := getRecordID(&models.RecordConfig{Original: "not-a-record"}); got != "" {
+		t.Errorf("getRecordID(unknown Original) = %q, want empty", got)
+	}
+}
+
+func wantMapKV(t *testing.T, m map[string]any, key string, want any) {
+	t.Helper()
+	got, ok := m[key]
+	if !ok {
+		t.Errorf("map missing key %q", key)
+		return
+	}
+	if got != want {
+		t.Errorf("map[%q] = %v (%T), want %v (%T)", key, got, got, want, want)
+	}
+}

--- a/providers/unifi/types_test.go
+++ b/providers/unifi/types_test.go
@@ -187,7 +187,7 @@ func TestNewToRecord(t *testing.T) {
 		},
 		{
 			name:       "SRV",
-			in:         &dnsPolicyRecord{Type: NewAPITypeSRV, Domain: "_sip._tcp.example.com", ServerDomain: "sip.example.com", Priority: 1, Weight: 5, Port: 5060, TTLSeconds: 300},
+			in:         &dnsPolicyRecord{Type: NewAPITypeSRV, Domain: "example.com", Service: "_sip", Protocol: "_tcp", ServerDomain: "sip.example.com", Priority: 1, Weight: 5, Port: 5060, TTLSeconds: 300},
 			wantType:   "SRV",
 			wantLabel:  "_sip._tcp",
 			wantTTL:    300,
@@ -362,9 +362,9 @@ func TestRecordToNew(t *testing.T) {
 		},
 		{
 			name: "SRV",
-			in:   &dnsPolicyRecord{Type: NewAPITypeSRV, Domain: "_sip._tcp.example.com", ServerDomain: "sip.example.com", Priority: 1, Weight: 5, Port: 5060, TTLSeconds: 300},
+			in:   &dnsPolicyRecord{Type: NewAPITypeSRV, Domain: "example.com", Service: "_sip", Protocol: "_tcp", ServerDomain: "sip.example.com", Priority: 1, Weight: 5, Port: 5060, TTLSeconds: 300},
 			check: func(t *testing.T, r *dnsPolicyRecord) {
-				if r.Type != NewAPITypeSRV || r.ServerDomain != "sip.example.com" || r.Priority != 1 || r.Weight != 5 || r.Port != 5060 || r.TTLSeconds != 0 {
+				if r.Type != NewAPITypeSRV || r.Service != "_sip" || r.Protocol != "_tcp" || r.Domain != "example.com" || r.ServerDomain != "sip.example.com" || r.Priority != 1 || r.Weight != 5 || r.Port != 5060 || r.TTLSeconds != 0 {
 					t.Errorf("unexpected SRV record: %+v", r)
 				}
 			},

--- a/providers/unifi/unifiProvider.go
+++ b/providers/unifi/unifiProvider.go
@@ -151,10 +151,17 @@ func (p *unifiProvider) GetZoneRecords(dc *models.DomainConfig) (models.Records,
 func (p *unifiProvider) GetZoneRecordsCorrections(dc *models.DomainConfig, existingRecords models.Records) ([]*models.Correction, int, error) {
 	var corrections []*models.Correction
 
-	// UniFi doesn't care about TTL much, but we normalize it
+	// Normalize TTL. UniFi has no per-record TTL for MX/TXT/SRV (the API omits
+	// it and always reads them back as 300), so force those to 300 to avoid a
+	// perpetual TTL diff. Other types keep their TTL, defaulting 0 to 300.
 	for _, record := range dc.Records {
-		if record.TTL == 0 {
+		switch record.Type {
+		case "MX", "TXT", "SRV":
 			record.TTL = 300
+		default:
+			if record.TTL == 0 {
+				record.TTL = 300
+			}
 		}
 	}
 


### PR DESCRIPTION
Tested UNIFI against `release_candidate_v5` (#4421) on a controller running the
new API (Network 10.x). The new API rejects several things the provider was
sending; fixes below. Validated with the integration test locally and against
the same controller via UniFi cloud (console proxy).

- `ttlSeconds` is only accepted for A/AAAA/CNAME — omit it for MX/TXT/SRV (the
  API returns `Unknown request body property '$.ttlSeconds'`).
- SRV: the new API splits the label into `service`/`protocol`/`domain`
  (e.g. `_sip`/`_tcp`/`example.com`). Added those fields, split on write and
  rebuild on read.
- MX/TXT/SRV have no per-record TTL, so normalize them to a fixed value to avoid
  a perpetual diff. UNIFI is excluded from the SRV-TTL test group.
- Reject TXT with interior double quotes (API returns `incorrectly quoted
  value`).
- API auto-detection cached negative results, so one transient probe failure
  marked both APIs unavailable for the rest of the session. Cache only positive
  results.
- Added unit tests for the record converters and switched to
  `SetTargetMX`/`SetTargetSRV` (cookbook).

Integration test green on local and cloud.
