### PR TITLE
TRANSIP: Fix TXT bug

### DIFF
--- a/providers/transip/transipProvider.go
+++ b/providers/transip/transipProvider.go
@@ -266,17 +266,10 @@ func recordToNative(config *models.RecordConfig) (domain.DNSEntry, error) {
 
 func nativeToRecord(entry domain.DNSEntry, dc *models.DomainConfig) (*models.RecordConfig, error) {
 	label := dc.LabelFromShort(entry.Name)
-	var rc *models.RecordConfig
-	var err error
-	if entry.Type == "TXT" {
-		rc, err = dc.NewRecordConfig(label, uint32(entry.Expire), entry.Type, entry.Content)
-	} else {
-		rc, err = dc.NewRecordConfigParse(label, uint32(entry.Expire), entry.Type, entry.Content)
-	}
+	rc, err := dc.NewRecordConfigParse(label, uint32(entry.Expire), entry.Type, entry.Content)
 	if err != nil {
 		return nil, fmt.Errorf("unparsable record received from TransIP: %w", err)
 	}
-	rc.Original = entry
 	return rc, nil
 }
 

--- a/providers/transip/transipProvider.go
+++ b/providers/transip/transipProvider.go
@@ -268,7 +268,11 @@ func nativeToRecord(entry domain.DNSEntry, dc *models.DomainConfig) (*models.Rec
 	label := dc.LabelFromShort(entry.Name)
 	var rc *models.RecordConfig
 	var err error
-	rc, err = dc.NewRecordConfigParse(label, uint32(entry.Expire), entry.Type, entry.Content)
+	if entry.Type == "TXT" {
+		rc, err = dc.NewRecordConfig(label, uint32(entry.Expire), entry.Type, entry.Content)
+	} else {
+		rc, err = dc.NewRecordConfigParse(label, uint32(entry.Expire), entry.Type, entry.Content)
+	}
 	if err != nil {
 		return nil, fmt.Errorf("unparsable record received from TransIP: %w", err)
 	}

--- a/providers/transip/transipProvider_test.go
+++ b/providers/transip/transipProvider_test.go
@@ -29,9 +29,6 @@ func TestNativeToRecordUsesV3RecordConfig(t *testing.T) {
 			if got.NameFQDN != tt.want.NameFQDN || got.TTL != tt.want.TTL || got.TypeNum != tt.want.TypeNum || got.GetRDATA().String() != tt.want.GetRDATA().String() {
 				t.Errorf("nativeToRecord() = %s %d IN %s %s, want %s %d IN %s %s", got.NameFQDN, got.TTL, got.Type, got.GetRDATA(), tt.want.NameFQDN, tt.want.TTL, tt.want.Type, tt.want.GetRDATA())
 			}
-			if got.Original != tt.in {
-				t.Error("nativeToRecord() did not preserve the original TransIP record")
-			}
 		})
 	}
 }


### PR DESCRIPTION
# Issue

TXT records aren't parsed correctly.

# Resolution

Use NewRecordConfig for TXT records.