### PR TITLE
CHORE: fix a tiny bashism

### DIFF
--- a/bin/generate-all.sh
+++ b/bin/generate-all.sh
@@ -3,7 +3,7 @@
 echo ========== go fmt
 go fmt ./...
 
-if [[ -x node_modules/.bin/prettier ]]; then
+if [ -x node_modules/.bin/prettier ]; then
   echo ========== prettier
   node_modules/.bin/prettier --write pkg/js/helpers.js
 fi


### PR DESCRIPTION
/bin/sh isn't symlinked to /bin/bash anymore in various distributions, ensure we don't use any bash-specific syntax in this script.

<!--
## Before submiting a pull request

Please make sure you've run the following commands from the root directory.

    bin/generate-all.sh

(this runs commands like "go generate", fixes formatting, and so on)

## Release changelog section

Help keep the release changelog clear by pre-naming the proper section in the GitHub pull request title.

Some examples:
* CICD: Add required GHA permissions for goreleaser
* DOCS: Fixed providers with "contributor support" table
* ROUTE53: Allow R53_ALIAS records to enable target health evaluation

More examples/context can be found in the file .goreleaser.yml under the 'build' > 'changelog' key.
!-->
