### PR TITLE
TENCENTDNS: Support line and weight metadata

### DIFF
--- a/documentation/provider/tencentdns.md
+++ b/documentation/provider/tencentdns.md
@@ -77,6 +77,29 @@ D("example.com", REG_TENCENT, DnsProvider(DSP_TENCENT),
 ```
 {% endcode %}
 
+## Record Line and Weight Metadata
+
+DNSPod resolution lines and weighted routing can be configured per record with provider-specific metadata:
+
+- `tencentdns_line`: The line name, for example `"电信"`. The default is `"默认"`.
+- `tencentdns_line_id`: The line ID, for example `"10=1"`. When both line fields are set, the line ID takes precedence, matching the DNSPod API behavior.
+- `tencentdns_weight`: An integer from `0` to `100`. A value of `0` disables weighted routing; omitting this field leaves weighted routing disabled.
+
+Example:
+
+{% code title="dnsconfig.js" %}
+```javascript
+D("example.com", REG_TENCENT, DnsProvider(DSP_TENCENT),
+    A("www", "1.2.3.4"), // Default line ("默认"), no weight
+    A("weighted", "2.3.4.5", {tencentdns_line: "电信", tencentdns_weight: "80"}),
+    A("weighted", "3.4.5.6", {tencentdns_line: "电信", tencentdns_weight: "20"}),
+    A("by-id", "4.5.6.7", {tencentdns_line_id: "10=1"})
+);
+```
+{% endcode %}
+
+Available line names, IDs, and weighted-routing features depend on the domain's DNSPod plan and site. Use the DNSPod `DescribeRecordLineList` API to obtain the valid line values for the domain. Using `tencentdns_line_id` avoids ambiguity and is recommended when managing records across different Tencent Cloud sites.
+
 ### Why use `ALIAS` for DNSPod
 
 DNSPod does not natively support the `ALIAS` record type.
@@ -126,7 +149,8 @@ Reference: https://docs.dnspod.com/dns/faq-dns-resolution/?lang=en
 - **MX Records**: Priority and target are handled automatically.
 - **Registrar Support**: Supports updating authoritative nameservers for domains registered with Tencent Cloud.
 - **Tencent Cloud Site**: Use `site: "intl"` for Tencent Cloud International site, use `site: "cn"` for Tencent Cloud China site.
-- **Line Management**: All records are created on the "默认" (Default) line.
+- **Line Management**: Use `tencentdns_line` or `tencentdns_line_id` record metadata to select a DNSPod resolution line. Records without either field use the "默认" (Default) line.
+- **Weighted Routing**: Use `tencentdns_weight` record metadata with a value from `0` to `100`. Availability depends on the DNSPod plan.
 - **New Domains**: DNSControl will automatically create non-existent domains in your account.
 
 ## Feature Summary

--- a/integrationTest/integration_test.go
+++ b/integrationTest/integration_test.go
@@ -1278,6 +1278,71 @@ func makeTests() []*TestGroup {
 			),
 		),
 
+		// Tencent Cloud DNSPod resolution lines and weighted routing.
+		testgroup("TENCENTDNS_LINE_WEIGHT",
+			only("TENCENTDNS"),
+			tc("create records on the default and telecom lines",
+				a("tencent-line", "1.2.3.4"),
+				withMeta(a("tencent-line", "1.2.3.4"), map[string]string{
+					"tencentdns_line": "电信",
+				}),
+			),
+			tc("change the telecom record value",
+				a("tencent-line", "1.2.3.4"),
+				withMeta(a("tencent-line", "5.6.7.8"), map[string]string{
+					"tencentdns_line": "电信",
+				}),
+			),
+			tc("change the record line",
+				a("tencent-line", "1.2.3.4"),
+				withMeta(a("tencent-line", "5.6.7.8"), map[string]string{
+					"tencentdns_line": "联通",
+				}),
+			),
+			tc("delete line metadata",
+				a("tencent-line", "1.2.3.4"),
+				a("tencent-line", "5.6.7.8"),
+			),
+			tc("restore line metadata",
+				a("tencent-line", "1.2.3.4"),
+				withMeta(a("tencent-line", "5.6.7.8"), map[string]string{
+					"tencentdns_line": "电信",
+				}),
+			),
+			tc("delete only the line-specific record",
+				a("tencent-line", "1.2.3.4"),
+			),
+			tcEmptyZone(),
+			tc("create weighted records",
+				withMeta(a("tencent-weight", "1.2.3.4"), map[string]string{
+					"tencentdns_weight": "80",
+				}),
+				withMeta(a("tencent-weight", "5.6.7.8"), map[string]string{
+					"tencentdns_weight": "20",
+				}),
+			),
+			tc("change weights",
+				withMeta(a("tencent-weight", "1.2.3.4"), map[string]string{
+					"tencentdns_weight": "50",
+				}),
+				withMeta(a("tencent-weight", "5.6.7.8"), map[string]string{
+					"tencentdns_weight": "50",
+				}),
+			),
+			tc("delete weight metadata",
+				a("tencent-weight", "1.2.3.4"),
+				a("tencent-weight", "5.6.7.8"),
+			),
+			tc("explicit zero weights are equivalent to omitted weights",
+				withMeta(a("tencent-weight", "1.2.3.4"), map[string]string{
+					"tencentdns_weight": "0",
+				}),
+				withMeta(a("tencent-weight", "5.6.7.8"), map[string]string{
+					"tencentdns_weight": "0",
+				}),
+			).ExpectNoChanges(),
+		),
+
 		// R53_WEIGHT_HEALTH_CHECK: Not included as an integration test because
 		// health checks are external AWS resources that must be pre-provisioned.
 		// The R53_HEALTH_CHECK_ID modifier is tested implicitly through the

--- a/providers/tencentdns/auditrecords.go
+++ b/providers/tencentdns/auditrecords.go
@@ -1,6 +1,9 @@
 package tencentdns
 
 import (
+	"fmt"
+	"strconv"
+
 	"github.com/DNSControl/dnscontrol/v4/models"
 	"github.com/DNSControl/dnscontrol/v4/pkg/rejectif"
 )
@@ -15,6 +18,23 @@ func AuditRecords(records []*models.RecordConfig) []error {
 	a.Add("TXT", rejectif.TxtIsEmpty)
 	a.Add("SRV", rejectif.SrvHasNullTarget)
 	a.Add("SRV", rejectif.SrvHasEmptyTarget)
+	a.Add("*", rejectifInvalidRecordWeight)
 
 	return a.Audit(records)
+}
+
+func rejectifInvalidRecordWeight(rc *models.RecordConfig) error {
+	weight := rc.Metadata[metaRecordWeight]
+	if weight == "" {
+		return nil
+	}
+
+	parsed, err := strconv.ParseUint(weight, 10, 64)
+	if err != nil {
+		return fmt.Errorf("%s %q is not a valid integer on %s %s", metaRecordWeight, weight, rc.Type, rc.GetLabelFQDN())
+	}
+	if parsed > 100 {
+		return fmt.Errorf("%s %d must be between 0 and 100 on %s %s", metaRecordWeight, parsed, rc.Type, rc.GetLabelFQDN())
+	}
+	return nil
 }

--- a/providers/tencentdns/auditrecords_test.go
+++ b/providers/tencentdns/auditrecords_test.go
@@ -31,3 +31,39 @@ func TestAuditRecords(t *testing.T) {
 	assert.Contains(t, errs[2].Error(), "srv has empty target")
 	assert.Contains(t, errs[3].Error(), "srv has empty target")
 }
+
+func TestAuditRecordsValidatesWeight(t *testing.T) {
+	tests := []struct {
+		name      string
+		weight    string
+		wantError bool
+	}{
+		{name: "unset"},
+		{name: "minimum", weight: "0"},
+		{name: "maximum", weight: "100"},
+		{name: "negative", weight: "-1", wantError: true},
+		{name: "too large", weight: "101", wantError: true},
+		{name: "not an integer", weight: "heavy", wantError: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			rc := &models.RecordConfig{
+				Type: "A",
+				Metadata: map[string]string{
+					metaRecordWeight: tc.weight,
+				},
+			}
+			rc.SetTarget("1.2.3.4")
+
+			errs := AuditRecords(models.Records{rc})
+			if tc.wantError {
+				if assert.Len(t, errs, 1) {
+					assert.Contains(t, errs[0].Error(), metaRecordWeight)
+				}
+				return
+			}
+			assert.Empty(t, errs)
+		})
+	}
+}

--- a/providers/tencentdns/convert.go
+++ b/providers/tencentdns/convert.go
@@ -2,6 +2,7 @@ package tencentdns
 
 import (
 	"fmt"
+	"strconv"
 
 	"github.com/DNSControl/dnscontrol/v4/models"
 	"github.com/DNSControl/dnscontrol/v4/pkg/txtutil"
@@ -12,6 +13,16 @@ func nativeToRecord(r *dnspod.RecordListItem, domainName string) (*models.Record
 	rc := &models.RecordConfig{
 		TTL:      uint32(*r.TTL),
 		Original: r,
+		Metadata: map[string]string{},
+	}
+	if r.Line != nil && *r.Line != "" {
+		rc.Metadata[metaRecordLine] = *r.Line
+	}
+	if r.LineId != nil && *r.LineId != "" {
+		rc.Metadata[metaRecordLineID] = *r.LineId
+	}
+	if r.Weight != nil {
+		rc.Metadata[metaRecordWeight] = strconv.FormatUint(*r.Weight, 10)
 	}
 	rc.SetLabel(*r.Name, domainName)
 
@@ -42,6 +53,38 @@ func nativeToRecord(r *dnspod.RecordListItem, domainName string) (*models.Record
 	return rc, nil
 }
 
+func recordLineMetadata(rc *models.RecordConfig) (line, lineID string) {
+	line = defaultRecordLine
+	if rc.Metadata == nil {
+		return line, ""
+	}
+	if configuredLine := rc.Metadata[metaRecordLine]; configuredLine != "" {
+		line = configuredLine
+	}
+	return line, rc.Metadata[metaRecordLineID]
+}
+
+func recordWeightMetadata(rc *models.RecordConfig) (uint64, bool) {
+	if rc == nil || rc.Metadata == nil || rc.Metadata[metaRecordWeight] == "" {
+		return 0, false
+	}
+	weight, err := strconv.ParseUint(rc.Metadata[metaRecordWeight], 10, 64)
+	if err != nil || weight > 100 {
+		return 0, false
+	}
+	return weight, true
+}
+
+// comparableRecordWeight treats an omitted weight and weight 0 as equivalent,
+// because DNSPod defines 0 as disabling weighted routing.
+func comparableRecordWeight(rc *models.RecordConfig) string {
+	weight, ok := recordWeightMetadata(rc)
+	if !ok || weight == 0 {
+		return ""
+	}
+	return strconv.FormatUint(weight, 10)
+}
+
 func recordToCreateRequest(rc *models.RecordConfig) *dnspod.CreateRecordRequest {
 	req := dnspod.NewCreateRecordRequest()
 	req.SubDomain = new(rc.GetLabel())
@@ -49,7 +92,14 @@ func recordToCreateRequest(rc *models.RecordConfig) *dnspod.CreateRecordRequest 
 	if rc.Type == "ALIAS" {
 		req.RecordType = new("CNAME")
 	}
-	req.RecordLine = new("默认")
+	line, lineID := recordLineMetadata(rc)
+	req.RecordLine = new(line)
+	if lineID != "" {
+		req.RecordLineId = new(lineID)
+	}
+	if weight, ok := recordWeightMetadata(rc); ok {
+		req.Weight = new(weight)
+	}
 
 	val := rc.GetTargetCombinedFunc(txtutil.EncodeQuoted)
 	if rc.Type == "MX" {
@@ -62,7 +112,7 @@ func recordToCreateRequest(rc *models.RecordConfig) *dnspod.CreateRecordRequest 
 	return req
 }
 
-func recordToModifyRequest(rc *models.RecordConfig, recordID uint64) *dnspod.ModifyRecordRequest {
+func recordToModifyRequest(rc *models.RecordConfig, recordID uint64, previous *models.RecordConfig) *dnspod.ModifyRecordRequest {
 	req := dnspod.NewModifyRecordRequest()
 	req.RecordId = new(recordID)
 	req.SubDomain = new(rc.GetLabel())
@@ -70,7 +120,17 @@ func recordToModifyRequest(rc *models.RecordConfig, recordID uint64) *dnspod.Mod
 	if rc.Type == "ALIAS" {
 		req.RecordType = new("CNAME")
 	}
-	req.RecordLine = new("默认")
+	line, lineID := recordLineMetadata(rc)
+	req.RecordLine = new(line)
+	if lineID != "" {
+		req.RecordLineId = new(lineID)
+	}
+	if weight, ok := recordWeightMetadata(rc); ok {
+		req.Weight = new(weight)
+	} else if comparableRecordWeight(previous) != "" {
+		// DNSPod requires weight 0 to explicitly disable weighted routing.
+		req.Weight = new(uint64(0))
+	}
 
 	val := rc.GetTargetCombinedFunc(txtutil.EncodeQuoted)
 	if rc.Type == "MX" {

--- a/providers/tencentdns/convert_test.go
+++ b/providers/tencentdns/convert_test.go
@@ -79,6 +79,43 @@ func TestNativeToRecord(t *testing.T) {
 	}
 }
 
+func TestNativeToRecordPreservesProviderMetadata(t *testing.T) {
+	domain := "example.com"
+	input := &dnspod.RecordListItem{
+		Name:   new("www"),
+		Type:   new("A"),
+		Value:  new("1.2.3.4"),
+		TTL:    new(uint64(600)),
+		Line:   new("电信"),
+		LineId: new("10=1"),
+		Weight: new(uint64(80)),
+	}
+
+	rc, err := nativeToRecord(input, domain)
+	if err != nil {
+		t.Fatalf("nativeToRecord failed: %v", err)
+	}
+
+	assert.Equal(t, "电信", rc.Metadata[metaRecordLine])
+	assert.Equal(t, "10=1", rc.Metadata[metaRecordLineID])
+	assert.Equal(t, "80", rc.Metadata[metaRecordWeight])
+}
+
+func TestNativeToRecordPreservesDisabledWeight(t *testing.T) {
+	input := &dnspod.RecordListItem{
+		Name:   new("www"),
+		Type:   new("A"),
+		Value:  new("1.2.3.4"),
+		TTL:    new(uint64(600)),
+		Weight: new(uint64(0)),
+	}
+
+	rc, err := nativeToRecord(input, "example.com")
+	if assert.NoError(t, err) {
+		assert.Equal(t, "0", rc.Metadata[metaRecordWeight])
+	}
+}
+
 func TestRecordToCreateRequest(t *testing.T) {
 	domain := "example.com"
 	rc := &models.RecordConfig{
@@ -91,8 +128,102 @@ func TestRecordToCreateRequest(t *testing.T) {
 	req := recordToCreateRequest(rc)
 	assert.Equal(t, "test", *req.SubDomain)
 	assert.Equal(t, "A", *req.RecordType)
+	assert.Equal(t, defaultRecordLine, *req.RecordLine)
+	assert.Nil(t, req.RecordLineId)
+	assert.Nil(t, req.Weight)
 	assert.Equal(t, "1.1.1.1", *req.Value)
 	assert.Equal(t, uint64(600), *req.TTL)
+}
+
+func TestRecordToCreateRequestWithWeight(t *testing.T) {
+	domain := "example.com"
+	rc := &models.RecordConfig{
+		Type: "A",
+		TTL:  600,
+		Metadata: map[string]string{
+			metaRecordWeight: "80",
+		},
+	}
+	rc.SetLabel("test", domain)
+	rc.SetTarget("1.1.1.1")
+
+	req := recordToCreateRequest(rc)
+	assert.Equal(t, uint64(80), *req.Weight)
+}
+
+func TestRecordToCreateRequestWithLine(t *testing.T) {
+	domain := "example.com"
+	rc := &models.RecordConfig{
+		Type: "A",
+		TTL:  600,
+		Metadata: map[string]string{
+			metaRecordLine: "电信",
+		},
+	}
+	rc.SetLabel("test", domain)
+	rc.SetTarget("1.1.1.1")
+
+	req := recordToCreateRequest(rc)
+	assert.Equal(t, "电信", *req.RecordLine)
+	assert.Nil(t, req.RecordLineId)
+}
+
+func TestRecordToCreateRequestWithLineID(t *testing.T) {
+	domain := "example.com"
+	rc := &models.RecordConfig{
+		Type: "A",
+		TTL:  600,
+		Metadata: map[string]string{
+			metaRecordLineID: "10=1",
+		},
+	}
+	rc.SetLabel("test", domain)
+	rc.SetTarget("1.1.1.1")
+
+	req := recordToCreateRequest(rc)
+	assert.Equal(t, defaultRecordLine, *req.RecordLine)
+	assert.Equal(t, "10=1", *req.RecordLineId)
+}
+
+func TestRecordToModifyRequestWithLineLineIDAndWeight(t *testing.T) {
+	domain := "example.com"
+	rc := &models.RecordConfig{
+		Type: "A",
+		TTL:  600,
+		Metadata: map[string]string{
+			metaRecordLine:   "电信",
+			metaRecordLineID: "10=1",
+			metaRecordWeight: "25",
+		},
+	}
+	rc.SetLabel("test", domain)
+	rc.SetTarget("1.1.1.1")
+
+	req := recordToModifyRequest(rc, 42, nil)
+	assert.Equal(t, uint64(42), *req.RecordId)
+	assert.Equal(t, "电信", *req.RecordLine)
+	assert.Equal(t, "10=1", *req.RecordLineId)
+	assert.Equal(t, uint64(25), *req.Weight)
+}
+
+func TestRecordToModifyRequestClearsRemovedWeight(t *testing.T) {
+	domain := "example.com"
+	previous := &models.RecordConfig{
+		Type: "A",
+		TTL:  600,
+		Metadata: map[string]string{
+			metaRecordWeight: "80",
+		},
+	}
+	previous.SetLabel("test", domain)
+	previous.SetTarget("1.1.1.1")
+
+	desired := &models.RecordConfig{Type: "A", TTL: 600}
+	desired.SetLabel("test", domain)
+	desired.SetTarget("1.1.1.1")
+
+	req := recordToModifyRequest(desired, 42, previous)
+	assert.Equal(t, uint64(0), *req.Weight)
 }
 
 func TestRecordToCreateRequest_MX(t *testing.T) {

--- a/providers/tencentdns/tencentdnsProvider.go
+++ b/providers/tencentdns/tencentdnsProvider.go
@@ -12,7 +12,14 @@ import (
 	dnspod "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dnspod/v20210323"
 )
 
-const defaultTTL = uint32(600)
+const (
+	defaultTTL          = uint32(600)
+	defaultRecordLine   = "默认"
+	defaultRecordLineID = "0"
+	metaRecordLine      = "tencentdns_line"
+	metaRecordLineID    = "tencentdns_line_id"
+	metaRecordWeight    = "tencentdns_weight"
+)
 
 var features = providers.DocumentationNotes{
 	providers.CanUseAlias:            providers.Can("DNSPod doesn't natively support the ALIAS record type."),
@@ -189,6 +196,51 @@ func prepDesiredRecords(dc *models.DomainConfig, minTTL uint32) {
 	}
 }
 
+// recordLineIDsByName returns only unambiguous line name-to-ID mappings.
+// The DNSPod default line always has ID 0.
+func recordLineIDsByName(existingRecords models.Records) map[string]string {
+	lineIDsByName := map[string]string{defaultRecordLine: defaultRecordLineID}
+	ambiguous := make(map[string]bool)
+	for _, rec := range existingRecords {
+		line, lineID := recordLineMetadata(rec)
+		if line == "" || lineID == "" || line == defaultRecordLine || ambiguous[line] {
+			continue
+		}
+		if knownID, ok := lineIDsByName[line]; ok && knownID != lineID {
+			delete(lineIDsByName, line)
+			ambiguous[line] = true
+			continue
+		}
+		lineIDsByName[line] = lineID
+	}
+	return lineIDsByName
+}
+
+// recordMetadataComparable returns a provider-specific comparison function
+// that makes DNSPod's record line and weight part of a record's identity.
+// DNSPod returns both a line name and an ID, while users may configure either
+// one. Unambiguous line names are normalized to their IDs before diffing.
+func recordMetadataComparable(existingRecords models.Records) diff2.ComparableFunc {
+	lineIDsByName := recordLineIDsByName(existingRecords)
+
+	return func(rec *models.RecordConfig) string {
+		line, lineID := recordLineMetadata(rec)
+		if lineID == "" {
+			lineID = lineIDsByName[line]
+		}
+		lineComparable := "line=" + line
+		if lineID != "" {
+			lineComparable = "line_id=" + lineID
+		}
+
+		weight := comparableRecordWeight(rec)
+		if weight == "" {
+			return lineComparable
+		}
+		return lineComparable + " weight=" + weight
+	}
+}
+
 func (p *tencentdnsProvider) GetZoneRecordsCorrections(dc *models.DomainConfig, existingRecords models.Records) ([]*models.Correction, int, error) {
 	var corrections []*models.Correction
 
@@ -199,7 +251,7 @@ func (p *tencentdnsProvider) GetZoneRecordsCorrections(dc *models.DomainConfig, 
 	prepDesiredRecords(dc, minTTL)
 
 	// Tencent Cloud is a "ByRecord" API.
-	changes, actualChangeCount, err := diff2.ByRecord(existingRecords, dc, nil)
+	changes, actualChangeCount, err := diff2.ByRecord(existingRecords, dc, recordMetadataComparable(existingRecords))
 	if err != nil {
 		return nil, 0, err
 	}
@@ -221,11 +273,12 @@ func (p *tencentdnsProvider) GetZoneRecordsCorrections(dc *models.DomainConfig, 
 			})
 		case diff2.CHANGE:
 			rc := change.New[0]
-			recordID := *(change.Old[0].Original.(*dnspod.RecordListItem).RecordId)
+			previous := change.Old[0]
+			recordID := *(previous.Original.(*dnspod.RecordListItem).RecordId)
 			corrections = append(corrections, &models.Correction{
 				Msg: msgs,
 				F: func() error {
-					return p.client.modifyRecord(domainName, recordToModifyRequest(rc, recordID))
+					return p.client.modifyRecord(domainName, recordToModifyRequest(rc, recordID, previous))
 				},
 			})
 		case diff2.DELETE:

--- a/providers/tencentdns/tencentdnsProvider_test.go
+++ b/providers/tencentdns/tencentdnsProvider_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/DNSControl/dnscontrol/v4/models"
+	"github.com/DNSControl/dnscontrol/v4/pkg/diff2"
 	"github.com/DNSControl/dnscontrol/v4/pkg/providers"
 	"github.com/stretchr/testify/assert"
 	intldomain "github.com/tencentcloud/tencentcloud-sdk-go-intl-en/tencentcloud/domain/v20180808"
@@ -138,6 +139,194 @@ func TestPrepDesiredRecordsAllowsPaidDomainTTL(t *testing.T) {
 	prepDesiredRecords(dc, 1)
 
 	assert.Equal(t, uint32(300), dc.Records[0].TTL)
+}
+
+func TestRecordLineComparableMatchesLineNameAndID(t *testing.T) {
+	domain := "example.com"
+	existingDefault := makeLineRecord(domain, "1.2.3.4", map[string]string{
+		metaRecordLine:   defaultRecordLine,
+		metaRecordLineID: "0",
+	})
+	existingTelecom := makeLineRecord(domain, "1.2.3.4", map[string]string{
+		metaRecordLine:   "电信",
+		metaRecordLineID: "10=1",
+	})
+	compare := recordMetadataComparable(models.Records{existingDefault, existingTelecom})
+
+	desiredDefault := makeLineRecord(domain, "1.2.3.4", nil)
+	desiredTelecomByName := makeLineRecord(domain, "1.2.3.4", map[string]string{
+		metaRecordLine: "电信",
+	})
+	desiredTelecomByID := makeLineRecord(domain, "1.2.3.4", map[string]string{
+		metaRecordLineID: "10=1",
+	})
+
+	assert.Equal(t, compare(existingDefault), compare(desiredDefault))
+	assert.Equal(t, compare(existingTelecom), compare(desiredTelecomByName))
+	assert.Equal(t, compare(existingTelecom), compare(desiredTelecomByID))
+}
+
+func TestRecordMetadataComparableDoesNotGuessAmbiguousLineID(t *testing.T) {
+	domain := "example.com"
+	first := makeLineRecord(domain, "192.0.2.1", map[string]string{
+		metaRecordLine:   "custom",
+		metaRecordLineID: "10=1",
+	})
+	second := makeLineRecord(domain, "192.0.2.1", map[string]string{
+		metaRecordLine:   "custom",
+		metaRecordLineID: "10=2",
+	})
+	desiredByName := makeLineRecord(domain, "192.0.2.1", map[string]string{
+		metaRecordLine: "custom",
+	})
+	compare := recordMetadataComparable(models.Records{first, second})
+
+	assert.NotEqual(t, compare(first), compare(desiredByName))
+	assert.NotEqual(t, compare(second), compare(desiredByName))
+}
+
+func TestRecordMetadataComparableKeepsDefaultLineMapping(t *testing.T) {
+	domain := "example.com"
+	existingDefault := makeLineRecord(domain, "192.0.2.1", map[string]string{
+		metaRecordLine: defaultRecordLine,
+	})
+	conflictingDefault := makeLineRecord(domain, "192.0.2.1", map[string]string{
+		metaRecordLine:   defaultRecordLine,
+		metaRecordLineID: "unexpected",
+	})
+	desiredDefault := makeLineRecord(domain, "192.0.2.1", nil)
+	compare := recordMetadataComparable(models.Records{existingDefault, conflictingDefault})
+
+	assert.Equal(t, compare(existingDefault), compare(desiredDefault))
+	assert.NotEqual(t, compare(conflictingDefault), compare(desiredDefault))
+}
+
+func TestRecordLineParticipatesInDiff(t *testing.T) {
+	domain := "example.com"
+	existing := models.Records{
+		makeLineRecord(domain, "1.2.3.4", map[string]string{
+			metaRecordLine:   defaultRecordLine,
+			metaRecordLineID: "0",
+		}),
+		makeLineRecord(domain, "1.2.3.4", map[string]string{
+			metaRecordLine:   "电信",
+			metaRecordLineID: "10=1",
+		}),
+	}
+	dc := models.MustNewDomainConfig(domain)
+	dc.Records = models.Records{
+		makeLineRecord(domain, "1.2.3.4", nil),
+		makeLineRecord(domain, "1.2.3.4", map[string]string{
+			metaRecordLineID: "10=1",
+		}),
+	}
+
+	changes, count, err := diff2.ByRecord(existing, dc, recordMetadataComparable(existing))
+
+	assert.NoError(t, err)
+	assert.Zero(t, count)
+	assert.Empty(t, changes)
+}
+
+func TestRecordLineDiffKeepsDefaultDomesticAndForeignRecords(t *testing.T) {
+	domain := "example.com"
+	existing := models.Records{
+		makeLineRecord(domain, "192.0.2.1", map[string]string{
+			metaRecordLine:   defaultRecordLine,
+			metaRecordLineID: "0",
+		}),
+		makeLineRecord(domain, "192.0.2.1", map[string]string{
+			metaRecordLine:   "境内",
+			metaRecordLineID: "3=0",
+		}),
+		makeLineRecord(domain, "192.0.2.2", map[string]string{
+			metaRecordLine:   "境外",
+			metaRecordLineID: "3=1",
+		}),
+	}
+	dc := models.MustNewDomainConfig(domain)
+	dc.Records = models.Records{
+		makeLineRecord(domain, "192.0.2.1", nil),
+		makeLineRecord(domain, "192.0.2.1", map[string]string{metaRecordLine: "境内"}),
+		makeLineRecord(domain, "192.0.2.2", map[string]string{metaRecordLine: "境外"}),
+	}
+
+	changes, count, err := diff2.ByRecord(existing, dc, recordMetadataComparable(existing))
+
+	assert.NoError(t, err)
+	assert.Zero(t, count)
+	assert.Empty(t, changes)
+}
+
+func TestRecordLineDiffDeletesOnlyExtraLine(t *testing.T) {
+	domain := "example.com"
+	existingDefault := makeLineRecord(domain, "1.2.3.4", map[string]string{
+		metaRecordLine:   defaultRecordLine,
+		metaRecordLineID: "0",
+	})
+	existingTelecom := makeLineRecord(domain, "1.2.3.4", map[string]string{
+		metaRecordLine:   "电信",
+		metaRecordLineID: "10=1",
+	})
+	existing := models.Records{existingDefault, existingTelecom}
+	dc := models.MustNewDomainConfig(domain)
+	dc.Records = models.Records{makeLineRecord(domain, "1.2.3.4", nil)}
+
+	changes, count, err := diff2.ByRecord(existing, dc, recordMetadataComparable(existing))
+
+	if assert.NoError(t, err) && assert.Len(t, changes, 1) {
+		assert.Equal(t, diff2.DELETE, changes[0].Type)
+		assert.Same(t, existingTelecom, changes[0].Old[0])
+	}
+	assert.Equal(t, 1, count)
+}
+
+func TestRecordWeightParticipatesInDiff(t *testing.T) {
+	domain := "example.com"
+	existing := models.Records{makeLineRecord(domain, "1.2.3.4", map[string]string{
+		metaRecordWeight: "80",
+	})}
+	dc := models.MustNewDomainConfig(domain)
+	dc.Records = models.Records{makeLineRecord(domain, "1.2.3.4", map[string]string{
+		metaRecordWeight: "20",
+	})}
+
+	changes, count, err := diff2.ByRecord(existing, dc, recordMetadataComparable(existing))
+
+	if assert.NoError(t, err) && assert.Len(t, changes, 1) {
+		assert.Equal(t, diff2.CHANGE, changes[0].Type)
+	}
+	assert.Equal(t, 1, count)
+}
+
+func TestRecordWeightComparisonNormalizesValues(t *testing.T) {
+	domain := "example.com"
+	existing := models.Records{makeLineRecord(domain, "1.2.3.4", map[string]string{
+		metaRecordWeight: "80",
+	})}
+	compare := recordMetadataComparable(existing)
+
+	desiredWithLeadingZero := makeLineRecord(domain, "1.2.3.4", map[string]string{
+		metaRecordWeight: "080",
+	})
+	desiredDisabled := makeLineRecord(domain, "1.2.3.4", map[string]string{
+		metaRecordWeight: "0",
+	})
+	desiredUnset := makeLineRecord(domain, "1.2.3.4", nil)
+
+	assert.Equal(t, compare(existing[0]), compare(desiredWithLeadingZero))
+	assert.Equal(t, compare(desiredUnset), compare(desiredDisabled))
+}
+
+func makeLineRecord(domain, target string, metadata map[string]string) *models.RecordConfig {
+	rc := &models.RecordConfig{
+		Type:     "A",
+		TTL:      600,
+		Metadata: metadata,
+	}
+	rc.SetLabel("www", domain)
+	rc.SetTarget(target)
+	return rc
 }
 
 func TestMinTTLForGrade(t *testing.T) {


### PR DESCRIPTION
Add weight and line support for tencentdns
<!--
## Before submiting a pull request

Please make sure you've run the following commands from the root directory.

    bin/generate-all.sh

(this runs commands like "go generate", fixes formatting, and so on)

## Release changelog section

Help keep the release changelog clear by pre-naming the proper section in the GitHub pull request title.

Some examples:
* CICD: Add required GHA permissions for goreleaser
* DOCS: Fixed providers with "contributor support" table
* ROUTE53: Allow R53_ALIAS records to enable target health evaluation

More examples/context can be found in the file .goreleaser.yml under the 'build' > 'changelog' key.
!-->
