### PR TITLE
CICD: Cancel superseded PR runs; pin tools; shallow checkout

### DIFF
--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -14,6 +14,11 @@ on:
     branches:
       - 'tlim_testpr'
 
+concurrency:
+  # Cancel superseded runs when new commits are pushed to the same PR/branch.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
@@ -33,8 +38,6 @@ jobs:
       TEST_RESULTS: "/tmp/test-results"
     steps:
     - uses: actions/checkout@v7
-      with:
-        fetch-depth: 0
     - name: Set up Go
       # setup-go caches the Go module + build cache (keyed on go.sum) by
       # default; no separate actions/cache step is needed.
@@ -44,7 +47,7 @@ jobs:
     - run: mkdir -p "$TEST_RESULTS"
     - name: Run unit tests
       run: |
-        go install gotest.tools/gotestsum@latest
+        go install gotest.tools/gotestsum@v1.13.0
         gotestsum --junitfile ${TEST_RESULTS}/gotestsum-report.xml -- $PACKAGE_NAMES
 #    - name: Enforce Go Formatted Code
 #      run: "[ `go fmt ./... | wc -l` -eq 0 ]"
@@ -54,11 +57,9 @@ jobs:
         path: ${{ env.TEST_RESULTS }}
 
 # build: Use GoReleaser to build binaries for all platforms.
-
-    # Stringer is needed because .goreleaser includes "go generate ./..."
-    - name: Install stringer
-      run: |
-        go install golang.org/x/tools/cmd/stringer@latest
+# No separate stringer install: .goreleaser's "go generate" uses the pinned
+# `go tool stringer` (a go.mod tool directive), so an @latest install is
+# redundant.
 
     -
       id: build_binaries_tagged

--- a/.github/workflows/pr_check_git_status.yml
+++ b/.github/workflows/pr_check_git_status.yml
@@ -6,6 +6,11 @@ on:
   pull_request:
   workflow_dispatch:
 
+concurrency:
+  # Cancel superseded runs when new commits are pushed to the same PR/branch.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
@@ -92,7 +97,8 @@ jobs:
       - uses: actions/setup-go@v7
         with:
           go-version: stable
-      - run: go install golang.org/x/tools/cmd/stringer@latest
+      # No stringer install: the go:generate directives use `go tool stringer`,
+      # pinned via the go.mod tool directive.
       - run: go generate ./...
       - uses: CatChen/check-git-status-action@v2
         with:

--- a/.github/workflows/pr_integration_tests.yml
+++ b/.github/workflows/pr_integration_tests.yml
@@ -3,6 +3,11 @@ name: "PR: Run INTEGRATION tests"
 permissions:
   contents: read
 
+concurrency:
+  # Cancel superseded runs when new commits are pushed to the same PR/branch.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 # When will this pipeline be activated?
 # 1. If someone pushes to a branch called "tlim_testpr".
 # 2. On a schedule (currently set to run every day at 4am UTC).
@@ -343,7 +348,7 @@ jobs:
         run: |-
           #
           echo "END: Running tests 0 to $END"
-          go install gotest.tools/gotestsum@latest
+          go install gotest.tools/gotestsum@v1.13.0
           if [ -n "$${{ matrix.provider }}_DOMAIN" ] ; then
             # NB(tlim): THe output of gotestsum needs to go to stdout AND the
             # gotestsum-output.txt file. That's why "tee" is used.

--- a/.github/workflows/pr_lint.yml
+++ b/.github/workflows/pr_lint.yml
@@ -8,6 +8,11 @@ on:
     branches:
       - "tlim_testpr"
 
+concurrency:
+  # Cancel superseded runs when new commits are pushed to the same PR/branch.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   golangci-lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
A) Add workflow-level concurrency with cancel-in-progress to the four PR
   workflows (pr_build, pr_check_git_status, pr_lint, pr_integration_tests)
   so pushing new commits to a PR cancels the superseded runs instead of
   letting stale runs finish. Frees runners and speeds feedback.

C) Stop installing tools from @latest:
   - Remove the redundant 'go install stringer@latest' steps: go generate already uses 'go tool stringer' (a pinned go.mod tool directive), so the install was unused.
   - Pin gotestsum to v1.13.0 (was @latest) in pr_build and pr_integration_tests for reproducibility and build-cache reuse.

D) Drop 'fetch-depth: 0' from pr_build's checkout; full history is only needed
   for the GoReleaser changelog on tags, not for a snapshot build.

(release_draft.yml intentionally left as-is: it's the release path.)

