### PR TITLE
CICD: Fix per-provider integration-test serialization across triggers

### DIFF
--- a/.github/workflows/pr_integration_tests.yml
+++ b/.github/workflows/pr_integration_tests.yml
@@ -276,7 +276,15 @@ jobs:
       TENCENTDNS_SECRET_KEY: ${{ secrets.TENCENTDNS_SECRET_KEY }}
 
     concurrency:
-      group: ${{ github.workflow }}-${{ matrix.provider }}
+      # Serialize by PROVIDER across the whole repo: each provider's tests share
+      # one live test zone, so the same provider must never run concurrently on
+      # two branches/runs. The group MUST be a stable literal (not
+      # ${{ github.workflow }}) because when these tests run via workflow_call
+      # (the release "verify" gate) github.workflow resolves to the *caller's*
+      # workflow name, which would put release-triggered and PR-triggered runs
+      # of the same provider in different groups and let them clobber each other.
+      # No github.ref here on purpose: serialization must span branches.
+      group: dnscontrol-integration-test-${{ matrix.provider }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
The integration-tests job serializes per provider via a job-level concurrency group so the same provider's shared live test zone is never used by two runs at once. The group was `${{ github.workflow }}-${{ matrix.provider }}`, but inside a reusable workflow `github.workflow` resolves to the CALLER's workflow name. Now that release_draft.yml's 'verify' gate runs these tests via workflow_call, a release-triggered run (group 'RELEASE...-CNR') and a PR-triggered run (group 'PR: Run INTEGRATION tests-CNR') land in DIFFERENT groups and no longer serialize -> they clobber each other's provider zone.

Use a stable literal group ('dnscontrol-integration-test-<provider>') that is identical regardless of branch or trigger path, so all runs of a given provider are mutually exclusive repo-wide.
