### PR TITLE
HETZNER_V2: address TODOs

### DIFF
--- a/.linkspector.yml
+++ b/.linkspector.yml
@@ -10,7 +10,6 @@ ignorePatterns:
   - pattern: '.*.md#$'
   - pattern: '^https://cloud.digitalocean.com/account/api/tokens'
   - pattern: '^https://cloud.digitalocean.com/settings/applications'
-  - pattern: '^https://dns.hetzner.com/settings/api-token'
   - pattern: '^https://github.com/DNSControl/dnscontrol/settings/.*$'
   - pattern: '^https://gitlab.com/cafferata/dnscontrol/-/pipelines/new.*$'
   - pattern: '^https://my.easyname.com/en/account/api'

--- a/providers/hetznerv2/hetznerv2Provider.go
+++ b/providers/hetznerv2/hetznerv2Provider.go
@@ -53,7 +53,7 @@ func init() {
 		DisplayName: "Hetzner DNS",
 		Kind:        providers.KindDNS,
 		DocsURL:     "https://docs.dnscontrol.org/provider/hetzner_v2",
-		PortalURL:   "https://dns.hetzner.com/settings/api-token", // TODO: Verify
+		PortalURL:   "https://console.hetzner.com/projects",
 		Fields: []providers.CredsField{
 			{
 				Key:      "api_token",
@@ -103,19 +103,11 @@ func (h *hetznerv2Provider) fetchAllZones() (map[string]*hcloud.Zone, error) {
 
 // EnsureZoneExists creates a zone if it does not exist.
 func (h *hetznerv2Provider) EnsureZoneExists(dc *models.DomainConfig) error {
-	domain := dc.Name
-
-	// TODO(tlim): This should no longer be needed.
-	// encoded, err := idna.ToASCII(domain)
-	// if err != nil {
-	// 	return err
-	// }
-	encoded := domain
-	if ok, err2 := h.zoneCache.HasZone(encoded); err2 != nil || ok {
+	if ok, err2 := h.zoneCache.HasZone(dc.Name); err2 != nil || ok {
 		return err2
 	}
 	result, _, err := h.client.Zone.Create(context.Background(), hcloud.ZoneCreateOpts{
-		Name: encoded,
+		Name: dc.Name,
 		Mode: hcloud.ZoneModePrimary,
 	})
 	if err != nil {
@@ -129,20 +121,13 @@ func (h *hetznerv2Provider) EnsureZoneExists(dc *models.DomainConfig) error {
 	if err != nil {
 		return err
 	}
-	h.zoneCache.SetZone(encoded, z)
+	h.zoneCache.SetZone(dc.Name, z)
 	return nil
 }
 
 // GetZoneRecordsCorrections returns a list of corrections that will turn existing records into dc.Records.
 func (h *hetznerv2Provider) GetZoneRecordsCorrections(dc *models.DomainConfig, existingRecords models.Records) ([]*models.Correction, int, error) {
-	// TODO(tlim): This should no longer be needed.
-	// encoded, err := idna.ToASCII(dc.Name)
-	// if err != nil {
-	// 	return nil, 0, err
-	// }
-	encoded := dc.Name
-
-	z, err := h.zoneCache.GetZone(encoded)
+	z, err := h.zoneCache.GetZone(dc.Name)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -236,16 +221,7 @@ func (h *hetznerv2Provider) GetNameservers(domain string) ([]*models.Nameserver,
 
 // GetZoneRecords gets the records of a zone and returns them in RecordConfig format.
 func (h *hetznerv2Provider) GetZoneRecords(dc *models.DomainConfig) (models.Records, error) {
-	domain := dc.Name
-
-	// TODO(tlim): This should no longer be needed.
-	// encoded, err := idna.ToASCII(domain)
-	// if err != nil {
-	// 	return nil, err
-	// }
-	encoded := domain
-
-	z, err := h.zoneCache.GetZone(encoded)
+	z, err := h.zoneCache.GetZone(dc.Name)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR is resolving the remaining TODOs from

- https://github.com/DNSControl/dnscontrol/pull/4290#discussion_r3262491194
- https://github.com/DNSControl/dnscontrol/pull/4554

The integration tests are passing, so does a manual push with umlauts in the domain/record, a 2nd push is empty.

```js
var REG_NONE = NewRegistrar('none')
var DSP = NewDnsProvider("HETZNER_V2")

D('testing-ö.dev', REG_NONE, DnsProvider(DSP),
  A('@', '127.0.0.3'),
  A('foö', '127.0.0.3')
)
``` 

```console
$ dig foö.testing-ö.dev @helium.ns.hetzner.de.

; <<>> DiG <<>> foö.testing-ö.dev @helium.ns.hetzner.de.
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 41006
;; flags: qr aa rd; QUERY: 1, ANSWER: 1, AUTHORITY: 3, ADDITIONAL: 1
;; WARNING: recursion requested but not available

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 4096
;; QUESTION SECTION:
;foö.testing-ö.dev.		IN	A

;; ANSWER SECTION:
foö.testing-ö.dev.	300	IN	A	127.0.0.3

;; AUTHORITY SECTION:
testing-ö.dev.		300	IN	NS	helium.ns.hetzner.de.
testing-ö.dev.		300	IN	NS	hydrogen.ns.hetzner.com.
testing-ö.dev.		300	IN	NS	oxygen.ns.hetzner.com.

;; Query time: 18 msec
;; SERVER: 2001:67c:192c::add:5#53(helium.ns.hetzner.de.) (UDP)
;; WHEN: Sun Jul 26 12:05:32 CEST 2026
;; MSG SIZE  rcvd: 168

```

<!--
## Before submiting a pull request

Please make sure you've run the following commands from the root directory.

    bin/generate-all.sh

(this runs commands like "go generate", fixes formatting, and so on)

## Release changelog section

Help keep the release changelog clear by pre-naming the proper section in the GitHub pull request title.

Some examples:
* CICD: Add required GHA permissions for goreleaser
* DOCS: Fixed providers with "contributor support" table
* ROUTE53: Allow R53_ALIAS records to enable target health evaluation

More examples/context can be found in the file .goreleaser.yml under the 'build' > 'changelog' key.
!-->
