### PR TITLE
DNSIMPLE: Modernize field access

### DIFF
--- a/integrationTest/integration_test.go
+++ b/integrationTest/integration_test.go
@@ -722,6 +722,7 @@ func makeTests() []*TestGroup {
 				"CNR",               // Test breaks limits.
 				// "CSCGLOBAL",     // Doesn't page. Works fine.  Due to the slow API we skip.
 				"DESEC",        // Skip due to daily update limits.
+				"DNSIMPLE",     // Daily update quota.
 				"DIGITALOCEAN", // No paging. Why bother?
 				"FORTIGATE",    // No paging
 				"GANDI_V5",     // Their API is so damn slow. We'll add it back as needed.
@@ -745,6 +746,7 @@ func makeTests() []*TestGroup {
 				// "CLOUDFLAREAPI",     // Infinite pagesize but due to slow speed, skipping.
 				// "CSCGLOBAL",         // Doesn't page. Works fine.  Due to the slow API we skip.
 				// "DESEC",             // Skip due to daily update limits.
+				// "DNSIMPLE",         // Daily update quota.
 				// "GANDI_V5",          // Their API is so damn slow. We'll add it back as needed.
 				// "GCLOUD",
 				"ORACLE",
@@ -762,6 +764,7 @@ func makeTests() []*TestGroup {
 				// "CLOUDFLAREAPI",     // Fails with >1000 corrections. See https://github.com/DNSControl/dnscontrol/issues/1440
 				// "CSCGLOBAL", // Doesn't page. Works fine.  Due to the slow API we skip.
 				// "DESEC",     // Skip due to daily update limits.
+				// "DNSIMPLE", // Daily update quota.
 				// "GANDI_V5",  // Their API is so damn slow. We'll add it back as needed.
 				"GCLOUD",
 				// "HEDNS",     // No paging done. No need to test.

--- a/integrationTest/profiles.json
+++ b/integrationTest/profiles.json
@@ -131,7 +131,7 @@
   },
   "DNSIMPLE": {
     "TYPE": "DNSIMPLE",
-    "baseurl": "https://api.sandbox.dnsimple.com",
+    "baseurl": "$DNSIMPLE_BASEURL",
     "domain": "$DNSIMPLE_DOMAIN",
     "token": "$DNSIMPLE_TOKEN"
   },

--- a/pkg/mustbe/hosts.go
+++ b/pkg/mustbe/hosts.go
@@ -69,7 +69,8 @@ func TargetHost(origin string, isEnabled nrc.Flags, arg any) string {
 	// Or, perhaps this was used before I decided to change the signatures of
 	// the Make*() functions to include isEnabled, after which I should have
 	// removed the origin=="." code.
-	// In the future we should unify around one way of doing this.
+	// In the future we should eliminate the origin=".".
+
 	if origin == "." && name == "" {
 		// if isEnabled.TargetIsFqdnNoDot && name == "" {
 		return "."

--- a/pkg/mustbe/hosts.go
+++ b/pkg/mustbe/hosts.go
@@ -28,6 +28,9 @@ import (
 //   - The reason for not storing the short or "@" version is that "preview" output becomes ambiguous. Explicit is better than implicit.
 //   - Wildcards ("@") are rejected since they are not valid in targets. That's why this is called TargetHost and not Host.
 //
+// * origin == ".":
+//   - This is a special flag for TargetIsFqdnNoDot mode.
+//
 // * Examples: (assume $origin = "domain.com")
 //   - `@` -> $origin
 //   - `foo.$origin.` -> `foo.$origin.`
@@ -35,9 +38,9 @@ import (
 //   - `other.com.` -> `other.com.`
 //   - `short` -> `short.$origin`
 func TargetHost(origin string, isEnabled nrc.Flags, arg any) string {
-	// Check for programmer error.
-	if strings.HasSuffix(origin, ".") {
-		panic("mustbe.Host must NOT be called with an origin ending with .")
+	// Check for programmer error. Origin shouldn't end in ".", unless it == "." which is a special mode.
+	if origin != "." && strings.HasSuffix(origin, ".") {
+		panic(fmt.Sprintf("mustbe.Host must NOT be called with an origin ending with . (origin=%q)", origin))
 	}
 
 	var name string
@@ -58,6 +61,20 @@ func TargetHost(origin string, isEnabled nrc.Flags, arg any) string {
 		return name
 	}
 
+	// TODO(tlim):
+	// origin == "." is a special flag that means the same thing as
+	// isEnabled.TargetIsFqdnNoDot == true.
+	// I'm not sure why we have to ways to signal this mode. Too much late-night
+	// coding, I suspect.
+	// Or, perhaps this was used before I decided to change the signatures of
+	// the Make*() functions to include isEnabled, after which I should have
+	// removed the origin=="." code.
+	// In the future we should unify around one way of doing this.
+	if origin == "." && name == "" {
+		// if isEnabled.TargetIsFqdnNoDot && name == "" {
+		return "."
+	}
+
 	// Special symbols:
 	switch name {
 	case "@", "":
@@ -68,9 +85,11 @@ func TargetHost(origin string, isEnabled nrc.Flags, arg any) string {
 	name = domaintags.EfficientToASCII(name)
 
 	if isEnabled.TargetIsFqdnNoDot {
+		// The dot is unexpected but we'll allow it.
 		if name[len(name)-1] == '.' {
 			return name
 		}
+		// Add the dot.
 		return name + "."
 	}
 

--- a/pkg/mustbe/hosts.go
+++ b/pkg/mustbe/hosts.go
@@ -64,15 +64,14 @@ func TargetHost(origin string, isEnabled nrc.Flags, arg any) string {
 	// TODO(tlim):
 	// origin == "." is a special flag that means the same thing as
 	// isEnabled.TargetIsFqdnNoDot == true.
-	// I'm not sure why we have to ways to signal this mode. Too much late-night
+	// I'm not sure why we have two ways to signal this mode. Too much late-night
 	// coding, I suspect.
-	// Or, perhaps this was used before I decided to change the signatures of
+	// Or, perhaps this was written before I decided to change the signatures of
 	// the Make*() functions to include isEnabled, after which I should have
 	// removed the origin=="." code.
 	// In the future we should eliminate the origin=".".
 
 	if origin == "." && name == "" {
-		// if isEnabled.TargetIsFqdnNoDot && name == "" {
 		return "."
 	}
 

--- a/pkg/mustbe/hosts_test.go
+++ b/pkg/mustbe/hosts_test.go
@@ -52,6 +52,9 @@ func TestTargetHost(t *testing.T) {
 		//{"f1", "domain.com", "", "domain.com.", ""}, // shouldn't happen.
 		{"f2", "domain.com", "42", "42.domain.com.", "42."},
 		{"f3", "domain.com", 99, "99.domain.com.", "99."},
+		// NullMX and NullSRV:
+		{"null", "example.com", ".", ".", "."},
+		{"null2", "", ".", ".", "."},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/providers/dnscale/dnscaleProvider.go
+++ b/providers/dnscale/dnscaleProvider.go
@@ -12,10 +12,8 @@ import (
 	"strings"
 	"time"
 
-	dnsv2 "codeberg.org/miekg/dns"
 	"github.com/DNSControl/dnscontrol/v5/models"
 	"github.com/DNSControl/dnscontrol/v5/pkg/diff2"
-	privatetypes "github.com/DNSControl/dnscontrol/v5/pkg/privatetypes"
 	"github.com/DNSControl/dnscontrol/v5/pkg/providers"
 )
 
@@ -539,8 +537,8 @@ func fromRecordConfig(rc *models.RecordConfig) Record {
 	var content string
 	priority := 0
 
-	switch rc.TypeNum {
-	case dnsv2.TypeCNAME, dnsv2.TypeNS, dnsv2.TypePTR, privatetypes.TypeALIAS:
+	switch rc.Type {
+	case "CNAME", "NS", "PTR", "ALIAS":
 		// Remove trailing dot for DNScale API
 		content = strings.TrimSuffix(content, ".")
 	case "MX":
@@ -557,25 +555,25 @@ func fromRecordConfig(rc *models.RecordConfig) Record {
 		// content = fmt.Sprintf("%d %d %d %s", rc.SrvPriority, rc.SrvWeight, rc.SrvPort, target)
 		content = rc.GetRDATA().String()
 
-	case dnsv2.TypeCAA:
+	case "CAA":
 		// TODO(tlim): Remove commented out code if new code works.
 		//content = fmt.Sprintf("%d %s \"%s\"", rc.CaaFlag, rc.CaaTag, rc.GetTargetField())
 		content = rc.GetRDATA().String()
-	case dnsv2.TypeTLSA:
+	case "TLSA":
 		// TODO(tlim): Remove commented out code if new code works.
 		//content = fmt.Sprintf("%d %d %d %s", rc.TlsaUsage, rc.TlsaSelector, rc.TlsaMatchingType, rc.GetTargetField())
 		content = rc.GetRDATA().String()
-	case dnsv2.TypeSSHFP:
+	case "SSHFP":
 		// TODO(tlim): Remove commented out code if new code works.
 		//content = fmt.Sprintf("%d %d %s", rc.SshfpAlgorithm, rc.SshfpFingerprint, rc.GetTargetField())
 		content = rc.GetRDATA().String()
-	case dnsv2.TypeHTTPS, dnsv2.TypeSVCB:
-		// Use GetTargetCombined() which formats SVCB/HTTPS records correctly via miekg/dns
+	case "HTTPS", "SVCB":
+		// Use GetRDATA().String() which formats SVCB/HTTPS records correctly via miekg/dns
 		// DNScale API requires selective quote handling for SVCB params:
 		// - alpn="h2,h3" must become alpn=h2,h3 (quotes stripped)
 		// - ech="base64..." must keep quotes (required for base64 values)
 		content = stripSvcbQuotesExceptEch(rc.GetRDATA().String())
-	case dnsv2.TypeTXT:
+	case "TXT":
 		content = rc.GetTargetTXTJoined()
 	default:
 		content = rc.GetRDATA().String()

--- a/providers/dnscale/dnscaleProvider.go
+++ b/providers/dnscale/dnscaleProvider.go
@@ -12,8 +12,10 @@ import (
 	"strings"
 	"time"
 
+	dnsv2 "codeberg.org/miekg/dns"
 	"github.com/DNSControl/dnscontrol/v5/models"
 	"github.com/DNSControl/dnscontrol/v5/pkg/diff2"
+	privatetypes "github.com/DNSControl/dnscontrol/v5/pkg/privatetypes"
 	"github.com/DNSControl/dnscontrol/v5/pkg/providers"
 )
 
@@ -530,14 +532,14 @@ func fromRecordConfig(rc *models.RecordConfig) Record {
 	content := rc.GetTargetField()
 	priority := 0
 
-	switch rc.Type {
-	case "CNAME", "NS", "PTR", "ALIAS":
+	switch rc.TypeNum {
+	case dnsv2.TypeCNAME, dnsv2.TypeNS, dnsv2.TypePTR, privatetypes.TypeALIAS:
 		// Remove trailing dot for DNScale API
 		content = strings.TrimSuffix(content, ".")
-	case "MX":
+	case dnsv2.TypeMX:
 		priority = int(rc.MxPreference)
 		content = strings.TrimSuffix(content, ".")
-	case "SRV":
+	case dnsv2.TypeSRV:
 		// TODO(tlim): Remove commented out code if new code works.
 		// DNScale API expects full content: "priority weight port target"
 		// target := rc.GetTargetField()
@@ -547,25 +549,25 @@ func fromRecordConfig(rc *models.RecordConfig) Record {
 		// content = fmt.Sprintf("%d %d %d %s", rc.SrvPriority, rc.SrvWeight, rc.SrvPort, target)
 		content = rc.GetRDATA().String()
 
-	case "CAA":
+	case dnsv2.TypeCAA:
 		// TODO(tlim): Remove commented out code if new code works.
 		//content = fmt.Sprintf("%d %s \"%s\"", rc.CaaFlag, rc.CaaTag, rc.GetTargetField())
 		content = rc.GetRDATA().String()
-	case "TLSA":
+	case dnsv2.TypeTLSA:
 		// TODO(tlim): Remove commented out code if new code works.
 		//content = fmt.Sprintf("%d %d %d %s", rc.TlsaUsage, rc.TlsaSelector, rc.TlsaMatchingType, rc.GetTargetField())
 		content = rc.GetRDATA().String()
-	case "SSHFP":
+	case dnsv2.TypeSSHFP:
 		// TODO(tlim): Remove commented out code if new code works.
 		//content = fmt.Sprintf("%d %d %s", rc.SshfpAlgorithm, rc.SshfpFingerprint, rc.GetTargetField())
 		content = rc.GetRDATA().String()
-	case "HTTPS", "SVCB":
+	case dnsv2.TypeHTTPS, dnsv2.TypeSVCB:
 		// Use GetTargetCombined() which formats SVCB/HTTPS records correctly via miekg/dns
 		// DNScale API requires selective quote handling for SVCB params:
 		// - alpn="h2,h3" must become alpn=h2,h3 (quotes stripped)
 		// - ech="base64..." must keep quotes (required for base64 values)
 		content = stripSvcbQuotesExceptEch(rc.GetRDATA().String())
-	case "TXT":
+	case dnsv2.TypeTXT:
 		content = rc.GetTargetTXTJoined()
 	}
 

--- a/providers/dnsimple/dnsimpleProvider.go
+++ b/providers/dnsimple/dnsimpleProvider.go
@@ -13,9 +13,9 @@ import (
 
 	"github.com/DNSControl/dnscontrol/v5/models"
 	"github.com/DNSControl/dnscontrol/v5/pkg/diff2"
+	"github.com/DNSControl/dnscontrol/v5/pkg/nrc"
 	"github.com/DNSControl/dnscontrol/v5/pkg/printer"
 	"github.com/DNSControl/dnscontrol/v5/pkg/providers"
-	"github.com/DNSControl/dnscontrol/v5/pkg/txtutil"
 	dnsimpleapi "github.com/dnsimple/dnsimple-go/v8/dnsimple"
 	"golang.org/x/oauth2"
 )
@@ -154,34 +154,33 @@ func qualifySVCBTarget(content string) string {
 }
 
 func toRecordConfig(dc *models.DomainConfig, r dnsimpleapi.ZoneRecord) (*models.RecordConfig, error) {
-	if r.Name == "" {
-		r.Name = "@"
-	}
-
-	if r.Type == "CNAME" || r.Type == "ALIAS" || r.Type == "NS" {
-		r.Content += "."
-	} else if r.Type == "MX" && r.Content != "." {
-		r.Content += "."
-	} else if r.Type == "SVCB" || r.Type == "HTTPS" {
-		r.Content = qualifySVCBTarget(r.Content)
-	}
+	label := dc.LabelFromShort(r.Name)
+	ttl := uint32(r.TTL)
 
 	var rec *models.RecordConfig
 	var err error
-	switch r.Type {
+	switch rtype := r.Type; rtype {
 	case "ALIAS", "URL":
-		rec, err = dc.NewRecordConfig(r.Name, uint32(r.TTL), r.Type, r.Content)
+		rec, err = dc.NewRecordConfig(label, ttl, rtype, r.Content,
+			nrc.Flags{TargetIsFqdnNoDot: true})
 	case "MX":
-		rec, err = dc.NewRecordConfig(r.Name, uint32(r.TTL), r.Type, r.Priority, r.Content)
+		rec, err = dc.NewRecordConfig(label, ttl, rtype, r.Priority, r.Content,
+			nrc.Flags{TargetIsFqdnNoDot: true})
+	case "SVCB", "HTTPS":
+		rec, err = dc.NewRecordConfigParse(label, ttl, rtype, qualifySVCBTarget(r.Content),
+			nrc.Flags{TargetIsFqdnNoDot: true})
 	case "SRV":
-		rec, err = dc.NewRecordConfigParse(r.Name, uint32(r.TTL), r.Type, fmt.Sprintf("%d %s", r.Priority, r.Content))
+		rec, err = dc.NewRecordConfigParse(label, ttl, rtype, fmt.Sprintf("%d %s", r.Priority, r.Content))
 	default:
-		rec, err = dc.NewRecordConfigParse(r.Name, uint32(r.TTL), r.Type, r.Content)
+		rec, err = dc.NewRecordConfigParse(label, ttl, rtype, r.Content,
+			nrc.Flags{TargetIsFqdnNoDot: true})
 	}
 	if err != nil {
 		return nil, err
 	}
+
 	rec.Original = r
+
 	return rec, nil
 }
 
@@ -669,12 +668,18 @@ func getTargetRecordContent(rc *models.RecordConfig) string {
 	// 		rc.GetTargetField())
 	// case "SSHFP":
 	// 	return fmt.Sprintf("%d %d %s", rc.SshfpAlgorithm, rc.SshfpFingerprint, rc.GetTargetField())
-	// case "SRV":
-	// 	return fmt.Sprintf("%d %d %s", rc.SrvWeight, rc.SrvPort, rc.GetTargetField())
+	case "SRV":
+		f := rc.AsSRV()
+		//return fmt.Sprintf("%d %d %s", rc.SrvWeight, rc.SrvPort, rc.GetTargetField())
+		return fmt.Sprintf("%d %d %s", f.Weight, f.Port, f.Target)
 	// case "TLSA":
 	// 	return fmt.Sprintf("%d %d %d %s", rc.TlsaUsage, rc.TlsaSelector, rc.TlsaMatchingType, rc.GetTargetField())
 	case "TXT":
-		return rc.GetTargetCombinedFunc(txtutil.EncodeQuoted)
+		return rc.AsTXT().String()
+		// If that doesn't work, try:
+		// return txtutil.EncodeQuoted(rc.GetTargetTXTJoined())
+		// If that doesn't work, revert to the original:
+		// return rc.GetTargetCombinedFunc(txtutil.EncodeQuoted)
 	}
 	return rc.GetRDATA().String()
 }

--- a/providers/dnsimple/dnsimpleProvider.go
+++ b/providers/dnsimple/dnsimpleProvider.go
@@ -161,9 +161,6 @@ func toRecordConfig(dc *models.DomainConfig, r dnsimpleapi.ZoneRecord) (*models.
 	var rec *models.RecordConfig
 	var err error
 
-	label := dc.LabelFromShort(r.Name)
-	ttl := uint32(r.TTL)
-
 	switch r.Type {
 	case "ALIAS", "URL":
 		rec, err = dc.NewRecordConfig(label, ttl, r.Type, r.Content,
@@ -174,13 +171,11 @@ func toRecordConfig(dc *models.DomainConfig, r dnsimpleapi.ZoneRecord) (*models.
 	case "SRV":
 		rec, err = dc.NewRecordConfig(label, ttl, dnsv2.TypeSRV, r.Priority, r.Content,
 			nrc.Flags{SrvWeirdSplit: true})
-		// If that doesn't work, try this:
-		//rec, err = dc.NewRecordConfigParse(label, ttl, dnsv2.TypeSRV, fmt.Sprintf("%d %s", r.Priority, r.Content))
 	case "SVCB", "HTTPS":
-		rec, err = dc.NewRecordConfigParse(label, ttl, rtype, qualifySVCBTarget(r.Content),
+		rec, err = dc.NewRecordConfigParse(label, ttl, r.Type, qualifySVCBTarget(r.Content),
 			nrc.Flags{TargetIsFqdnNoDot: true})
 	default:
-		rec, err = dc.NewRecordConfigParse(label, ttl, rtype, r.Content,
+		rec, err = dc.NewRecordConfigParse(label, ttl, r.Type, r.Content,
 			nrc.Flags{TargetIsFqdnNoDot: true})
 
 	}
@@ -668,14 +663,10 @@ func getTargetRecordContent(rc *models.RecordConfig) string {
 			return fmt.Sprintf("%d %s %s", f.Priority, target, models.Svcbv2ValueToString(f.Value))
 		}
 		return fmt.Sprintf("%d %s", f.Priority, target)
-	case dnsv2.TypeSRV:
-		f := rc.AsSRV()
-		return fmt.Sprintf("%d %d %s", f.Weight, f.Port, f.Target)
 	case dnsv2.TypeMX:
 		return rc.AsMX().Mx
 	case dnsv2.TypeSRV:
 		f := rc.AsSRV()
-		//return fmt.Sprintf("%d %d %s", rc.SrvWeight, rc.SrvPort, rc.GetTargetField())
 		return fmt.Sprintf("%d %d %s", f.Weight, f.Port, f.Target)
 	case dnsv2.TypeTXT:
 		return rc.AsTXT().String()

--- a/providers/dnsimple/dnsimpleProvider.go
+++ b/providers/dnsimple/dnsimpleProvider.go
@@ -11,11 +11,12 @@ import (
 	"strings"
 	"sync"
 
+	dnsv2 "codeberg.org/miekg/dns"
 	"github.com/DNSControl/dnscontrol/v5/models"
 	"github.com/DNSControl/dnscontrol/v5/pkg/diff2"
+	"github.com/DNSControl/dnscontrol/v5/pkg/nrc"
 	"github.com/DNSControl/dnscontrol/v5/pkg/printer"
 	"github.com/DNSControl/dnscontrol/v5/pkg/providers"
-	"github.com/DNSControl/dnscontrol/v5/pkg/txtutil"
 	dnsimpleapi "github.com/dnsimple/dnsimple-go/v8/dnsimple"
 	"golang.org/x/oauth2"
 )
@@ -168,15 +169,20 @@ func toRecordConfig(dc *models.DomainConfig, r dnsimpleapi.ZoneRecord) (*models.
 
 	var rec *models.RecordConfig
 	var err error
+	label := dc.LabelFromShort(r.Name)
+	ttl := uint32(r.TTL)
 	switch r.Type {
 	case "ALIAS", "URL":
-		rec, err = dc.NewRecordConfig(r.Name, uint32(r.TTL), r.Type, r.Content)
+		rec, err = dc.NewRecordConfig(label, ttl, r.Type, r.Content)
 	case "MX":
-		rec, err = dc.NewRecordConfig(r.Name, uint32(r.TTL), r.Type, r.Priority, r.Content)
+		rec, err = dc.NewRecordConfig(label, ttl, dnsv2.TypeMX, r.Priority, r.Content)
 	case "SRV":
-		rec, err = dc.NewRecordConfigParse(r.Name, uint32(r.TTL), r.Type, fmt.Sprintf("%d %s", r.Priority, r.Content))
+		rec, err = dc.NewRecordConfig(label, ttl, dnsv2.TypeSRV, r.Priority, r.Content,
+			nrc.Flags{SrvWeirdSplit: true})
+		// If that doesn't work, try this:
+		//rec, err = dc.NewRecordConfigParse(label, ttl, dnsv2.TypeSRV, fmt.Sprintf("%d %s", r.Priority, r.Content))
 	default:
-		rec, err = dc.NewRecordConfigParse(r.Name, uint32(r.TTL), r.Type, r.Content)
+		rec, err = dc.NewRecordConfigParse(label, ttl, r.Type, r.Content)
 	}
 	if err != nil {
 		return nil, err
@@ -527,7 +533,7 @@ func (c *dnsimpleProvider) recordUpdate(old *dnsimpleapi.ZoneRecord, rc *models.
 	// priority:0 from the PATCH payload. Without an explicit priority,
 	// the API keeps the old (non-zero) priority and rejects the update.
 	// Work around this by deleting and recreating the record.
-	if rc.Type == "MX" && rc.GetTargetField() == "." {
+	if rc.TypeNum == dnsv2.TypeMX && rc.AsMX().Mx == "." {
 		if err := c.recordDelete(old.ID, domainName); err != nil {
 			return err
 		}
@@ -613,12 +619,12 @@ func newProvider(m map[string]string, _ json.RawMessage) (*dnsimpleProvider, err
 func removeOtherApexNS(dc *models.DomainConfig) {
 	newList := make([]*models.RecordConfig, 0, len(dc.Records))
 	for _, rec := range dc.Records {
-		if rec.Type == "NS" {
+		if rec.TypeNum == dnsv2.TypeNS {
 			// apex NS inside dnsimple are expected.
 			// We ignore them, warning as needed.
 			// Child delegations are supported so we allow non-apex NS records.
 			if rec.GetLabelFQDN() == dc.Name {
-				if !isDnsimpleNameServerDomain(rec.GetTargetField()) {
+				if !isDnsimpleNameServerDomain(rec.AsNS().Ns) {
 					printer.Printf("Warning: dnsimple.com does not allow NS records to be modified. %s will not be added.\n", rec.GetTargetField())
 				}
 				continue
@@ -630,14 +636,13 @@ func removeOtherApexNS(dc *models.DomainConfig) {
 }
 
 // Returns the correct combined content for all special record types, Target for everything else
-// Using RecordConfig.GetTargetCombined returns priority in the string, which we do not allow.
+// Using RecordConfig.GetRDATA().String() returns priority in the string, which we do not allow.
+// NB(tlim): For SRV this returns the fields in the order weight, port, target.
+// The priority is not included in the string, but is returned separately by
+// getTargetRecordPriority.
 func getTargetRecordContent(rc *models.RecordConfig) string {
-	switch rtype := rc.Type; rtype {
-	// case "CAA":
-	// 	return rc.GetRDATA().String()
-	// case "DS":
-	// 	return rc.GetRDATA().String()
-	case "HTTPS":
+	switch rc.TypeNum {
+	case dnsv2.TypeHTTPS:
 		// DNSimple API does not accept FQDN trailing dots in SVCB/HTTPS targets.
 		// Preserve "." for AliasMode (priority 0) self-referencing records.
 		f := rc.AsHTTPS()
@@ -649,7 +654,7 @@ func getTargetRecordContent(rc *models.RecordConfig) string {
 			return fmt.Sprintf("%d %s %s", f.Priority, target, models.Svcbv2ValueToString(f.Value))
 		}
 		return fmt.Sprintf("%d %s", f.Priority, target)
-	case "SVCB":
+	case dnsv2.TypeSVCB:
 		// DNSimple API does not accept FQDN trailing dots in SVCB/HTTPS targets.
 		// Preserve "." for AliasMode (priority 0) self-referencing records.
 		f := rc.AsSVCB()
@@ -661,32 +666,27 @@ func getTargetRecordContent(rc *models.RecordConfig) string {
 			return fmt.Sprintf("%d %s %s", f.Priority, target, models.Svcbv2ValueToString(f.Value))
 		}
 		return fmt.Sprintf("%d %s", f.Priority, target)
-	case "MX":
+	case dnsv2.TypeSRV:
+		f := rc.AsSRV()
+		return fmt.Sprintf("%d %d %s", f.Weight, f.Port, f.Target)
+	case dnsv2.TypeMX:
 		return rc.AsMX().Mx
-	// case "NAPTR":
-	// 	return fmt.Sprintf(`%d %d "%s" "%s" "%s" %s`,
-	// 		rc.NaptrOrder, rc.NaptrPreference, rc.NaptrFlags, rc.NaptrService, rc.NaptrRegexp,
-	// 		rc.GetTargetField())
-	// case "SSHFP":
-	// 	return fmt.Sprintf("%d %d %s", rc.SshfpAlgorithm, rc.SshfpFingerprint, rc.GetTargetField())
-	// case "SRV":
-	// 	return fmt.Sprintf("%d %d %s", rc.SrvWeight, rc.SrvPort, rc.GetTargetField())
-	// case "TLSA":
-	// 	return fmt.Sprintf("%d %d %d %s", rc.TlsaUsage, rc.TlsaSelector, rc.TlsaMatchingType, rc.GetTargetField())
-	case "TXT":
-		return rc.GetTargetCombinedFunc(txtutil.EncodeQuoted)
+	case dnsv2.TypeTXT:
+		return rc.AsTXT().String()
+		// If that doesn't work, use this:
+		//return txtutil.EncodeQuoted(rc.GetTargetTXTJoined())
 	}
 	return rc.GetRDATA().String()
 }
 
 // Returns the correct priority for the record type, 0 for records without priority.
 func getTargetRecordPriority(rc *models.RecordConfig) int {
-	switch rtype := rc.Type; rtype {
-	case "MX":
-		return int(rc.MxPreference)
-	case "SRV":
-		return int(rc.SrvPriority)
-	case "NAPTR":
+	switch rc.TypeNum {
+	case dnsv2.TypeMX:
+		return int(rc.AsMX().Preference)
+	case dnsv2.TypeSRV:
+		return int(rc.AsSRV().Priority)
+	case dnsv2.TypeNAPTR:
 		// Neither order nor preference
 		return 0
 	default:

--- a/providers/dnsimple/dnsimpleProvider_test.go
+++ b/providers/dnsimple/dnsimpleProvider_test.go
@@ -38,7 +38,7 @@ func TestToRecordConfig(t *testing.T) {
 			if got := rc.GetLabel(); got != tc.wantLabel {
 				t.Errorf("label = %q, want %q", got, tc.wantLabel)
 			}
-			if got := rc.GetTargetCombined(); got != tc.wantTarget {
+			if got := rc.GetRDATA().String(); got != tc.wantTarget {
 				t.Errorf("target = %q, want %q", got, tc.wantTarget)
 			}
 			original, ok := rc.Original.(dnsimpleapi.ZoneRecord)


### PR DESCRIPTION
Hi @onlyhavecans !

One more round of changes for you to test.

I decided to create an account on DNSSimple so that I could add it to the automated tests.  I was able to fix SRV and other issues before I ran out of quota:  ` : 429 Global quota exceeded`

The account I'm using is `dnscontrolproject` at `gmail.com`

I know its a big ask (and it may be politically unviable for you to even ask) but is it possible to our our quota raised?  It would help the project greatly if we could run the full test serveral times each day. This will improve reliability for the DNSControl users that use DNSimple.

Thanks!
Tom