### PR TITLE
Modernize Azure DNS provider

### DIFF
--- a/providers/azuredns/auditrecords.go
+++ b/providers/azuredns/auditrecords.go
@@ -10,10 +10,5 @@ import (
 // supported, an empty list is returned.
 func AuditRecords(records []*models.RecordConfig) []error {
 	a := rejectif.Auditor{}
-
-	a.Add("MX", rejectif.MxNull) // Last verified 2020-12-28
-
-	a.Add("TXT", rejectif.TxtIsEmpty) // Last verified 2023-11-11
-
 	return a.Audit(records)
 }

--- a/providers/azuredns/azureDnsProvider.go
+++ b/providers/azuredns/azureDnsProvider.go
@@ -487,7 +487,6 @@ func safeTarget(t *string) string {
 }
 
 func nativeToRecords(set *adns.RecordSet, dc *models.DomainConfig) []*models.RecordConfig {
-	origin := dc.Name
 	var results []*models.RecordConfig
 	label := dc.LabelFromFQDNWithDot(*set.Properties.Fqdn)
 	ttl := uint32(*set.Properties.TTL)
@@ -534,64 +533,50 @@ func nativeToRecords(set *adns.RecordSet, dc *models.DomainConfig) []*models.Rec
 		}
 	case "Microsoft.Network/dnszones/NS":
 		for _, rec := range set.Properties.NsRecords {
-			rc := &models.RecordConfig{TTL: uint32(*set.Properties.TTL), Original: set}
-			rc.SetLabelFromFQDN(*set.Properties.Fqdn, origin)
-			rc.Type = "NS"
-			_ = rc.SetTarget(*rec.Nsdname)
+			rc, _ := dc.NewRecordConfig(label, ttl, dnsv2.TypeNS, *rec.Nsdname)
+			rc.Original = set
 			results = append(results, rc)
 		}
 	case "Microsoft.Network/dnszones/PTR":
 		for _, rec := range set.Properties.PtrRecords {
-			rc := &models.RecordConfig{TTL: uint32(*set.Properties.TTL), Original: set}
-			rc.SetLabelFromFQDN(*set.Properties.Fqdn, origin)
-			rc.Type = "PTR"
-			_ = rc.SetTarget(*rec.Ptrdname)
+			rc, _ := dc.NewRecordConfig(label, ttl, dnsv2.TypePTR, *rec.Ptrdname)
+			rc.Original = set
 			results = append(results, rc)
 		}
 	case "Microsoft.Network/dnszones/TXT":
 		if len(set.Properties.TxtRecords) == 0 { // Empty String Record Parsing
 			// This is a null TXT record.
-			rc := &models.RecordConfig{TTL: uint32(*set.Properties.TTL), Original: set}
-			rc.SetLabelFromFQDN(*set.Properties.Fqdn, origin)
-			rc.Type = "TXT"
-			_ = rc.SetTargetTXT("")
+			rc, _ := dc.NewRecordConfig(label, ttl, dnsv2.TypeTXT, "")
+			rc.Original = set
 			results = append(results, rc)
 		} else {
 			// This is a normal TXT record. Collect all its segments.
 			for _, rec := range set.Properties.TxtRecords {
-				rc := &models.RecordConfig{TTL: uint32(*set.Properties.TTL), Original: set}
-				rc.SetLabelFromFQDN(*set.Properties.Fqdn, origin)
-				rc.Type = "TXT"
 				var txts []string
 				for _, txt := range rec.Value {
 					txts = append(txts, *txt)
 				}
-				_ = rc.SetTargetTXTs(txts)
+				rc, _ := dc.NewRecordConfig(label, ttl, dnsv2.TypeTXT, strings.Join(txts, ""))
+				rc.Original = set
 				results = append(results, rc)
 			}
 		}
 	case "Microsoft.Network/dnszones/MX":
 		for _, rec := range set.Properties.MxRecords {
-			rc := &models.RecordConfig{TTL: uint32(*set.Properties.TTL), Original: set}
-			rc.SetLabelFromFQDN(*set.Properties.Fqdn, origin)
-			rc.Type = "MX"
-			_ = rc.SetTargetMX(uint16(*rec.Preference), *rec.Exchange)
+			rc, _ := dc.NewRecordConfig(label, ttl, dnsv2.TypeMX, uint16(*rec.Preference), *rec.Exchange)
+			rc.Original = set
 			results = append(results, rc)
 		}
 	case "Microsoft.Network/dnszones/SRV":
 		for _, rec := range set.Properties.SrvRecords {
-			rc := &models.RecordConfig{TTL: uint32(*set.Properties.TTL), Original: set}
-			rc.SetLabelFromFQDN(*set.Properties.Fqdn, origin)
-			rc.Type = "SRV"
-			_ = rc.SetTargetSRV(uint16(*rec.Priority), uint16(*rec.Weight), uint16(*rec.Port), *rec.Target)
+			rc, _ := dc.NewRecordConfig(label, ttl, dnsv2.TypeSRV, uint16(*rec.Priority), uint16(*rec.Weight), uint16(*rec.Port), *rec.Target)
+			rc.Original = set
 			results = append(results, rc)
 		}
 	case "Microsoft.Network/dnszones/CAA":
 		for _, rec := range set.Properties.CaaRecords {
-			rc := &models.RecordConfig{TTL: uint32(*set.Properties.TTL), Original: set}
-			rc.SetLabelFromFQDN(*set.Properties.Fqdn, origin)
-			rc.Type = "CAA"
-			_ = rc.SetTargetCAA(uint8(*rec.Flags), *rec.Tag, *rec.Value)
+			rc, _ := dc.NewRecordConfig(label, ttl, dnsv2.TypeCAA, uint8(*rec.Flags), *rec.Tag, *rec.Value)
+			rc.Original = set
 			results = append(results, rc)
 		}
 	case "Microsoft.Network/dnszones/SOA":

--- a/providers/azuredns/azureDnsProvider_test.go
+++ b/providers/azuredns/azureDnsProvider_test.go
@@ -7,8 +7,102 @@ import (
 	"strings"
 	"testing"
 
+	dnsv2 "codeberg.org/miekg/dns"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	adns "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/dns/armdns"
+	"github.com/DNSControl/dnscontrol/v4/models"
 )
+
+func ptr[T any](v T) *T {
+	return &v
+}
+
+func TestNativeToRecordsUsesV3RecordConfig(t *testing.T) {
+	dc := models.MustNewDomainConfig("example.com")
+	tests := []struct {
+		name       string
+		azureType  string
+		properties func() *adns.RecordSetProperties
+		want       *models.RecordConfig
+	}{
+		{
+			name:      "NS",
+			azureType: "Microsoft.Network/dnszones/NS",
+			properties: func() *adns.RecordSetProperties {
+				return &adns.RecordSetProperties{NsRecords: []*adns.NsRecord{{Nsdname: ptr("ns1.example.net.")}}}
+			},
+			want: dc.MustNewRecordConfig("www", 300, dnsv2.TypeNS, "ns1.example.net."),
+		},
+		{
+			name:      "PTR",
+			azureType: "Microsoft.Network/dnszones/PTR",
+			properties: func() *adns.RecordSetProperties {
+				return &adns.RecordSetProperties{PtrRecords: []*adns.PtrRecord{{Ptrdname: ptr("host.example.net.")}}}
+			},
+			want: dc.MustNewRecordConfig("www", 300, dnsv2.TypePTR, "host.example.net."),
+		},
+		{
+			name:      "empty TXT record set",
+			azureType: "Microsoft.Network/dnszones/TXT",
+			properties: func() *adns.RecordSetProperties {
+				return &adns.RecordSetProperties{}
+			},
+			want: dc.MustNewRecordConfig("www", 300, dnsv2.TypeTXT, ""),
+		},
+		{
+			name:      "segmented TXT",
+			azureType: "Microsoft.Network/dnszones/TXT",
+			properties: func() *adns.RecordSetProperties {
+				return &adns.RecordSetProperties{TxtRecords: []*adns.TxtRecord{{Value: []*string{ptr("first"), ptr("second")}}}}
+			},
+			want: dc.MustNewRecordConfig("www", 300, dnsv2.TypeTXT, "firstsecond"),
+		},
+		{
+			name:      "MX",
+			azureType: "Microsoft.Network/dnszones/MX",
+			properties: func() *adns.RecordSetProperties {
+				return &adns.RecordSetProperties{MxRecords: []*adns.MxRecord{{Preference: ptr(int32(10)), Exchange: ptr("mail.example.net.")}}}
+			},
+			want: dc.MustNewRecordConfig("www", 300, dnsv2.TypeMX, uint16(10), "mail.example.net."),
+		},
+		{
+			name:      "SRV",
+			azureType: "Microsoft.Network/dnszones/SRV",
+			properties: func() *adns.RecordSetProperties {
+				return &adns.RecordSetProperties{SrvRecords: []*adns.SrvRecord{{Priority: ptr(int32(1)), Weight: ptr(int32(2)), Port: ptr(int32(443)), Target: ptr("service.example.net.")}}}
+			},
+			want: dc.MustNewRecordConfig("www", 300, dnsv2.TypeSRV, uint16(1), uint16(2), uint16(443), "service.example.net."),
+		},
+		{
+			name:      "CAA",
+			azureType: "Microsoft.Network/dnszones/CAA",
+			properties: func() *adns.RecordSetProperties {
+				return &adns.RecordSetProperties{CaaRecords: []*adns.CaaRecord{{Flags: ptr(int32(0)), Tag: ptr("issue"), Value: ptr("letsencrypt.org")}}}
+			},
+			want: dc.MustNewRecordConfig("www", 300, dnsv2.TypeCAA, uint8(0), "issue", "letsencrypt.org"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			properties := tt.properties()
+			properties.Fqdn = ptr("www.example.com.")
+			properties.TTL = ptr(int64(300))
+			set := &adns.RecordSet{Type: ptr(tt.azureType), Properties: properties}
+
+			got := nativeToRecords(set, dc)
+			if len(got) != 1 {
+				t.Fatalf("nativeToRecords() returned %d records, want 1", len(got))
+			}
+			if got[0].NameFQDN != tt.want.NameFQDN || got[0].TTL != tt.want.TTL || got[0].TypeNum != tt.want.TypeNum || got[0].GetRDATA().String() != tt.want.GetRDATA().String() {
+				t.Errorf("nativeToRecords() = %s %d IN %s %s, want %s %d IN %s %s", got[0].NameFQDN, got[0].TTL, got[0].Type, got[0].GetRDATA(), tt.want.NameFQDN, tt.want.TTL, tt.want.Type, tt.want.GetRDATA())
+			}
+			if got[0].Original != set {
+				t.Error("nativeToRecords() did not preserve the original Azure record set")
+			}
+		})
+	}
+}
 
 func TestRetryableRecordSetMutation(t *testing.T) {
 	tests := []struct {

--- a/providers/azuredns/azureDnsProvider_test.go
+++ b/providers/azuredns/azureDnsProvider_test.go
@@ -13,10 +13,6 @@ import (
 	"github.com/DNSControl/dnscontrol/v4/models"
 )
 
-func ptr[T any](v T) *T {
-	return &v
-}
-
 func TestNativeToRecordsUsesV3RecordConfig(t *testing.T) {
 	dc := models.MustNewDomainConfig("example.com")
 	tests := []struct {
@@ -29,7 +25,7 @@ func TestNativeToRecordsUsesV3RecordConfig(t *testing.T) {
 			name:      "NS",
 			azureType: "Microsoft.Network/dnszones/NS",
 			properties: func() *adns.RecordSetProperties {
-				return &adns.RecordSetProperties{NsRecords: []*adns.NsRecord{{Nsdname: ptr("ns1.example.net.")}}}
+				return &adns.RecordSetProperties{NsRecords: []*adns.NsRecord{{Nsdname: new("ns1.example.net.")}}}
 			},
 			want: dc.MustNewRecordConfig("www", 300, dnsv2.TypeNS, "ns1.example.net."),
 		},
@@ -37,7 +33,7 @@ func TestNativeToRecordsUsesV3RecordConfig(t *testing.T) {
 			name:      "PTR",
 			azureType: "Microsoft.Network/dnszones/PTR",
 			properties: func() *adns.RecordSetProperties {
-				return &adns.RecordSetProperties{PtrRecords: []*adns.PtrRecord{{Ptrdname: ptr("host.example.net.")}}}
+				return &adns.RecordSetProperties{PtrRecords: []*adns.PtrRecord{{Ptrdname: new("host.example.net.")}}}
 			},
 			want: dc.MustNewRecordConfig("www", 300, dnsv2.TypePTR, "host.example.net."),
 		},
@@ -53,7 +49,7 @@ func TestNativeToRecordsUsesV3RecordConfig(t *testing.T) {
 			name:      "segmented TXT",
 			azureType: "Microsoft.Network/dnszones/TXT",
 			properties: func() *adns.RecordSetProperties {
-				return &adns.RecordSetProperties{TxtRecords: []*adns.TxtRecord{{Value: []*string{ptr("first"), ptr("second")}}}}
+				return &adns.RecordSetProperties{TxtRecords: []*adns.TxtRecord{{Value: []*string{new("first"), new("second")}}}}
 			},
 			want: dc.MustNewRecordConfig("www", 300, dnsv2.TypeTXT, "firstsecond"),
 		},
@@ -61,7 +57,7 @@ func TestNativeToRecordsUsesV3RecordConfig(t *testing.T) {
 			name:      "MX",
 			azureType: "Microsoft.Network/dnszones/MX",
 			properties: func() *adns.RecordSetProperties {
-				return &adns.RecordSetProperties{MxRecords: []*adns.MxRecord{{Preference: ptr(int32(10)), Exchange: ptr("mail.example.net.")}}}
+				return &adns.RecordSetProperties{MxRecords: []*adns.MxRecord{{Preference: new(int32(10)), Exchange: new("mail.example.net.")}}}
 			},
 			want: dc.MustNewRecordConfig("www", 300, dnsv2.TypeMX, uint16(10), "mail.example.net."),
 		},
@@ -69,7 +65,7 @@ func TestNativeToRecordsUsesV3RecordConfig(t *testing.T) {
 			name:      "SRV",
 			azureType: "Microsoft.Network/dnszones/SRV",
 			properties: func() *adns.RecordSetProperties {
-				return &adns.RecordSetProperties{SrvRecords: []*adns.SrvRecord{{Priority: ptr(int32(1)), Weight: ptr(int32(2)), Port: ptr(int32(443)), Target: ptr("service.example.net.")}}}
+				return &adns.RecordSetProperties{SrvRecords: []*adns.SrvRecord{{Priority: new(int32(1)), Weight: new(int32(2)), Port: new(int32(443)), Target: new("service.example.net.")}}}
 			},
 			want: dc.MustNewRecordConfig("www", 300, dnsv2.TypeSRV, uint16(1), uint16(2), uint16(443), "service.example.net."),
 		},
@@ -77,7 +73,7 @@ func TestNativeToRecordsUsesV3RecordConfig(t *testing.T) {
 			name:      "CAA",
 			azureType: "Microsoft.Network/dnszones/CAA",
 			properties: func() *adns.RecordSetProperties {
-				return &adns.RecordSetProperties{CaaRecords: []*adns.CaaRecord{{Flags: ptr(int32(0)), Tag: ptr("issue"), Value: ptr("letsencrypt.org")}}}
+				return &adns.RecordSetProperties{CaaRecords: []*adns.CaaRecord{{Flags: new(int32(0)), Tag: new("issue"), Value: new("letsencrypt.org")}}}
 			},
 			want: dc.MustNewRecordConfig("www", 300, dnsv2.TypeCAA, uint8(0), "issue", "letsencrypt.org"),
 		},
@@ -86,9 +82,9 @@ func TestNativeToRecordsUsesV3RecordConfig(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			properties := tt.properties()
-			properties.Fqdn = ptr("www.example.com.")
-			properties.TTL = ptr(int64(300))
-			set := &adns.RecordSet{Type: ptr(tt.azureType), Properties: properties}
+			properties.Fqdn = new("www.example.com.")
+			properties.TTL = new(int64(300))
+			set := &adns.RecordSet{Type: new(tt.azureType), Properties: properties}
 
 			got := nativeToRecords(set, dc)
 			if len(got) != 1 {


### PR DESCRIPTION
## What changed

- replace legacy `RecordConfig` literals and target setters in Azure DNS record conversion with `DomainConfig.NewRecordConfig`
- preserve the original Azure record-set metadata on converted records
- add table-driven coverage for NS, PTR, empty and segmented TXT, MX, SRV, and CAA records

## Why

This adopts the RecordConfig v3 factories described in `documentation/developer-info/modernizingproviders.md` and removes the remaining legacy APIs from `providers/azuredns`.

## Impact

No intended user-facing behavior change. Azure DNS records are now constructed through the domain-aware v3 factory path.

## Validation

- `providers/azuredns/../../bin/is_modern.sh`
- `go test ./providers/azuredns`
- `go test ./...`
- `git diff --check`
