### PR TITLE
CICD: Don't double-cache Go artifacts

### DIFF
--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -19,10 +19,6 @@ permissions:
 
 # Environment Variables
 env:
-  # cache-key: Change to force cache reset `pwsh > Get-Date -UFormat %s`
-  cache-key: 1639697695
-  # go-mod-path: Where go-mod writes temp files
-  go-mod-path: /go/pkg/mod
   # BIND_DOMAIN: BIND is the one providers that we always test. By
   # defining this here, we know it will always be set.
   BIND_DOMAIN: example.com
@@ -40,15 +36,11 @@ jobs:
       with:
         fetch-depth: 0
     - name: Set up Go
+      # setup-go caches the Go module + build cache (keyed on go.sum) by
+      # default; no separate actions/cache step is needed.
       uses: actions/setup-go@v7
       with:
         go-version: stable
-    - name: restore_cache
-      uses: actions/cache@v6.1.0
-      with:
-        key: linux-go-${{ hashFiles('go.sum') }}-${{ env.cache-key }}
-        restore-keys: linux-go-${{ hashFiles('go.sum') }}-${{ env.cache-key }}
-        path: ${{ env.go-mod-path }}
     - run: mkdir -p "$TEST_RESULTS"
     - name: Run unit tests
       run: |

--- a/.github/workflows/pr_integration_tests.yml
+++ b/.github/workflows/pr_integration_tests.yml
@@ -40,10 +40,6 @@ on:
 
 # Environment Variables
 env:
-  # cache-key: Change to force cache reset (e.g. `date +%s`)
-  cache-key: 1639697695
-  # go-mod-path: Where go-mod writes temp files
-  go-mod-path: /go/pkg/mod
   # BIND_DOMAIN: BIND is the one providers that we always test. By
   # defining this here, we know it will always be set.
   BIND_DOMAIN: example.com
@@ -282,13 +278,14 @@ jobs:
         provider: ${{ fromJson(needs.integration-test-providers.outputs.integration_test_providers )}}
     steps:
       - uses: actions/checkout@v7
-      - run: mkdir -p "$TEST_RESULTS"
-      - name: restore_cache
-        uses: actions/cache@v6.1.0
+      # setup-go caches the module + build cache (keyed on go.sum). Its cache
+      # key matches the other jobs' setup-go (same OS/arch/go-version), so they
+      # share one cache family instead of maintaining a second, redundant
+      # actions/cache entry that pushed the repo over the 10 GB cache limit.
+      - uses: actions/setup-go@v7
         with:
-          key: linux-go-${{ hashFiles('go.sum') }}-${{ env.cache-key }}
-          restore-keys: linux-go-${{ hashFiles('go.sum') }}-${{ env.cache-key }}
-          path: ${{ env.go-mod-path }}
+          go-version: "1.26"
+      - run: mkdir -p "$TEST_RESULTS"
       - name: Set END value for PRs
         # For PRs we only run a smoke test (the first 3 tests) to save time.
         # For pushes to main or if the PR has the 'longtest' label, we run all tests.

--- a/.github/workflows/pr_integration_tests.yml
+++ b/.github/workflows/pr_integration_tests.yml
@@ -40,7 +40,7 @@ on:
 
 # Environment Variables
 env:
-  # cache-key: Change to force cache reset `pwsh > Get-Date -UFormat %s`
+  # cache-key: Change to force cache reset (e.g. `date +%s`)
   cache-key: 1639697695
   # go-mod-path: Where go-mod writes temp files
   go-mod-path: /go/pkg/mod
@@ -65,24 +65,28 @@ jobs:
           sparse-checkout-cone-mode: false
       - name: Set Integration Test Providers
         id: get_integration_test_providers
-        shell: pwsh
+        shell: bash
+        # A provider is enabled for testing when its <PROVIDER>_DOMAIN is set.
+        # Those values live in the `env` and `vars` contexts (see the
+        # integration-tests job, which reads every *_DOMAIN from vars.*), so we
+        # only inspect those two. We deliberately do NOT read `toJson(secrets)`:
+        # that would copy every org/repo secret onto the runner (CodeQL
+        # "actions/excessive-secrets-exposure"), and no *_DOMAIN is stored as a
+        # secret anyway.
         run: |
-          $Providers = @()
-          $AllProviders = (Get-Content integrationTest/profiles.json | ConvertFrom-Json -AsHashtable).Keys
-          $EnvContext = ConvertFrom-Json -InputObject $env:ENV_CONTEXT
-          $VarsContext = ConvertFrom-Json -InputObject $env:VARS_CONTEXT
-          $SecretsContext = ConvertFrom-Json -InputObject $env:SECRETS_CONTEXT
-          $AllProviders | ForEach-Object {
-            if(($null -ne $EnvContext."$($_)_DOMAIN") -or ($null -ne $VarsContext."$($_)_DOMAIN") -or ($null -ne $SecretsContext."$($_)_DOMAIN")) {
-              $Providers += $_
-            }
-          }
-          Write-Host "Integration test providers: $Providers"
-          echo "integration_test_providers=$(ConvertTo-Json -InputObject $Providers -Compress)" >> $env:GITHUB_OUTPUT
+          set -euo pipefail
+          providers="$(
+            jq -c \
+              --argjson env "$ENV_CONTEXT" \
+              --argjson vars "$VARS_CONTEXT" \
+              '[ keys_unsorted[] | select( ($env[. + "_DOMAIN"] // $vars[. + "_DOMAIN"]) != null ) ]' \
+              integrationTest/profiles.json
+          )"
+          echo "Integration test providers: $providers"
+          echo "integration_test_providers=$providers" >> "$GITHUB_OUTPUT"
         env:
           ENV_CONTEXT: ${{ toJson(env) }}
           VARS_CONTEXT: ${{ toJson(vars) }}
-          SECRETS_CONTEXT: ${{ toJson(secrets) }}
 
   # integration-tests: Run the integration tests on any provider listed
   # in needs.integration-test-providers.outputs.integration_test_providers.


### PR DESCRIPTION
  - pr_build.yml: remove the redundant actions/cache step; rely on setup-go.
  - pr_integration_tests.yml: remove the manual cache and add actions/setup-go
    to the integration-tests job so it shares the single setup-go cache family
    instead of maintaining a second one.
  - Remove the now-dead cache-key and go-mod-path env vars from both.

  This frees ~4.6 GB (total ~10.6 GB -> ~6 GB), ends eviction, and lets the setup-go build cache persist between runs.