### PR TITLE
REFACTOR: Add models.MustNewDomainConfig for test fixtures

### DIFF
--- a/integrationTest/helpers_integration_test.go
+++ b/integrationTest/helpers_integration_test.go
@@ -97,7 +97,7 @@ func CfFlattenOn() *TestCase {
 }
 
 func getDomainConfigWithNameservers(t *testing.T, prv providers.DNSServiceProvider, domainName string) *models.DomainConfig {
-	dc, _ := models.NewDomainConfig(domainName)
+	dc := models.MustNewDomainConfig(domainName)
 	dc.PostProcess()
 	rtypecontrol.FixLegacyDC(dc)
 

--- a/models/domain.go
+++ b/models/domain.go
@@ -73,6 +73,7 @@ type DomainConfig struct {
 	pendingPopulateCorrections map[string][]*Correction // Corrections for zone creations at each provider
 }
 
+// NewDomainConfig creates and initializes a *models.DomainConfig.
 func NewDomainConfig(name string) (*DomainConfig, error) {
 	if strings.HasSuffix(name, ".") {
 		return nil, fmt.Errorf("do not call NewDomainName with trailing dot: %q", name)
@@ -83,6 +84,16 @@ func NewDomainConfig(name string) (*DomainConfig, error) {
 	dc.PopulateNamesFromRaw(name)
 
 	return dc, nil
+}
+
+// MustNewDomainConfig is like NewDomainConfig but panics if initialization
+// fails.  It is intended for use in variable initializations in unit tests.
+func MustNewDomainConfig(name string) *DomainConfig {
+	dc, err := NewDomainConfig(name)
+	if err != nil {
+		panic(err)
+	}
+	return dc
 }
 
 func (dc *DomainConfig) PopulateNamesFromRaw(rawname string) {

--- a/providers/mikrotik/mikrotikProvider_test.go
+++ b/providers/mikrotik/mikrotikProvider_test.go
@@ -577,7 +577,7 @@ func TestGetZoneRecords_FiltersAndConverts(t *testing.T) {
 	})
 	defer srv.Close()
 
-	dc, _ := models.NewDomainConfig("example.com")
+	dc := models.MustNewDomainConfig("example.com")
 	rcs, err := p.GetZoneRecords(dc)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -603,7 +603,7 @@ func TestGetZoneRecords_ForwarderZone(t *testing.T) {
 	})
 	defer srv.Close()
 
-	dc, _ := models.NewDomainConfig(ForwarderZone)
+	dc := models.MustNewDomainConfig(ForwarderZone)
 	rcs, err := p.GetZoneRecords(dc)
 
 	if err != nil {

--- a/providers/powerdns/dnssec_test.go
+++ b/providers/powerdns/dnssec_test.go
@@ -14,7 +14,7 @@ import (
 func TestGetDNSSECCorrectionsSkipsCryptokeysWhenAutoDNSSECUnset(t *testing.T) {
 	dsp := &powerdnsProvider{}
 
-	dc, _ := models.NewDomainConfig("example.com")
+	dc := models.MustNewDomainConfig("example.com")
 	corrections, err := dsp.getDNSSECCorrections(dc)
 
 	require.NoError(t, err)
@@ -36,7 +36,7 @@ func TestGetDNSSECCorrectionsIgnoresMissingCryptokeysEndpoint(t *testing.T) {
 		ServerName: "localhost",
 	}
 
-	dc, _ := models.NewDomainConfig("example.com")
+	dc := models.MustNewDomainConfig("example.com")
 	dc.AutoDNSSEC = "on"
 	corrections, err := dsp.getDNSSECCorrections(dc)
 

--- a/providers/tencentdns/tencentdnsProvider_test.go
+++ b/providers/tencentdns/tencentdnsProvider_test.go
@@ -113,7 +113,7 @@ func TestSiteConfigForSite(t *testing.T) {
 }
 
 func TestPrepDesiredRecordsRewritesLowTTL(t *testing.T) {
-	dc, _ := models.NewDomainConfig("example.com")
+	dc := models.MustNewDomainConfig("example.com")
 	dc.Records = models.Records{
 		{TTL: 0},
 		{TTL: 300},
@@ -130,7 +130,7 @@ func TestPrepDesiredRecordsRewritesLowTTL(t *testing.T) {
 }
 
 func TestPrepDesiredRecordsAllowsPaidDomainTTL(t *testing.T) {
-	dc, _ := models.NewDomainConfig("example.com")
+	dc := models.MustNewDomainConfig("example.com")
 	dc.Records = models.Records{
 		{TTL: 300},
 	}

--- a/providers/vultr/convert_test.go
+++ b/providers/vultr/convert_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestConversion(t *testing.T) {
-	dc, _ := models.NewDomainConfig("example.com")
+	dc := models.MustNewDomainConfig("example.com")
 
 	records := []govultr.DomainRecord{
 		{


### PR DESCRIPTION
# Issue

unit tests commonly call models.NewDomainConfig() without checking for errors because the inputs are literals.

# Resolution

Provide a models.MustNewDomainConfig() to do this safely.