### PR TITLE
DOMAINNAMESHOP: Reject NS records at apex

### DIFF
--- a/providers/domainnameshop/auditrecords.go
+++ b/providers/domainnameshop/auditrecords.go
@@ -1,10 +1,23 @@
 package domainnameshop
 
-import "github.com/DNSControl/dnscontrol/v5/models"
+import (
+	"github.com/DNSControl/dnscontrol/v5/models"
+	"github.com/DNSControl/dnscontrol/v5/pkg/rejectif"
+)
 
 // AuditRecords returns a list of errors corresponding to the records
 // that aren't supported by this provider.  If all records are
 // supported, an empty list is returned.
 func AuditRecords(records []*models.RecordConfig) []error {
-	return nil
+	a := rejectif.Auditor{}
+
+	// last verified 2026-08-05
+	// Domeneshop does not allow NS records at the apex: the apex nameservers
+	// are managed at the delegation level and are synthesized read-only from
+	// the /domains endpoint (see api.go). POSTing an apex NS record returns
+	// "400 - DNS record failed validation".
+	// NS records at subdomains work fine and are left untouched.
+	a.Add("NS", rejectif.NsAtApex)
+
+	return a.Audit(records)
 }


### PR DESCRIPTION
Closes #4699.

## Problem

The integration test `NS_only_APEX:Single_NS_at_apex` fails against DOMAINNAMESHOP with `400 - DNS record failed validation`. Domeneshop does not allow creating NS records at the apex — the apex nameservers are managed at the delegation level and are exposed read-only via the `/domains` endpoint (the provider already synthesizes them as `@ NS` records in `api.go`). Attempting to `POST` an apex NS record to `/domains/{id}/dns` is rejected with HTTP 400.

## Fix

Add `rejectif.NsAtApex` to the provider's `AuditRecords`, matching the existing pattern in the Joker and Vercel providers. Apex NS records are now rejected during validation, and the integration test skips them.

## Scope

This is **apex-only**. NS records at subdomains are supported by Domeneshop and remain unaffected. Confirmed against a live integration test run:

```
--- PASS: .../NS:NS_for_subdomain
--- PASS: .../NS:Dual_NS_for_subdomain
--- PASS: .../NS:NS_Record_pointing_to_@
--- FAIL: .../NS_only_APEX:Single_NS_at_apex   (before this change)
```

The subdomain cases actually created records on Domeneshop (real record IDs returned) and were cleaned up; only the apex case fails.

Thanks to @TomOnTime for pointing at `rejectif.NsAtApex` in the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VESo8kcAdjSvRxNWetq8Ru
