### PR TITLE
Misc fixes: CLOUDFLAREAPI, TRANSIP, and nrc.Flags

### DIFF
--- a/models/rdata.go
+++ b/models/rdata.go
@@ -47,6 +47,16 @@ func (rc *RecordConfig) ClearRDATA() {
 }
 
 func MyNewData(typeNum uint16, contents string, origin string) (dnsv2.RDATA, error) {
+	switch typeNum {
+
+	case dnsv2.TypeTXT:
+		// NewData expects quotes around TXT contents.
+		if len(contents) > 0 && (contents[0] != '"' && contents[len(contents)-1] != '"') {
+			contents = `"` + contents + `"`
+		}
+
+	}
+
 	rd2, err := dnsv2.NewData(typeNum, contents, origin+".")
 	if err != nil {
 		return nil, fmt.Errorf("NewData(%d, %q, %q) failed: %w", typeNum, contents, origin+".", err)

--- a/pkg/nrc/nrcflag.go
+++ b/pkg/nrc/nrcflag.go
@@ -1,8 +1,5 @@
 package nrc
 
-// FlagType is
-// type FlagType int
-
 type Flags struct {
 	// SrvWeirdSplit the last field contains multiple fields.
 	// Only for use with NewRecordConfigParse() && rtype=="SRV" && len(args) == 2.
@@ -21,13 +18,3 @@ type Flags struct {
 	// TxtDontParse tells NewRecordConfigParse() that the TXT data is raw bytes, not to be parsed.
 	TxtDontParse bool
 }
-
-var SRV_WEIRD_SPLIT = Flags{SrvWeirdSplit: true}
-var TARGET_IS_FQDN_NO_DOT = Flags{TargetIsFqdnNoDot: true}
-var TXT_DONT_PARSE = Flags{TxtDontParse: true}
-
-// const (
-// 	SrvWeirdSplit FlagType = iota
-// 	TargetIsFqdnNoDot
-// 	TxtDontParse
-// )

--- a/providers/cloudflare/cloudflareProvider.go
+++ b/providers/cloudflare/cloudflareProvider.go
@@ -943,20 +943,29 @@ func (c *cloudflareProvider) nativeToRecord(dc *models.DomainConfig, cr cloudfla
 
 	label := dc.LabelFromFQDNNoDot(cr.Name)
 	ttl := uint32(cr.TTL)
-	nFlags := nrc.TARGET_IS_FQDN_NO_DOT
 
 	var rc *models.RecordConfig
 	var err error
 
 	switch rType := cr.Type; rType { // #rtype_variations
 	case "MX":
-		rc, err = dc.NewRecordConfig(label, ttl, dnsv2.TypeMX, *cr.Priority, cr.Content, nFlags)
+		rc, err = dc.NewRecordConfig(label, ttl, dnsv2.TypeMX, *cr.Priority, cr.Content,
+			nrc.TARGET_IS_FQDN_NO_DOT)
 	case "SRV":
 		data := cr.Data.(map[string]any)
 		target := stringDefault(data["target"], "MISSING.TARGET")
-		rc, err = dc.NewRecordConfig(label, ttl, dnsv2.TypeSRV, uint16Zero(data["priority"]), uint16Zero(data["weight"]), uint16Zero(data["port"]), target, nFlags)
+		rc, err = dc.NewRecordConfig(label, ttl, dnsv2.TypeSRV, uint16Zero(data["priority"]), uint16Zero(data["weight"]), uint16Zero(data["port"]), target,
+			nrc.TARGET_IS_FQDN_NO_DOT)
+	case "TXT":
+		// t := cr.Content
+		// if len(t) > 0 && (t[0] != '"' && t[len(t)-1] != '"') {
+		// 	t = `"` + t + `"`
+		// }
+		// rc, err = dc.NewRecordConfigParse(label, ttl, rType, t)
+		rc, err = dc.NewRecordConfigParse(label, ttl, rType, cr.Content)
 	default:
-		rc, err = dc.NewRecordConfigParse(label, ttl, rType, cr.Content, nFlags)
+		rc, err = dc.NewRecordConfigParse(label, ttl, rType, cr.Content,
+			nrc.TARGET_IS_FQDN_NO_DOT)
 	}
 	if err != nil {
 		return nil, fmt.Errorf("unparsable %q record received from cloudflare: %w", cr.Type, err)

--- a/providers/cloudflare/cloudflareProvider.go
+++ b/providers/cloudflare/cloudflareProvider.go
@@ -950,22 +950,17 @@ func (c *cloudflareProvider) nativeToRecord(dc *models.DomainConfig, cr cloudfla
 	switch rType := cr.Type; rType { // #rtype_variations
 	case "MX":
 		rc, err = dc.NewRecordConfig(label, ttl, dnsv2.TypeMX, *cr.Priority, cr.Content,
-			nrc.TARGET_IS_FQDN_NO_DOT)
+			nrc.Flags{TargetIsFqdnNoDot: true})
 	case "SRV":
 		data := cr.Data.(map[string]any)
 		target := stringDefault(data["target"], "MISSING.TARGET")
 		rc, err = dc.NewRecordConfig(label, ttl, dnsv2.TypeSRV, uint16Zero(data["priority"]), uint16Zero(data["weight"]), uint16Zero(data["port"]), target,
-			nrc.TARGET_IS_FQDN_NO_DOT)
+			nrc.Flags{TargetIsFqdnNoDot: true})
 	case "TXT":
-		// t := cr.Content
-		// if len(t) > 0 && (t[0] != '"' && t[len(t)-1] != '"') {
-		// 	t = `"` + t + `"`
-		// }
-		// rc, err = dc.NewRecordConfigParse(label, ttl, rType, t)
 		rc, err = dc.NewRecordConfigParse(label, ttl, rType, cr.Content)
 	default:
 		rc, err = dc.NewRecordConfigParse(label, ttl, rType, cr.Content,
-			nrc.TARGET_IS_FQDN_NO_DOT)
+			nrc.Flags{TargetIsFqdnNoDot: true})
 	}
 	if err != nil {
 		return nil, fmt.Errorf("unparsable %q record received from cloudflare: %w", cr.Type, err)
@@ -974,7 +969,6 @@ func (c *cloudflareProvider) nativeToRecord(dc *models.DomainConfig, cr cloudfla
 	// Save a pointer to the original cr so that "push" can refer to it for IDs, etc.
 	rc.Original = cr
 
-	//if cr.Type == "A" || cr.Type == "AAAA" || cr.Type == "CNAME" {
 	if rc.TypeNum == dnsv2.TypeA || rc.TypeNum == dnsv2.TypeAAAA || rc.TypeNum == dnsv2.TypeCNAME {
 		if cr.Proxied != nil {
 			if *(cr.Proxied) {

--- a/providers/cloudflare/rest.go
+++ b/providers/cloudflare/rest.go
@@ -10,7 +10,6 @@ import (
 	"github.com/DNSControl/dnscontrol/v5/models"
 	"github.com/DNSControl/dnscontrol/v5/pkg/privatetypes"
 	privatetypesrdata "github.com/DNSControl/dnscontrol/v5/pkg/privatetypes/rdata"
-	"github.com/DNSControl/dnscontrol/v5/pkg/txtutil"
 	"github.com/cloudflare/cloudflare-go"
 	"golang.org/x/net/idna"
 )
@@ -315,7 +314,7 @@ func (c *cloudflareProvider) modifyRecord(domainID, recID string, proxied bool, 
 
 	switch rec.Type {
 	case "TXT":
-		r.Content = txtutil.EncodeQuoted(rec.GetTargetTXTJoined())
+		r.Content = rec.GetRDATA().String()
 	case "SRV":
 		r.Data = cfSrvData(rec)
 		r.Name = rec.GetLabelFQDN()

--- a/providers/cloudns/cloudnsProvider.go
+++ b/providers/cloudns/cloudnsProvider.go
@@ -380,6 +380,8 @@ func (c *cloudnsProvider) ListZones() ([]string, error) {
 
 // parses the ClouDNS format into our standard RecordConfig.
 func toRc(dc *models.DomainConfig, r *domainRecord) (*models.RecordConfig, error) {
+	var err error
+
 	ttl_, err := strconv.ParseUint(r.TTL, 10, 32)
 	if err != nil {
 		return nil, err
@@ -453,6 +455,9 @@ func toRc(dc *models.DomainConfig, r *domainRecord) (*models.RecordConfig, error
 	default:
 		rc, err = dc.NewRecordConfigParse(label, ttl, rtype, r.Target)
 	}
+	if err != nil {
+		return nil, err
+	}
 
 	// Add metadata for GeoDNS
 	// Note: By default, it works only with A, AAAA, CNAME, NAPTR or SRV record
@@ -460,10 +465,6 @@ func toRc(dc *models.DomainConfig, r *domainRecord) (*models.RecordConfig, error
 	// for your ClouDNS account.
 	if r.GeodnsCode != "" {
 		rc.Metadata[metaGeodnsCode] = r.GeodnsCode
-	}
-
-	if err != nil {
-		return nil, err
 	}
 
 	rc.Original = r

--- a/providers/cloudns/cloudnsProvider.go
+++ b/providers/cloudns/cloudnsProvider.go
@@ -448,6 +448,9 @@ func toRc(dc *models.DomainConfig, r *domainRecord) (*models.RecordConfig, error
 			r.LocLatDeg, r.LocLatMin, latSec, r.LocLatDir,
 			r.LocLongDeg, r.LocLongMin, longSec, r.LocLongDir,
 			altitude, size, hPrec, vPrec)
+		if err != nil {
+			return nil, err
+		}
 
 	case "NAPTR":
 		target := dc.ToFqdnWithDot(r.NaptrReplacement + ".")

--- a/providers/cnr/records.go
+++ b/providers/cnr/records.go
@@ -186,7 +186,8 @@ func toRC(dc *models.DomainConfig, data map[string]string) (*models.RecordConfig
 		return nil, fmt.Errorf("invalid TTL value for domain %s: %s", dc.Name, data["TTL"])
 	}
 
-	rc, err := dc.NewRecordConfigParse(dc.LabelFromShort(data["NAME"]), uint32(ttl), data["TYPE"], data["CONTENT"], nrc.TARGET_IS_FQDN_NO_DOT)
+	rc, err := dc.NewRecordConfigParse(dc.LabelFromShort(data["NAME"]), uint32(ttl), data["TYPE"], data["CONTENT"],
+		nrc.Flags{TargetIsFqdnNoDot: true})
 	if err != nil {
 		return nil, fmt.Errorf("parse error: %w", err)
 	}

--- a/providers/digitalocean/digitaloceanProvider.go
+++ b/providers/digitalocean/digitaloceanProvider.go
@@ -313,19 +313,21 @@ func toRc(dc *models.DomainConfig, r *godo.DomainRecord) (*models.RecordConfig, 
 	label := dc.LabelFromShort(r.Name)
 	ttl := uint32(r.TTL)
 
-	nFlags := nrc.TARGET_IS_FQDN_NO_DOT
-
 	var rc *models.RecordConfig
 	var err error
 	switch rtype := r.Type; rtype {
 	case "MX":
-		rc, err = dc.NewRecordConfig(label, ttl, dnsv2.TypeMX, uint16(r.Priority), r.Data, nFlags)
+		rc, err = dc.NewRecordConfig(label, ttl, dnsv2.TypeMX, uint16(r.Priority), r.Data,
+			nrc.Flags{TargetIsFqdnNoDot: true})
 	case "SRV":
-		rc, err = dc.NewRecordConfig(label, ttl, dnsv2.TypeSRV, uint16(r.Priority), uint16(r.Weight), uint16(r.Port), r.Data, nFlags)
+		rc, err = dc.NewRecordConfig(label, ttl, dnsv2.TypeSRV, uint16(r.Priority), uint16(r.Weight), uint16(r.Port), r.Data,
+			nrc.Flags{TargetIsFqdnNoDot: true})
 	case "CAA":
-		rc, err = dc.NewRecordConfig(label, ttl, dnsv2.TypeCAA, uint8(r.Flags), r.Tag, r.Data, nFlags)
+		rc, err = dc.NewRecordConfig(label, ttl, dnsv2.TypeCAA, uint8(r.Flags), r.Tag, r.Data,
+			nrc.Flags{TargetIsFqdnNoDot: true})
 	default:
-		rc, err = dc.NewRecordConfig(label, ttl, r.Type, r.Data, nFlags)
+		rc, err = dc.NewRecordConfig(label, ttl, r.Type, r.Data,
+			nrc.Flags{TargetIsFqdnNoDot: true})
 	}
 	if err != nil {
 		return nil, err

--- a/providers/hedns/hednsProvider.go
+++ b/providers/hedns/hednsProvider.go
@@ -514,18 +514,18 @@ func recordToRC(dc *models.DomainConfig, rec Record) (*models.RecordConfig, erro
 		rtype = "TXT"
 	}
 
-	nFlags := nrc.Flags{TargetIsFqdnNoDot: true}
-	stFlags := nrc.Flags{SrvWeirdSplit: true, TargetIsFqdnNoDot: true}
-
 	var rc *models.RecordConfig
 	var err error
 	switch rtype {
 	case "MX":
-		rc, err = dc.NewRecordConfig(label, ttl, dnsv2.TypeMX, rec.Priority, rec.Data, nFlags)
+		rc, err = dc.NewRecordConfig(label, ttl, dnsv2.TypeMX, rec.Priority, rec.Data,
+			nrc.Flags{TargetIsFqdnNoDot: true})
 	case "SRV":
-		rc, err = dc.NewRecordConfig(label, ttl, dnsv2.TypeSRV, rec.Priority, rec.Data, stFlags)
+		rc, err = dc.NewRecordConfig(label, ttl, dnsv2.TypeSRV, rec.Priority, rec.Data,
+			nrc.Flags{SrvWeirdSplit: true, TargetIsFqdnNoDot: true})
 	default:
-		rc, err = dc.NewRecordConfigParse(label, ttl, rtype, rec.Data, nFlags)
+		rc, err = dc.NewRecordConfigParse(label, ttl, rtype, rec.Data,
+			nrc.Flags{TargetIsFqdnNoDot: true})
 	}
 	if err != nil {
 		return nil, err

--- a/providers/inwx/inwxProvider.go
+++ b/providers/inwx/inwxProvider.go
@@ -457,9 +457,11 @@ func (api *inwxAPI) GetZoneRecords(dc *models.DomainConfig) (models.Records, err
 		case "MX":
 			rc, err = dc.NewRecordConfig(label, ttl, rType, record.Priority, record.Content)
 		case "SRV":
-			rc, err = dc.NewRecordConfig(label, ttl, rType, record.Priority, record.Content, nrc.Flags{SrvWeirdSplit: true})
+			rc, err = dc.NewRecordConfig(label, ttl, rType, record.Priority, record.Content,
+				nrc.Flags{SrvWeirdSplit: true})
 		default:
-			rc, err = dc.NewRecordConfigParse(label, ttl, rType, record.Content, nrc.Flags{TxtDontParse: true})
+			rc, err = dc.NewRecordConfigParse(label, ttl, rType, record.Content,
+				nrc.Flags{TxtDontParse: true})
 		}
 		if err != nil {
 			return nil, fmt.Errorf("INWX: unparsable record received: %w", err)

--- a/providers/namedotcom/records.go
+++ b/providers/namedotcom/records.go
@@ -100,9 +100,11 @@ func toRecord(r *namecom.Record, dc *models.DomainConfig) (*models.RecordConfig,
 	case "MX":
 		rc, err = dc.NewRecordConfig(label, r.TTL, dnsv2.TypeMX, r.Priority, r.Answer)
 	case "SRV":
-		rc, err = dc.NewRecordConfig(label, r.TTL, dnsv2.TypeSRV, r.Priority, r.Answer, nrc.Flags{SrvWeirdSplit: true, TargetIsFqdnNoDot: true})
+		rc, err = dc.NewRecordConfig(label, r.TTL, dnsv2.TypeSRV, r.Priority, r.Answer,
+			nrc.Flags{SrvWeirdSplit: true, TargetIsFqdnNoDot: true})
 	default:
-		rc, err = dc.NewRecordConfigParse(label, r.TTL, rtype, r.Answer, nrc.TXT_DONT_PARSE)
+		rc, err = dc.NewRecordConfigParse(label, r.TTL, rtype, r.Answer,
+			nrc.Flags{TxtDontParse: true})
 	}
 	if err != nil {
 		return nil, fmt.Errorf("unparsable record received from ndc: %w", err)

--- a/providers/ns1/records.go
+++ b/providers/ns1/records.go
@@ -186,7 +186,6 @@ func convert(zr *dns.ZoneRecord, dc *models.DomainConfig) (models.Records, error
 
 		label := dc.LabelFromFQDNNoDot(zr.Domain)
 		ttl := uint32(zr.TTL)
-		npFlags := nrc.TXT_DONT_PARSE
 
 		var rec *models.RecordConfig
 		var err error
@@ -218,7 +217,8 @@ func convert(zr *dns.ZoneRecord, dc *models.DomainConfig) (models.Records, error
 			continue
 		default:
 			// NS1 returns TXT values as plain strings, not RFC1035 quoted presentation.
-			rec, err = dc.NewRecordConfigParse(label, ttl, rtype, ans, npFlags)
+			rec, err = dc.NewRecordConfigParse(label, ttl, rtype, ans,
+				nrc.Flags{TxtDontParse: true})
 		}
 		if err != nil {
 			return nil, fmt.Errorf("unparsable %s record received from ns1: %w", zr.Type, err)

--- a/providers/transip/retry.go
+++ b/providers/transip/retry.go
@@ -33,6 +33,12 @@ func retryNeeded(err error) bool {
 		return false             // Success! No need to retry.
 	}
 
+	if serr.StatusCode == 502 {
+		// "502 Bad Gateway" seen occasionally when TransIP becomes overloaded.
+		backoff = initialBackoff // Reset
+		return true
+	}
+
 	if serr.StatusCode != 429 {
 		return false
 	}

--- a/providers/vercel/vercelProvider.go
+++ b/providers/vercel/vercelProvider.go
@@ -148,22 +148,23 @@ func vercelRecordToRC(dc *models.DomainConfig, r DNSRecord) (*models.RecordConfi
 	label := dc.LabelFromShort(r.Name)
 	ttl := uint32(r.TTL)
 
-	nFlags := nrc.Flags{TargetIsFqdnNoDot: true, SrvWeirdSplit: true}
-	npFlags := nrc.Flags{TargetIsFqdnNoDot: true}
-
 	var rc *models.RecordConfig
 	var err error
 	switch rtype := r.RecordType; rtype {
 	case "CNAME":
-		rc, err = dc.NewRecordConfig(label, ttl, rtype, r.Value, nFlags)
+		rc, err = dc.NewRecordConfig(label, ttl, rtype, r.Value,
+			nrc.Flags{TargetIsFqdnNoDot: true})
 	case "MX":
-		rc, err = dc.NewRecordConfig(label, ttl, rtype, r.MXPriority, r.Value, nFlags)
+		rc, err = dc.NewRecordConfig(label, ttl, rtype, r.MXPriority, r.Value,
+			nrc.Flags{TargetIsFqdnNoDot: true})
 	case "SRV", "HTTPS", "SVCB":
-		rc, err = dc.NewRecordConfig(label, ttl, rtype, r.Priority, r.Value, nFlags)
+		rc, err = dc.NewRecordConfig(label, ttl, rtype, r.Priority, r.Value,
+			nrc.Flags{TargetIsFqdnNoDot: true, SrvWeirdSplit: true})
 	case "TXT":
-		rc, err = dc.NewRecordConfig(label, ttl, dnsv2.TypeTXT, r.Value, nFlags)
+		rc, err = dc.NewRecordConfig(label, ttl, dnsv2.TypeTXT, r.Value)
 	default:
-		rc, err = dc.NewRecordConfigParse(label, ttl, rtype, r.Value, npFlags)
+		rc, err = dc.NewRecordConfigParse(label, ttl, rtype, r.Value,
+			nrc.Flags{TargetIsFqdnNoDot: true})
 	}
 	if err != nil {
 		return nil, fmt.Errorf("unparsable %s record received from vercel: %w", r.RecordType, err)


### PR DESCRIPTION
* CLOUDFLAREAPI: Fix TXT records
* pkg/nrc: Remove old comments. Reformat all uses of nrc to be consistent.
* CLOUDNS: Fix linting
* TRANSIP: Retry on 502 bad gateway