### PR TITLE
DNSMADEEASY: Cover label conversion in types_test.go

### DIFF
--- a/providers/dnsmadeeasy/types_test.go
+++ b/providers/dnsmadeeasy/types_test.go
@@ -7,22 +7,23 @@ import (
 )
 
 func TestToRecordConfig(t *testing.T) {
-	dc, err := models.NewDomainConfig("example.com")
-	if err != nil {
-		t.Fatal(err)
-	}
+	dc := models.MustNewDomainConfig("example.com")
 
 	tests := []struct {
 		name       string
 		record     recordResponseDataEntry
 		wantType   string
+		wantLabel  string
 		wantTarget string
 	}{
-		{"MX", recordResponseDataEntry{Name: "@", Type: "MX", Value: "mail.example.net.", TTL: 300, MxLevel: 10}, "MX", "10 mail.example.net."},
-		{"SRV", recordResponseDataEntry{Name: "_sip._tcp", Type: "SRV", Value: "sip.example.net.", TTL: 300, Priority: 1, Weight: 2, Port: 5060}, "SRV", "1 2 5060 sip.example.net."},
-		{"CAA", recordResponseDataEntry{Name: "@", Type: "CAA", Value: `"letsencrypt.org"`, TTL: 300, CaaType: "issue", IssuerCritical: 1}, "CAA", `1 issue "letsencrypt.org"`},
-		{"TXT", recordResponseDataEntry{Name: "@", Type: "TXT", Value: `"quoted text"`, TTL: 300}, "TXT", `"quoted text"`},
-		{"ANAME", recordResponseDataEntry{Name: "@", Type: "ANAME", Value: "target.example.net.", TTL: 300}, "ALIAS", "target.example.net."},
+		{"MX", recordResponseDataEntry{Name: "@", Type: "MX", Value: "mail.example.net.", TTL: 300, MxLevel: 10}, "MX", "@", "10 mail.example.net."},
+		{"SRV", recordResponseDataEntry{Name: "_sip._tcp", Type: "SRV", Value: "sip.example.net.", TTL: 300, Priority: 1, Weight: 2, Port: 5060}, "SRV", "_sip._tcp", "1 2 5060 sip.example.net."},
+		{"CAA", recordResponseDataEntry{Name: "@", Type: "CAA", Value: `"letsencrypt.org"`, TTL: 300, CaaType: "issue", IssuerCritical: 1}, "CAA", "@", `1 issue "letsencrypt.org"`},
+		{"TXT", recordResponseDataEntry{Name: "@", Type: "TXT", Value: `"quoted text"`, TTL: 300}, "TXT", "@", `"quoted text"`},
+		{"ANAME", recordResponseDataEntry{Name: "@", Type: "ANAME", Value: "target.example.net.", TTL: 300}, "ALIAS", "@", "target.example.net."},
+		// The API returns an empty name for records at the zone apex.
+		{"apex empty name", recordResponseDataEntry{Name: "", Type: "A", Value: "1.2.3.4", TTL: 300}, "A", "@", "1.2.3.4"},
+		{"mixed case name", recordResponseDataEntry{Name: "WWW", Type: "A", Value: "1.2.3.4", TTL: 300}, "A", "www", "1.2.3.4"},
 	}
 
 	for _, tc := range tests {
@@ -32,12 +33,53 @@ func TestToRecordConfig(t *testing.T) {
 			if got := rc.Type; got != tc.wantType {
 				t.Errorf("type = %q, want %q", got, tc.wantType)
 			}
+			if got := rc.GetLabel(); got != tc.wantLabel {
+				t.Errorf("label = %q, want %q", got, tc.wantLabel)
+			}
 			if got := rc.GetRDATA().String(); got != tc.wantTarget {
 				t.Errorf("target = %q, want %q", got, tc.wantTarget)
+			}
+			if got := rc.TTL; got != uint32(tc.record.TTL) {
+				t.Errorf("ttl = %d, want %d", got, tc.record.TTL)
 			}
 			if rc.Original != &record {
 				t.Error("original provider record was not retained")
 			}
 		})
+	}
+}
+
+// TestApexRoundTrip checks both halves of the apex label mapping: the API sends
+// an empty name for apex records, and expects one back.
+func TestApexRoundTrip(t *testing.T) {
+	dc := models.MustNewDomainConfig("example.com")
+
+	rc := toRecordConfig(dc, &recordResponseDataEntry{Name: "", Type: "A", Value: "1.2.3.4", TTL: 300})
+	if got := rc.GetLabelFQDN(); got != "example.com" {
+		t.Errorf("fqdn = %q, want %q", got, "example.com")
+	}
+	if got := fromRecordConfig(rc).Name; got != "" {
+		t.Errorf("name = %q, want %q", got, "")
+	}
+}
+
+func TestSystemNameServerToRecordConfig(t *testing.T) {
+	dc := models.MustNewDomainConfig("example.com")
+
+	rc := systemNameServerToRecordConfig(dc, "ns1.example.net")
+	if got := rc.Type; got != "NS" {
+		t.Errorf("type = %q, want %q", got, "NS")
+	}
+	if got := rc.GetLabel(); got != "@" {
+		t.Errorf("label = %q, want %q", got, "@")
+	}
+	if got := rc.GetLabelFQDN(); got != "example.com" {
+		t.Errorf("fqdn = %q, want %q", got, "example.com")
+	}
+	if got := rc.GetRDATA().String(); got != "ns1.example.net." {
+		t.Errorf("target = %q, want %q", got, "ns1.example.net.")
+	}
+	if got := rc.TTL; got != fixedNameServerRecordTTL {
+		t.Errorf("ttl = %d, want %d", got, fixedNameServerRecordTTL)
 	}
 }


### PR DESCRIPTION
Test-only change.

After #4679 unified label creation via `dc.LabelFromShort()`, nothing in the test
suite exercised that path — `TestToRecordConfig` asserted only on type, rdata and
`rc.Original`. The zone-apex case, which is what #4679 fixed, had no coverage.

- Label and TTL assertions on every table case, plus two new cases: apex
  (`Name: ""` → `"@"`) and mixed case (`WWW` → `www`).
- `TestApexRoundTrip` — `""` → `"@"` on read, `"@"` → `""` on write.
- `TestSystemNameServerToRecordConfig` — system NS records had no coverage at all.

Reverting `label := dc.LabelFromShort(record.Name)` back to `record.Name` fails
exactly these new assertions, so they guard the fix rather than restate it.

Also switches to `models.MustNewDomainConfig()` and replaces `GetTargetField()`
with `GetRDATA().String()` to keep the file clean under `bin/is_modern.sh`.

Base branch is release_candidate_v5.