### PR TITLE
AUTODNS: support two factor authentication via TOTP

### DIFF
--- a/documentation/provider/autodns.md
+++ b/documentation/provider/autodns.md
@@ -18,6 +18,57 @@ Example:
 ```
 {% endcode %}
 
+### Two factor authentication
+
+If two-factor authentication has been enabled on your account you will also need to provide a valid TOTP code.
+This can also be done via an environment variable:
+
+{% code title="creds.json" %}
+```json
+{
+  "autodns": {
+    "TYPE": "AUTODNS",
+    "username": "autodns.service-account@example.com",
+    "password": "[***]",
+    "context": "33004",
+    "totp": "$AUTODNS_TOTP"
+  }
+}
+```
+{% endcode %}
+
+and then you can run
+
+```shell
+AUTODNS_TOTP=123456 dnscontrol preview
+```
+
+It is also possible to directly provide the shared TOTP secret using the key "totp-key" in `creds.json`. This secret is
+only available when first enabling two-factor authentication.
+
+**Security Warning**:
+* Anyone with access to this `creds.json` file will have *full* access to your AutoDNS account
+  and will be able to modify and delete your DNS entries.
+* Storing the shared secret together with the password weakens two factor authentication
+  because both factors are stored in a single place.
+
+{% code title="creds.json" %}
+```json
+{
+  "autodns": {
+    "TYPE": "AUTODNS",
+    "username": "autodns.service-account@example.com",
+    "password": "[***]",
+    "context": "33004",
+    "totp-key": "yourTOTPSharedSecret"
+  }
+}
+```
+{% endcode %}
+
+`totp` and `totp-key` must not be set at the same time. Omit both if the account does not use
+two factor authentication.
+
 ### Including sub-user zones
 
 By default DNSControl only sees zones owned directly by the configured user. If

--- a/integrationTest/profiles.json
+++ b/integrationTest/profiles.json
@@ -27,6 +27,7 @@
     "context": "$AUTODNS_CONTEXT",
     "domain": "$AUTODNS_DOMAIN",
     "password": "$AUTODNS_PASSWORD",
+    "totp-key": "$AUTODNS_TOTP_SECRET",
     "username": "$AUTODNS_USERNAME"
   },
   "AXFRDDNS": {

--- a/providers/autodns/api.go
+++ b/providers/autodns/api.go
@@ -43,6 +43,26 @@ var (
 	defaultRetryMax  = 4
 )
 
+const otpHeader = "X-Domainrobot-2FA-Token"
+
+// requestHeaders returns the headers for a single request. defaultHeaders is
+// shared between concurrent requests, so it is cloned rather than modified.
+func (api *autoDNSProvider) requestHeaders() (http.Header, error) {
+	token, err := api.otp()
+	if err != nil {
+		return nil, err
+	}
+
+	if token == "" {
+		return api.defaultHeaders, nil
+	}
+
+	headers := api.defaultHeaders.Clone()
+	headers.Set(otpHeader, token)
+
+	return headers, nil
+}
+
 func (api *autoDNSProvider) request(method string, requestPath string, data any) ([]byte, error) {
 	var retryCounter = 0
 
@@ -51,19 +71,27 @@ func (api *autoDNSProvider) request(method string, requestPath string, data any)
 	requestURL := api.baseURL
 	requestURL.Path = api.baseURL.Path + requestPath
 
-	request := &http.Request{
-		URL:    &requestURL,
-		Header: api.defaultHeaders,
-		Method: method,
-	}
-
+	var body []byte
 	if data != nil {
-		body, _ := json.Marshal(data)
-		buffer := bytes.NewBuffer(body)
-		request.Body = io.NopCloser(buffer)
+		body, _ = json.Marshal(data)
 	}
 
 	for {
+		headers, err := api.requestHeaders()
+		if err != nil {
+			return nil, err
+		}
+
+		request := &http.Request{
+			URL:    &requestURL,
+			Header: headers,
+			Method: method,
+		}
+
+		if data != nil {
+			request.Body = io.NopCloser(bytes.NewBuffer(body))
+		}
+
 		response, err := client.Do(request)
 		if err != nil {
 			return nil, err
@@ -196,7 +224,10 @@ func (api *autoDNSProvider) getZones() ([]string, error) {
 		},
 	}
 
-	rawCountZoneResponse, _ := api.request("POST", "zone/_search", countZoneRequest)
+	rawCountZoneResponse, err := api.request("POST", "zone/_search", countZoneRequest)
+	if err != nil {
+		return nil, err
+	}
 
 	var countZoneResponse JSONResponseDataZone
 	if err := json.Unmarshal(rawCountZoneResponse, &countZoneResponse); err != nil {

--- a/providers/autodns/autoDnsProvider.go
+++ b/providers/autodns/autoDnsProvider.go
@@ -11,6 +11,9 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
+
+	"github.com/pquerna/otp/totp"
 
 	"github.com/DNSControl/dnscontrol/v4/models"
 	"github.com/DNSControl/dnscontrol/v4/pkg/diff2"
@@ -39,6 +42,8 @@ type autoDNSProvider struct {
 	baseURL         url.URL
 	defaultHeaders  http.Header
 	includeChildren bool
+	totpValue       string
+	totpKey         string
 }
 
 func init() {
@@ -46,12 +51,20 @@ func init() {
 	const providerMaintainer = "@arnoschoon"
 	fns := providers.DspFuncs{
 		Initializer: func(settings map[string]string, _ json.RawMessage) (providers.DNSServiceProvider, error) {
-			return newAutoDNSProvider(settings), nil
+			api, err := newAutoDNSProvider(settings)
+			if err != nil {
+				return nil, err
+			}
+			return api, nil
 		},
 		RecordAuditor: AuditRecords,
 	}
 	providers.RegisterRegistrarType(providerName, func(settings map[string]string) (providers.Registrar, error) {
-		return newAutoDNSProvider(settings), nil
+		api, err := newAutoDNSProvider(settings)
+		if err != nil {
+			return nil, err
+		}
+		return api, nil
 	}, features)
 	providers.RegisterDomainServiceProviderType(providerName, fns, features)
 	providers.RegisterMaintainer(providerName, providerMaintainer)
@@ -81,6 +94,12 @@ func init() {
 				Required: true,
 			},
 			{
+				Key:    "totp-key",
+				Label:  "TOTP shared secret (optional)",
+				Help:   "Shared TOTP secret used to generate the 2FA token. Only needed if two factor authentication is enabled for the account.",
+				Secret: true,
+			},
+			{
 				Key:   "children",
 				Label: "Include sub-user zones",
 				Help:  "Set to \"true\" so get-zones also lists zones owned by sub-users (master/admin accounts). Optional; defaults to off.",
@@ -89,7 +108,7 @@ func init() {
 	})
 }
 
-func newAutoDNSProvider(settings map[string]string) *autoDNSProvider {
+func newAutoDNSProvider(settings map[string]string) (*autoDNSProvider, error) {
 	api := &autoDNSProvider{}
 
 	api.baseURL = url.URL{
@@ -112,7 +131,32 @@ func newAutoDNSProvider(settings map[string]string) *autoDNSProvider {
 	// (the same optional toggle the web UI offers). Opt-in via creds.json.
 	api.includeChildren = settings["children"] == "true"
 
-	return api
+	api.totpValue, api.totpKey = settings["totp"], settings["totp-key"]
+
+	if api.totpValue != "" && api.totpKey != "" {
+		return nil, errors.New("AUTODNS: totp and totp-key must not be specified at the same time")
+	}
+
+	if api.totpKey != "" {
+		if _, err := totp.GenerateCode(api.totpKey, time.Now()); err != nil {
+			return nil, fmt.Errorf("AUTODNS: unable to generate a 2FA token from totp-key: %w", err)
+		}
+	}
+
+	return api, nil
+}
+
+func (api *autoDNSProvider) otp() (string, error) {
+	if api.totpKey == "" {
+		return api.totpValue, nil
+	}
+
+	token, err := totp.GenerateCode(api.totpKey, time.Now())
+	if err != nil {
+		return "", fmt.Errorf("AUTODNS: unable to generate a 2FA token from totp-key: %w", err)
+	}
+
+	return token, nil
 }
 
 // GetZoneRecordsCorrections returns a list of corrections that will turn existing records into dc.Records.


### PR DESCRIPTION
Adds support for AutoDNS accounts with two factor authentication enabled.

Configuration with `totp` or `totp-key` in `creds.json`