### PR TITLE
AKAMAIEDGEDNS: Modernize record conversion

### DIFF
--- a/providers/akamaiedgedns/akamaiEdgeDnsProvider.go
+++ b/providers/akamaiedgedns/akamaiEdgeDnsProvider.go
@@ -241,10 +241,8 @@ func (a *edgeDNSProvider) GetNameservers(domain string) ([]*models.Nameserver, e
 
 // GetZoneRecords returns an array of RecordConfig structs for a zone.
 func (a *edgeDNSProvider) GetZoneRecords(dc *models.DomainConfig) (models.Records, error) {
-	domain := dc.Name
-
 	ctx := context.Background()
-	records, err := a.getRecords(ctx, domain)
+	records, err := a.getRecords(ctx, dc)
 	if err != nil {
 		return nil, err
 	}

--- a/providers/akamaiedgedns/akamaiEdgeDnsService.go
+++ b/providers/akamaiedgedns/akamaiEdgeDnsService.go
@@ -225,7 +225,7 @@ func (a *edgeDNSProvider) rcToRs(records []*models.RecordConfig) (*dns.RecordBod
 		if r.Type == "AKAMAITLC" {
 			akaRecord.Target = append(akaRecord.Target, r.AnswerType+" "+r.GetTargetField())
 		} else {
-			akaRecord.Target = append(akaRecord.Target, r.GetTargetCombined())
+			akaRecord.Target = append(akaRecord.Target, r.GetRDATA().String())
 		}
 	}
 

--- a/providers/akamaiedgedns/akamaiEdgeDnsService.go
+++ b/providers/akamaiedgedns/akamaiEdgeDnsService.go
@@ -17,7 +17,7 @@ import (
 
 	"github.com/DNSControl/dnscontrol/v5/models"
 	"github.com/DNSControl/dnscontrol/v5/pkg/printer"
-	"github.com/DNSControl/dnscontrol/v5/pkg/txtutil"
+	"github.com/DNSControl/dnscontrol/v5/pkg/privatetypes"
 	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v12/pkg/dns"
 	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v12/pkg/edgegrid"
 	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v12/pkg/session"
@@ -303,7 +303,8 @@ func (a *edgeDNSProvider) deleteRecordset(ctx context.Context, records []*models
 */
 
 // getRecords returns all RecordConfig records in the zone.
-func (a *edgeDNSProvider) getRecords(ctx context.Context, zonename string) ([]*models.RecordConfig, error) {
+func (a *edgeDNSProvider) getRecords(ctx context.Context, dc *models.DomainConfig) ([]*models.RecordConfig, error) {
+	zonename := dc.Name
 	queryArgs := dns.RecordSetQueryArgs{ShowAll: true}
 
 	rsetResp, err := a.client.GetRecordSets(ctx, dns.GetRecordSetsRequest{
@@ -322,6 +323,7 @@ func (a *edgeDNSProvider) getRecords(ctx context.Context, zonename string) ([]*m
 		akaname := akarecset.Name
 		akatype := akarecset.Type
 		akattl := akarecset.TTL
+		label := dc.LabelFromFQDNNoDot(akaname)
 
 		// Don't report the existence of an SOA record (because DnsControl will try to delete the SOA record).
 		if akatype == "SOA" {
@@ -335,10 +337,8 @@ func (a *edgeDNSProvider) getRecords(ctx context.Context, zonename string) ([]*m
 			if len(parts) != 2 {
 				return nil, fmt.Errorf("AKAMAITLC rdata must contain 2 fields, got: %v", akarecset.Rdata)
 			}
-			rc := &models.RecordConfig{Type: akatype, TTL: uint32(akattl)}
-			rc.SetLabelFromFQDN(akaname, zonename)
-			rc.AnswerType = parts[0]
-			if err = rc.SetTarget(parts[1]); err != nil {
+			rc, err := dc.NewRecordConfig(label, uint32(akattl), privatetypes.TypeAKAMAITLC, parts[0], parts[1])
+			if err != nil {
 				return nil, err
 			}
 			rc.Metadata = map[string]string{"akamai_raw_rdata": combined}
@@ -348,20 +348,11 @@ func (a *edgeDNSProvider) getRecords(ctx context.Context, zonename string) ([]*m
 
 		// ... convert the recordset into 1 or more RecordConfig structs
 		for _, r := range akarecset.Rdata {
-			rc := &models.RecordConfig{
-				Type: akatype,
-				TTL:  uint32(akattl),
+			data := r
+			if akatype == "LOC" {
+				data = fixLocAltitude(r)
 			}
-			rc.SetLabelFromFQDN(akaname, zonename)
-
-			switch akatype {
-			case "TXT":
-				err = rc.PopulateFromStringFunc(akatype, r, zonename, txtutil.ParseQuoted)
-			case "LOC":
-				err = rc.PopulateFromString(akatype, fixLocAltitude(r), zonename)
-			default:
-				err = rc.PopulateFromString(akatype, r, zonename)
-			}
+			rc, err := dc.NewRecordConfigParse(label, uint32(akattl), akatype, data)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
Dear @edglynes. I could use your help. I'm doing upgrades to the code base and I have no way to test your provider. Please run the integration test and let me know the result. How to run integration tests is here: https://docs.dnscontrol.org/developer-info/integration-tests

## What changed

- construct Akamai Edge DNS records with `DomainConfig.NewRecordConfig` and `NewRecordConfigParse`
- pass `DomainConfig` into record conversion so labels are created with `LabelFromFQDNNoDot`
- preserve the existing Akamai raw-RDATA metadata and LOC normalization

## Why

This removes legacy `RecordConfig` literals, label setters, and `PopulateFromString` calls as part of the DNSControl v5 provider modernization.

## Impact

The change is limited to `providers/akamaiedgedns` and retains the existing Akamai-specific record handling.

## Validation

- `../../bin/is_modern.sh` (no matches in required Steps 1–5)
- `go test ./providers/akamaiedgedns`
- `bin/generate-all.sh`
- `go test ./...`
