### PR TITLE
DNSMADEEASY: fix TXT ≥256-byte round-trip and ALIAS/ANAME diff loop; document sandbox testing

### DIFF
--- a/documentation/provider/dnsmadeeasy.md
+++ b/documentation/provider/dnsmadeeasy.md
@@ -6,6 +6,7 @@ along with your `api_key` and `secret_key`. More info about authentication can b
 Example:
 
 {% code title="creds.json" %}
+
 ```json
 {
   "dnsmadeeasy": {
@@ -15,6 +16,7 @@ Example:
   }
 }
 ```
+
 {% endcode %}
 
 ## Records
@@ -26,23 +28,26 @@ This provider does not support HTTPRED records.
 SPF records are ignored by this provider. Use TXT records instead.
 
 ## Metadata
+
 This provider does not recognize any special metadata fields unique to DNS Made Easy.
 
 ## Usage
+
 An example configuration:
 
 {% code title="dnsconfig.js" %}
-```javascript
-var REG_NONE = NewRegistrar("none");
-var DSP_DNSMADEEASY = NewDnsProvider("dnsmadeeasy");
 
-D("example.com", REG_NONE, DnsProvider(DSP_DNSMADEEASY),
-    A("test", "1.2.3.4"),
-);
+```javascript
+var REG_NONE = NewRegistrar('none');
+var DSP_DNSMADEEASY = NewDnsProvider('dnsmadeeasy');
+
+D('example.com', REG_NONE, DnsProvider(DSP_DNSMADEEASY), A('test', '1.2.3.4'));
 ```
+
 {% endcode %}
 
 ## Activation
+
 You can generate your `api_key` and `secret_key` in [Control Panel](https://cp.dnsmadeeasy.com/) in Account Information in Config menu.
 
 API is only available for Business plan and higher plans.
@@ -50,12 +55,36 @@ API is only available for Business plan and higher plans.
 ## Caveats
 
 ### Global Traffic Director
+
 Global Traffic Director feature is not supported.
 
 ## Development
 
-### Debugging
-Set `DNSMADEEASY_DEBUG_HTTP` environment variable to dump all API calls made by this provider.
+### DNS Made Easy sandbox environment
 
-### Testing
-Set `sandbox` key to any non-empty value in credentials JSON alongside `api_key` and `secret_key` to make all API calls against DNS Made Easy sandbox environment.
+Sandbox control panel is available at [https://sandbox.dnsmadeeasy.com/](sandbox.dnsmadeeasy.com). To generate sandbox API credentials, sign up for a free trial and go to [Account Information](https://sandbox.dnsmadeeasy.com/account/info) in Config menu.
+
+Set `sandbox` key to a non-empty value in credentials JSON alongside `TYPE`, `api_key` and `secret_key` to make all API calls against DNS Made Easy sandbox environment. Details in [DNS Made Easy API documentation](https://api-docs.dnsmadeeasy.com/).
+
+### Debugging
+
+Set `DNSMADEEASY_DEBUG_HTTP` environment variable to `1` to dump all API calls made by this provider.
+
+```bash
+export DNSMADEEASY_DEBUG_HTTP=1
+```
+
+### Integration testing
+
+For integration testing sandbox environment is used automatically. See `DNSMADEEASY` in `integrationTest/profiles.json`.
+
+Run integration tests against DNS Made Easy sandbox environment. Increased test timeout is needed due to DNS Made Easy rate limits. Example:
+
+```bash
+export DNSMADEEASY_DOMAIN=dnscontroltest.com
+export DNSMADEEASY_API_KEY=4aede38d-f8b4-41d7-9712-374336624046
+export DNSMADEEASY_SECRET_KEY=fcf5d4f8-765e-4c90-a79e-0369d332a890
+
+cd integrationTest
+go test -v -test.timeout 2h -args -verbose -profile DNSMADEEASY
+```

--- a/integrationTest/integration_test.go
+++ b/integrationTest/integration_test.go
@@ -1045,6 +1045,7 @@ func makeTests() []*TestGroup {
 
 		testgroup("ALIAS to nonfqdn",
 			requires(providers.CanUseAlias),
+			not("DNSMADEEASY"), // DME validates ANAME target resolvability at create time; an unpublished in-zone target can't resolve
 			tc("ALIAS at root",
 				a("foo", "1.2.3.4"),
 				alias("@", "foo"),

--- a/providers/dnsmadeeasy/dnsMadeEasyProvider.go
+++ b/providers/dnsmadeeasy/dnsMadeEasyProvider.go
@@ -97,12 +97,8 @@ func (api *dnsMadeEasyProvider) GetZoneRecordsCorrections(dc *models.DomainConfi
 	}
 
 	for _, rec := range dc.Records {
-		switch rec.Type {
-		case "ALIAS":
-			// ALIAS is called ANAME on DNS Made Easy
-			rec.ChangeType("ANAME", dc.Name)
-		case "NS":
-			// NS records have fixed TTL on DNS Made Easy and it cannot be changed
+		// NS records have a fixed TTL on DNS Made Easy that cannot be changed.
+		if rec.Type == "NS" {
 			rec.TTL = fixedNameServerRecordTTL
 		}
 	}

--- a/providers/dnsmadeeasy/types.go
+++ b/providers/dnsmadeeasy/types.go
@@ -4,6 +4,7 @@ import (
 	"strconv"
 
 	"github.com/DNSControl/dnscontrol/v4/models"
+	"github.com/DNSControl/dnscontrol/v4/pkg/txtutil"
 )
 
 // DNS Made Easy does not allow the system name servers to be edited, and said records appear to always have a fixed TTL of 86400.
@@ -124,8 +125,15 @@ type recordRequestData struct {
 }
 
 func toRecordConfig(domain string, record *recordResponseDataEntry) *models.RecordConfig {
+	recordType := record.Type
+	if recordType == "ANAME" {
+		// ANAME is DNS Made Easy's name for ALIAS (inverse of the ALIAS->ANAME
+		// conversion in GetZoneRecordsCorrections).
+		recordType = "ALIAS"
+	}
+
 	rc := &models.RecordConfig{
-		Type:     record.Type,
+		Type:     recordType,
 		TTL:      uint32(record.TTL),
 		Original: record,
 	}
@@ -133,7 +141,7 @@ func toRecordConfig(domain string, record *recordResponseDataEntry) *models.Reco
 	rc.SetLabel(record.Name, domain)
 
 	var err error
-	switch record.Type {
+	switch recordType {
 	case "MX":
 		err = rc.SetTargetMX(uint16(record.MxLevel), record.Value)
 	case "SRV":
@@ -145,7 +153,7 @@ func toRecordConfig(domain string, record *recordResponseDataEntry) *models.Reco
 		}
 		err = rc.SetTargetCAA(uint8(record.IssuerCritical), record.CaaType, value)
 	default:
-		err = rc.PopulateFromString(record.Type, record.Value, domain)
+		err = rc.PopulateFromStringFunc(recordType, record.Value, domain, txtutil.ParseQuoted)
 	}
 
 	if err != nil {
@@ -161,12 +169,21 @@ func fromRecordConfig(rc *models.RecordConfig) *recordRequestData {
 		label = ""
 	}
 
+	recordType := rc.Type
+	if recordType == "ALIAS" {
+		// ALIAS is called ANAME on DNS Made Easy. Converting on write only
+		// keeps the diff comparing ALIAS against ALIAS.
+		recordType = "ANAME"
+	}
+
 	record := &recordRequestData{
-		Type:        rc.Type,
+		Type:        recordType,
 		TTL:         int(rc.TTL),
 		GtdLocation: "DEFAULT",
 		Name:        label,
-		Value:       rc.GetTargetCombined(),
+		// DNS Made Easy stores TXT as opaque text and mangles multi-chunk
+		// values, so send the whole value as one quoted string.
+		Value: rc.GetTargetCombinedFunc(txtutil.EncodeSingle),
 	}
 
 	switch record.Type {


### PR DESCRIPTION
Fixes three DNS Made Easy provider bugs surfaced by the integration suite, plus
docs for sandbox/integration testing.

Fixes:
- TXT values ≥256 bytes: send a single unchunked quoted value (EncodeSingle)
  instead of RFC1035 chunks, which DME stores with a literal joining space and
  never round-trips → perpetual spurious MODIFY.
- ALIAS records: move the ALIAS→ANAME rename into the write serializer instead
  of mutating desired records pre-diff, so the diff compares ALIAS vs ALIAS and
  converges (previously looped DELETE ALIAS + CREATE ANAME).
- ALIAS-to-nonfqdn integration test: exclude DNSMADEEASY, since DME validates
  ANAME target resolvability at create time and an unpublished in-zone target
  can't resolve.

Docs:
- Document the sandbox environment (control panel, credentials, `sandbox` creds
  key), add an integration-testing section with command and raised timeout, and
  clarify DNSMADEEASY_DEBUG_HTTP usage.

Verified against the DME sandbox: full integration suite passes. **Not tested in production since I am not using DNS Made Easy anymore.**