### PR TITLE
GIGAHOST: Fix API quirks surfaced by the integration tests

### DIFF
--- a/integrationTest/integration_test.go
+++ b/integrationTest/integration_test.go
@@ -839,7 +839,10 @@ func makeTests() []*TestGroup {
 				naptr("test", 100, 10, "U", "E2U+sip", "!^.*$!sip:customer-service@example.com!", "."),
 				naptr("test", 102, 10, "U", "E2U+email", "!^.*$!mailto:information@example.com!", "."),
 			),
-			tc("NAPTR delete second record", naptr("test", 100, 10, "U", "E2U+sip", "!^.*$!sip:customer-service@example.com!", ".")),
+			// AllowNoChanges: providers that audit-reject multiple NAPTRs at
+			// one label (e.g. GIGAHOST) skip "NAPTR second record" above, so
+			// this state may already be converged.
+			tc("NAPTR delete second record", naptr("test", 100, 10, "U", "E2U+sip", "!^.*$!sip:customer-service@example.com!", ".")).AllowNoChanges(),
 			tc("NAPTR change order", naptr("test", 103, 10, "U", "E2U+email", "!^.*$!mailto:information@example.com!", ".")),
 			tc("NAPTR change preference", naptr("test", 103, 20, "U", "E2U+email", "!^.*$!mailto:information@example.com!", ".")),
 			tc("NAPTR change flags", naptr("test", 103, 20, "A", "E2U+email", "!^.*$!mailto:information@example.com!", ".")),

--- a/providers/gigahost/api.go
+++ b/providers/gigahost/api.go
@@ -10,6 +10,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/DNSControl/dnscontrol/v5/pkg/printer"
 )
 
 const baseURL = "https://api.gigahost.no/api/v0"
@@ -85,13 +87,13 @@ type recordRequest struct {
 // request performs an HTTP request against the Gigahost API, unwraps the
 // standard envelope, surfaces meta-level errors, and decodes data into target.
 func (c *gigahostProvider) request(method, path string, query url.Values, body, target any) error {
-	var reqBody io.Reader
+	var bodyJSON []byte
 	if body != nil {
 		j, err := json.Marshal(body)
 		if err != nil {
 			return err
 		}
-		reqBody = bytes.NewBuffer(j)
+		bodyJSON = j
 	}
 
 	u := baseURL + path
@@ -99,39 +101,67 @@ func (c *gigahostProvider) request(method, path string, query url.Values, body, 
 		u += "?" + query.Encode()
 	}
 
-	req, err := http.NewRequest(method, u, reqBody)
-	if err != nil {
-		return err
-	}
-	req.Header.Set("Authorization", "Bearer "+c.apiKey)
-	req.Header.Set("Accept", "application/json")
-	if reqBody != nil {
-		req.Header.Set("Content-Type", "application/json")
-	}
-
-	resp, err := httpClient.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-
-	raw, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return err
-	}
-
+	// The API rate-limits aggressively enough that a normal push can trip it,
+	// so retry 429s with a backoff (honoring Retry-After when present).
+	const maxRetries = 5
+	var resp *http.Response
+	var raw []byte
 	var env apiEnvelope
-	if len(raw) > 0 {
-		if err := json.Unmarshal(raw, &env); err != nil {
-			return fmt.Errorf("gigahost: could not decode response for %s %s (HTTP %d): %w", method, path, resp.StatusCode, err)
+	var status int
+	for attempt := 0; ; attempt++ {
+		var reqBody io.Reader
+		if bodyJSON != nil {
+			reqBody = bytes.NewReader(bodyJSON)
 		}
+		req, err := http.NewRequest(method, u, reqBody)
+		if err != nil {
+			return err
+		}
+		req.Header.Set("Authorization", "Bearer "+c.apiKey)
+		req.Header.Set("Accept", "application/json")
+		if reqBody != nil {
+			req.Header.Set("Content-Type", "application/json")
+		}
+
+		resp, err = httpClient.Do(req)
+		if err != nil {
+			return err
+		}
+		raw, err = io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if err != nil {
+			return err
+		}
+
+		env = apiEnvelope{}
+		if len(raw) > 0 {
+			if err := json.Unmarshal(raw, &env); err != nil {
+				return fmt.Errorf("gigahost: could not decode response for %s %s (HTTP %d): %w", method, path, resp.StatusCode, err)
+			}
+		}
+
+		// Prefer the envelope's meta.status, falling back to the HTTP status code.
+		status = env.Meta.Status
+		if status == 0 {
+			status = resp.StatusCode
+		}
+
+		if status != http.StatusTooManyRequests || attempt >= maxRetries {
+			break
+		}
+		wait := time.Duration(2<<attempt) * time.Second // 2s, 4s, 8s, 16s, 32s
+		if ra := resp.Header.Get("Retry-After"); ra != "" {
+			if secs, err := strconv.ParseInt(ra, 10, 64); err == nil {
+				if secs > 180 {
+					return fmt.Errorf("gigahost: %s %s rate limited; Retry-After %ds too long", method, path, secs)
+				}
+				wait = time.Duration(secs+1) * time.Second
+			}
+		}
+		printer.Warnf("GIGAHOST: rate limited, retrying in %v\n", wait)
+		time.Sleep(wait)
 	}
 
-	// Prefer the envelope's meta.status, falling back to the HTTP status code.
-	status := env.Meta.Status
-	if status == 0 {
-		status = resp.StatusCode
-	}
 	if status >= 400 {
 		msg := env.Meta.Message
 		if msg == "" {

--- a/providers/gigahost/gigahostProvider.go
+++ b/providers/gigahost/gigahostProvider.go
@@ -11,6 +11,7 @@ import (
 	"github.com/DNSControl/dnscontrol/v5/pkg/printer"
 	"github.com/DNSControl/dnscontrol/v5/pkg/providers"
 	"github.com/DNSControl/dnscontrol/v5/pkg/rejectif"
+	"github.com/DNSControl/dnscontrol/v5/pkg/txtutil"
 )
 
 // features describes the capabilities of the Gigahost provider. Start with
@@ -69,10 +70,33 @@ func newGigahost(settings map[string]string, _ json.RawMessage) (providers.DNSSe
 // aren't supported by this provider.
 func AuditRecords(records []*models.RecordConfig) []error {
 	a := rejectif.Auditor{}
+	a.Add("MX", rejectif.MxNull) // The API rejects a "." target ("MX record value must be a valid mail server hostname").
 	a.Add("TXT", rejectif.TxtIsEmpty)
+	// The API cannot round-trip double quotes in TXT values: raw interior
+	// quotes are rejected by its zone parser, and if sent escaped
+	// (`"right\""`) the record is stored correctly but the read-back
+	// record_value is mangled (`right\`), breaking diffing and deletes.
+	a.Add("TXT", rejectif.TxtHasDoubleQuotes)
+	a.Add("TXT", rejectif.TxtStartsOrEndsWithSpaces) // The API trims leading/trailing whitespace on store.
 	a.Add("CAA", rejectif.CaaTargetContainsWhitespace)
 	a.Add("SRV", rejectif.SrvHasNullTarget)
-	return a.Audit(records)
+	errs := a.Audit(records)
+
+	// The API silently replaces the entire NAPTR RRset on every create
+	// (POSTing a second NAPTR at a label deletes the first), so only one
+	// NAPTR per label can be represented. Verified against the live API
+	// 2026-07-27.
+	naptrSeen := map[string]bool{}
+	for _, rc := range records {
+		if rc.Type != "NAPTR" {
+			continue
+		}
+		if naptrSeen[rc.GetLabelFQDN()] {
+			errs = append(errs, fmt.Errorf("only one NAPTR record per label is supported (%s)", rc.GetLabelFQDN()))
+		}
+		naptrSeen[rc.GetLabelFQDN()] = true
+	}
+	return errs
 }
 
 // findZone resolves a domain name to its Gigahost zone, caching the zone list.
@@ -201,7 +225,7 @@ func (c *gigahostProvider) GetZoneRecordsCorrections(dc *models.DomainConfig, ex
 			corrections = append(corrections, &models.Correction{
 				Msg: inst.Msgs[0],
 				F: func() error {
-					return c.deleteRecord(z.ZoneID, old.RecordID, old.RecordName, old.RecordType, old.RecordValue)
+					return c.deleteRecord(z.ZoneID, old.RecordID, old.RecordName, old.RecordType, deleteValue(old))
 				},
 			})
 		default:
@@ -224,7 +248,19 @@ func nativeToRecordConfig(dc *models.DomainConfig, r *record) (*models.RecordCon
 		// dot, some without); RecordConfig targets are always FQDNs.
 		rc, err = dc.NewRecordConfig(r.RecordName, r.RecordTTL.Value, r.RecordType, addDot(r.RecordValue))
 	case "TXT":
-		rc, err = dc.NewRecordConfig(r.RecordName, r.RecordTTL.Value, r.RecordType, r.RecordValue)
+		val := r.RecordValue
+		// The API returns >255-octet TXT values in the RFC1035 chunked form
+		// we sent (see recordConfigToRequest) with the outer quotes stripped,
+		// e.g. `aaa...aaa" "bbb`. A single TXT character-string cannot exceed
+		// 255 octets, so a longer record_value must be that form: re-wrap and
+		// decode to the raw joined text. Shorter values are stored and
+		// returned verbatim (kept as-is on decode failure).
+		if len(val) > 255 {
+			if decoded, derr := txtutil.ParseQuoted(`"` + val + `"`); derr == nil {
+				val = decoded
+			}
+		}
+		rc, err = dc.NewRecordConfig(r.RecordName, r.RecordTTL.Value, r.RecordType, val)
 	default:
 		rc, err = dc.NewRecordConfigParse(r.RecordName, r.RecordTTL.Value, r.RecordType, r.RecordValue)
 	}
@@ -252,7 +288,15 @@ func recordConfigToRequest(rc *models.RecordConfig) *recordRequest {
 		// needed and reads are re-dotted in nativeToRecordConfig.
 		r.RecordValue = strings.TrimSuffix(rc.GetTargetField(), ".")
 	case "TXT":
-		r.RecordValue = rc.GetTargetTXTJoined()
+		txt := rc.GetTargetTXTJoined()
+		// The API requires values over 255 octets to be sent as RFC1035
+		// quoted 255-octet chunks: `"aaa...aaa" "bbb"`. Shorter values are
+		// sent raw and stored verbatim. (Values with double quotes are
+		// rejected by AuditRecords: the API cannot round-trip them.)
+		if len(txt) > 255 {
+			txt = txtutil.EncodeQuoted(txt)
+		}
+		r.RecordValue = txt
 	case "CAA", "SRV", "NAPTR":
 		// These are stored as full RFC1035 presentation strings in record_value.
 		r.RecordValue = rc.GetRDATA().String()
@@ -260,6 +304,18 @@ func recordConfigToRequest(rc *models.RecordConfig) *recordRequest {
 		r.RecordValue = rc.GetTargetField()
 	}
 	return r
+}
+
+// deleteValue returns the value the DELETE endpoint matches against. For most
+// types this is record_value exactly as the API returns it, but for MX the
+// endpoint matches the internal RDATA presentation ("<priority> <target.>"),
+// NOT the priority-less record_value it returns; sending record_value yields
+// 404 "Record not found". Verified against the live API 2026-07-27.
+func deleteValue(r *record) string {
+	if r.RecordType == "MX" {
+		return fmt.Sprintf("%d %s", r.RecordPrio.Value, addDot(r.RecordValue))
+	}
+	return r.RecordValue
 }
 
 // addDot appends a trailing dot to a hostname if it lacks one.


### PR DESCRIPTION
Fixes for #4553 — provider-level Gigahost API quirks the integration tests surfaced, all verified against the live API with a dedicated test zone. None are caused by the modernization changes; they were latent in the provider (or the API's behavior has changed since the provider was written).

## Fixes

- **MX DELETE value form**: the delete endpoint 404s when given the `record_value` the API itself returns for MX; it requires the internal RDATA presentation `"<priority> <target>."`. Added `deleteValue()`.
- **429 rate limiting**: the API throttles hard enough that a normal-sized push can trip it. `request()` now retries up to 5 times with 2s→32s backoff, honoring `Retry-After`.
- **Null MX**: the API rejects a `.` target ("MX record value must be a valid mail server hostname") → audit-reject with `rejectif.MxNull`.
- **TXT >255 octets**: must be sent as RFC1035 quoted 255-octet chunks; the API returns that form with the outer quotes stripped, so it is decoded on read (unambiguous: a single character-string can't exceed 255 octets).
- **TXT with double quotes**: cannot round-trip. Raw interior quotes are rejected by the API's zone parser (it blindly wraps values in quotes); the escaped form stores correctly (verified via `dig`) but reads back mangled (trailing `\"` → `\`), breaking diffing and deletes → `rejectif.TxtHasDoubleQuotes`.
- **TXT leading/trailing spaces**: trimmed by the API on store → `rejectif.TxtStartsOrEndsWithSpaces`.
- **NAPTR is single-record per label**: POSTing a second NAPTR at the same label silently replaces the entire NAPTR RRset (201 "created", first record gone — verified via API and `dig`). Audit-rejects >1 NAPTR per label, and marks the `NAPTR delete second record` testcase `.AllowNoChanges()` so providers that audit-skip the multi-NAPTR case don't fail on the already-converged state.

## Validation

```
cd integrationTest && go test -v -verbose -profile GIGAHOST -run TestDNSProviders
ok  github.com/DNSControl/dnscontrol/v5/integrationTest  87.9s
239 PASS / 77 SKIP / 0 FAIL
```

Also: `go vet`, `gofmt`, `go test ./providers/gigahost` clean.