### PR TITLE
BUG: preview no longer errors when a zone will be created by push

### DIFF
--- a/commands/ppreviewPush.go
+++ b/commands/ppreviewPush.go
@@ -340,7 +340,7 @@ func prun(args PPreviewArgs, push bool, interactive bool, out printer.CLI, repor
 		out.PrintfIf(fullMode, "Concurrently gathering: %q\n", zone.UniqueName)
 		go func(zone *models.DomainConfig, args PPreviewArgs, zcache *CmdZoneCache) {
 			start := time.Now()
-			err := oneZone(zone, args)
+			err := oneZone(zone, args, push)
 			if err != nil {
 				concurrentErrors.Store(true)
 			}
@@ -358,7 +358,7 @@ func prun(args PPreviewArgs, push bool, interactive bool, out printer.CLI, repor
 	out.Printf("SERIALLY gathering records of %d zone(s)\n", len(zonesSerial))
 	for _, zone := range zonesSerial {
 		out.Printf("Serially Gathering: %q\n", zone.UniqueName)
-		if err := oneZone(zone, args); err != nil {
+		if err := oneZone(zone, args, push); err != nil {
 			anyErrors = true
 		}
 	}
@@ -567,7 +567,7 @@ func oneZonePopulate(zone *models.DomainConfig, zc *CmdZoneCache) error {
 	return errors.Join(errs...)
 }
 
-func oneZone(zone *models.DomainConfig, args PPreviewArgs) error {
+func oneZone(zone *models.DomainConfig, args PPreviewArgs, push bool) error {
 	var errs []error
 	// Fix the parent zone's delegation: (if able/needed)
 	delegationCorrections, dcCount, err := generateDelegationCorrections(zone, zone.DNSProviderInstances, zone.RegistrarInstance)
@@ -578,6 +578,17 @@ func oneZone(zone *models.DomainConfig, args PPreviewArgs) error {
 	// Loop over the (selected) providers configured for that zone:
 	providersToProcess := whichProvidersToProcess(zone.DNSProviderInstances, args.Providers)
 	for _, provider := range providersToProcess {
+		// If Phase 1 found the zone missing and queued a creation correction
+		// that this run will not execute, fetching records for the not-yet-
+		// created zone would fail with a raw provider error and a non-zero
+		// exit. Report that the zone will be created on push instead.
+		if reportZonePendingCreation(zone, provider.Name, push, args.PopulateOnPreview) {
+			zone.StoreCorrections(provider.Name, []*models.Correction{{
+				Msg: fmt.Sprintf("Zone %q does not yet exist at provider %q. It will be created when you run `dnscontrol push`.", zone.Name, provider.Name),
+			}})
+			continue
+		}
+
 		// Update the zone's records at the provider:
 		zoneCor, rep, actualChangeCount, err := generateZoneCorrections(zone, provider)
 		zone.StoreCorrections(provider.Name, rep)
@@ -742,6 +753,30 @@ func writeReport(report string, reportItems []*ReportItem) error {
 		return err
 	}
 	return nil
+}
+
+// zoneWillBeCreated reports whether Phase 1 found the zone missing at the named
+// provider and queued a creation correction for it. Such corrections carry a
+// non-nil F that runs EnsureZoneExists, and only execute during push.
+func zoneWillBeCreated(zone *models.DomainConfig, providerName string) bool {
+	for _, c := range zone.GetPopulateCorrections(providerName) {
+		if c.F != nil {
+			return true
+		}
+	}
+	return false
+}
+
+// reportZonePendingCreation reports whether oneZone should emit an
+// informational "will be created on push" correction instead of fetching
+// records. That applies only when the zone is queued for creation and this run
+// does not actually create it: push runs the creation, and so does preview with
+// --populate-on-preview, in which case the real record diff should be shown.
+func reportZonePendingCreation(zone *models.DomainConfig, providerName string, push, populateOnPreview bool) bool {
+	if push || populateOnPreview {
+		return false
+	}
+	return zoneWillBeCreated(zone, providerName)
 }
 
 func generatePopulateCorrections(provider *models.DNSProviderInstance, dc *models.DomainConfig, zcache *CmdZoneCache) ([]*models.Correction, error) {

--- a/commands/ppreviewPush_test.go
+++ b/commands/ppreviewPush_test.go
@@ -181,3 +181,72 @@ func Test_whichZonesToProcess(t *testing.T) {
 		})
 	}
 }
+
+func Test_zoneWillBeCreated(t *testing.T) {
+	const provider = "cf"
+
+	tests := []struct {
+		name        string
+		corrections []*models.Correction
+		want        bool
+	}{
+		{
+			name:        "no populate corrections",
+			corrections: nil,
+			want:        false,
+		},
+		{
+			name:        "informational correction only (zone exists or not creatable)",
+			corrections: []*models.Correction{{Msg: "nothing to do"}},
+			want:        false,
+		},
+		{
+			name:        "pending zone creation (non-nil F)",
+			corrections: []*models.Correction{{Msg: "Ensuring zone exists", F: func() error { return nil }}},
+			want:        true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			zone := &models.DomainConfig{Name: "example.com"}
+			zone.StorePopulateCorrections(provider, tc.corrections)
+			if got := zoneWillBeCreated(zone, provider); got != tc.want {
+				t.Errorf("zoneWillBeCreated() = %v, want %v", got, tc.want)
+			}
+			// A different provider name must never report a pending creation.
+			if zoneWillBeCreated(zone, "other") {
+				t.Error("zoneWillBeCreated() reported a creation for an unrelated provider")
+			}
+		})
+	}
+}
+
+func Test_reportZonePendingCreation(t *testing.T) {
+	const provider = "cf"
+	pending := []*models.Correction{{Msg: "Ensuring zone exists", F: func() error { return nil }}}
+	none := []*models.Correction{{Msg: "nothing to do"}}
+
+	tests := []struct {
+		name              string
+		corrections       []*models.Correction
+		push              bool
+		populateOnPreview bool
+		want              bool
+	}{
+		{name: "preview, zone pending creation", corrections: pending, want: true},
+		{name: "push, zone pending creation", corrections: pending, push: true, want: false},
+		{name: "preview with --populate-on-preview creates the zone", corrections: pending, populateOnPreview: true, want: false},
+		{name: "preview, zone not pending creation", corrections: none, want: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			zone := &models.DomainConfig{Name: "example.com"}
+			zone.StorePopulateCorrections(provider, tc.corrections)
+			if got := reportZonePendingCreation(zone, provider, tc.push, tc.populateOnPreview); got != tc.want {
+				t.Errorf("reportZonePendingCreation() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
`dnscontrol preview` exits non-zero with a raw provider error whenever `dnsconfig.js` references a domain that does not yet exist at the provider, even though `push` would create that zone without error. Preview intentionally does not run the zone-creation correction, but Phase 2 still fetched records for the not-yet-created zone, turning a "will be created" case into a hard failure. This breaks CI that runs `dnscontrol preview` on pull requests adding new domains.

This threads the `push` flag into `oneZone` and, when previewing a zone that Phase 1 flagged for creation, reports that the zone will be created on push instead of fetching its records. The message is suppressed when this run actually creates the zone (push, or preview with `--populate-on-preview`), so those keep showing the real record diff. Push behavior is unchanged, and providers that cannot create the zone still surface a real error.

Fixes #4322
Related: #4422
