### PR TITLE
CICD: Tag release directly instead of via a PR

### DIFF
--- a/.github/workflows/release_draft.yml
+++ b/.github/workflows/release_draft.yml
@@ -87,7 +87,7 @@ jobs:
       full: true
     secrets: inherit
 
-  # release: create the release commit + tag (dispatch only) and run GoReleaser.
+  # release: create the tag (dispatch only) and run GoReleaser.
   # Runs for a manual tag push (unchanged behavior) OR after a successful
   # dispatch+verify.
   release:
@@ -108,7 +108,6 @@ jobs:
     permissions:
       packages: write
       contents: write
-      pull-requests: write
     steps:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
@@ -137,37 +136,27 @@ jobs:
             echo "Release \`${{ inputs.version }}\` was cut with **skip_longtest=true** — the full integration suite did NOT run."
           } >> "$GITHUB_STEP_SUMMARY"
 
-      # DISPATCH ONLY: main is protected (PRs required, enforced for admins), so
-      # the empty "Release vX.Y.Z" commit is landed via an auto-merged PR (0
-      # required reviews/checks make this possible with GITHUB_TOKEN), then
-      # tagged. Pushing the tag with GITHUB_TOKEN intentionally does NOT
-      # re-trigger this workflow's tag-push path, so there is no double release.
-      - name: Create release commit and tag
+      # DISPATCH ONLY: tag the tip of the selected branch and push the tag.
+      #
+      # We deliberately do NOT land an empty "Release vX.Y.Z" commit on the
+      # branch: main is protected (PRs required, enforced for admins) and this
+      # org forbids GitHub Actions from creating pull requests, so an
+      # automated, PAT-free PR is impossible. Tagging is unaffected by branch
+      # protection (no tag protection rules), and the changelog is still correct
+      # because GORELEASER_PREVIOUS_TAG is computed by version below (it does
+      # not rely on the tag sitting on its own commit). The annotated tag itself
+      # carries the "Release vX.Y.Z" message.
+      #
+      # Pushing the tag with GITHUB_TOKEN intentionally does NOT re-trigger this
+      # workflow's tag-push path, so there is no double release.
+      - name: Create and push tag
         if: github.event_name == 'workflow_dispatch'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ inputs.version }}
-          BRANCH: ${{ github.ref_name }}
         run: |
           set -eu
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-
-          work="release/${VERSION}"
-          git switch -c "$work"
-          git commit --allow-empty -m "Release ${VERSION}"
-          git push -u origin "$work"
-
-          gh pr create --base "$BRANCH" --head "$work" \
-            --title "Release ${VERSION}" \
-            --body "Automated empty commit marking release ${VERSION}."
-          gh pr edit "$work" --add-label longtest || echo "WARNING: could not add 'longtest' label (continuing)."
-          gh pr merge "$work" --squash --delete-branch
-
-          # Fast-forward the local checkout to the merged commit, then tag it.
-          git fetch origin "$BRANCH"
-          git checkout "$BRANCH"
-          git reset --hard "origin/${BRANCH}"
           git tag -a "$VERSION" -m "Release ${VERSION}"
           git push origin "refs/tags/${VERSION}"
 

--- a/documentation/release/release-engineering.md
+++ b/documentation/release/release-engineering.md
@@ -78,12 +78,13 @@ The workflow then, in order:
 1. **preflight** — validates the version; refuses if the tag already exists.
 2. **verify** — runs the **entire** `longtest` integration suite as a gate. If
    anything fails, nothing is tagged or published.
-3. **release** — creates the empty `Release <version>` commit via an
-   auto-merged PR (labeled `longtest`), tags it, and runs GoReleaser to produce
-   the **draft** release.
+3. **release** — tags the tip of the selected branch and runs GoReleaser to
+   produce the **draft** release.
 
-The empty commit guarantees each release/RC lands on its own commit, so the
-changelog range is computed correctly.
+The release is tagged directly (not via an empty `Release <version>` commit):
+this org forbids GitHub Actions from opening pull requests and `main` is
+protected, so a PAT-free automated PR is not possible. The changelog range is
+still correct because it is computed by version, not by commit ancestry.
 
 ### Manual (escape hatch)
 


### PR DESCRIPTION
The dispatch release workflow created the empty "Release vX.Y.Z" commit by opening an auto-merged PR, but this org forbids GitHub Actions from creating pull requests ("GitHub Actions is not permitted to create or approve pull requests"), so the run failed at gh pr create.

Since main is protected (PR required, enforced for admins) and a PAT is not an option, land the release without a PR: the release job now tags the tip of the selected branch directly and pushes the tag. Tag pushes are unaffected by branch protection (no tag protection rules), and the changelog stays correct because GORELEASER_PREVIOUS_TAG is computed by version, not commit ancestry.

- Drop the empty-commit + gh pr create/merge steps; tag the tip instead.
- Remove the now-unused pull-requests: write permission.
- Update release-engineering.md to describe the direct-tag approach.

The annotated tag still carries the "Release vX.Y.Z" message. preflight validation, the full longtest gate, skip_longtest, previous_tag override, release-from-any-branch, and the manual tag-push path are unchanged.

<!--
## Before submiting a pull request

Please make sure you've run the following commands from the root directory.

    bin/generate-all.sh

(this runs commands like "go generate", fixes formatting, and so on)

## Release changelog section

Help keep the release changelog clear by pre-naming the proper section in the GitHub pull request title.

Some examples:
* CICD: Add required GHA permissions for goreleaser
* DOCS: Fixed providers with "contributor support" table
* ROUTE53: Allow R53_ALIAS records to enable target health evaluation

More examples/context can be found in the file .goreleaser.yml under the 'build' > 'changelog' key.
!-->
