### PR TITLE
NETBIRD: Add apiurl creds argument

### DIFF
--- a/documentation/provider/netbird.md
+++ b/documentation/provider/netbird.md
@@ -15,6 +15,22 @@ Example:
 ```
 {% endcode %}
 
+If you use a self-hosted instance you need to set `apiurl` in the credentials configuration.
+
+Example:
+
+{% code title="creds.json" %}
+```json
+{
+  "netbird": {
+    "TYPE": "NETBIRD",
+    "token": "your-netbird-api-token",
+    "apiurl": "https://your-netbird-host/api"
+  }
+}
+```
+{% endcode %}
+
 ## Metadata
 
 This provider recognizes the following metadata fields:

--- a/providers/netbird/netbirdProvider.go
+++ b/providers/netbird/netbirdProvider.go
@@ -50,10 +50,15 @@ func NewNetbird(m map[string]string, metadata json.RawMessage) (providers.DNSSer
 		return nil, errors.New("no NetBird token provided")
 	}
 
+	apiUrl := m["apiurl"]
+	if apiUrl == "" {
+		apiUrl = netbirdAPIURL
+	}
+
 	api := &netbirdProvider{
 		token:   m["token"],
 		client:  &http.Client{},
-		apiURL:  netbirdAPIURL,
+		apiURL:  apiUrl,
 		zoneMap: make(map[string]*zoneInfo),
 	}
 
@@ -109,6 +114,7 @@ func init() {
 		PortalURL:   "https://app.netbird.io/settings",
 		Fields: []providers.CredsField{
 			{Key: "token", Label: "API Token", Required: true, Secret: true},
+			{Key: "apiurl", Label: "API Url", Default: netbirdAPIURL},
 		},
 	})
 }


### PR DESCRIPTION
<!--
## Before submiting a pull request

Please make sure you've run the following commands from the root directory.

    bin/generate-all.sh

(this runs commands like "go generate", fixes formatting, and so on)

## Release changelog section

Help keep the release changelog clear by pre-naming the proper section in the GitHub pull request title.

Some examples:
* CICD: Add required GHA permissions for goreleaser
* DOCS: Fixed providers with "contributor support" table
* ROUTE53: Allow R53_ALIAS records to enable target health evaluation

More examples/context can be found in the file .goreleaser.yml under the 'build' > 'changelog' key.
!-->
Greetings,
This PR aim to add the parameter `apiurl` to the `creds.json` thus enabling self hosted netbirds instances to be updated by dnscontrol.