### PR TITLE
oracle: Modernize record conversion

### DIFF
--- a/providers/oracle/oracleProvider.go
+++ b/providers/oracle/oracleProvider.go
@@ -213,23 +213,21 @@ func (o *oracleProvider) GetZoneRecords(dc *models.DomainConfig) (models.Records
 				continue
 			}
 
-			rc := &models.RecordConfig{
-				Type:     *record.Rtype,
-				TTL:      uint32(*record.Ttl),
-				Original: record,
-			}
-			rc.SetLabelFromFQDN(*record.Domain, zone)
+			label := dc.LabelFromFQDNNoDot(*record.Domain)
+			ttl := uint32(*record.Ttl)
+			var rc *models.RecordConfig
 
-			switch rc.Type {
+			switch *record.Rtype {
 			case "ALIAS":
-				err = rc.SetTarget(*record.Rdata)
+				rc, err = dc.NewRecordConfig(label, ttl, *record.Rtype, *record.Rdata)
 			default:
-				err = rc.PopulateFromString(*record.Rtype, *record.Rdata, zone)
+				rc, err = dc.NewRecordConfigParse(label, ttl, *record.Rtype, *record.Rdata)
 			}
 
 			if err != nil {
 				return nil, err
 			}
+			rc.Original = record
 
 			records = append(records, rc)
 		}
@@ -356,7 +354,7 @@ func convertToRecordOperation(rec *models.RecordConfig, op dns.RecordOperationOp
 
 	fqdn := rec.GetLabelFQDN()
 	rtype := rec.Type
-	rdata := rec.GetTargetCombined()
+	rdata := rec.GetRDATA().String()
 	ttl := int(rec.TTL)
 
 	return dns.RecordOperation{


### PR DESCRIPTION
Dear @kallsyms. I could use your help. I'm doing upgrades to the code base and I have no way to test your provider. Please run the integration test and let me know the result. How to run integration tests is here: https://docs.dnscontrol.org/developer-info/integration-tests

## Summary

- build downloaded Oracle records with modern record factories
- precompute labels and TTLs shared by conversion branches
- use modern RDATA serialization for record operations

## Validation

- `../../bin/is_modern.sh` (Steps 1-7 clean)
- `go test ./providers/oracle`
- `bin/generate-all.sh`
- `go test ./...`
