### PR TITLE
REFACTOR: TargetHost is never @, add TargetHostSRV

### DIFF
--- a/models/makers.go
+++ b/models/makers.go
@@ -316,7 +316,7 @@ func MakeSRV(origin string, _ map[string]string, args ...any) (dnsv2.RDATA, erro
 	if len(args) != 4 {
 		return nil, fmt.Errorf("MakeSRV expects exactly 4 arguments, got %d: %+v", len(args), args)
 	}
-	return dnsrdatav2.SRV{Priority: mustbe.Uint16(args[0]), Weight: mustbe.Uint16(args[1]), Port: mustbe.Uint16(args[2]), Target: mustbe.TargetHost(origin, args[3])}, nil
+	return dnsrdatav2.SRV{Priority: mustbe.Uint16(args[0]), Weight: mustbe.Uint16(args[1]), Port: mustbe.Uint16(args[2]), Target: mustbe.TargetHostSRV(origin, args[3])}, nil
 }
 
 func MakeSSHFP(origin string, _ map[string]string, args ...any) (dnsv2.RDATA, error) {

--- a/pkg/mustbe/hosts.go
+++ b/pkg/mustbe/hosts.go
@@ -8,19 +8,33 @@ import (
 )
 
 // TargetHost returns a FQDN (or @) suitable as a target for CNAME and other records.
-// * origin must be a FQDN without a trailing dot OR "". If "", no attempt is made to turn the string into a FQDN.
-// * arg may be a string or it will be converted to a string.
-// * Unicode is converted to PunyCode.
-// * The result always ends with a "." unless it is "@".
-// * It does not try to turn a FQDN into a shortname, but it will replace the origin with "@". The reason for not shortening it is that "preview" output is unclear when the user sees a shortname. Explicit is better than implicit.
-// * This does not handle "*" (wildcards) since they are not valid in targets. That's why this is called TargetHost and not Host.
-// Examples: (assume $origin = "domain.com")
-// * `@` -> `@`
-// * `foo.$origin.` -> `foo.$origin.`
-// * `short` -> `short.$origin`
-// * `other.com.` -> `other.com.`
-// * NOT: `$origin.` -> `@`  (We no longer do this for the same reason we don't product shortnames any more.)
+// What is a target?
+// * A "target" is a hostname used in fields of a DNS record. For example, in "foo IN MX 10 bar.example.com.", "bar" is the target.
+// * A target is stored as a FQDN+"." with all Unicode converted to ASCII (PunyCode).
+// * It is never stored as "@" or a shortname.
+// * If you require a shortname, use dc.TargetAsShort(target) or dc.TargetAsShortOrAt(target).
+//
+// * origin must be a FQDN without a trailing dot. Violations cause a panic so that this is caught before code is shipped.
+// * if origin is "", a special mode is activated that disables most action.
+//   - This is for legacy situations where the origin is unknown.
+//   - This will eventually be an error.
+//   - In this mode, Either the original string is returned, or if that string is "", "UNKNOWNORIGIN." is returned. This is the only situation where this function might return "@".
+//
+// * Normal operation:
+//   - arg may be a string or it will be converted to a string using fmt.Printf("%v").
+//   - Unicode is converted to PunyCode.
+//   - The result always ends with a "."
+//   - The reason for not storing the short or "@" version is that "preview" output becomes ambiguous. Explicit is better than implicit.
+//   - Wildcards ("@") are rejected since they are not valid in targets. That's why this is called TargetHost and not Host.
+//
+// * Examples: (assume $origin = "domain.com")
+//   - `@` -> $origin
+//   - `foo.$origin.` -> `foo.$origin.`
+//   - `$origin.` -> `$origin.`
+//   - `other.com.` -> `other.com.`
+//   - `short` -> `short.$origin`
 func TargetHost(origin string, arg any) string {
+	// Check for programmer error.
 	if strings.HasSuffix(origin, ".") {
 		panic("mustbe.Host must NOT be called with an origin ending with .")
 	}
@@ -35,34 +49,48 @@ func TargetHost(origin string, arg any) string {
 		name = fmt.Sprintf("%v", arg)
 	}
 
+	// Special mode for legacy situations.
+	if origin == "" {
+		if name == "" {
+			return "UNKNOWNORIGIN."
+		}
+		return name
+	}
+
 	// Special symbols:
 	switch name {
-	case "@":
-		return name
-	case "":
+	case "@", "":
 		return origin + "."
 	}
 
 	// Normalize it
 	name = domaintags.EfficientToASCII(name)
 
-	// // shorten origin to "@".
-	// if origin != "" && name == origin+"." {
-	//	return "@"
-	//}
-
 	// Is this already a FQDN? Return it.
 	if strings.HasSuffix(name, ".") {
 		return name
 	}
 
-	// origin not specified. Leave things as-is.
-	if origin == "" {
-		// TODO(tlim): Shouldn't this be "return name"?
-		return name + "."
-
-	}
-
 	// This must be a shortname without a dot. Add origin and dot.
 	return name + "." + origin + "."
+}
+
+// TargetHostSRV is like TargetHost with the exception that "." and "" have special meaning and are left alone.
+func TargetHostSRV(origin string, arg any) string {
+
+	var name string
+	switch v := arg.(type) {
+	case string:
+		name = v
+	case int:
+		name = fmt.Sprintf("%d", arg)
+	default:
+		name = fmt.Sprintf("%v", arg)
+	}
+
+	if name == "" || name == "." {
+		return name
+	}
+
+	return TargetHost(origin, name)
 }

--- a/pkg/mustbe/hosts_test.go
+++ b/pkg/mustbe/hosts_test.go
@@ -15,11 +15,12 @@ func TestTargetHost(t *testing.T) {
 		want   string
 	}{
 		// Examples in the docs:
-		{"a", "domain.com", "@", "@"},
-		{"b", "domain.com", "domain.com.", "domain.com."},
+		{"a", "domain.com", "@", "domain.com."},
+		{"b", "domain.com", "", "domain.com."},
 		{"c", "domain.com", "foo.domain.com.", "foo.domain.com."},
-		{"d", "domain.com", "short", "short.domain.com."},
+		{"d", "domain.com", "domain.com.", "domain.com."},
 		{"e", "domain.com", "other.com.", "other.com."},
+		{"f", "domain.com", "short", "short.domain.com."},
 		// Doc examples with name in Unicode:
 		{"f", "domain.com", "München.domain.com.", "xn--mnchen-3ya.domain.com."},
 		{"g", "domain.com", "münchen.domain.com.", "xn--mnchen-3ya.domain.com."},
@@ -27,19 +28,23 @@ func TestTargetHost(t *testing.T) {
 		{"i", "domain.com", "münchen", "xn--mnchen-3ya.domain.com."},
 		{"j", "domain.com", "other.com.", "other.com."},
 		// Doc examples with origin as Punycode:
-		{"k", "xn--mnchen-3ya.com", "@", "@"},
-		{"l", "xn--mnchen-3ya.com", "xn--mnchen-3ya.com.", "xn--mnchen-3ya.com."},
+		{"k", "xn--mnchen-3ya.com", "@", "xn--mnchen-3ya.com."},
+		{"k", "xn--mnchen-3ya.com", "", "xn--mnchen-3ya.com."},
 		{"m", "xn--mnchen-3ya.com", "foo.xn--mnchen-3ya.com.", "foo.xn--mnchen-3ya.com."},
-		{"n", "xn--mnchen-3ya.com", "short", "short.xn--mnchen-3ya.com."},
+		{"l", "xn--mnchen-3ya.com", "xn--mnchen-3ya.com.", "xn--mnchen-3ya.com."},
 		{"o", "xn--mnchen-3ya.com", "other.com.", "other.com."},
+		{"n", "xn--mnchen-3ya.com", "short", "short.xn--mnchen-3ya.com."},
 		// Doc examples with origin as Punycode and name in Unicode:
-		{"p", "xn--mnchen-3ya.com", "München.com.", "xn--mnchen-3ya.com."},
+		{"p", "xn--mnchen-3ya.com", "@", "xn--mnchen-3ya.com."},
+		{"p", "xn--mnchen-3ya.com", "", "xn--mnchen-3ya.com."},
 		{"q", "xn--mnchen-3ya.com", "foo.München.com.", "foo.xn--mnchen-3ya.com."},
 		{"r", "xn--mnchen-3ya.com", "München", "xn--mnchen-3ya.xn--mnchen-3ya.com."},
+		{"p", "xn--mnchen-3ya.com", "München.com.", "xn--mnchen-3ya.com."},
 		{"s", "xn--mnchen-3ya.com", "other.com.", "other.com."},
-		// Doc examamples with orgin and name in PunyCode:
-		{"t", "xn--mnchen-3ya.com", "xn--mnchen-3ya.com.", "xn--mnchen-3ya.com."},
+		// Doc examples with orgin and name in PunyCode:
 		{"u", "xn--mnchen-3ya.com", "foo.xn--mnchen-3ya.com.", "foo.xn--mnchen-3ya.com."},
+		{"u", "xn--mnchen-3ya.com", "xn--mnchen-3ya.xn--mnchen-3ya.com.", "xn--mnchen-3ya.xn--mnchen-3ya.com."},
+		{"t", "xn--mnchen-3ya.com", "xn--mnchen-3ya.com.", "xn--mnchen-3ya.com."},
 		{"v", "xn--mnchen-3ya.com", "xn--mnchen-3ya", "xn--mnchen-3ya.xn--mnchen-3ya.com."},
 		// Other cases:
 		{"w", "domain.com", "", "domain.com."},

--- a/providers/tencentdns/auditrecords_test.go
+++ b/providers/tencentdns/auditrecords_test.go
@@ -3,25 +3,28 @@ package tencentdns
 import (
 	"testing"
 
+	dnsv2 "codeberg.org/miekg/dns"
 	"github.com/DNSControl/dnscontrol/v4/models"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestAuditRecords(t *testing.T) {
-	mxNull := &models.RecordConfig{Type: "MX"}
-	assert.NoError(t, mxNull.SetTargetMX(0, "."))
+	dc := models.MustNewDomainConfig("example.com")
 
-	txtEmpty := &models.RecordConfig{Type: "TXT"}
-	assert.NoError(t, txtEmpty.SetTargetTXT(""))
+	mxNull, err := dc.NewRecordConfig("foo", 0, dnsv2.TypeMX, 10, ".")
+	assert.NoError(t, err)
 
-	srvNull := &models.RecordConfig{Type: "SRV"}
-	assert.NoError(t, srvNull.SetTargetSRV(0, 0, 1, "."))
+	txtEmpty, err := dc.NewRecordConfig("foo", 0, dnsv2.TypeTXT, "")
+	assert.NoError(t, err)
 
-	srvEmpty := &models.RecordConfig{Type: "SRV"}
-	assert.NoError(t, srvEmpty.SetTargetSRV(0, 0, 1, ""))
+	srvNull, err := dc.NewRecordConfig("foo", 0, dnsv2.TypeSRV, 0, 0, 1, ".")
+	assert.NoError(t, err)
 
-	validA := &models.RecordConfig{Type: "A"}
-	validA.SetTarget("1.2.3.4")
+	srvEmpty, err := dc.NewRecordConfig("foo", 0, dnsv2.TypeSRV, 0, 0, 1, "")
+	assert.NoError(t, err)
+
+	validA, err := dc.NewRecordConfig("foo", 0, dnsv2.TypeA, "1.2.3.4")
+	assert.NoError(t, err)
 
 	errs := AuditRecords(models.Records{mxNull, txtEmpty, srvNull, srvEmpty, validA})
 


### PR DESCRIPTION
* Add TargetHostSRV which is like TargetHost, but handles SRV's special case of "." and ""
* Update TargetHost to always return an FQDN, never "@".
* Fix TenCent's tests to use modern constructors.