### PR TITLE
UNIFI: Skip SRV TTL integration test, add console_id to test profile

### DIFF
--- a/integrationTest/integration_test.go
+++ b/integrationTest/integration_test.go
@@ -898,6 +898,7 @@ func makeTests() []*TestGroup {
 			not(
 				"OPENWRT",   // OpenWRT does not support per record TTL
 				"NAMECHEAP", // Namecheap does not support per record TTL
+				"UNIFI",     // UniFi API does not support TTL on SRV records
 			),
 			tc("Create SRV333", ttl(srv("_sip._tcp", 5, 6, 7, "foo.com."), 333)),
 			tc("Change TTL999", ttl(srv("_sip._tcp", 5, 6, 7, "foo.com."), 999)),

--- a/integrationTest/profiles.json
+++ b/integrationTest/profiles.json
@@ -411,6 +411,7 @@
   "UNIFI": {
     "TYPE": "UNIFI",
     "api_key": "$UNIFI_API_KEY",
+    "console_id": "$UNIFI_CONSOLE_ID",
     "domain": "$UNIFI_DOMAIN",
     "host": "$UNIFI_HOST",
     "knownFailures": "26,43",


### PR DESCRIPTION
## Summary

- Add `UNIFI` to the `not()` list of the SRV TTL testgroup (issue #2066): the UniFi API does not support TTL on SRV records (`ttlSeconds` is rejected on write with `Unknown request body property '$.ttlSeconds'`), so this test can never pass. Same approach already used for OPENWRT and NAMECHEAP, which lack per-record TTL support.
- Add `console_id` to the UNIFI profile in `integrationTest/profiles.json` so tests can also run via UniFi cloud access (api.ui.com), not only against a local controller.

## Context

Found while running integration tests for #4582: `44:SRV:Change_TTL999` failed with "Expected changes, but got none". The failure is pre-existing on `release_candidate_v5` and is by design: the provider normalizes TTL to 300 for MX/TXT/SRV in `GetZoneRecordsCorrections` because the API cannot store it.

## Validation

- `go test -timeout 20m -run TestDNSProviders -v -args -verbose -profile UNIFI` against a local controller: **196 PASS, 0 FAIL** (previously 1 FAIL: `44:SRV:Change_TTL999`, now correctly skipped)
- Tested with go1.26.5 darwin/arm64