### PR TITLE
CSCGLOBAL: Modernize record conversion

### DIFF
--- a/providers/cscglobal/convert.go
+++ b/providers/cscglobal/convert.go
@@ -3,141 +3,53 @@ package cscglobal
 // Convert the provider's native record description to models.RecordConfig.
 
 import (
-	"net/netip"
-
+	dnsv2 "codeberg.org/miekg/dns"
 	"github.com/DNSControl/dnscontrol/v5/models"
 )
 
-// nativeToRecordA takes an A record from DNS and returns a native RecordConfig struct.
-func nativeToRecordA(nr nativeRecordA, origin string, defaultTTL uint32) *models.RecordConfig {
-	ttl := nr.TTL
+func recordTTL(ttl, defaultTTL uint32) uint32 {
 	if ttl == 0 {
-		ttl = defaultTTL
+		return defaultTTL
 	}
-	rc := &models.RecordConfig{
-		Type: "A",
-		TTL:  ttl,
-	}
-	rc.SetLabel(nr.Key, origin)
-	if err := rc.SetTargetIP(netip.MustParseAddr(nr.Value)); err != nil {
-		panic(err) // Should never happen.
-	}
-	return rc
+	return ttl
+}
+
+// nativeToRecordA takes an A record from DNS and returns a native RecordConfig struct.
+func nativeToRecordA(nr nativeRecordA, dc *models.DomainConfig, defaultTTL uint32) *models.RecordConfig {
+	return dc.MustNewRecordConfig(dc.LabelFromShort(nr.Key), recordTTL(nr.TTL, defaultTTL), dnsv2.TypeA, nr.Value)
 }
 
 // nativeToRecordCNAME takes a CNAME record from DNS and returns a native RecordConfig struct.
-func nativeToRecordCNAME(nr nativeRecordCNAME, origin string, defaultTTL uint32) *models.RecordConfig {
-	ttl := nr.TTL
-	if ttl == 0 {
-		ttl = defaultTTL
-	}
-	rc := &models.RecordConfig{
-		Type: "CNAME",
-		TTL:  ttl,
-	}
-	rc.SetLabel(nr.Key, origin)
-	if err := rc.SetTarget(nr.Value); err != nil {
-		panic(err) // Should never happen.
-	}
-	return rc
+func nativeToRecordCNAME(nr nativeRecordCNAME, dc *models.DomainConfig, defaultTTL uint32) *models.RecordConfig {
+	return dc.MustNewRecordConfig(dc.LabelFromShort(nr.Key), recordTTL(nr.TTL, defaultTTL), dnsv2.TypeCNAME, nr.Value)
 }
 
 // nativeToRecordAAAA takes an AAAA record from DNS and returns a native RecordConfig struct.
-func nativeToRecordAAAA(nr nativeRecordAAAA, origin string, defaultTTL uint32) *models.RecordConfig {
-	ttl := nr.TTL
-	if ttl == 0 {
-		ttl = defaultTTL
-	}
-	rc := &models.RecordConfig{
-		Type: "AAAA",
-		TTL:  ttl,
-	}
-	rc.SetLabel(nr.Key, origin)
-	if err := rc.SetTargetIP(netip.MustParseAddr(nr.Value)); err != nil {
-		panic(err) // Should never happen.
-	}
-	return rc
+func nativeToRecordAAAA(nr nativeRecordAAAA, dc *models.DomainConfig, defaultTTL uint32) *models.RecordConfig {
+	return dc.MustNewRecordConfig(dc.LabelFromShort(nr.Key), recordTTL(nr.TTL, defaultTTL), dnsv2.TypeAAAA, nr.Value)
 }
 
 // nativeToRecordTXT takes a TXT record from DNS and returns a native RecordConfig struct.
-func nativeToRecordTXT(nr nativeRecordTXT, origin string, defaultTTL uint32) *models.RecordConfig {
-	ttl := nr.TTL
-	if ttl == 0 {
-		ttl = defaultTTL
-	}
-	rc := &models.RecordConfig{
-		Type: "TXT",
-		TTL:  ttl,
-	}
-	rc.SetLabel(nr.Key, origin)
-	if err := rc.SetTargetTXT(nr.Value); err != nil {
-		panic(err) // Should never happen.
-	}
-	return rc
+func nativeToRecordTXT(nr nativeRecordTXT, dc *models.DomainConfig, defaultTTL uint32) *models.RecordConfig {
+	return dc.MustNewRecordConfig(dc.LabelFromShort(nr.Key), recordTTL(nr.TTL, defaultTTL), dnsv2.TypeTXT, nr.Value)
 }
 
-// nativeToRecordMX takes a MX record from DNS and returns a native RecordConfig struct.
-func nativeToRecordMX(nr nativeRecordMX, origin string, defaultTTL uint32) *models.RecordConfig {
-	ttl := nr.TTL
-	if ttl == 0 {
-		ttl = defaultTTL
-	}
-	rc := &models.RecordConfig{
-		Type: "MX",
-		TTL:  ttl,
-	}
-	rc.SetLabel(nr.Key, origin)
-	if err := rc.SetTargetMX(nr.Priority, nr.Value); err != nil {
-		panic(err) // Should never happen.
-	}
-	return rc
+// nativeToRecordMX takes an MX record from DNS and returns a native RecordConfig struct.
+func nativeToRecordMX(nr nativeRecordMX, dc *models.DomainConfig, defaultTTL uint32) *models.RecordConfig {
+	return dc.MustNewRecordConfig(dc.LabelFromShort(nr.Key), recordTTL(nr.TTL, defaultTTL), dnsv2.TypeMX, nr.Priority, nr.Value)
 }
 
 // nativeToRecordNS takes a NS record from DNS and returns a native RecordConfig struct.
-func nativeToRecordNS(nr nativeRecordNS, origin string, defaultTTL uint32) *models.RecordConfig {
-	ttl := nr.TTL
-	if ttl == 0 {
-		ttl = defaultTTL
-	}
-	rc := &models.RecordConfig{
-		Type: "NS",
-		TTL:  ttl,
-	}
-	rc.SetLabel(nr.Key, origin)
-	rc.MustSetTarget(nr.Value)
-	return rc
+func nativeToRecordNS(nr nativeRecordNS, dc *models.DomainConfig, defaultTTL uint32) *models.RecordConfig {
+	return dc.MustNewRecordConfig(dc.LabelFromShort(nr.Key), recordTTL(nr.TTL, defaultTTL), dnsv2.TypeNS, nr.Value)
 }
 
 // nativeToRecordSRV takes a SRV record from DNS and returns a native RecordConfig struct.
-func nativeToRecordSRV(nr nativeRecordSRV, origin string, defaultTTL uint32) *models.RecordConfig {
-	ttl := nr.TTL
-	if ttl == 0 {
-		ttl = defaultTTL
-	}
-	rc := &models.RecordConfig{
-		Type: "SRV",
-		TTL:  ttl,
-	}
-	rc.SetLabel(nr.Key, origin)
-	if err := rc.SetTargetSRV(nr.Priority, nr.Weight, nr.Port, nr.Value); err != nil {
-		panic(err) // Should never happen.
-	}
-	return rc
+func nativeToRecordSRV(nr nativeRecordSRV, dc *models.DomainConfig, defaultTTL uint32) *models.RecordConfig {
+	return dc.MustNewRecordConfig(dc.LabelFromShort(nr.Key), recordTTL(nr.TTL, defaultTTL), dnsv2.TypeSRV, nr.Priority, nr.Weight, nr.Port, nr.Value)
 }
 
 // nativeToRecordCAA takes a CAA record from DNS and returns a native RecordConfig struct.
-func nativeToRecordCAA(nr nativeRecordCAA, origin string, defaultTTL uint32) *models.RecordConfig {
-	ttl := nr.TTL
-	if ttl == 0 {
-		ttl = defaultTTL
-	}
-	rc := &models.RecordConfig{
-		Type: "CAA",
-		TTL:  ttl,
-	}
-	rc.SetLabel(nr.Key, origin)
-	if err := rc.SetTargetCAA(nr.Flag, nr.Tag, nr.Value); err != nil {
-		panic(err) // Should never happen.
-	}
-	return rc
+func nativeToRecordCAA(nr nativeRecordCAA, dc *models.DomainConfig, defaultTTL uint32) *models.RecordConfig {
+	return dc.MustNewRecordConfig(dc.LabelFromShort(nr.Key), recordTTL(nr.TTL, defaultTTL), dnsv2.TypeCAA, nr.Flag, nr.Tag, nr.Value)
 }

--- a/providers/cscglobal/convert_test.go
+++ b/providers/cscglobal/convert_test.go
@@ -1,0 +1,25 @@
+package cscglobal
+
+import (
+	"testing"
+
+	"github.com/DNSControl/dnscontrol/v5/models"
+)
+
+func TestNativeRecordConversion(t *testing.T) {
+	t.Parallel()
+
+	dc := models.MustNewDomainConfig("example.com")
+	a := nativeToRecordA(nativeRecordA{Key: "www", Value: "192.0.2.1"}, dc, 600)
+	if a.TTL != 600 || a.GetRDATA().String() != "192.0.2.1" {
+		t.Errorf("unexpected A conversion: TTL=%d RDATA=%q", a.TTL, a.GetRDATA().String())
+	}
+
+	srv := nativeToRecordSRV(nativeRecordSRV{
+		Key: "_sip._tcp", Value: "service.example.net.", TTL: 300,
+		Priority: 1, Weight: 2, Port: 443,
+	}, dc, 600)
+	if got := srv.GetRDATA().String(); got != "1 2 443 service.example.net." {
+		t.Errorf("unexpected SRV conversion: %q", got)
+	}
+}

--- a/providers/cscglobal/dns.go
+++ b/providers/cscglobal/dns.go
@@ -18,7 +18,7 @@ func (client *providerClient) GetZoneRecords(dc *models.DomainConfig) (models.Re
 
 	// Convert them to DNScontrol's native format:
 
-	existingRecords := []*models.RecordConfig{}
+	existingRecords := models.Records{}
 
 	// Option 1: One long list.  If your provider returns one long list,
 	// convert each one to RecordType like this:
@@ -41,28 +41,28 @@ func (client *providerClient) GetZoneRecords(dc *models.DomainConfig) (models.Re
 	// RecordConfig structures.
 	defaultTTL := records.Soa.TTL
 	for _, rr := range records.A {
-		existingRecords = append(existingRecords, nativeToRecordA(rr, domain, defaultTTL))
+		existingRecords = append(existingRecords, nativeToRecordA(rr, dc, defaultTTL))
 	}
 	for _, rr := range records.Cname {
-		existingRecords = append(existingRecords, nativeToRecordCNAME(rr, domain, defaultTTL))
+		existingRecords = append(existingRecords, nativeToRecordCNAME(rr, dc, defaultTTL))
 	}
 	for _, rr := range records.Aaaa {
-		existingRecords = append(existingRecords, nativeToRecordAAAA(rr, domain, defaultTTL))
+		existingRecords = append(existingRecords, nativeToRecordAAAA(rr, dc, defaultTTL))
 	}
 	for _, rr := range records.Txt {
-		existingRecords = append(existingRecords, nativeToRecordTXT(rr, domain, defaultTTL))
+		existingRecords = append(existingRecords, nativeToRecordTXT(rr, dc, defaultTTL))
 	}
 	for _, rr := range records.Mx {
-		existingRecords = append(existingRecords, nativeToRecordMX(rr, domain, defaultTTL))
+		existingRecords = append(existingRecords, nativeToRecordMX(rr, dc, defaultTTL))
 	}
 	for _, rr := range records.Ns {
-		existingRecords = append(existingRecords, nativeToRecordNS(rr, domain, defaultTTL))
+		existingRecords = append(existingRecords, nativeToRecordNS(rr, dc, defaultTTL))
 	}
 	for _, rr := range records.Srv {
-		existingRecords = append(existingRecords, nativeToRecordSRV(rr, domain, defaultTTL))
+		existingRecords = append(existingRecords, nativeToRecordSRV(rr, dc, defaultTTL))
 	}
 	for _, rr := range records.Caa {
-		existingRecords = append(existingRecords, nativeToRecordCAA(rr, domain, defaultTTL))
+		existingRecords = append(existingRecords, nativeToRecordCAA(rr, dc, defaultTTL))
 	}
 
 	return existingRecords, nil


### PR DESCRIPTION
Dear @mikenz. I could use your help. I'm doing upgrades to the code base and I have no way to test your provider. Please run the integration test and let me know the result. How to run integration tests is here: https://docs.dnscontrol.org/developer-info/integration-tests

## What changed

- construct CSC Global records with the v3 `DomainConfig` factories and typed constants
- centralize the provider's existing default-TTL behavior
- pass the existing `DomainConfig` through each native conversion
- add focused A/default-TTL and SRV conversion coverage

## Why

This removes legacy `RecordConfig` literals and target setters as part of the DNSControl v5 provider modernization.

## Impact

Changes are limited to `providers/cscglobal`; the native record mappings and TTL fallback remain unchanged.

## Validation

- `../../bin/is_modern.sh` (no matches in required Steps 1–5)
- `go test ./providers/cscglobal`
- `bin/generate-all.sh`
- `go test ./...`
