### PR TITLE
DESEC: Fix TXT records quote, disable TTL tests

### DIFF
--- a/integrationTest/integration_test.go
+++ b/integrationTest/integration_test.go
@@ -247,6 +247,7 @@ func makeTests() []*TestGroup {
 		// weirdest edge-case we've ever seen.
 
 		testgroup("Attl",
+			not("DESEC"),   // deSEC does not support TTL lower than 3600.
 			not("LINODE"),  // Linode does not support arbitrary TTLs: both are rounded up to 3600.
 			not("OPENWRT"), // OpenWRT does not support per record TTL
 			tc("Create Arc", ttl(a("testa", "1.1.1.1"), 333)),
@@ -254,6 +255,7 @@ func makeTests() []*TestGroup {
 		),
 
 		testgroup("TTL",
+			not("DESEC"),   // deSEC does not support TTL lower than 3600.
 			not("NETCUP"),  // NETCUP does not support TTLs.
 			not("LINODE"),  // Linode does not support arbitrary TTLs: 666 and 1000 are both rounded up to 3600.
 			not("OPENWRT"), // OpenWRT does not support per record TTL

--- a/providers/desec/convert.go
+++ b/providers/desec/convert.go
@@ -5,7 +5,6 @@ package desec
 import (
 	"fmt"
 
-	dnsv2 "codeberg.org/miekg/dns"
 	"github.com/DNSControl/dnscontrol/v5/models"
 	"github.com/DNSControl/dnscontrol/v5/pkg/printer"
 )
@@ -18,19 +17,10 @@ func nativeToRecords(n resourceRecord, dc *models.DomainConfig) (rcs []*models.R
 	// n.Records rather than having many resourceRecord's.
 	// We must split them out into individual records, one for each value.
 	for _, value := range n.Records {
-		var rc *models.RecordConfig
-		var err error
-
 		label := dc.LabelFromShort(n.Subname)
 		ttl := n.TTL
 
-		if n.Type == "TXT" {
-			// deSEC returns TXT data as raw text, matching the provider's
-			// historical behavior.
-			rc, err = dc.NewRecordConfig(label, ttl, dnsv2.TypeTXT, value)
-		} else {
-			rc, err = dc.NewRecordConfigParse(label, ttl, n.Type, value)
-		}
+		rc, err := dc.NewRecordConfigParse(label, ttl, n.Type, value)
 		if err != nil {
 			panic(fmt.Errorf("unparsable record received from deSEC: %w", err))
 		}

--- a/providers/desec/convert.go
+++ b/providers/desec/convert.go
@@ -20,12 +20,16 @@ func nativeToRecords(n resourceRecord, dc *models.DomainConfig) (rcs []*models.R
 	for _, value := range n.Records {
 		var rc *models.RecordConfig
 		var err error
+
+		label := dc.LabelFromShort(n.Subname)
+		ttl := n.TTL
+
 		if n.Type == "TXT" {
 			// deSEC returns TXT data as raw text, matching the provider's
 			// historical behavior.
-			rc, err = dc.NewRecordConfig(n.Subname, n.TTL, dnsv2.TypeTXT, value)
+			rc, err = dc.NewRecordConfig(label, ttl, dnsv2.TypeTXT, value)
 		} else {
-			rc, err = dc.NewRecordConfigParse(n.Subname, n.TTL, n.Type, value)
+			rc, err = dc.NewRecordConfigParse(label, ttl, n.Type, value)
 		}
 		if err != nil {
 			panic(fmt.Errorf("unparsable record received from deSEC: %w", err))

--- a/providers/desec/convert_test.go
+++ b/providers/desec/convert_test.go
@@ -45,7 +45,7 @@ func TestNativeToRecordsPreservesRawTXT(t *testing.T) {
 
 	records := nativeToRecords(resourceRecord{
 		Subname: "@",
-		Records: []string{`"quoted" text`},
+		Records: []string{`\"quoted\" text`},
 		TTL:     300,
 		Type:    "TXT",
 	}, dc)


### PR DESCRIPTION
<!--
## Before submiting a pull request

Please make sure you've run the following commands from the root directory.

    bin/generate-all.sh

(this runs commands like "go generate", fixes formatting, and so on)

## Release changelog section

Help keep the release changelog clear by pre-naming the proper section in the GitHub pull request title.

Some examples:
* CICD: Add required GHA permissions for goreleaser
* DOCS: Fixed providers with "contributor support" table
* ROUTE53: Allow R53_ALIAS records to enable target health evaluation

More examples/context can be found in the file .goreleaser.yml under the 'build' > 'changelog' key.
!-->
Fixes part of #4675
