### PR TITLE
BUNNY_DNS: Fixes for DNSControl v5 modernization

### DIFF
--- a/integrationTest/integration_test.go
+++ b/integrationTest/integration_test.go
@@ -2314,8 +2314,8 @@ func makeTests() []*TestGroup {
 
 		testgroup("Bunny DNS Pull Zone",
 			only("BUNNY_DNS"),
-			tc("Create PZ", bunnyPullZone("@", "5269987")),
-			tc("Change PZ", bunnyPullZone("@", "5269992")),
+			tc("Create PZ", bunnyPullZone("@", "6214614")),
+			tc("Change PZ", bunnyPullZone("@", "6214615")),
 		),
 
 		// HEDNS: Dynamic DNS

--- a/integrationTest/integration_test.go
+++ b/integrationTest/integration_test.go
@@ -479,6 +479,7 @@ func makeTests() []*TestGroup {
 		testgroup("NS only APEX",
 			not(
 				"AZURE_PRIVATE_DNS", // Apex NS records are managed by Azure.
+				"BUNNY_DNS",         // Apex NS records are managed by BunnyDNS.
 				"DNSCALE",           // Apex NS records are managed by DNScale.
 				"DNSIMPLE",          // Does not support NS records nor subdomains.
 				"DYNU",              // Apex NS records are managed by Dynu.

--- a/providers/bunnydns/api.go
+++ b/providers/bunnydns/api.go
@@ -10,8 +10,6 @@ import (
 
 	"slices"
 
-	dnsv2 "codeberg.org/miekg/dns"
-	"github.com/DNSControl/dnscontrol/v5/models"
 	"github.com/DNSControl/dnscontrol/v5/pkg/printer"
 )
 
@@ -26,10 +24,6 @@ type zone struct {
 	Nameserver1 string `json:"Nameserver1"`
 	Nameserver2 string `json:"Nameserver2"`
 	HasDNSSEC   bool   `json:"DnsSecEnabled"`
-}
-
-func (zone *zone) Nameservers() []string {
-	return []string{zone.Nameserver1, zone.Nameserver2}
 }
 
 type record struct {
@@ -60,24 +54,6 @@ type getZoneResponse struct {
 }
 
 type queryParams map[string]string
-
-func (b *bunnydnsProvider) getImplicitRecordConfigs(dc *models.DomainConfig, zone *zone) (models.Records, error) {
-	nameservers := zone.Nameservers()
-	records := make(models.Records, 0, len(nameservers))
-
-	// NS records on the zone apex must be implicitly added, as Bunny DNS does not expose them via API
-	for _, ns := range nameservers {
-		rc, err := dc.NewRecordConfig("@", 0, dnsv2.TypeNS, ns+".")
-		if err != nil {
-			return nil, err
-		}
-		rc.Original = &record{}
-
-		records = append(records, rc)
-	}
-
-	return records, nil
-}
 
 func (b *bunnydnsProvider) findZoneByDomain(domain string) (*zone, error) {
 	if b.zones == nil {

--- a/providers/bunnydns/auditrecords.go
+++ b/providers/bunnydns/auditrecords.go
@@ -10,7 +10,7 @@ import (
 // supported, an empty list is returned.
 func AuditRecords(records []*models.RecordConfig) []error {
 	a := rejectif.Auditor{}
-	a.Add("TXT", rejectif.TxtIsEmpty) // Last verified 2024-01-02
+	a.Add("TXT", rejectif.TxtIsEmpty) // Last verified 2026-07-24
 
 	return a.Audit(records)
 }

--- a/providers/bunnydns/bunnydnsProvider.go
+++ b/providers/bunnydns/bunnydnsProvider.go
@@ -79,11 +79,8 @@ func newBunnydns(settings map[string]string, _ json.RawMessage) (providers.DNSSe
 	}, nil
 }
 
+// GetNameservers returns empty array, since BunnyDNS does not permit apex NS records.
+// This prevents DNSControl from trying to create default NS records for the domain.
 func (b *bunnydnsProvider) GetNameservers(domain string) ([]*models.Nameserver, error) {
-	zone, err := b.findZoneByDomain(domain)
-	if err != nil {
-		return nil, err
-	}
-
-	return models.ToNameservers(zone.Nameservers())
+	return []*models.Nameserver{}, nil
 }

--- a/providers/bunnydns/convert.go
+++ b/providers/bunnydns/convert.go
@@ -128,7 +128,7 @@ func toRecordConfig(dc *models.DomainConfig, r *record) (*models.RecordConfig, e
 	case "TLSA":
 		rc, err = dc.NewRecordConfigParse(label, r.TTL, dnsv2.TypeTLSA, recordValue)
 	case "TXT":
-		rc, err = dc.NewRecordConfig(label, r.TTL, dnsv2.TypeTXT, recordValue)
+		rc, err = dc.NewRecordConfigParse(label, r.TTL, dnsv2.TypeTXT, recordValue)
 	default:
 		rc, err = dc.NewRecordConfigParse(label, r.TTL, rtype, recordValue)
 	}

--- a/providers/bunnydns/convert.go
+++ b/providers/bunnydns/convert.go
@@ -17,16 +17,10 @@ var fqdnTypes = []recordType{recordTypeCNAME, recordTypeHTTPS, recordTypeMX, rec
 var nullTypes = []recordType{recordTypeHTTPS, recordTypeMX, recordTypeSVCB}
 
 func fromRecordConfig(rc *models.RecordConfig) (*record, error) {
-
-	ttl := rc.TTL
-	if rc.Type == "NS" {
-		ttl = 0
-	}
-
 	r := record{
 		Type: recordTypeFromString(rc.Type),
 		Name: rc.GetLabel(),
-		TTL:  ttl,
+		TTL:  rc.TTL,
 	}
 
 	switch r.Type {

--- a/providers/bunnydns/records.go
+++ b/providers/bunnydns/records.go
@@ -133,7 +133,7 @@ func (b *bunnydnsProvider) mkChangeCorrection(zoneID int64, oldRec, newRec *mode
 	return &models.Correction{
 		Msg: msg,
 		F: func() error {
-			existingID := oldRec.Original.(string)
+			existingID := oldRec.Original.(int64)
 			if existingID == 0 {
 				return errors.New("BUNNY_DNS: cannot change implicit records")
 			}
@@ -152,7 +152,7 @@ func (b *bunnydnsProvider) mkDeleteCorrection(zoneID int64, oldRec *models.Recor
 	return &models.Correction{
 		Msg: msg,
 		F: func() error {
-			existingID := oldRec.Original.(*record).ID
+			existingID := oldRec.Original.(int64)
 			if existingID == 0 {
 				return errors.New("BUNNY_DNS: cannot delete implicit records")
 			}

--- a/providers/bunnydns/records.go
+++ b/providers/bunnydns/records.go
@@ -1,7 +1,6 @@
 package bunnydns
 
 import (
-	"errors"
 	"fmt"
 	"slices"
 
@@ -23,13 +22,7 @@ func (b *bunnydnsProvider) GetZoneRecords(dc *models.DomainConfig) (models.Recor
 		return nil, err
 	}
 
-	implicitRecs, err := b.getImplicitRecordConfigs(dc, zone)
-	if err != nil {
-		return nil, err
-	}
-
-	recs := make(models.Records, 0, len(nativeRecs)+len(implicitRecs))
-	recs = append(recs, implicitRecs...)
+	recs := make(models.Records, 0, len(nativeRecs))
 
 	// Define a list of record types that are currently not supported by this provider.
 	unsupportedTypes := []recordType{
@@ -134,10 +127,6 @@ func (b *bunnydnsProvider) mkChangeCorrection(zoneID int64, oldRec, newRec *mode
 		Msg: msg,
 		F: func() error {
 			existingID := oldRec.Original.(int64)
-			if existingID == 0 {
-				return errors.New("BUNNY_DNS: cannot change implicit records")
-			}
-
 			desired, err := fromRecordConfig(newRec)
 			if err != nil {
 				return err
@@ -153,10 +142,6 @@ func (b *bunnydnsProvider) mkDeleteCorrection(zoneID int64, oldRec *models.Recor
 		Msg: msg,
 		F: func() error {
 			existingID := oldRec.Original.(int64)
-			if existingID == 0 {
-				return errors.New("BUNNY_DNS: cannot delete implicit records")
-			}
-
 			return b.deleteRecord(zoneID, existingID)
 		},
 	}


### PR DESCRIPTION
This PR fixes some remaining issues in #4540 - all integration tests pass again on RCv5 with these commits in place.