### PR TITLE
NAMECHEAP: Add SRV Record Support

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,7 +17,7 @@ updates:
     schedule:
       interval: "monthly"
     ignore:
-      - dependency-name: "github.com/billputer/go-namecheap"
+      - dependency-name: "github.com/willpower232/go-namecheap"
       - dependency-name: "github.com/dnsimple/dnsimple-go"
       - dependency-name: "github.com/exoscale/egoscale"
       - dependency-name: "github.com/ovh/go-ovh"

--- a/documentation/provider/index.md
+++ b/documentation/provider/index.md
@@ -277,7 +277,7 @@ Jump to a table:
 | [`LUADNS`](luadns.md) | ❔ | ❔ | ✅ | ❔ |
 | [`MIKROTIK`](mikrotik.md) | ❔ | ❌ | ✅ | ❌ |
 | [`MYTHICBEASTS`](mythicbeasts.md) | ❔ | ❔ | ✅ | ❔ |
-| [`NAMECHEAP`](namecheap.md) | ❔ | ❔ | ❌ | ❔ |
+| [`NAMECHEAP`](namecheap.md) | ❔ | ❔ | ✅ | ❔ |
 | [`NAMEDOTCOM`](namedotcom.md) | ❔ | ❔ | ✅ | ❔ |
 | [`NETBIRD`](netbird.md) | ❌ | ❌ | ❌ | ❌ |
 | [`NETCUP`](netcup.md) | ❔ | ❔ | ✅ | ❔ |

--- a/documentation/provider/namecheap.md
+++ b/documentation/provider/namecheap.md
@@ -91,7 +91,7 @@ In order to activate API functionality on your Namecheap account, you must enabl
 - Service discovery
   - [`DHCID`](../language-reference/domain-modifiers/DHCID.md): ❔
   - [`NAPTR`](../language-reference/domain-modifiers/NAPTR.md): ❔
-  - [`SRV`](../language-reference/domain-modifiers/SRV.md): ❌
+  - [`SRV`](../language-reference/domain-modifiers/SRV.md): ✅
   - [`SVCB`](../language-reference/domain-modifiers/SVCB.md): ❔
 - Security
   - [`CAA`](../language-reference/domain-modifiers/CAA.md): ✅

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/spf13/viper v1.21.0 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
+	github.com/willpower232/go-namecheap v0.0.0-20260720171816-b13495139f3c // indirect
 	go.uber.org/ratelimit v0.3.1 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
@@ -48,7 +49,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/route53 v1.64.1
 	github.com/aws/aws-sdk-go-v2/service/route53domains v1.37.1
 	github.com/babolivier/go-doh-client v0.0.0-20201028162107-a76cff4cb8b6
-	github.com/billputer/go-namecheap v0.0.0-20210108011502-994a912fb7f9
 	github.com/cloudflare/cloudflare-go v0.117.0
 	github.com/digitalocean/godo v1.199.0
 	github.com/ditashi/jsbeautifier-go v0.0.0-20141206144643-2520a8026a9c

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,6 @@ require (
 	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/spf13/viper v1.21.0 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
-	github.com/willpower232/go-namecheap v0.0.0-20260720171816-b13495139f3c // indirect
 	go.uber.org/ratelimit v0.3.1 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
@@ -109,6 +108,7 @@ require (
 	github.com/urfave/cli/v3 v3.10.1
 	github.com/vercel/terraform-provider-vercel v1.14.1
 	github.com/vultr/govultr/v2 v2.17.2
+	github.com/willpower232/go-namecheap v0.0.0-20260720171816-b13495139f3c
 	golang.org/x/text v0.40.0
 	golang.org/x/time v0.15.0
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -95,8 +95,6 @@ github.com/benbjohnson/clock v1.3.5 h1:VvXlSJBzZpA/zum6Sj74hxwYI2DIxRWuNIoXAzHZz
 github.com/benbjohnson/clock v1.3.5/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
-github.com/billputer/go-namecheap v0.0.0-20210108011502-994a912fb7f9 h1:2vQTbEJvFsyd1VefzZ34GUkUD6TkJleYYJh9/25WBE4=
-github.com/billputer/go-namecheap v0.0.0-20210108011502-994a912fb7f9/go.mod h1:bqqNsI2akL+lLWyApkYY0cxquWPKwEBU0Wd3chi3TEg=
 github.com/bits-and-blooms/bitset v1.24.4 h1:95H15Og1clikBrKr/DuzMXkQzECs1M6hhoGXLwLQOZE=
 github.com/bits-and-blooms/bitset v1.24.4/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
 github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
@@ -443,6 +441,8 @@ github.com/vercel/terraform-provider-vercel v1.14.1 h1:ghAjFkMMzka4XuoBYdu1OXM/K
 github.com/vercel/terraform-provider-vercel v1.14.1/go.mod h1:AdFCiUD0XP8XOi6tnhaCh7I0vyq2TAPmI+GcIp3+7SI=
 github.com/vultr/govultr/v2 v2.17.2 h1:gej/rwr91Puc/tgh+j33p/BLR16UrIPnSr+AIwYWZQs=
 github.com/vultr/govultr/v2 v2.17.2/go.mod h1:ZFOKGWmgjytfyjeyAdhQlSWwTjh2ig+X49cAp50dzXI=
+github.com/willpower232/go-namecheap v0.0.0-20260720171816-b13495139f3c h1:crbR1KcJIrVWMm1rNmKwrTFO8LwcC/O9J3ZSQK0Fwm0=
+github.com/willpower232/go-namecheap v0.0.0-20260720171816-b13495139f3c/go.mod h1:geRAHdcGE14UKJ835LVWlIC6X9c7Ft+c+UCXQ571Mig=
 github.com/xddxdd/ottoext v0.0.0-20221109171055-210517fa4419 h1:PT5KYEimicg1GRkBtBxCLcHWvMcBRGljOLwG/y4+T5c=
 github.com/xddxdd/ottoext v0.0.0-20221109171055-210517fa4419/go.mod h1:BxZUa1xZ189Ww28wRT0LjHcmHgQmPh27hqfHIwET0ok=
 github.com/xdg-go/pbkdf2 v1.0.0/go.mod h1:jrpuAogTd400dnrH08LKmI/xc1MbPOebTwRqcT5RDeI=

--- a/integrationTest/integration_test.go
+++ b/integrationTest/integration_test.go
@@ -896,7 +896,10 @@ func makeTests() []*TestGroup {
 		// https://github.com/DNSControl/dnscontrol/issues/2066
 		testgroup("SRV",
 			requires(providers.CanUseSRV),
-			not("OPENWRT"), // OpenWRT does not support per record TTL
+			not(
+				"OPENWRT", // OpenWRT does not support per record TTL
+				"NAMECHEAP", // Namecheap does not support per record TTL
+			),
 			tc("Create SRV333", ttl(srv("_sip._tcp", 5, 6, 7, "foo.com."), 333)),
 			tc("Change TTL999", ttl(srv("_sip._tcp", 5, 6, 7, "foo.com."), 999)),
 		),

--- a/integrationTest/integration_test.go
+++ b/integrationTest/integration_test.go
@@ -897,7 +897,7 @@ func makeTests() []*TestGroup {
 		testgroup("SRV",
 			requires(providers.CanUseSRV),
 			not(
-				"OPENWRT", // OpenWRT does not support per record TTL
+				"OPENWRT",   // OpenWRT does not support per record TTL
 				"NAMECHEAP", // Namecheap does not support per record TTL
 			),
 			tc("Create SRV333", ttl(srv("_sip._tcp", 5, 6, 7, "foo.com."), 333)),

--- a/providers/namecheap/namecheapProvider.go
+++ b/providers/namecheap/namecheapProvider.go
@@ -348,7 +348,7 @@ func (n *namecheapProvider) generateRecords(dc *models.DomainConfig) error {
 				Protocol: recProtocol,
 				Priority: int(r.SrvPriority),
 				Port:     int(r.SrvPort),
-				Target:   value,
+				Target:   r.GetTargetField(),
 				Weight:   int(r.SrvWeight),
 			}
 

--- a/providers/namecheap/namecheapProvider.go
+++ b/providers/namecheap/namecheapProvider.go
@@ -18,7 +18,7 @@ import (
 	"github.com/DNSControl/dnscontrol/v4/pkg/diff"
 	"github.com/DNSControl/dnscontrol/v4/pkg/printer"
 	"github.com/DNSControl/dnscontrol/v4/pkg/providers"
-	nc "github.com/billputer/go-namecheap"
+	nc "github.com/willpower232/go-namecheap"
 	"golang.org/x/net/publicsuffix"
 )
 

--- a/providers/namecheap/namecheapProvider.go
+++ b/providers/namecheap/namecheapProvider.go
@@ -213,6 +213,10 @@ func (n *namecheapProvider) GetZoneRecords(dc *models.DomainConfig) (models.Reco
 		return nil, err
 	}
 
+	if srvRecords == nil {
+		return recordModels, nil
+	}
+
 	srvRecordModels, err := toSRVRecords(srvRecords, domain)
 
 	if err != nil {

--- a/providers/namecheap/namecheapProvider.go
+++ b/providers/namecheap/namecheapProvider.go
@@ -308,11 +308,13 @@ func toRecords(result *nc.DomainDNSGetHostsResult, origin string) ([]*models.Rec
 
 func toSRVRecords(result *nc.DomainSRVGetRecordsResult, origin string) ([]*models.RecordConfig, error) {
 	var records []*models.RecordConfig
-	for _, srvRecord := range result.Result {
+	for _, srvRecord := range result.Records {
 		record := models.RecordConfig{
-			Type: "srv",
+			Type: "SRV",
 			Name: srvRecord.Service + srvRecord.Protocol,
 		}
+
+		record.SetLabel(srvRecord.Service + srvRecord.Protocol, origin)
 
 		err := record.SetTargetSRVStrings(
 			strconv.Itoa(srvRecord.Priority),

--- a/providers/namecheap/namecheapProvider.go
+++ b/providers/namecheap/namecheapProvider.go
@@ -66,7 +66,7 @@ var features = providers.DocumentationNotes{
 	providers.CanUseCAA:              providers.Can(),
 	providers.CanUseLOC:              providers.Cannot(),
 	providers.CanUsePTR:              providers.Cannot(),
-	providers.CanUseSRV:              providers.Cannot("The namecheap web console allows you to make SRV records, but their api does not let you read or set them"),
+	providers.CanUseSRV:              providers.Can(),
 	providers.CanUseTLSA:             providers.Cannot(),
 	providers.DocCreateDomains:       providers.Cannot("Requires domain registered through their service"),
 	providers.DocDualHost:            providers.Cannot("Doesn't allow control of apex NS records"),
@@ -181,9 +181,14 @@ func (n *namecheapProvider) GetZoneRecords(dc *models.DomainConfig) (models.Reco
 
 	sld, tld := splitDomain(domain)
 	var records *nc.DomainDNSGetHostsResult
+	var srvRecords *nc.DomainSRVGetRecordsResult
 	var err error
 	doWithRetry(func() error {
 		records, err = n.client.DomainsDNSGetHosts(sld, tld)
+		if err != nil {
+			return err
+		}
+		srvRecords, err = n.client.DomainsSRVGetRecords(sld, tld)
 		return err
 	})
 	if err != nil {
@@ -202,7 +207,19 @@ func (n *namecheapProvider) GetZoneRecords(dc *models.DomainConfig) (models.Reco
 		}
 	}
 
-	return toRecords(records, domain)
+	recordModels, err := toRecords(records, domain)
+
+	if err != nil {
+		return nil, err
+	}
+
+	srvRecordModels, err := toSRVRecords(srvRecords, domain)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return append(recordModels, srvRecordModels...), nil
 }
 
 // GetZoneRecordsCorrections returns a list of corrections that will turn existing records into dc.Records.
@@ -285,34 +302,82 @@ func toRecords(result *nc.DomainDNSGetHostsResult, origin string) ([]*models.Rec
 	return records, nil
 }
 
+func toSRVRecords(result *nc.DomainSRVGetRecordsResult, origin string) ([]*models.RecordConfig, error) {
+	var records []*models.RecordConfig
+	for _, srvRecord := range result.Result {
+		record := models.RecordConfig{
+			Type: "srv",
+			Name: srvRecord.Service + srvRecord.Protocol,
+		}
+
+		err := record.SetTargetSRVStrings(
+			strconv.Itoa(srvRecord.Priority),
+			strconv.Itoa(srvRecord.Weight),
+			strconv.Itoa(srvRecord.Port),
+			srvRecord.Target,
+		)
+
+		if err != nil {
+			return nil, err
+		}
+
+		records = append(records, &record)
+	}
+
+	return records, nil
+}
+
 func (n *namecheapProvider) generateRecords(dc *models.DomainConfig) error {
 	var recs []nc.DomainDNSHost
+	var srvRecs []nc.DomainSRVRecord
 
 	id := 1
 	for _, r := range dc.Records {
 		var value string
-		switch rtype := r.Type; rtype { // #rtype_variations
-		case "CAA":
-			value = r.GetTargetCombined()
-		default:
-			value = r.GetTargetField()
+
+		if r.Type == "SRV" {
+			recServiceAndProtocol := strings.SplitAfterN(r.GetLabel(), ".", 2)
+			recService, recProtocol := recServiceAndProtocol[0], recServiceAndProtocol[1]
+
+			rec := nc.DomainSRVRecord{
+				Service:  recService,
+				Protocol: recProtocol,
+				Priority: int(r.SrvPriority),
+				Port:     int(r.SrvPort),
+				Target:   value,
+				Weight:   int(r.SrvWeight),
+			}
+
+			srvRecs = append(srvRecs, rec)
+		} else {
+			switch rtype := r.Type; rtype { // #rtype_variations
+			case "CAA":
+				value = r.GetTargetCombined()
+			default:
+				value = r.GetTargetField()
+			}
+
+			rec := nc.DomainDNSHost{
+				ID:      id,
+				Name:    r.GetLabel(),
+				Type:    r.Type,
+				Address: value,
+				MXPref:  int(r.MxPreference),
+				TTL:     int(r.TTL),
+			}
+			recs = append(recs, rec)
 		}
 
-		rec := nc.DomainDNSHost{
-			ID:      id,
-			Name:    r.GetLabel(),
-			Type:    r.Type,
-			Address: value,
-			MXPref:  int(r.MxPreference),
-			TTL:     int(r.TTL),
-		}
-		recs = append(recs, rec)
 		id++
 	}
 	sld, tld := splitDomain(dc.Name)
 	var err error
 	doWithRetry(func() error {
 		_, err = n.client.DomainDNSSetHosts(sld, tld, recs)
+		if err != nil {
+			return err
+		}
+		_, err = n.client.DomainSRVSetRecords(sld, tld, srvRecs)
 		return err
 	})
 	return err

--- a/providers/namecheap/namecheapProvider.go
+++ b/providers/namecheap/namecheapProvider.go
@@ -239,6 +239,17 @@ func (n *namecheapProvider) GetZoneRecordsCorrections(dc *models.DomainConfig, a
 		return true
 	})
 
+	// namecheap does not believe in TTLs for SRV records,
+	// zero off what was provided to avoid infinite push loop
+	recs := []*models.RecordConfig{}
+	for _, r := range dc.Records {
+		if r.Type == "SRV" {
+			r.TTL = 0
+		}
+		recs = append(recs, r)
+	}
+	dc.Records = recs
+
 	toReport, toCreate, toDelete, toModify, actualChangeCount, err := diff.NewCompat(dc).IncrementalDiff(actual)
 	if err != nil {
 		return nil, 0, err
@@ -314,7 +325,7 @@ func toSRVRecords(result *nc.DomainSRVGetRecordsResult, origin string) ([]*model
 			Name: srvRecord.Service + srvRecord.Protocol,
 		}
 
-		record.SetLabel(srvRecord.Service + srvRecord.Protocol, origin)
+		record.SetLabel(srvRecord.Service+srvRecord.Protocol, origin)
 
 		err := record.SetTargetSRVStrings(
 			strconv.Itoa(srvRecord.Priority),

--- a/providers/namecheap/namecheapProvider_test.go
+++ b/providers/namecheap/namecheapProvider_test.go
@@ -8,7 +8,7 @@ import (
 	"reflect"
 	"testing"
 
-	nc "github.com/billputer/go-namecheap"
+	nc "github.com/willpower232/go-namecheap"
 )
 
 func TestListZonesPaginates(t *testing.T) {


### PR DESCRIPTION
Resolves #3680 

I've forked and added to the original namecheap go library used here, its been untouched for some time but I'll add a PR over there momentarily.

The only annoying part is the absence of TTL support but they don't seem to care in spite of providing a dropdown for TTLs in their website UI. I referenced `dc.Filter` to hack out any TTLs provided by dnsconfig.js for SRV records, not sure if there is a better way.

I've verified I can add and remove records using this and it passes the SRV tests.

Not sure if @BrainStone has the ability to test or not but enjoy!