### PR TITLE
DNSIMPLE: fix mod_dnsimple: SVCB & HTTPS are also unqualified at dnsimple

### DIFF
--- a/providers/dnsimple/dnsimpleProvider.go
+++ b/providers/dnsimple/dnsimpleProvider.go
@@ -142,6 +142,17 @@ func (c *dnsimpleProvider) GetZoneRecords(dc *models.DomainConfig) (models.Recor
 	return cleanedRecords, nil
 }
 
+func qualifySVCBTarget(content string) string {
+	fields := strings.SplitN(content, " ", 3)
+	if len(fields) < 2 {
+		return content
+	}
+	if target := fields[1]; !strings.HasSuffix(target, ".") {
+		fields[1] = target + "."
+	}
+	return strings.Join(fields, " ")
+}
+
 func toRecordConfig(dc *models.DomainConfig, r dnsimpleapi.ZoneRecord) (*models.RecordConfig, error) {
 	if r.Name == "" {
 		r.Name = "@"
@@ -151,6 +162,8 @@ func toRecordConfig(dc *models.DomainConfig, r dnsimpleapi.ZoneRecord) (*models.
 		r.Content += "."
 	} else if r.Type == "MX" && r.Content != "." {
 		r.Content += "."
+	} else if r.Type == "SVCB" || r.Type == "HTTPS" {
+		r.Content = qualifySVCBTarget(r.Content)
 	}
 
 	var rec *models.RecordConfig

--- a/providers/dnsimple/dnsimpleProvider_test.go
+++ b/providers/dnsimple/dnsimpleProvider_test.go
@@ -23,6 +23,10 @@ func TestToRecordConfig(t *testing.T) {
 		{"apex TXT", dnsimpleapi.ZoneRecord{Name: "", Type: "TXT", Content: `"quoted text"`, TTL: 300}, "@", `"quoted text"`},
 		{"MX", dnsimpleapi.ZoneRecord{Name: "", Type: "MX", Content: "mail.example.net", TTL: 300, Priority: 10}, "@", "10 mail.example.net."},
 		{"SRV", dnsimpleapi.ZoneRecord{Name: "_sip._tcp", Type: "SRV", Content: "2 5060 sip.example.net.", TTL: 300, Priority: 1}, "_sip._tcp", "1 2 5060 sip.example.net."},
+		{"HTTPS alias mode", dnsimpleapi.ZoneRecord{Name: "", Type: "HTTPS", Content: "0 target.example.net", TTL: 300}, "@", "0 target.example.net."},
+		{"HTTPS with params", dnsimpleapi.ZoneRecord{Name: "", Type: "HTTPS", Content: `3 target.example.net alpn="h2,h3" port="999"`, TTL: 300}, "@", `3 target.example.net. alpn="h2,h3" port="999"`},
+		{"SVCB alias mode", dnsimpleapi.ZoneRecord{Name: "", Type: "SVCB", Content: "0 target.example.net", TTL: 300}, "@", "0 target.example.net."},
+		{"SVCB already qualified", dnsimpleapi.ZoneRecord{Name: "", Type: "SVCB", Content: "0 target.example.net.", TTL: 300}, "@", "0 target.example.net."},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
This is a "quick" fix to the mod_dnsimple branch and PR https://github.com/DNSControl/dnscontrol/pull/4545 which fixes SVCB & HTTPS records.

DNSimple does not return qualified domains in these either so add a quick helper to manage all the various forms.