### PR TITLE
AKAMAIEDGEDNS: Fix bugs mentioned in Issue (#4466) while running integration tests (#4421)

### DIFF
--- a/documentation/provider/akamaiedgedns.md
+++ b/documentation/provider/akamaiedgedns.md
@@ -51,6 +51,21 @@ The AKAMAITLC record can only be used once per zone.
 #### ALIAS
 Akamai Edge DNS does directly support `ALIAS` records. This provider will convert `ALIAS` records used at the zone apex (`@`) to `AKAMAITLC` records, and any other names to `CNAME` records.
 
+#### IGNORE
+
+`IGNORE()` is supported. Records matched by an `IGNORE()` rule will be left as-is on Akamai Edge DNS and not deleted.
+
+#### TTL with IGNORE
+
+Akamai Edge DNS stores a single TTL for all records that share the same name and type (a "recordset"). If you manage some records in a recordset while ignoring others, the TTL you set on the managed records will be applied to the whole recordset — including the ignored ones.
+
+If the ignored records currently have a different TTL than what you've set, DNSControl will print a warning during both `preview` and `push`:
+
+```
+WARNING: TTL mismatch in app.example.com A: using 900 (managed), ignoring 300
+```
+
+
 ### Secondary zones
 
 This provider only supports creating primary zones in Akamai. If a secondary zone has been manually created, only `AKAMAICDN` and `AKAMAITLC` records can be managed, as all other records are read-only.

--- a/models/populatelegacy.go
+++ b/models/populatelegacy.go
@@ -24,6 +24,11 @@ func (rc *RecordConfig) copyRDtoLegacyFields() error {
 		rc.SetTarget(rd.Target)
 	case privatetypesrdata.ADGUARDHOMEAAAAPASSTHROUGH:
 		rc.SetTarget(rd.Target)
+	case privatetypesrdata.AKAMAICDN:
+		rc.SetTarget(rd.Target)
+	case privatetypesrdata.AKAMAITLC:
+		rc.AnswerType = rd.AnswerType
+		rc.SetTarget(rd.Target)
 	case privatetypesrdata.ALIAS:
 		rc.SetTarget(rd.Target)
 	case privatetypesrdata.AZUREALIAS:

--- a/models/populaterd.go
+++ b/models/populaterd.go
@@ -108,7 +108,9 @@ func (rc *RecordConfig) copyLegacyFieldsToRD(origin string) {
 	case privatetypes.TypeAKAMAICDN:
 		// no-op
 	case privatetypes.TypeAKAMAITLC:
-		// no-op
+		rd, err := privatetypesrdata.MakeAKAMAITLC(origin, nil, rc.AnswerType, rc.GetTargetField())
+		errorChk(err)
+		rc.SetRDATA(rd)
 	case privatetypes.TypeBUNNYDNSPZ:
 		// no-op
 	case privatetypes.TypeBUNNYDNSRDR:

--- a/providers/akamaiedgedns/akamaiEdgeDnsProvider.go
+++ b/providers/akamaiedgedns/akamaiEdgeDnsProvider.go
@@ -13,10 +13,9 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"strings"
 
 	"github.com/DNSControl/dnscontrol/v4/models"
-	"github.com/DNSControl/dnscontrol/v4/pkg/diff"
+	"github.com/DNSControl/dnscontrol/v4/pkg/diff2"
 	"github.com/DNSControl/dnscontrol/v4/pkg/printer"
 	"github.com/DNSControl/dnscontrol/v4/pkg/providers"
 	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v12/pkg/dns"
@@ -28,7 +27,6 @@ var features = providers.DocumentationNotes{
 	providers.CanAutoDNSSEC:          providers.Can(),
 	providers.CanConcur:              providers.Unimplemented(),
 	providers.CanGetZones:            providers.Can(),
-	providers.CanOnlyDiff1Features:   providers.Can(),
 	providers.CanUseAKAMAICDN:        providers.Can(),
 	providers.CanUseAKAMAITLC:        providers.Can(),
 	providers.CanUseAlias:            providers.Can("Akamai Edge DNS does not directly support ALIAS. Apex record will be converted to AKAMAITLC, any others to CNAME."),
@@ -172,84 +170,41 @@ func (a *edgeDNSProvider) GetZoneRecordsCorrections(dc *models.DomainConfig, exi
 		return nil, 0, err
 	}
 
-	keysToUpdate, toReport, actualChangeCount, err := diff.NewCompat(dc).ChangedGroups(existingRecords)
+	changes, actualChangeCount, err := diff2.ByRecordSet(existingRecords, dc, nil)
 	if err != nil {
 		return nil, 0, err
 	}
-	// Start corrections with the reports
-	corrections := diff.GenerateMessageCorrections(toReport)
 
-	existingRecordsMap := make(map[models.RecordKey][]*models.RecordConfig)
-	for _, r := range existingRecords {
-		key := models.RecordKey{NameFQDN: r.NameFQDN, Type: r.Type}
-		existingRecordsMap[key] = append(existingRecordsMap[key], r)
-	}
+	var corrections []*models.Correction
 
-	desiredRecordsMap := dc.Records.GroupedByKey()
-
-	// Deletes must occur first. For example, if replacing a existing CNAME with an A of the same name:
-	//    DELETE CNAME foo.example.net
-	// must occur before
-	//    CREATE A foo.example.net
-	// because both an A and a CNAME for the same name is not allowed.
-
-	lastCorrections := []*models.Correction{} // creates and replaces last
-
-	for key, msg := range keysToUpdate {
-		existing, okExisting := existingRecordsMap[key]
-		desired, okDesired := desiredRecordsMap[key]
-
-		if okExisting && !okDesired {
-			// In the existing map but not in the desired map: Delete
+	for _, change := range changes {
+		switch change.Type {
+		case diff2.REPORT:
+			corrections = append(corrections, &models.Correction{Msg: change.MsgsJoined})
+		case diff2.CREATE:
 			corrections = append(corrections, &models.Correction{
-				Msg: strings.Join(msg, "\n   "),
-				F: func() error {
-					return a.deleteRecordset(ctx, existing, dc.Name)
-				},
+				Msg: change.MsgsJoined,
+				F:   func() error { return a.createRecordset(ctx, change.New, dc.Name) },
 			})
-			printer.Debugf("deleteRecordset: %s %s\n", key.NameFQDN, key.Type)
-			for _, rdata := range existing {
-				printer.Debugf("  Rdata: %s\n", rdata.GetTargetCombined())
-			}
-		} else if !okExisting && okDesired {
-			// Not in the existing map but in the desired map: Create
-			lastCorrections = append(lastCorrections, &models.Correction{
-				Msg: strings.Join(msg, "\n   "),
-				F: func() error {
-					return a.createRecordset(ctx, desired, dc.Name)
-				},
-			})
-			printer.Debugf("createRecordset: %s %s\n", key.NameFQDN, key.Type)
-			for _, rdata := range desired {
-				printer.Debugf("  Rdata: %s\n", rdata.GetTargetCombined())
-			}
-		} else if okExisting && okDesired {
-			filteredTargets := make(map[string]bool, len(existing))
-			for _, r := range existing {
-				if recordMatchesAnyIgnoreRule(dc, r) {
-					continue
-				}
-				if raw, ok := r.Metadata["akamai_raw_rdata"]; ok {
-					filteredTargets[raw] = true
-				} else {
-					filteredTargets[r.GetTargetCombined()] = true
+		case diff2.CHANGE:
+			ttl := managedTTL(dc, change.New[0].NameFQDN, change.New[0].Type)
+			for _, r := range change.New {
+				if r.TTL != ttl {
+					printer.Warnf("TTL mismatch in %s %s: using %d (managed), ignoring %d\n", change.New[0].NameFQDN, change.New[0].Type, ttl, r.TTL)
+					break
 				}
 			}
-			lastCorrections = append(lastCorrections, &models.Correction{
-				Msg: strings.Join(msg, "\n   "),
-				F: func() error {
-					return a.replaceRecordset(ctx, desired, filteredTargets, dc.Name)
-				},
+			corrections = append(corrections, &models.Correction{
+				Msg: change.MsgsJoined,
+				F:   func() error { return a.replaceRecordset(ctx, change.New, ttl, dc.Name) },
 			})
-			printer.Debugf("replaceRecordset: %s %s\n", key.NameFQDN, key.Type)
-			for _, rdata := range desired {
-				printer.Debugf("  Rdata: %s\n", rdata.GetTargetCombined())
-			}
+		case diff2.DELETE:
+			corrections = append(corrections, &models.Correction{
+				Msg: change.MsgsJoined,
+				F:   func() error { return a.deleteRecordset(ctx, change.Old, dc.Name) },
+			})
 		}
 	}
-
-	// Deletes first, then creates and replaces
-	corrections = append(corrections, lastCorrections...)
 
 	// AutoDnsSec correction
 	existingAutoDNSSecEnabled, err := a.isAutoDNSSecEnabled(ctx, dc.Name)
@@ -260,23 +215,15 @@ func (a *edgeDNSProvider) GetZoneRecordsCorrections(dc *models.DomainConfig, exi
 	desiredAutoDNSSecEnabled := dc.AutoDNSSEC == "on"
 
 	if !existingAutoDNSSecEnabled && desiredAutoDNSSecEnabled {
-		// Existing false (disabled), Desired true (enabled)
 		corrections = append(corrections, &models.Correction{
 			Msg: "Enable AutoDnsSec\n",
-			F: func() error {
-				return a.autoDNSSecEnable(ctx, true, dc.Name)
-			},
+			F:   func() error { return a.autoDNSSecEnable(ctx, true, dc.Name) },
 		})
-		printer.Debugf("autoDNSSecEnable: Enable AutoDnsSec for zone %s\n", dc.Name)
 	} else if existingAutoDNSSecEnabled && !desiredAutoDNSSecEnabled {
-		// Existing true (enabled), Desired false (disabled)
 		corrections = append(corrections, &models.Correction{
 			Msg: "Disable AutoDnsSec\n",
-			F: func() error {
-				return a.autoDNSSecEnable(ctx, false, dc.Name)
-			},
+			F:   func() error { return a.autoDNSSecEnable(ctx, false, dc.Name) },
 		})
-		printer.Debugf("autoDNSSecEnable: Disable AutoDnsSec for zone %s\n", dc.Name)
 	}
 
 	return corrections, actualChangeCount, nil
@@ -314,26 +261,14 @@ func (a *edgeDNSProvider) ListZones() ([]string, error) {
 	return zones, nil
 }
 
-// recordMatchesAnyIgnoreRule returns true if rec is covered by any IGNORE() rule in dc.
-func recordMatchesAnyIgnoreRule(dc *models.DomainConfig, rec *models.RecordConfig) bool {
-	for _, uc := range dc.Unmanaged {
-		labelMatch := uc.LabelGlob == nil || uc.LabelGlob.Match(rec.GetLabel())
-		if !labelMatch {
-			continue
-		}
-		typeMatch := len(uc.RTypeMap) == 0
-		if !typeMatch {
-			_, typeMatch = uc.RTypeMap[rec.Type]
-		}
-		if !typeMatch {
-			continue
-		}
-		targetMatch := uc.TargetGlob == nil || uc.TargetGlob.Match(rec.GetTargetField())
-		if targetMatch {
-			return true
+
+func managedTTL(dc *models.DomainConfig, fqdn, rtype string) uint32 {
+	for _, r := range dc.Records {
+		if r.NameFQDN == fqdn && r.Type == rtype {
+			return r.TTL
 		}
 	}
-	return false
+	return 0
 }
 
 func (a *edgeDNSProvider) preprocessConfig(dc *models.DomainConfig) error {

--- a/providers/akamaiedgedns/akamaiEdgeDnsProvider.go
+++ b/providers/akamaiedgedns/akamaiEdgeDnsProvider.go
@@ -224,11 +224,21 @@ func (a *edgeDNSProvider) GetZoneRecordsCorrections(dc *models.DomainConfig, exi
 				printer.Debugf("  Rdata: %s\n", rdata.GetTargetCombined())
 			}
 		} else if okExisting && okDesired {
-			// In the existing map and in the desired map: Replace
+			filteredTargets := make(map[string]bool, len(existing))
+			for _, r := range existing {
+				if recordMatchesAnyIgnoreRule(dc, r) {
+					continue
+				}
+				if raw, ok := r.Metadata["akamai_raw_rdata"]; ok {
+					filteredTargets[raw] = true
+				} else {
+					filteredTargets[r.GetTargetCombined()] = true
+				}
+			}
 			lastCorrections = append(lastCorrections, &models.Correction{
 				Msg: strings.Join(msg, "\n   "),
 				F: func() error {
-					return a.replaceRecordset(ctx, desired, dc.Name)
+					return a.replaceRecordset(ctx, desired, filteredTargets, dc.Name)
 				},
 			})
 			printer.Debugf("replaceRecordset: %s %s\n", key.NameFQDN, key.Type)
@@ -304,6 +314,28 @@ func (a *edgeDNSProvider) ListZones() ([]string, error) {
 	return zones, nil
 }
 
+// recordMatchesAnyIgnoreRule returns true if rec is covered by any IGNORE() rule in dc.
+func recordMatchesAnyIgnoreRule(dc *models.DomainConfig, rec *models.RecordConfig) bool {
+	for _, uc := range dc.Unmanaged {
+		labelMatch := uc.LabelGlob == nil || uc.LabelGlob.Match(rec.GetLabel())
+		if !labelMatch {
+			continue
+		}
+		typeMatch := len(uc.RTypeMap) == 0
+		if !typeMatch {
+			_, typeMatch = uc.RTypeMap[rec.Type]
+		}
+		if !typeMatch {
+			continue
+		}
+		targetMatch := uc.TargetGlob == nil || uc.TargetGlob.Match(rec.GetTargetField())
+		if targetMatch {
+			return true
+		}
+	}
+	return false
+}
+
 func (a *edgeDNSProvider) preprocessConfig(dc *models.DomainConfig) error {
 	for _, rec := range dc.Records {
 		// Convert ALIAS records to the Akamai equivalents. AKAMAITLC is only valid
@@ -312,6 +344,7 @@ func (a *edgeDNSProvider) preprocessConfig(dc *models.DomainConfig) error {
 			if rec.Name == "@" {
 				rec.ChangeType("AKAMAITLC", dc.Name)
 				rec.AnswerType = "DUAL"
+				rec.RecomputeV3Fields(dc.Name)
 			} else {
 				rec.ChangeType("CNAME", dc.Name)
 			}

--- a/providers/akamaiedgedns/akamaiEdgeDnsProvider.go
+++ b/providers/akamaiedgedns/akamaiEdgeDnsProvider.go
@@ -261,7 +261,6 @@ func (a *edgeDNSProvider) ListZones() ([]string, error) {
 	return zones, nil
 }
 
-
 func managedTTL(dc *models.DomainConfig, fqdn, rtype string) uint32 {
 	for _, r := range dc.Records {
 		if r.NameFQDN == fqdn && r.Type == rtype {

--- a/providers/akamaiedgedns/akamaiEdgeDnsService.go
+++ b/providers/akamaiedgedns/akamaiEdgeDnsService.go
@@ -12,9 +12,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"regexp"
+	"strings"
 
 	"github.com/DNSControl/dnscontrol/v4/models"
 	"github.com/DNSControl/dnscontrol/v4/pkg/printer"
+	"github.com/DNSControl/dnscontrol/v4/pkg/txtutil"
 	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v12/pkg/dns"
 	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v12/pkg/edgegrid"
 	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v12/pkg/session"
@@ -219,7 +222,11 @@ func (a *edgeDNSProvider) rcToRs(records []*models.RecordConfig) (*dns.RecordBod
 	}
 
 	for _, r := range records {
-		akaRecord.Target = append(akaRecord.Target, r.GetTargetCombined())
+		if r.Type == "AKAMAITLC" {
+			akaRecord.Target = append(akaRecord.Target, r.AnswerType+" "+r.GetTargetField())
+		} else {
+			akaRecord.Target = append(akaRecord.Target, r.GetTargetCombined())
+		}
 	}
 
 	return akaRecord, nil
@@ -243,10 +250,27 @@ func (a *edgeDNSProvider) createRecordset(ctx context.Context, records []*models
 }
 
 // replaceRecordset replaces an existing AkamaiEdgeDNS recordset in the zone.
-func (a *edgeDNSProvider) replaceRecordset(ctx context.Context, records []*models.RecordConfig, zonename string) error {
+func (a *edgeDNSProvider) replaceRecordset(ctx context.Context, records []*models.RecordConfig, filteredExistingTargets map[string]bool, zonename string) error {
 	akaRecord, err := a.rcToRs(records)
 	if err != nil {
 		return err
+	}
+
+	existingRecord, getErr := a.client.GetRecord(ctx, dns.GetRecordRequest{
+		Zone:       zonename,
+		Name:       akaRecord.Name,
+		RecordType: akaRecord.RecordType,
+	})
+	if getErr == nil && existingRecord != nil {
+		desired := make(map[string]bool, len(akaRecord.Target))
+		for _, t := range akaRecord.Target {
+			desired[t] = true
+		}
+		for _, t := range existingRecord.Target {
+			if !desired[t] && !filteredExistingTargets[t] {
+				akaRecord.Target = append(akaRecord.Target, t)
+			}
+		}
 	}
 
 	err = a.client.UpdateRecord(ctx, dns.UpdateRecordRequest{
@@ -320,6 +344,24 @@ func (a *edgeDNSProvider) getRecords(ctx context.Context, zonename string) ([]*m
 			continue
 		}
 
+		// AKAMAITLC has 2 rdata entries that form 1 logical record: [answerType, target]
+		if akatype == "AKAMAITLC" {
+			combined := strings.Join(akarecset.Rdata, " ")
+			parts := strings.Fields(combined)
+			if len(parts) != 2 {
+				return nil, fmt.Errorf("AKAMAITLC rdata must contain 2 fields, got: %v", akarecset.Rdata)
+			}
+			rc := &models.RecordConfig{Type: akatype, TTL: uint32(akattl)}
+			rc.SetLabelFromFQDN(akaname, zonename)
+			rc.AnswerType = parts[0]
+			if err = rc.SetTarget(parts[1]); err != nil {
+				return nil, err
+			}
+			rc.Metadata = map[string]string{"akamai_raw_rdata": combined}
+			recordConfigs = append(recordConfigs, rc)
+			continue
+		}
+
 		// ... convert the recordset into 1 or more RecordConfig structs
 		for _, r := range akarecset.Rdata {
 			rc := &models.RecordConfig{
@@ -327,14 +369,29 @@ func (a *edgeDNSProvider) getRecords(ctx context.Context, zonename string) ([]*m
 				TTL:  uint32(akattl),
 			}
 			rc.SetLabelFromFQDN(akaname, zonename)
-			err = rc.PopulateFromString(akatype, r, zonename)
+
+			switch akatype {
+			case "TXT":
+				err = rc.PopulateFromStringFunc(akatype, r, zonename, txtutil.ParseQuoted)
+			case "LOC":
+				err = rc.PopulateFromString(akatype, fixLocAltitude(r), zonename)
+			default:
+				err = rc.PopulateFromString(akatype, r, zonename)
+			}
 			if err != nil {
 				return nil, err
 			}
 
+			rc.Metadata = map[string]string{"akamai_raw_rdata": r}
 			recordConfigs = append(recordConfigs, rc)
 		}
 	}
 
 	return recordConfigs, nil
+}
+
+var reLocNegAlt = regexp.MustCompile(`(-\d+)\.-(\d+)(m\s)`)
+
+func fixLocAltitude(rdata string) string {
+	return strings.TrimSpace(reLocNegAlt.ReplaceAllString(rdata+" ", `$1.$2$3`))
 }

--- a/providers/akamaiedgedns/akamaiEdgeDnsService.go
+++ b/providers/akamaiedgedns/akamaiEdgeDnsService.go
@@ -250,28 +250,12 @@ func (a *edgeDNSProvider) createRecordset(ctx context.Context, records []*models
 }
 
 // replaceRecordset replaces an existing AkamaiEdgeDNS recordset in the zone.
-func (a *edgeDNSProvider) replaceRecordset(ctx context.Context, records []*models.RecordConfig, filteredExistingTargets map[string]bool, zonename string) error {
+func (a *edgeDNSProvider) replaceRecordset(ctx context.Context, records []*models.RecordConfig, ttl uint32, zonename string) error {
 	akaRecord, err := a.rcToRs(records)
 	if err != nil {
 		return err
 	}
-
-	existingRecord, getErr := a.client.GetRecord(ctx, dns.GetRecordRequest{
-		Zone:       zonename,
-		Name:       akaRecord.Name,
-		RecordType: akaRecord.RecordType,
-	})
-	if getErr == nil && existingRecord != nil {
-		desired := make(map[string]bool, len(akaRecord.Target))
-		for _, t := range akaRecord.Target {
-			desired[t] = true
-		}
-		for _, t := range existingRecord.Target {
-			if !desired[t] && !filteredExistingTargets[t] {
-				akaRecord.Target = append(akaRecord.Target, t)
-			}
-		}
-	}
+	akaRecord.TTL = int(ttl)
 
 	err = a.client.UpdateRecord(ctx, dns.UpdateRecordRequest{
 		Zone:   zonename,


### PR DESCRIPTION
### AKAMAIEDGEDNS
### Issue - #4466:
**Issues Addressed**: 
1. UNEXPECTED #0: ± MODIFY TXT foo.bat.example_domain.com: (""simple"" ttl=300) -> ("simple" ttl=300)
2. recordset creation failed. error: AKAMAITLC rdata must contain 2 fields
3. LOC: parse error on read-back -- bad LOC Altitude: "-24.-05"
4. IGNORE: IGNORE'd record reappears after a modify

### Issue - #4421:
- All Integration Tests pass after applying the above fixes
