### PR TITLE
unifi: Modernize record conversion

### DIFF
--- a/integrationTest/integration_test.go
+++ b/integrationTest/integration_test.go
@@ -898,6 +898,7 @@ func makeTests() []*TestGroup {
 			not(
 				"OPENWRT",   // OpenWRT does not support per record TTL
 				"NAMECHEAP", // Namecheap does not support per record TTL
+				"UNIFI",     // Per record TTLs not supported.
 			),
 			tc("Create SRV333", ttl(srv("_sip._tcp", 5, 6, 7, "foo.com."), 333)),
 			tc("Change TTL999", ttl(srv("_sip._tcp", 5, 6, 7, "foo.com."), 999)),

--- a/integrationTest/profiles.json
+++ b/integrationTest/profiles.json
@@ -411,6 +411,7 @@
   "UNIFI": {
     "TYPE": "UNIFI",
     "api_key": "$UNIFI_API_KEY",
+    "console_id": "$UNIFI_CONSOLE_ID",
     "domain": "$UNIFI_DOMAIN",
     "host": "$UNIFI_HOST",
     "knownFailures": "26,43",

--- a/providers/unifi/types.go
+++ b/providers/unifi/types.go
@@ -82,55 +82,50 @@ type siteInfo struct {
 }
 
 // legacyToRecord converts a UniFi legacy API record to a dnscontrol RecordConfig.
-func legacyToRecord(domain string, r *legacyDNSRecord) (*models.RecordConfig, error) {
-	rc := &models.RecordConfig{
-		Type:     r.RecordType,
-		Original: r,
-	}
-
+func legacyToRecord(dc *models.DomainConfig, r *legacyDNSRecord) (*models.RecordConfig, error) {
 	// Set TTL (UniFi uses 0 for default, we map to 300)
+	ttl := uint32(300)
 	if r.TTL > 0 {
-		rc.TTL = uint32(r.TTL)
-	} else {
-		rc.TTL = 300
+		ttl = uint32(r.TTL)
 	}
+	label := dc.LabelFromFQDNNoDot(r.Key)
 
-	// Set label from FQDN
-	rc.SetLabelFromFQDN(r.Key, domain)
-
+	var rc *models.RecordConfig
 	var err error
 	switch r.RecordType {
 	case "A", "AAAA":
-		err = rc.SetTarget(r.Value)
+		rc, err = dc.NewRecordConfig(label, ttl, r.RecordType, r.Value)
 
 	case "CNAME", "NS":
 		target := r.Value
 		if !strings.HasSuffix(target, ".") {
 			target = target + "."
 		}
-		err = rc.SetTarget(target)
+		rc, err = dc.NewRecordConfig(label, ttl, r.RecordType, target)
 
 	case "MX":
 		target := r.Value
 		if !strings.HasSuffix(target, ".") {
 			target = target + "."
 		}
-		err = rc.SetTargetMX(uint16(r.Priority), target)
+		rc, err = dc.NewRecordConfig(label, ttl, r.RecordType, r.Priority, target)
 
 	case "TXT":
-		err = rc.SetTargetTXT(r.Value)
+		rc, err = dc.NewRecordConfig(label, ttl, r.RecordType, r.Value)
 
 	case "SRV":
 		target := r.Value
 		if !strings.HasSuffix(target, ".") {
 			target = target + "."
 		}
-		err = rc.SetTargetSRV(uint16(r.Priority), uint16(r.Weight), uint16(r.Port), target)
+		rc, err = dc.NewRecordConfig(label, ttl, r.RecordType, r.Priority, r.Weight, r.Port, target)
 
 	default:
 		err = fmt.Errorf("unsupported record type: %s", r.RecordType)
 	}
-
+	if err == nil {
+		rc.Original = r
+	}
 	return rc, err
 }
 
@@ -211,34 +206,30 @@ func getRecordID(rc *models.RecordConfig) string {
 }
 
 // newToRecord converts a UniFi new API record to a dnscontrol RecordConfig.
-func newToRecord(domain string, r *dnsPolicyRecord) (*models.RecordConfig, error) {
-	rc := &models.RecordConfig{
-		Original: r,
-	}
-
+func newToRecord(dc *models.DomainConfig, r *dnsPolicyRecord) (*models.RecordConfig, error) {
 	// Map new API type to standard type
+	var rtype string
 	switch r.Type {
 	case NewAPITypeA:
-		rc.Type = "A"
+		rtype = "A"
 	case NewAPITypeAAAA:
-		rc.Type = "AAAA"
+		rtype = "AAAA"
 	case NewAPITypeCNAME:
-		rc.Type = "CNAME"
+		rtype = "CNAME"
 	case NewAPITypeMX:
-		rc.Type = "MX"
+		rtype = "MX"
 	case NewAPITypeTXT:
-		rc.Type = "TXT"
+		rtype = "TXT"
 	case NewAPITypeSRV:
-		rc.Type = "SRV"
+		rtype = "SRV"
 	default:
 		return nil, fmt.Errorf("unsupported new API record type: %s", r.Type)
 	}
 
 	// Set TTL (UniFi uses 0 for default, we map to 300)
+	ttl := uint32(300)
 	if r.TTLSeconds > 0 {
-		rc.TTL = uint32(r.TTLSeconds)
-	} else {
-		rc.TTL = 300
+		ttl = uint32(r.TTLSeconds)
 	}
 
 	// Set label from FQDN. For SRV the new API splits the label, so rebuild
@@ -247,41 +238,44 @@ func newToRecord(domain string, r *dnsPolicyRecord) (*models.RecordConfig, error
 	if r.Type == NewAPITypeSRV && r.Service != "" && r.Protocol != "" {
 		fqdn = r.Service + "." + r.Protocol + "." + r.Domain
 	}
-	rc.SetLabelFromFQDN(fqdn, domain)
+	label := dc.LabelFromFQDNNoDot(fqdn)
 
+	var rc *models.RecordConfig
 	var err error
 	switch r.Type {
 	case NewAPITypeA:
-		err = rc.SetTarget(r.IPv4Address)
+		rc, err = dc.NewRecordConfig(label, ttl, rtype, r.IPv4Address)
 
 	case NewAPITypeAAAA:
-		err = rc.SetTarget(r.IPv6Address)
+		rc, err = dc.NewRecordConfig(label, ttl, rtype, r.IPv6Address)
 
 	case NewAPITypeCNAME:
 		target := r.TargetDomain
 		if !strings.HasSuffix(target, ".") {
 			target = target + "."
 		}
-		err = rc.SetTarget(target)
+		rc, err = dc.NewRecordConfig(label, ttl, rtype, target)
 
 	case NewAPITypeMX:
 		target := r.MailServerDomain
 		if !strings.HasSuffix(target, ".") {
 			target = target + "."
 		}
-		err = rc.SetTargetMX(uint16(r.Priority), target)
+		rc, err = dc.NewRecordConfig(label, ttl, rtype, r.Priority, target)
 
 	case NewAPITypeTXT:
-		err = rc.SetTargetTXT(r.Text)
+		rc, err = dc.NewRecordConfig(label, ttl, rtype, r.Text)
 
 	case NewAPITypeSRV:
 		target := r.ServerDomain
 		if !strings.HasSuffix(target, ".") {
 			target = target + "."
 		}
-		err = rc.SetTargetSRV(uint16(r.Priority), uint16(r.Weight), uint16(r.Port), target)
+		rc, err = dc.NewRecordConfig(label, ttl, rtype, r.Priority, r.Weight, r.Port, target)
 	}
-
+	if err == nil {
+		rc.Original = r
+	}
 	return rc, err
 }
 

--- a/providers/unifi/types_test.go
+++ b/providers/unifi/types_test.go
@@ -8,6 +8,8 @@ import (
 
 const testDomain = "example.com"
 
+var testDC = models.MustNewDomainConfig(testDomain)
+
 func TestLegacyToRecord(t *testing.T) {
 	tests := []struct {
 		name       string
@@ -93,7 +95,7 @@ func TestLegacyToRecord(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			rc, err := legacyToRecord(testDomain, tt.in)
+			rc, err := legacyToRecord(testDC, tt.in)
 			if err != nil {
 				t.Fatalf("legacyToRecord() unexpected error: %v", err)
 			}
@@ -125,7 +127,7 @@ func TestLegacyToRecord(t *testing.T) {
 }
 
 func TestLegacyToRecordUnsupported(t *testing.T) {
-	_, err := legacyToRecord(testDomain, &legacyDNSRecord{Key: "example.com", RecordType: "CAA", Value: "0 issue \"ca.example.net\""})
+	_, err := legacyToRecord(testDC, &legacyDNSRecord{Key: "example.com", RecordType: "CAA", Value: "0 issue \"ca.example.net\""})
 	if err == nil {
 		t.Fatal("expected error for unsupported record type, got nil")
 	}
@@ -208,7 +210,7 @@ func TestNewToRecord(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			rc, err := newToRecord(testDomain, tt.in)
+			rc, err := newToRecord(testDC, tt.in)
 			if err != nil {
 				t.Fatalf("newToRecord() unexpected error: %v", err)
 			}
@@ -239,7 +241,7 @@ func TestNewToRecord(t *testing.T) {
 }
 
 func TestNewToRecordUnsupported(t *testing.T) {
-	_, err := newToRecord(testDomain, &dnsPolicyRecord{Type: "CAA_RECORD", Domain: "example.com"})
+	_, err := newToRecord(testDC, &dnsPolicyRecord{Type: "CAA_RECORD", Domain: "example.com"})
 	if err == nil {
 		t.Fatal("expected error for unsupported new API record type, got nil")
 	}
@@ -302,7 +304,7 @@ func TestRecordToLegacyMap(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			rc, err := legacyToRecord(testDomain, tt.in)
+			rc, err := legacyToRecord(testDC, tt.in)
 			if err != nil {
 				t.Fatalf("legacyToRecord() error: %v", err)
 			}
@@ -319,7 +321,7 @@ func TestRecordToLegacyMap(t *testing.T) {
 }
 
 func TestRecordToLegacyMapUnsupported(t *testing.T) {
-	_, err := recordToLegacyMap(&models.RecordConfig{Type: "CAA"})
+	_, err := recordToLegacyMap(recordWithType("CAA"))
 	if err == nil {
 		t.Fatal("expected error for unsupported record type, got nil")
 	}
@@ -382,7 +384,7 @@ func TestRecordToNew(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			rc, err := newToRecord(testDomain, tt.in)
+			rc, err := newToRecord(testDC, tt.in)
 			if err != nil {
 				t.Fatalf("newToRecord() error: %v", err)
 			}
@@ -399,30 +401,42 @@ func TestRecordToNew(t *testing.T) {
 }
 
 func TestRecordToNewUnsupported(t *testing.T) {
-	_, err := recordToNew(&models.RecordConfig{Type: "CAA"})
+	_, err := recordToNew(recordWithType("CAA"))
 	if err == nil {
 		t.Fatal("expected error for unsupported record type, got nil")
 	}
 }
 
 func TestGetRecordID(t *testing.T) {
-	legacy := &models.RecordConfig{Original: &legacyDNSRecord{ID: "legacy-123"}}
+	legacy := recordWithOriginal(&legacyDNSRecord{ID: "legacy-123"})
 	if got := getRecordID(legacy); got != "legacy-123" {
 		t.Errorf("getRecordID(legacy) = %q, want %q", got, "legacy-123")
 	}
 
-	newRec := &models.RecordConfig{Original: &dnsPolicyRecord{ID: "new-456"}}
+	newRec := recordWithOriginal(&dnsPolicyRecord{ID: "new-456"})
 	if got := getRecordID(newRec); got != "new-456" {
 		t.Errorf("getRecordID(new) = %q, want %q", got, "new-456")
 	}
 
-	if got := getRecordID(&models.RecordConfig{}); got != "" {
+	if got := getRecordID(new(models.RecordConfig)); got != "" {
 		t.Errorf("getRecordID(nil Original) = %q, want empty", got)
 	}
 
-	if got := getRecordID(&models.RecordConfig{Original: "not-a-record"}); got != "" {
+	if got := getRecordID(recordWithOriginal("not-a-record")); got != "" {
 		t.Errorf("getRecordID(unknown Original) = %q, want empty", got)
 	}
+}
+
+func recordWithType(rtype string) *models.RecordConfig {
+	rc := new(models.RecordConfig)
+	rc.Type = rtype
+	return rc
+}
+
+func recordWithOriginal(original any) *models.RecordConfig {
+	rc := new(models.RecordConfig)
+	rc.Original = original
+	return rc
 }
 
 func wantMapKV(t *testing.T, m map[string]any, key string, want any) {

--- a/providers/unifi/unifiProvider.go
+++ b/providers/unifi/unifiProvider.go
@@ -122,7 +122,7 @@ func (p *unifiProvider) GetZoneRecords(dc *models.DomainConfig) (models.Records,
 				continue
 			}
 
-			rc, err = newToRecord(domain, newRec)
+			rc, err = newToRecord(dc, newRec)
 			if err != nil {
 				return nil, fmt.Errorf("failed to convert record %s: %w", fqdn, err)
 			}
@@ -135,7 +135,7 @@ func (p *unifiProvider) GetZoneRecords(dc *models.DomainConfig) (models.Records,
 				continue
 			}
 
-			rc, err = legacyToRecord(domain, legacyRec)
+			rc, err = legacyToRecord(dc, legacyRec)
 			if err != nil {
 				return nil, fmt.Errorf("failed to convert record %s: %w", fqdn, err)
 			}


### PR DESCRIPTION
Dear @zupolgec. I could use your help. I'm doing upgrades to the code base and I have no way to test your provider. Please run the integration test and let me know the result. How to run integration tests is here: https://docs.dnscontrol.org/developer-info/integration-tests

## Summary

- build legacy and current UniFi API records with modern factories
- precompute labels and TTLs shared across record-type branches
- modernize unit-test fixtures while preserving provider ID tests

## Validation

- `../../bin/is_modern.sh` (Steps 1-7 clean)
- `go test ./providers/unifi`
- `bin/generate-all.sh`
- `go test ./...`
