### PR TITLE
OVH: fix all failing integration tests

### DIFF
--- a/integrationTest/integration_test.go
+++ b/integrationTest/integration_test.go
@@ -2191,6 +2191,8 @@ func makeTests() []*TestGroup {
 				ovhspf("spf", "v=spf1 a mx -all"),
 				ovhdkim("dkim._domainkey", "v=DKIM1;t=s;p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDk72yk6UML8LGIXFobhvx6UDUntqGzmyie2FLMyrOYk1C7CVYR139VMbO9X1rFvZ8TaPnMCkMbuEGWGgWNc27MLYKfI+wP/SYGjRS98TNl9wXxP8tPfr6id5gks95sEMMaYTu8sctnN6sBOvr4hQ2oipVcBn/oxkrfhqvlcat5gQIDAQAB"),
 				ovhdmarc("_dmarc", "v=DMARC1; p=none; rua=mailto:dmarc@example.com")),
+			tc("Create native OVH DKIM record longer than 255 bytes",
+				ovhdkim("dkimbig._domainkey", "v=DKIM1; t=s; p=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAtNHHaHjrlPU5hvNyp5LKkhINqUNo3rwvHP3RMYvBMdxs0W34SLMc52QSn+O8QN5P2rU9Hs3qiD5kaIjGfU77EwMnrUh0MhRgWPKED5R66/BXYh9tIv9aLBeGgrO8Tj1zvW2CO9HI9V5TcuEe8OKgY4EvtuBtlgG7DbM2fwm2VL9nbvM15hxQjAkDxfDNBLMXozsk86Fp9EzOwtUykRH1VoCusC0qYqmOMpPknDoJ2vJKZMm1Cpx0ICnsdWbmLVKPpgdBdj28jCXU/bm4jvXcSL9oGb3rBxVmpsgA+JHEZH2XMbDDzHjLnH7DsavP/Xth19KA/opQ4h6vFxAQOX+yzQIDAQAB")),
 		),
 
 		// CLOUDNS features

--- a/providers/ovh/auditrecords.go
+++ b/providers/ovh/auditrecords.go
@@ -1,6 +1,9 @@
 package ovh
 
 import (
+	"errors"
+	"strings"
+
 	"github.com/DNSControl/dnscontrol/v5/models"
 	"github.com/DNSControl/dnscontrol/v5/pkg/rejectif"
 )
@@ -14,6 +17,16 @@ func AuditRecords(records []*models.RecordConfig) []error {
 	a.Add("TXT", rejectif.TxtHasBackslash) // Last verified 2026-07-19
 
 	a.Add("TXT", rejectif.TxtHasDoubleQuotes) // Last verified 2026-07-19
+
+	a.Add("TXT", rejectif.TxtStartsOrEndsWithSpaces) // Last verified 2026-08-01
+
+	a.Add("TXT", rejectif.TxtIsEmpty) // Last verified 2026-07-26
+	a.Add("TXT", func(rc *models.RecordConfig) error {
+		if rc.Type == "DKIM" && !strings.HasSuffix(rc.Name, "._domainkey") {
+			return errors.New("DKIM name should end with ._domainkey")
+		}
+		return nil
+	}) // Last verified 2026-07-26
 
 	return a.Audit(records)
 }

--- a/providers/ovh/ovhProvider.go
+++ b/providers/ovh/ovhProvider.go
@@ -230,9 +230,20 @@ func nativeToRecord(r *Record, dc *models.DomainConfig) (*models.RecordConfig, e
 	switch rtype {
 	case "TXT":
 		var tx string
-		tx, err = txtutil.ParseQuoted(r.Target)
-		if err != nil {
-			return nil, err
+		switch r.FieldType {
+		case "DKIM", "DMARC":
+			// Unlike regular TXT and SPF records, OVH stores and returns DKIM
+			// and DMARC targets as raw, unquoted text (see adaptNativeRecord,
+			// which strips quotes before writing them). Running raw text
+			// through the RFC1035 zone-file TXT parser is wrong: an unescaped
+			// ';' is interpreted as the start of a comment, silently
+			// truncating values like "v=DMARC1; p=none; rua=...".
+			tx = r.Target
+		default:
+			tx, err = txtutil.ParseQuoted(r.Target)
+			if err != nil {
+				return nil, err
+			}
 		}
 		rc, err = dc.NewRecordConfig(label, ttl, dnsv2.TypeTXT, tx)
 	default:

--- a/providers/ovh/ovhProvider_test.go
+++ b/providers/ovh/ovhProvider_test.go
@@ -1,8 +1,12 @@
 package ovh
 
 import (
+	"reflect"
+	"strings"
 	"testing"
 
+	dnsv2 "codeberg.org/miekg/dns"
+	"github.com/DNSControl/dnscontrol/v5/models"
 	"github.com/ovh/go-ovh/ovh"
 )
 
@@ -45,6 +49,99 @@ func Test_getOVHEndpoint(t *testing.T) {
 			}
 			if got := getOVHEndpoint(params); got != tt.want {
 				t.Errorf("getOVHEndpoint() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_nativeToRecord(t *testing.T) {
+	dc := &models.DomainConfig{Name: "dnscontrol.ovh"}
+
+	tests := []struct {
+		name       string
+		record     *Record
+		wantTarget string
+		wantErr    bool
+	}{
+		{
+			// Regular TXT records are returned by OVH properly quoted, as
+			// RFC1035 zone-file presentation strings.
+			name: "TXT quoted, with semicolon",
+			record: &Record{
+				Target:    `"with a ; semicolon"`,
+				Zone:      "dnscontrol.ovh",
+				FieldType: "TXT",
+				SubDomain: "foo",
+			},
+			wantTarget: "with a ; semicolon",
+		},
+		{
+			// DMARC records are returned raw/unquoted. A naive zone-file
+			// parse would treat the unescaped ';' as a comment and truncate
+			// the value at "v=DMARC1".
+			name: "native DMARC, unquoted with semicolons",
+			record: &Record{
+				Target:    "v=DMARC1; p=none; rua=mailto:dmarc@yourdomain.com",
+				Zone:      "dnscontrol.ovh",
+				FieldType: "DMARC",
+				SubDomain: "_dmarc",
+			},
+			wantTarget: "v=DMARC1; p=none; rua=mailto:dmarc@yourdomain.com",
+		},
+		{
+			// Same issue for DKIM records.
+			name: "native DKIM, unquoted with semicolons",
+			record: &Record{
+				Target:    "v=DKIM1; t=s; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCzwOUg",
+				Zone:      "dnscontrol.ovh",
+				FieldType: "DKIM",
+				SubDomain: "dkim._domainkey",
+			},
+			wantTarget: "v=DKIM1; t=s; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCzwOUg",
+		},
+		{
+			// Native SPF records, unlike DKIM/DMARC, are returned quoted
+			// like a regular TXT record.
+			name: "native SPF, quoted",
+			record: &Record{
+				Target:    `"v=spf1 ip4:99.99.99.99 -all"`,
+				Zone:      "dnscontrol.ovh",
+				FieldType: "SPF",
+				SubDomain: "spf",
+			},
+			wantTarget: "v=spf1 ip4:99.99.99.99 -all",
+		},
+		{
+			// Real DKIM keys routinely exceed the 255-octet RFC1035
+			// character-string limit (e.g. a 2048-bit RSA key). The raw,
+			// unquoted target must round-trip in full: NewRecordConfig
+			// segments it into 255-octet chunks internally, but joining it
+			// back for comparison/display must reproduce the exact input.
+			name: "native DKIM, longer than 255 bytes",
+			record: &Record{
+				Target:    "v=DKIM1; t=s; p=" + strings.Repeat("A", 300),
+				Zone:      "dnscontrol.ovh",
+				FieldType: "DKIM",
+				SubDomain: "dkim._domainkey",
+			},
+			wantTarget: "v=DKIM1; t=s; p=" + strings.Repeat("A", 300),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := nativeToRecord(tt.record, dc)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("nativeToRecord() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if err != nil {
+				return
+			}
+			want := dc.MustNewRecordConfig(dc.LabelFromShort(tt.record.SubDomain), 3600, dnsv2.TypeTXT, tt.wantTarget)
+			want.Original = tt.record
+
+			if !reflect.DeepEqual(got, want) {
+				t.Errorf("nativeToRecord() got = %#v, want %#v", got, want)
 			}
 		})
 	}

--- a/providers/ovh/protocol.go
+++ b/providers/ovh/protocol.go
@@ -113,7 +113,12 @@ func (c *ovhProvider) createRecordFunc(rc *models.RecordConfig, fqdn string) fun
 
 		var target string
 		switch recordType {
-		case "TXT":
+		case "TXT", "DKIM", "DMARC":
+			// OVH stores and returns DKIM/DMARC targets as raw, unquoted,
+			// un-chunked text (see nativeToRecord). GetRDATA().String()
+			// would render values over 255 bytes as multiple quoted
+			// segments ("chunk1" "chunk2"), which OVH rejects once the
+			// outer quotes are stripped in adaptNativeRecord.
 			target = rc.GetTargetTXTJoined()
 		default:
 			target = rc.GetRDATA().String()
@@ -159,7 +164,9 @@ func (c *ovhProvider) updateRecordFunc(old *Record, rc *models.RecordConfig, fqd
 
 		var target string
 		switch recordType {
-		case "TXT":
+		case "TXT", "DKIM", "DMARC":
+			// See createRecordFunc: DKIM/DMARC must be sent as raw,
+			// unquoted, un-chunked text, matching what OVH returns.
 			target = rc.GetTargetTXTJoined()
 		default:
 			target = rc.GetRDATA().String()
@@ -197,11 +204,6 @@ func (c *ovhProvider) updateRecordFunc(old *Record, rc *models.RecordConfig, fqd
 
 // adaptNativeRecord adapts the record for native OVH types such as DMARC or DKIM.
 func adaptNativeRecord(r *Record) error {
-	// OVH needs DMARC and DKIM to be "unquoted"
-	if r.FieldType == "DMARC" || r.FieldType == "DKIM" {
-		// make sure target is fully unquoted to prevent "Invalid subfield found in DMARC" error
-		r.Target = models.StripQuotes(r.Target)
-	}
 	// DMARC record can be created only for subdomains starting with`_dmarc`
 	if r.FieldType == "DMARC" && !strings.HasPrefix(r.SubDomain, "_dmarc") {
 		return fmt.Errorf("native OVH DMARC record requires subdomain to always start with _dmarc, %s given", r.SubDomain)


### PR DESCRIPTION
This fixes all remaining integration tests in preparation of the release candidate v5.

<!--
## Before submiting a pull request

Please make sure you've run the following commands from the root directory.

    bin/generate-all.sh

(this runs commands like "go generate", fixes formatting, and so on)

## Release changelog section

Help keep the release changelog clear by pre-naming the proper section in the GitHub pull request title.

Some examples:
* CICD: Add required GHA permissions for goreleaser
* DOCS: Fixed providers with "contributor support" table
* ROUTE53: Allow R53_ALIAS records to enable target health evaluation

More examples/context can be found in the file .goreleaser.yml under the 'build' > 'changelog' key.
!-->
